### PR TITLE
Add `posix_fadvise()` and related constants

### DIFF
--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -365,6 +365,13 @@ pub const POSIX_MADV_SEQUENTIAL: ::c_int = 2;
 pub const POSIX_MADV_WILLNEED: ::c_int = 3;
 pub const POSIX_MADV_DONTNEED: ::c_int = 4;
 
+pub const POSIX_FADV_NORMAL: ::c_int = 0;
+pub const POSIX_FADV_RANDOM: ::c_int = 1;
+pub const POSIX_FADV_SEQUENTIAL: ::c_int = 2;
+pub const POSIX_FADV_WILLNEED: ::c_int = 3;
+pub const POSIX_FADV_DONTNEED: ::c_int = 4;
+pub const POSIX_FADV_NOREUSE: ::c_int = 5;
+
 pub const _SC_IOV_MAX: ::c_int = 56;
 pub const _SC_GETGR_R_SIZE_MAX: ::c_int = 70;
 pub const _SC_GETPW_R_SIZE_MAX: ::c_int = 71;
@@ -630,6 +637,10 @@ extern {
                     hdtr: *mut ::sf_hdtr,
                     sbytes: *mut ::off_t,
                     flags: ::c_int) -> ::c_int;
+
+    pub fn posix_fadvise(fd: ::c_int, offset: ::off_t, len: ::off_t, 
+                         advise: ::c_int) -> ::c_int;
+
 }
 
 cfg_if! {

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -534,6 +534,13 @@ pub const SPLICE_F_GIFT: ::c_uint = 0x08;
 
 pub const RTLD_LOCAL: ::c_int = 0;
 
+pub const POSIX_FADV_NORMAL: ::c_int = 0;
+pub const POSIX_FADV_RANDOM: ::c_int = 1;
+pub const POSIX_FADV_SEQUENTIAL: ::c_int = 2;
+pub const POSIX_FADV_WILLNEED: ::c_int = 3;
+pub const POSIX_FADV_DONTNEED: ::c_int = 4;
+pub const POSIX_FADV_NOREUSE: ::c_int = 5;
+
 f! {
     pub fn FD_CLR(fd: ::c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
@@ -642,6 +649,9 @@ extern {
                     iov: *const ::iovec,
                     nr_segs: ::size_t,
                     flags: ::c_uint) -> ::ssize_t;
+
+    pub fn posix_fadvise(fd: ::c_int, offset: ::off_t, len: ::off_t, 
+                         advise: ::c_int) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
Closes #148 

I didn't touch the `POSIX_MADV` constants, those can be consolidated in another PR.

I also wrote a quick test to make sure that the call was written correctly and that `posix_fadvise()` actually works for my use-case:

https://gist.github.com/cybergeek94/ce5e989c6ac6823acea4

As you can see, the uncached file takes much longer to read without the call to `posix_fadvise()`, which is exactly the result I wanted to see. A test file size of 8M is around what I'll be dealing with in my particular use-case (large libraries of images).

cc @alexcrichton 