### PR TITLE
Fix deprecated NetBSD sigaction/sigaltstack symbols

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -500,11 +500,13 @@ extern {
                       optval: *mut ::c_void,
                       optlen: *mut ::socklen_t) -> ::c_int;
     pub fn raise(signum: ::c_int) -> ::c_int;
+    #[cfg_attr(target_os = "netbsd", link_name = "__sigaction14")]
     pub fn sigaction(signum: ::c_int,
                      act: *const sigaction,
                      oldact: *mut sigaction) -> ::c_int;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "sigaltstack$UNIX2003")]
+    #[cfg_attr(target_os = "netbsd", link_name = "__sigaltstack14")]
     pub fn sigaltstack(ss: *const stack_t,
                        oss: *mut stack_t) -> ::c_int;
 


### PR DESCRIPTION
Especially `sigaction` is needed for NetBSD/amd64, as otherwise every invocation crashes with ENOSYS since the legacy system call was never available on x86_64.

This replaces rust-lang/libc#191