### PR TITLE
Add build script and LIBC_PATH environ variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ A library for types and bindings to native C functions often found in libc or
 other common platform libraries.
 """
 include = ["Cargo.toml", "rust/src/liblibc/*"]
+build = "build.rs"
 
 [features]
 default = ["cargo-build"]
@@ -21,3 +22,5 @@ cargo-build = []
 [lib]
 name = "libc"
 path = "rust/src/liblibc/lib.rs"
+
+

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+use std::env;
+
+fn main() {
+    if let Ok(path) = env::var("LIBC_PATH") {
+        println!("cargo:rustc-link-search={}", path);
+    }
+}


### PR DESCRIPTION
Well, the solution here is probably not optimal. But it's the easiest way I've found so far to build libc (as dependency) for `x86_64-unknown-linux-musl`.

The problem is that when building with musl, the target libc is not the one in default path. So I get output similar to:
```
error: could not find native static library `c`, perhaps an -L flag is missing?
Could not compile `libc`.

Caused by:
  Process didn't exit successfully: `rustc libc/rust/src/liblibc/lib.rs --crate-name libc --crate-type lib -g --cfg feature="cargo-build" --cfg feature="default" -C metadata=49eeab76b364dec9 
-C extra-filename=-49eeab76b364dec9 --out-dir /work/target/x86_64-unknown-linux-musl/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-musl -L dependency=/work/target/x86_64-unknown-linux-musl/debug/deps -L dependency=/work/target/x86_64-unknown-linux-musl/debug/deps`
```

According to cargo docs the `build.rs` script is there suited to find dependencies (or sometimes build one if not found). So with this script setting env var  to `LIBC_PATH=/usr/local/musl/lib` I can now build my project.

Any other ideas of how to build the lib are appreciated.