### PR TITLE
Add ucontext struct for Linux/x86

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -132,6 +132,7 @@ fn main() {
 
     if linux {
         cfg.header("mqueue.h");
+        cfg.header("ucontext.h");
         cfg.header("sys/signalfd.h");
         cfg.header("sys/xattr.h");
         cfg.header("sys/ipc.h");

--- a/src/unix/notbsd/linux/other/b32/x86.rs
+++ b/src/unix/notbsd/linux/other/b32/x86.rs
@@ -18,3 +18,27 @@ pub const SO_SNDTIMEO: ::c_int = 21;
 
 pub const FIOCLEX: ::c_ulong = 0x5451;
 pub const FIONBIO: ::c_ulong = 0x5421;
+
+s! {
+
+    pub struct mcontext_t {
+        __private: [u32; 22]
+    }
+
+    pub struct ucontext_t {
+        pub uc_flags: ::c_ulong,
+        pub uc_link: *mut ucontext_t,
+        pub uc_stack: ::stack_t,
+        pub uc_mcontext: mcontext_t,
+        pub uc_sigmask: ::sigset_t,
+        __private: [u8; 112],
+    }
+
+}
+
+extern {
+    pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;
+    pub fn setcontext(ucp: *const ucontext_t) -> ::c_int;
+    pub fn makecontext(ucp: *mut ucontext_t, func:  extern fn (), argc: ::c_int, ...);
+    pub fn swapcontext(uocp: *mut ucontext_t, ucp: *const ucontext_t) -> ::c_int;
+}

--- a/src/unix/notbsd/linux/other/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/other/b64/x86_64.rs
@@ -79,4 +79,29 @@ s! {
     pub struct pthread_attr_t {
         __size: [u64; 7]
     }
+
+}
+
+s! {
+
+    pub struct mcontext_t {
+        __private: [u64; 32],
+    }
+
+    pub struct ucontext_t {
+        pub uc_flags: ::c_ulong,
+        pub uc_link: *mut ucontext_t,
+        pub uc_stack: ::stack_t,
+        pub uc_mcontext: mcontext_t,
+        pub uc_sigmask: ::sigset_t,
+        __private: [u8; 512],
+    }
+
+}
+
+extern {
+    pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;
+    pub fn setcontext(ucp: *const ucontext_t) -> ::c_int;
+    pub fn makecontext(ucp: *mut ucontext_t, func:  extern fn (), argc: ::c_int, ...);
+    pub fn swapcontext(uocp: *mut ucontext_t, ucp: *const ucontext_t) -> ::c_int;
 }


### PR DESCRIPTION
I need the following structs from glibc for low level work. I pulled the information about the types from the [glibc source](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/x86/sys/ucontext.h;hb=de6e5df27ead590c7f590a63665cb87764cf6de3). There is a lot of duplication due to the structure of rust libc. If the structs for other platforms would be added (and I might do that in the future), some of that repetiton might be eliminated.
I hid some structs in a module called 'detail'. I wanted to use the `s!`-macro for some structs that I did not want to provided public access to. Only the parts specified in the linux man page for getcontext are exposed publicly.