### PR TITLE
Various Rumprun fixes

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -350,10 +350,6 @@ fn main() {
             // they're implemented on rumprun yet, just let them slide for now.
             // Some of them look like they have headers but then don't have
             // corresponding actual definitions either...
-            "backtrace" |
-            "pthread_main_np" |
-            "pthread_set_name_np" |
-            "pthread_stackseg_np" |
             "shm_open" |
             "shm_unlink" |
             "syscall" |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 ))]
 
 // Attributes needed when building as part of the standard library
-#![cfg_attr(stdbuild, feature(no_std, core, core_slice_ext, staged_api, custom_attribute))]
+#![cfg_attr(stdbuild, feature(no_std, core, core_slice_ext, staged_api, custom_attribute, cfg_target_vendor))]
 #![cfg_attr(stdbuild, no_std)]
 #![cfg_attr(stdbuild, staged_api)]
 #![cfg_attr(stdbuild, allow(warnings))]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,7 +23,7 @@ macro_rules! cfg_if {
 macro_rules! __cfg_if_items {
     (($($not:meta,)*) ; ) => {};
     (($($not:meta,)*) ; ( ($($m:meta),*) ($($it:item)*) ), $($rest:tt)*) => {
-        __cfg_if_apply! { cfg(all($($m,)* not(any($($not),*)))), $($it)* }
+        __cfg_if_apply! { cfg(all(not(any($($not),*)), $($m,)*)), $($it)* }
         __cfg_if_items! { ($($not,)* $($m,)*) ; $($rest)* }
     }
 }

--- a/src/unix/bsd/openbsdlike/bitrig.rs
+++ b/src/unix/bsd/openbsdlike/bitrig.rs
@@ -227,6 +227,10 @@ extern {
                        flags: ::c_int) -> ::c_int;
     pub fn mprotect(addr: *const ::c_void, len: ::size_t, prot: ::c_int)
                     -> ::c_int;
+    pub fn pthread_main_np() -> ::c_int;
+    pub fn pthread_set_name_np(tid: ::pthread_t, name: *const ::c_char);
+    pub fn pthread_stackseg_np(thread: ::pthread_t,
+                               sinfo: *mut ::stack_t) -> ::c_int;
     pub fn sysctl(name: *mut ::c_int,
                   namelen: ::c_uint,
                   oldp: *mut ::c_void,

--- a/src/unix/bsd/openbsdlike/mod.rs
+++ b/src/unix/bsd/openbsdlike/mod.rs
@@ -384,10 +384,6 @@ extern {
     pub fn __errno() -> *mut ::c_int;
     pub fn shm_open(name: *const ::c_char, oflag: ::c_int, mode: ::mode_t)
                     -> ::c_int;
-    pub fn pthread_main_np() -> ::c_int;
-    pub fn pthread_set_name_np(tid: ::pthread_t, name: *const ::c_char);
-    pub fn pthread_stackseg_np(thread: ::pthread_t,
-                               sinfo: *mut ::stack_t) -> ::c_int;
     pub fn memrchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
     pub fn mkostemp(template: *mut ::c_char, flags: ::c_int) -> ::c_int;
     pub fn mkostemps(template: *mut ::c_char, suffixlen: ::c_int, flags: ::c_int) -> ::c_int;

--- a/src/unix/bsd/openbsdlike/openbsd.rs
+++ b/src/unix/bsd/openbsdlike/openbsd.rs
@@ -232,6 +232,10 @@ extern {
                        flags: ::c_int) -> ::c_int;
     pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int)
                     -> ::c_int;
+    pub fn pthread_main_np() -> ::c_int;
+    pub fn pthread_set_name_np(tid: ::pthread_t, name: *const ::c_char);
+    pub fn pthread_stackseg_np(thread: ::pthread_t,
+                               sinfo: *mut ::stack_t) -> ::c_int;
     pub fn sysctl(name: *const ::c_int,
                   namelen: ::c_uint,
                   oldp: *mut ::c_void,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -143,6 +143,12 @@ cfg_if! {
     } else if #[cfg(target_os = "emscripten")] {
         #[link(name = "c")]
         extern {}
+    } else if #[cfg(all(target_vendor = "rumprun", target_os = "netbsd"))] {
+        // Since we don't use -nodefaultlibs on Rumprun, libc is always pulled in
+        // automatically by the linker. We avoid passing it explicitly, as it
+        // causes some versions of binutils to crash with an assertion failure.
+        #[link(name = "m")]
+        extern {}
     } else if #[cfg(any(target_os = "macos",
                         target_os = "ios",
                         target_os = "android",


### PR DESCRIPTION
This moves some pthread_*_np definitions that ended up in the wrong BSD modules. Additionally, it avoids linking against libc and librt on Rumprun when building libstd. librt is not available on Rumprun, and libc is pulled in automatically by Rumpruns own linker.

Because conditional compilation for Rumprun is using the unstable `target_vendor` attribute, I'm relying on the fact that `#[cfg]` evaluation is short-circuiting regarding feature gate checks.I had to change the `cfg_if!` macro to support this. Now, if the `if #[cfg(..)]` clause is true, then the `else if #[cfg(..)]` clause will not be evaluated, allowing me to use unstable attributes for libstd builds.