### PR TITLE
Use 32-bit mode_t on 64-bit Android devices

### DIFF
--- a/src/unix/notbsd/android/b32.rs
+++ b/src/unix/notbsd/android/b32.rs
@@ -1,3 +1,5 @@
+pub type mode_t = u16;
+
 s! {
     pub struct sigaction {
         pub sa_sigaction: ::sighandler_t,

--- a/src/unix/notbsd/android/b64.rs
+++ b/src/unix/notbsd/android/b64.rs
@@ -1,3 +1,5 @@
+pub type mode_t = u32;
+
 s! {
     pub struct sigaction {
         pub sa_flags: ::c_uint,

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -13,7 +13,6 @@ pub type ino_t = u32;
 pub type blkcnt_t = u32;
 pub type blksize_t = u32;
 pub type dev_t = u32;
-pub type mode_t = u16;
 pub type nlink_t = u32;
 pub type useconds_t = u32;
 pub type socklen_t = i32;


### PR DESCRIPTION
The `aarch64-linux-android` target uses 32-bit `mode_t`, unlike regular `arm-linux-androideabi*`.
This fixes rust-lang/rust#31595.