### PR TITLE
PowerPC64 fixes

### DIFF
--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -84,11 +84,9 @@ s! {
     }
 
     pub struct pthread_mutexattr_t {
-        #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64",
-                  target_arch = "powerpc64le"))]
+        #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64"))]
         __align: [::c_int; 0],
-        #[cfg(not(any(target_arch = "x86_64", target_arch = "powerpc64",
-                      target_arch = "powerpc64le")))]
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "powerpc64")))]
         __align: [::c_long; 0],
         size: [u8; __SIZEOF_PTHREAD_MUTEXATTR_T],
     }

--- a/src/unix/notbsd/linux/other/b64/mod.rs
+++ b/src/unix/notbsd/linux/other/b64/mod.rs
@@ -22,7 +22,7 @@ cfg_if! {
     if #[cfg(target_arch = "aarch64")] {
         mod aarch64;
         pub use self::aarch64::*;
-    } else if #[cfg(any(target_arch = "powerpc64", target_arch = "powerpc64le"))] {
+    } else if #[cfg(any(target_arch = "powerpc64"))] {
         mod powerpc64;
         pub use self::powerpc64::*;
     } else {

--- a/src/unix/notbsd/linux/other/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/other/b64/powerpc64.rs
@@ -1,7 +1,7 @@
 //! PowerPC64-specific definitions for 64-bit linux-like values
 
 pub type c_char = u8;
-pub type wchar_t = u32;
+pub type wchar_t = i32;
 pub type nlink_t = u64;
 pub type blksize_t = i64;
 

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -454,8 +454,7 @@ cfg_if! {
         pub use self::b32::*;
     } else if #[cfg(any(target_arch = "x86_64",
                         target_arch = "aarch64",
-                        target_arch = "powerpc64",
-                        target_arch = "powerpc64le"))] {
+                        target_arch = "powerpc64"))] {
         mod b64;
         pub use self::b64::*;
     } else {


### PR DESCRIPTION
Remove checks for the powerpc64le target_arch, and fix the wchar_t type.