### PR TITLE
Fixed a typo in the #[cfg()] of gettimeofday.

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -411,7 +411,7 @@ extern {
 
     pub fn flock(fd: ::c_int, operation: ::c_int) -> ::c_int;
 
-    #[cfg_attr(arget_os = "netbsd", link_name = "__gettimeofday50")]
+    #[cfg_attr(target_os = "netbsd", link_name = "__gettimeofday50")]
     pub fn gettimeofday(tp: *mut ::timeval,
                         tz: *mut ::c_void) -> ::c_int;
 


### PR DESCRIPTION
The #[cfg()] was looking for 'arget_os' instead of 'target_os'.