### PR TITLE
Add NR_GETRANDOM syscall numbers

### DIFF
--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -391,13 +391,13 @@ pub const CLONE_IO: ::c_uint = 0x80000000;
 
 // syscall numbers
 #[cfg(target_arch = "x86_64")]
-pub const NR_GETRANDOM: ::c_long = 318;
+pub const SYS_getrandom: ::c_long = 318;
 #[cfg(target_arch = "x86")]
-pub const NR_GETRANDOM: ::c_long = 355;
+pub const SYS_getrandom: ::c_long = 355;
 #[cfg(any(target_arch = "arm", target_arch = "powerpc"))]
-pub const NR_GETRANDOM: ::c_long = 384;
+pub const SYS_getrandom: ::c_long = 384;
 #[cfg(target_arch = "aarch64")]
-pub const NR_GETRANDOM: ::c_long = 278;
+pub const SYS_getrandom: ::c_long = 278;
 
 extern {
     pub fn shm_open(name: *const c_char, oflag: ::c_int,

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -389,6 +389,16 @@ pub const CLONE_NEWPID: ::c_uint = 0x20000000;
 pub const CLONE_NEWNET: ::c_uint = 0x40000000;
 pub const CLONE_IO: ::c_uint = 0x80000000;
 
+// syscall numbers
+#[cfg(target_arch = "x86_64")]
+pub const NR_GETRANDOM: ::c_long = 318;
+#[cfg(target_arch = "x86")]
+pub const NR_GETRANDOM: ::c_long = 355;
+#[cfg(any(target_arch = "arm", target_arch = "powerpc"))]
+pub const NR_GETRANDOM: ::c_long = 384;
+#[cfg(target_arch = "aarch64")]
+pub const NR_GETRANDOM: ::c_long = 278;
+
 extern {
     pub fn shm_open(name: *const c_char, oflag: ::c_int,
                     mode: mode_t) -> ::c_int;


### PR DESCRIPTION
Pulled directly from src/libstd/rand/os.rs in the main rust repo. We can
delete them from there once this commit is added in rust's liblibc
submodule.