### PR TITLE
Add a style checking script to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
     else
       cargo build;
       cargo build --no-default-features;
+      rustc ci/style.rs && ./style src;
     fi
 os:
   - linux

--- a/ci/style.rs
+++ b/ci/style.rs
@@ -1,0 +1,204 @@
+//! Simple script to verify the coding style of this library
+//!
+//! ## How to run
+//!
+//! The first argument to this script is the directory to run on, so running
+//! this script should be as simple as:
+//!
+//! ```notrust
+//! rustc ci/style.rs
+//! ./style src
+//! ```
+//!
+//! ## Guidelines
+//!
+//! The current style is:
+//!
+//! * No trailing whitespace
+//! * No tabs
+//! * 80-character lines
+//! * `extern` instead of `extern "C"`
+//! * Specific module layout:
+//!     1. use directives
+//!     2. typedefs
+//!     3. structs
+//!     4. constants
+//!     5. f! { ... } functions
+//!     6. extern functions
+//!     7. modules + pub use
+//!
+//! Things not verified:
+//!
+//! * alignment
+//! * 4-space tabs
+//! * leading colons on paths
+
+use std::env;
+use std::fs;
+use std::io::prelude::*;
+use std::path::Path;
+
+macro_rules! t {
+    ($e:expr) => (match $e {
+        Ok(e) => e,
+        Err(e) => panic!("{} failed with {}", stringify!($e), e),
+    })
+}
+
+fn main() {
+    let arg = env::args().skip(1).next().unwrap_or(".".to_string());
+
+    let mut errors = Errors { errs: false };
+    walk(Path::new(&arg), &mut errors);
+
+    if errors.errs {
+        panic!("found some lint errors");
+    } else {
+        println!("good style!");
+    }
+}
+
+fn walk(path: &Path, err: &mut Errors) {
+    for entry in t!(path.read_dir()).map(|e| t!(e)) {
+        let path = entry.path();
+        if t!(entry.file_type()).is_dir() {
+            walk(&path, err);
+            continue
+        }
+
+        let name = entry.file_name().into_string().unwrap();
+        match &name[..] {
+            n if !n.ends_with(".rs") => continue,
+
+            "dox.rs" |
+            "lib.rs" |
+            "macros.rs" => continue,
+
+            _ => {}
+        }
+
+        let mut contents = String::new();
+        t!(t!(fs::File::open(&path)).read_to_string(&mut contents));
+
+        check_style(&contents, &path, err);
+    }
+}
+
+struct Errors {
+    errs: bool,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum State {
+    Start,
+    Imports,
+    Typedefs,
+    Structs,
+    Constants,
+    FunctionDefinitions,
+    Functions,
+    Modules,
+}
+
+fn check_style(file: &str, path: &Path, err: &mut Errors) {
+    let mut state = State::Start;
+    let mut s_macros = 0;
+    let mut f_macros = 0;
+    let mut prev_blank = false;
+
+    for (i, line) in file.lines().enumerate() {
+        if line == "" {
+            if prev_blank {
+                err.error(path, i, "double blank line");
+            }
+            prev_blank = true;
+        } else {
+            prev_blank = false;
+        }
+        if line != line.trim_right() {
+            err.error(path, i, "trailing whitespace");
+        }
+        if line.contains("\t") {
+            err.error(path, i, "tab character");
+        }
+        if line.len() > 80 {
+            err.error(path, i, "line longer than 80 chars");
+        }
+        if line.contains("extern \"C\"") {
+            err.error(path, i, "use `extern` instead of `extern \"C\"");
+        }
+        if line.contains("#[cfg(") && !line.contains(" if ") {
+            if state != State::Structs {
+                err.error(path, i, "use cfg_if! and submodules \
+                                    instead of #[cfg]");
+            }
+        }
+
+        let line = line.trim_left();
+        let is_pub = line.starts_with("pub ");
+        let line = if is_pub {&line[4..]} else {line};
+
+        let line_state = if line.starts_with("use ") {
+            if is_pub {
+                State::Modules
+            } else {
+                State::Imports
+            }
+        } else if line.starts_with("const ") {
+            State::Constants
+        } else if line.starts_with("type ") {
+            State::Typedefs
+        } else if line.starts_with("s! {") {
+            s_macros += 1;
+            State::Structs
+        } else if line.starts_with("f! {") {
+            f_macros += 1;
+            State::FunctionDefinitions
+        } else if line.starts_with("extern ") {
+            State::Functions
+        } else if line.starts_with("mod ") {
+            State::Modules
+        } else {
+            continue
+        };
+
+        if state as usize > line_state as usize {
+            err.error(path, i, &format!("{} found after {} when \
+                                         it belongs before",
+                                        line_state.desc(), state.desc()));
+        }
+
+        if f_macros == 2 {
+            f_macros += 1;
+            err.error(path, i, "multiple f! macros in one module");
+        }
+        if s_macros == 2 {
+            s_macros += 1;
+            err.error(path, i, "multiple s! macros in one module");
+        }
+
+        state = line_state;
+    }
+}
+
+impl State {
+    fn desc(&self) -> &str {
+        match *self {
+            State::Start => "start",
+            State::Imports => "import",
+            State::Typedefs => "typedef",
+            State::Structs => "struct",
+            State::Constants => "constant",
+            State::FunctionDefinitions => "function definition",
+            State::Functions => "extern function",
+            State::Modules => "module",
+        }
+    }
+}
+
+impl Errors {
+    fn error(&mut self, path: &Path, line: usize, msg: &str) {
+        self.errs = true;
+        println!("{}:{} - {}", path.display(), line + 1, msg);
+    }
+}

--- a/src/unix/bsd/apple/b32.rs
+++ b/src/unix/bsd/apple/b32.rs
@@ -3,13 +3,13 @@
 pub type c_long = i32;
 pub type c_ulong = u32;
 
-pub const __PTHREAD_MUTEX_SIZE__: usize = 40;
-pub const __PTHREAD_COND_SIZE__: usize = 24;
-pub const __PTHREAD_RWLOCK_SIZE__: usize = 124;
-
 s! {
     pub struct pthread_attr_t {
         __sig: c_long,
         __opaque: [::c_char; 36]
     }
 }
+
+pub const __PTHREAD_MUTEX_SIZE__: usize = 40;
+pub const __PTHREAD_COND_SIZE__: usize = 24;
+pub const __PTHREAD_RWLOCK_SIZE__: usize = 124;

--- a/src/unix/bsd/apple/b64.rs
+++ b/src/unix/bsd/apple/b64.rs
@@ -3,13 +3,13 @@
 pub type c_long = i64;
 pub type c_ulong = u64;
 
-pub const __PTHREAD_MUTEX_SIZE__: usize = 56;
-pub const __PTHREAD_COND_SIZE__: usize = 40;
-pub const __PTHREAD_RWLOCK_SIZE__: usize = 192;
-
 s! {
     pub struct pthread_attr_t {
         __sig: c_long,
         __opaque: [::c_char; 56]
     }
 }
+
+pub const __PTHREAD_MUTEX_SIZE__: usize = 56;
+pub const __PTHREAD_COND_SIZE__: usize = 40;
+pub const __PTHREAD_RWLOCK_SIZE__: usize = 192;

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -8,6 +8,11 @@ pub type c_ulong = u64;
 pub type time_t = i64;
 pub type suseconds_t = i64;
 
+pub type uuid_t = ::uuid;
+
+pub type fsblkcnt_t = u64;
+pub type fsfilcnt_t = u64;
+
 s! {
     pub struct dirent {
         pub d_fileno: ::ino_t,
@@ -74,11 +79,6 @@ s! {
         pub st_qspare2: ::int64_t,
     }
 }
-
-pub type uuid_t = ::uuid;
-
-pub type fsblkcnt_t = u64;
-pub type fsfilcnt_t = u64;
 
 pub const RAND_MAX: ::c_int = 0x7fff_ffff;
 pub const PTHREAD_STACK_MIN: ::size_t = 1024;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -4,6 +4,9 @@ pub type ino_t = u32;
 pub type nlink_t = u16;
 pub type blksize_t = u32;
 
+pub type fsblkcnt_t = ::uint64_t;
+pub type fsfilcnt_t = ::uint64_t;
+
 s! {
     pub struct dirent {
         pub d_fileno: u32,
@@ -27,9 +30,6 @@ s! {
         pub f_namemax: ::c_ulong,
     }
 }
-
-pub type fsblkcnt_t = ::uint64_t;
-pub type fsfilcnt_t = ::uint64_t;
 
 pub const RAND_MAX: ::c_int = 0x7fff_fffd;
 pub const PTHREAD_STACK_MIN: ::size_t = 2048;
@@ -57,6 +57,9 @@ pub const POSIX_FADV_WILLNEED: ::c_int = 3;
 pub const POSIX_FADV_DONTNEED: ::c_int = 4;
 pub const POSIX_FADV_NOREUSE: ::c_int = 5;
 
+pub const MADV_PROTECT: ::c_int = 10;
+pub const RUSAGE_THREAD: ::c_int = 1;
+
 extern {
     pub fn __error() -> *mut ::c_int;
 
@@ -70,7 +73,9 @@ extern {
     pub fn posix_fadvise(fd: ::c_int, offset: ::off_t, len: ::off_t,
                          advise: ::c_int) -> ::c_int;
     pub fn mkostemp(template: *mut ::c_char, flags: ::c_int) -> ::c_int;
-    pub fn mkostemps(template: *mut ::c_char, suffixlen: ::c_int, flags: ::c_int) -> ::c_int;
+    pub fn mkostemps(template: *mut ::c_char,
+                     suffixlen: ::c_int,
+                     flags: ::c_int) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -385,8 +385,6 @@ pub const RLIM_INFINITY: rlim_t = 0x7fff_ffff_ffff_ffff;
 
 pub const RUSAGE_SELF: ::c_int = 0;
 pub const RUSAGE_CHILDREN: ::c_int = -1;
-#[cfg(not(target_os = "dragonfly"))]
-pub const RUSAGE_THREAD: ::c_int = 1;
 
 pub const MADV_NORMAL: ::c_int = 0;
 pub const MADV_RANDOM: ::c_int = 1;
@@ -398,8 +396,6 @@ pub const MADV_NOSYNC: ::c_int = 6;
 pub const MADV_AUTOSYNC: ::c_int = 7;
 pub const MADV_NOCORE: ::c_int = 8;
 pub const MADV_CORE: ::c_int = 9;
-#[cfg(not(target_os = "dragonfly"))]
-pub const MADV_PROTECT: ::c_int = 10;
 
 pub const MINCORE_INCORE: ::c_int =  0x1;
 pub const MINCORE_REFERENCED: ::c_int = 0x2;
@@ -578,9 +574,13 @@ extern {
                         newlen: ::size_t)
                         -> ::c_int;
     pub fn pthread_set_name_np(tid: ::pthread_t, name: *const ::c_char);
-    pub fn sched_setscheduler(pid: ::pid_t, policy: ::c_int, param: *const sched_param) -> ::c_int;
+    pub fn sched_setscheduler(pid: ::pid_t,
+                              policy: ::c_int,
+                              param: *const sched_param) -> ::c_int;
     pub fn sched_getscheduler(pid: ::pid_t) -> ::c_int;
-    pub fn memrchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
+    pub fn memrchr(cx: *const ::c_void,
+                   c: ::c_int,
+                   n: ::size_t) -> *mut ::c_void;
     pub fn sendfile(fd: ::c_int,
                     s: ::c_int,
                     offset: ::off_t,

--- a/src/unix/bsd/openbsdlike/mod.rs
+++ b/src/unix/bsd/openbsdlike/mod.rs
@@ -384,9 +384,13 @@ extern {
     pub fn __errno() -> *mut ::c_int;
     pub fn shm_open(name: *const ::c_char, oflag: ::c_int, mode: ::mode_t)
                     -> ::c_int;
-    pub fn memrchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
+    pub fn memrchr(cx: *const ::c_void,
+                   c: ::c_int,
+                   n: ::size_t) -> *mut ::c_void;
     pub fn mkostemp(template: *mut ::c_char, flags: ::c_int) -> ::c_int;
-    pub fn mkostemps(template: *mut ::c_char, suffixlen: ::c_int, flags: ::c_int) -> ::c_int;
+    pub fn mkostemps(template: *mut ::c_char,
+                     suffixlen: ::c_int,
+                     flags: ::c_int) -> ::c_int;
     pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
 }
 

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -3,6 +3,8 @@
 //! More functions and definitions can be found in the more specific modules
 //! according to the platform in question.
 
+use dox::Option;
+
 pub type pid_t = i32;
 pub type uid_t = u32;
 pub type gid_t = u32;
@@ -144,8 +146,8 @@ cfg_if! {
         #[link(name = "c")]
         extern {}
     } else if #[cfg(all(target_vendor = "rumprun", target_os = "netbsd"))] {
-        // Since we don't use -nodefaultlibs on Rumprun, libc is always pulled in
-        // automatically by the linker. We avoid passing it explicitly, as it
+        // Since we don't use -nodefaultlibs on Rumprun, libc is always pulled
+        // in automatically by the linker. We avoid passing it explicitly, as it
         // causes some versions of binutils to crash with an assertion failure.
         #[link(name = "m")]
         extern {}
@@ -373,7 +375,8 @@ extern {
     pub fn munmap(addr: *mut ::c_void, len: ::size_t) -> ::c_int;
 
     pub fn if_nametoindex(ifname: *const c_char) -> ::c_uint;
-    pub fn if_indextoname(ifindex: ::c_uint, ifname: *mut ::c_char) -> *mut ::c_char;
+    pub fn if_indextoname(ifindex: ::c_uint,
+                          ifname: *mut ::c_char) -> *mut ::c_char;
 
     #[cfg_attr(target_os = "macos", link_name = "lstat$INODE64")]
     #[cfg_attr(target_os = "netbsd", link_name = "__lstat50")]
@@ -440,7 +443,7 @@ extern {
     #[cfg_attr(target_os = "netbsd", link_name = "__libc_thr_yield")]
     pub fn sched_yield() -> ::c_int;
     pub fn pthread_key_create(key: *mut pthread_key_t,
-                              dtor: ::dox::Option<unsafe extern fn(*mut ::c_void)>)
+                              dtor: Option<unsafe extern fn(*mut ::c_void)>)
                               -> ::c_int;
     pub fn pthread_key_delete(key: pthread_key_t) -> ::c_int;
     pub fn pthread_getspecific(key: pthread_key_t) -> *mut ::c_void;
@@ -552,10 +555,14 @@ extern {
                  dev: ::dev_t) -> ::c_int;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "writev$UNIX2003")]
-    pub fn writev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
+    pub fn writev(fd: ::c_int,
+                  iov: *const ::iovec,
+                  iovcnt: ::c_int) -> ::ssize_t;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "readv$UNIX2003")]
-    pub fn readv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
+    pub fn readv(fd: ::c_int,
+                 iov: *const ::iovec,
+                 iovcnt: ::c_int) -> ::ssize_t;
     pub fn uname(buf: *mut ::utsname) -> ::c_int;
     pub fn daemon(nochdir: ::c_int, noclose: ::c_int) -> ::c_int;
     pub fn gethostname(name: *mut ::c_char, len: ::size_t) -> ::c_int;
@@ -577,7 +584,9 @@ extern {
     pub fn putenv(string: *mut c_char) -> ::c_int;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "sendmsg$UNIX2003")]
-    pub fn sendmsg(fd: ::c_int, msg: *const msghdr, flags: ::c_int) -> ::ssize_t;
+    pub fn sendmsg(fd: ::c_int,
+                   msg: *const msghdr,
+                   flags: ::c_int) -> ::ssize_t;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "recvmsg$UNIX2003")]
     pub fn recvmsg(fd: ::c_int, msg: *mut msghdr, flags: ::c_int) -> ::ssize_t;
@@ -596,8 +605,8 @@ extern {
                   timeout: *mut timeval) -> ::c_int;
 }
 
-// TODO: get rid of this #[cfg(not(...))]
-#[cfg(not(target_os = "android"))]
+// TODO: get rid of this cfg(not(...))
+#[cfg(not(target_os = "android"))] // " if " -- appease style checker
 extern {
     pub fn getifaddrs(ifap: *mut *mut ifaddrs) -> ::c_int;
     pub fn freeifaddrs(ifa: *mut ifaddrs);
@@ -605,8 +614,8 @@ extern {
     #[cfg_attr(target_os = "netbsd", link_name = "__glob30")]
     pub fn glob(pattern: *const c_char,
                 flags: ::c_int,
-                errfunc: ::dox::Option<extern "C" fn(epath: *const c_char,
-                                                     errno: ::c_int) -> ::c_int>,
+                errfunc: Option<extern fn(epath: *const c_char,
+                                          errno: ::c_int) -> ::c_int>,
                 pglob: *mut glob_t) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__globfree30")]
     pub fn globfree(pglob: *mut glob_t);

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -571,11 +571,13 @@ f! {
         (*termios).c_cflag & ::CBAUD
     }
     pub fn cfsetispeed(termios: *mut ::termios, speed: ::speed_t) -> ::c_int {
-        (*termios).c_cflag = ((*termios).c_cflag & !::CBAUD) | (speed & ::CBAUD);
+        let cbaud = ::CBAUD;
+        (*termios).c_cflag = ((*termios).c_cflag & !cbaud) | (speed & cbaud);
         return 0
     }
     pub fn cfsetospeed(termios: *mut ::termios, speed: ::speed_t) -> ::c_int {
-        (*termios).c_cflag = ((*termios).c_cflag & !::CBAUD) | (speed & ::CBAUD);
+        let cbaud = ::CBAUD;
+        (*termios).c_cflag = ((*termios).c_cflag & !cbaud) | (speed & cbaud);
         return 0
     }
     pub fn tcgetattr(fd: ::c_int, termios: *mut ::termios) -> ::c_int {
@@ -658,5 +660,3 @@ cfg_if! {
         // ...
     }
 }
-
-

--- a/src/unix/notbsd/linux/mips.rs
+++ b/src/unix/notbsd/linux/mips.rs
@@ -485,8 +485,9 @@ extern {
                      sz: ::c_int) -> ::c_int;
     pub fn glob64(pattern: *const ::c_char,
                   flags: ::c_int,
-                  errfunc: ::dox::Option<extern "C" fn(epath: *const ::c_char,
-                                                       errno: ::c_int) -> ::c_int>,
+                  errfunc: ::dox::Option<extern fn(epath: *const ::c_char,
+                                                   errno: ::c_int)
+                                                   -> ::c_int>,
                   pglob: *mut glob64_t) -> ::c_int;
     pub fn globfree64(pglob: *mut glob64_t);
     pub fn getnameinfo(sa: *const ::sockaddr,

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -185,31 +185,6 @@ s! {
     }
 }
 
-f! {
-    pub fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {
-        for slot in cpuset.bits.iter_mut() {
-            *slot = 0;
-        }
-    }
-
-    pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size = mem::size_of_val(&cpuset.bits[0]);
-        let (idx, offset) = (cpu / size, cpu % size);
-        cpuset.bits[idx] |= 1 << offset;
-        ()
-    }
-
-    pub fn CPU_ISSET(cpu: usize, cpuset: &cpu_set_t) -> bool {
-        let size = mem::size_of_val(&cpuset.bits[0]);
-        let (idx, offset) = (cpu / size, cpu % size);
-        0 != (cpuset.bits[idx] & (1 << offset))
-    }
-
-    pub fn CPU_EQUAL(set1: &cpu_set_t, set2: &cpu_set_t) -> bool {
-        set1.bits == set2.bits
-    }
-}
-
 pub const FILENAME_MAX: ::c_uint = 4096;
 pub const L_tmpnam: ::c_uint = 20;
 pub const _PC_NAME_MAX: ::c_int = 3;
@@ -345,9 +320,6 @@ pub const RTLD_DEFAULT: *mut ::c_void = 0i64 as *mut ::c_void;
 pub const RTLD_NODELETE: ::c_int = 0x1000;
 pub const RTLD_NOW: ::c_int = 0x2;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub const MAP_32BIT: ::c_int = 0x0040;
-
 pub const TCP_MD5SIG: ::c_int = 14;
 
 pub const F_DUPFD_CLOEXEC: ::c_int = 1030;
@@ -420,13 +392,44 @@ pub const CLONE_NEWPID: ::c_int = 0x20000000;
 pub const CLONE_NEWNET: ::c_int = 0x40000000;
 pub const CLONE_IO: ::c_int = 0x80000000;
 
+pub const AF_NETLINK: ::c_int = 16;
+
+f! {
+    pub fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {
+        for slot in cpuset.bits.iter_mut() {
+            *slot = 0;
+        }
+    }
+
+    pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
+        let size = mem::size_of_val(&cpuset.bits[0]);
+        let (idx, offset) = (cpu / size, cpu % size);
+        cpuset.bits[idx] |= 1 << offset;
+        ()
+    }
+
+    pub fn CPU_ISSET(cpu: usize, cpuset: &cpu_set_t) -> bool {
+        let size = mem::size_of_val(&cpuset.bits[0]);
+        let (idx, offset) = (cpu / size, cpu % size);
+        0 != (cpuset.bits[idx] & (1 << offset))
+    }
+
+    pub fn CPU_EQUAL(set1: &cpu_set_t, set2: &cpu_set_t) -> bool {
+        set1.bits == set2.bits
+    }
+}
+
 extern {
     pub fn shm_open(name: *const c_char, oflag: ::c_int,
                     mode: mode_t) -> ::c_int;
     pub fn shmget(key: ::key_t, size: ::size_t, shmflg: ::c_int) -> ::c_int;
-    pub fn shmat(shmid: ::c_int, shmaddr: *const ::c_void, shmflg: ::c_int) -> *mut ::c_void;
+    pub fn shmat(shmid: ::c_int,
+                 shmaddr: *const ::c_void,
+                 shmflg: ::c_int) -> *mut ::c_void;
     pub fn shmdt(shmaddr: *const ::c_void) -> ::c_int;
-    pub fn shmctl(shmid: ::c_int, cmd: ::c_int, buf: *mut ::shmid_ds) -> ::c_int;
+    pub fn shmctl(shmid: ::c_int,
+                  cmd: ::c_int,
+                  buf: *mut ::shmid_ds) -> ::c_int;
     pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int)
                     -> ::c_int;
     pub fn __errno_location() -> *mut ::c_int;
@@ -541,7 +544,9 @@ extern {
     pub fn sethostname(name: *const ::c_char, len: ::size_t) -> ::c_int;
     pub fn setns(fd: ::c_int, nstype: ::c_int) -> ::c_int;
     pub fn mkostemp(template: *mut ::c_char, flags: ::c_int) -> ::c_int;
-    pub fn mkostemps(template: *mut ::c_char, suffixlen: ::c_int, flags: ::c_int) -> ::c_int;
+    pub fn mkostemps(template: *mut ::c_char,
+                     suffixlen: ::c_int,
+                     flags: ::c_int) -> ::c_int;
     pub fn sigtimedwait(set: *const sigset_t,
                         info: *mut siginfo_t,
                         timeout: *const ::timespec) -> ::c_int;
@@ -562,5 +567,3 @@ cfg_if! {
         pub use self::other::*;
     }
 }
-
-pub const AF_NETLINK: ::c_int = 16;

--- a/src/unix/notbsd/linux/musl/b32/arm.rs
+++ b/src/unix/notbsd/linux/musl/b32/arm.rs
@@ -1,6 +1,83 @@
 pub type c_char = u8;
 pub type wchar_t = u32;
 
+s! {
+    pub struct stat {
+        pub st_dev: ::dev_t,
+        __st_dev_padding: ::c_int,
+        __st_ino_truncated: ::c_long,
+        pub st_mode: ::mode_t,
+        pub st_nlink: ::nlink_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        __st_rdev_padding: ::c_int,
+        pub st_size: ::off_t,
+        pub st_blksize: ::blksize_t,
+        pub st_blocks: ::blkcnt_t,
+        pub st_atim: ::timespec,
+        pub st_mtim: ::timespec,
+        pub st_ctim: ::timespec,
+        pub st_ino: ::ino_t,
+    }
+
+    pub struct stat64 {
+        pub st_dev: ::dev_t,
+        __st_dev_padding: ::c_int,
+        __st_ino_truncated: ::c_long,
+        pub st_mode: ::mode_t,
+        pub st_nlink: ::nlink_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        __st_rdev_padding: ::c_int,
+        pub st_size: ::off_t,
+        pub st_blksize: ::blksize_t,
+        pub st_blocks: ::blkcnt_t,
+        pub st_atim: ::timespec,
+        pub st_mtim: ::timespec,
+        pub st_ctim: ::timespec,
+        pub st_ino: ::ino_t,
+    }
+
+    pub struct stack_t {
+        pub ss_sp: *mut ::c_void,
+        pub ss_flags: ::c_int,
+        pub ss_size: ::size_t
+    }
+
+    pub struct shmid_ds {
+        pub shm_perm: ::ipc_perm,
+        pub shm_segsz: ::size_t,
+        pub shm_atime: ::time_t,
+        __unused1: ::c_int,
+        pub shm_dtime: ::time_t,
+        __unused2: ::c_int,
+        pub shm_ctime: ::time_t,
+        __unused3: ::c_int,
+        pub shm_cpid: ::pid_t,
+        pub shm_lpid: ::pid_t,
+        pub shm_nattch: ::c_ulong,
+        __pad1: ::c_ulong,
+        __pad2: ::c_ulong,
+    }
+
+    pub struct statfs {
+        pub f_type: ::c_ulong,
+        pub f_bsize: ::c_ulong,
+        pub f_blocks: ::fsblkcnt_t,
+        pub f_bfree: ::fsblkcnt_t,
+        pub f_bavail: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
+        pub f_fsid: ::fsid_t,
+        pub f_namelen: ::c_ulong,
+        pub f_frsize: ::c_ulong,
+        pub f_flags: ::c_ulong,
+        pub f_spare: [::c_ulong; 4],
+    }
+}
+
 pub const O_DIRECT: ::c_int = 0x4000;
 pub const O_DIRECTORY: ::c_int = 0x10000;
 pub const O_NOFOLLOW: ::c_int = 0x20000;
@@ -219,80 +296,3 @@ pub const TIOCMBIC: ::c_ulong = 0x5417;
 pub const TIOCMSET: ::c_ulong = 0x5418;
 pub const FIONREAD: ::c_ulong = 0x541B;
 pub const TIOCCONS: ::c_ulong = 0x541D;
-
-s! {
-    pub struct stat {
-        pub st_dev: ::dev_t,
-        __st_dev_padding: ::c_int,
-        __st_ino_truncated: ::c_long,
-        pub st_mode: ::mode_t,
-        pub st_nlink: ::nlink_t,
-        pub st_uid: ::uid_t,
-        pub st_gid: ::gid_t,
-        pub st_rdev: ::dev_t,
-        __st_rdev_padding: ::c_int,
-        pub st_size: ::off_t,
-        pub st_blksize: ::blksize_t,
-        pub st_blocks: ::blkcnt_t,
-        pub st_atim: ::timespec,
-        pub st_mtim: ::timespec,
-        pub st_ctim: ::timespec,
-        pub st_ino: ::ino_t,
-    }
-
-    pub struct stat64 {
-        pub st_dev: ::dev_t,
-        __st_dev_padding: ::c_int,
-        __st_ino_truncated: ::c_long,
-        pub st_mode: ::mode_t,
-        pub st_nlink: ::nlink_t,
-        pub st_uid: ::uid_t,
-        pub st_gid: ::gid_t,
-        pub st_rdev: ::dev_t,
-        __st_rdev_padding: ::c_int,
-        pub st_size: ::off_t,
-        pub st_blksize: ::blksize_t,
-        pub st_blocks: ::blkcnt_t,
-        pub st_atim: ::timespec,
-        pub st_mtim: ::timespec,
-        pub st_ctim: ::timespec,
-        pub st_ino: ::ino_t,
-    }
-
-    pub struct stack_t {
-        pub ss_sp: *mut ::c_void,
-        pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
-    }
-
-    pub struct shmid_ds {
-        pub shm_perm: ::ipc_perm,
-        pub shm_segsz: ::size_t,
-        pub shm_atime: ::time_t,
-        __unused1: ::c_int,
-        pub shm_dtime: ::time_t,
-        __unused2: ::c_int,
-        pub shm_ctime: ::time_t,
-        __unused3: ::c_int,
-        pub shm_cpid: ::pid_t,
-        pub shm_lpid: ::pid_t,
-        pub shm_nattch: ::c_ulong,
-        __pad1: ::c_ulong,
-        __pad2: ::c_ulong,
-    }
-
-    pub struct statfs {
-        pub f_type: ::c_ulong,
-        pub f_bsize: ::c_ulong,
-        pub f_blocks: ::fsblkcnt_t,
-        pub f_bfree: ::fsblkcnt_t,
-        pub f_bavail: ::fsblkcnt_t,
-        pub f_files: ::fsfilcnt_t,
-        pub f_ffree: ::fsfilcnt_t,
-        pub f_fsid: ::fsid_t,
-        pub f_namelen: ::c_ulong,
-        pub f_frsize: ::c_ulong,
-        pub f_flags: ::c_ulong,
-        pub f_spare: [::c_ulong; 4],
-    }
-}

--- a/src/unix/notbsd/linux/musl/b32/asmjs.rs
+++ b/src/unix/notbsd/linux/musl/b32/asmjs.rs
@@ -1,6 +1,83 @@
 pub type c_char = u8;
 pub type wchar_t = u32;
 
+s! {
+    pub struct stat {
+        pub st_dev: ::dev_t,
+        __st_dev_padding: ::c_int,
+        __st_ino_truncated: ::c_long,
+        pub st_mode: ::mode_t,
+        pub st_nlink: ::nlink_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        __st_rdev_padding: ::c_int,
+        pub st_size: ::off_t,
+        pub st_blksize: ::blksize_t,
+        pub st_blocks: ::blkcnt_t,
+        pub st_atim: ::timespec,
+        pub st_mtim: ::timespec,
+        pub st_ctim: ::timespec,
+        pub st_ino: ::ino_t,
+    }
+
+    pub struct stat64 {
+        pub st_dev: ::dev_t,
+        __st_dev_padding: ::c_int,
+        __st_ino_truncated: ::c_long,
+        pub st_mode: ::mode_t,
+        pub st_nlink: ::nlink_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        __st_rdev_padding: ::c_int,
+        pub st_size: ::off_t,
+        pub st_blksize: ::blksize_t,
+        pub st_blocks: ::blkcnt_t,
+        pub st_atim: ::timespec,
+        pub st_mtim: ::timespec,
+        pub st_ctim: ::timespec,
+        pub st_ino: ::ino_t,
+    }
+
+    pub struct stack_t {
+        pub ss_sp: *mut ::c_void,
+        pub ss_flags: ::c_int,
+        pub ss_size: ::size_t
+    }
+
+    pub struct shmid_ds {
+        pub shm_perm: ::ipc_perm,
+        pub shm_segsz: ::size_t,
+        pub shm_atime: ::time_t,
+        __unused1: ::c_int,
+        pub shm_dtime: ::time_t,
+        __unused2: ::c_int,
+        pub shm_ctime: ::time_t,
+        __unused3: ::c_int,
+        pub shm_cpid: ::pid_t,
+        pub shm_lpid: ::pid_t,
+        pub shm_nattch: ::c_ulong,
+        __pad1: ::c_ulong,
+        __pad2: ::c_ulong,
+    }
+
+    pub struct statfs {
+        pub f_type: ::c_ulong,
+        pub f_bsize: ::c_ulong,
+        pub f_blocks: ::fsblkcnt_t,
+        pub f_bfree: ::fsblkcnt_t,
+        pub f_bavail: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
+        pub f_fsid: ::fsid_t,
+        pub f_namelen: ::c_ulong,
+        pub f_frsize: ::c_ulong,
+        pub f_flags: ::c_ulong,
+        pub f_spare: [::c_ulong; 4],
+    }
+}
+
 pub const O_DIRECT: ::c_int = 0x4000;
 pub const O_DIRECTORY: ::c_int = 0x10000;
 pub const O_NOFOLLOW: ::c_int = 0x20000;
@@ -219,80 +296,3 @@ pub const TIOCMBIC: ::c_ulong = 0x5417;
 pub const TIOCMSET: ::c_ulong = 0x5418;
 pub const FIONREAD: ::c_ulong = 0x541B;
 pub const TIOCCONS: ::c_ulong = 0x541D;
-
-s! {
-    pub struct stat {
-        pub st_dev: ::dev_t,
-        __st_dev_padding: ::c_int,
-        __st_ino_truncated: ::c_long,
-        pub st_mode: ::mode_t,
-        pub st_nlink: ::nlink_t,
-        pub st_uid: ::uid_t,
-        pub st_gid: ::gid_t,
-        pub st_rdev: ::dev_t,
-        __st_rdev_padding: ::c_int,
-        pub st_size: ::off_t,
-        pub st_blksize: ::blksize_t,
-        pub st_blocks: ::blkcnt_t,
-        pub st_atim: ::timespec,
-        pub st_mtim: ::timespec,
-        pub st_ctim: ::timespec,
-        pub st_ino: ::ino_t,
-    }
-
-    pub struct stat64 {
-        pub st_dev: ::dev_t,
-        __st_dev_padding: ::c_int,
-        __st_ino_truncated: ::c_long,
-        pub st_mode: ::mode_t,
-        pub st_nlink: ::nlink_t,
-        pub st_uid: ::uid_t,
-        pub st_gid: ::gid_t,
-        pub st_rdev: ::dev_t,
-        __st_rdev_padding: ::c_int,
-        pub st_size: ::off_t,
-        pub st_blksize: ::blksize_t,
-        pub st_blocks: ::blkcnt_t,
-        pub st_atim: ::timespec,
-        pub st_mtim: ::timespec,
-        pub st_ctim: ::timespec,
-        pub st_ino: ::ino_t,
-    }
-
-    pub struct stack_t {
-        pub ss_sp: *mut ::c_void,
-        pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
-    }
-
-    pub struct shmid_ds {
-        pub shm_perm: ::ipc_perm,
-        pub shm_segsz: ::size_t,
-        pub shm_atime: ::time_t,
-        __unused1: ::c_int,
-        pub shm_dtime: ::time_t,
-        __unused2: ::c_int,
-        pub shm_ctime: ::time_t,
-        __unused3: ::c_int,
-        pub shm_cpid: ::pid_t,
-        pub shm_lpid: ::pid_t,
-        pub shm_nattch: ::c_ulong,
-        __pad1: ::c_ulong,
-        __pad2: ::c_ulong,
-    }
-
-    pub struct statfs {
-        pub f_type: ::c_ulong,
-        pub f_bsize: ::c_ulong,
-        pub f_blocks: ::fsblkcnt_t,
-        pub f_bfree: ::fsblkcnt_t,
-        pub f_bavail: ::fsblkcnt_t,
-        pub f_files: ::fsfilcnt_t,
-        pub f_ffree: ::fsfilcnt_t,
-        pub f_fsid: ::fsid_t,
-        pub f_namelen: ::c_ulong,
-        pub f_frsize: ::c_ulong,
-        pub f_flags: ::c_ulong,
-        pub f_spare: [::c_ulong; 4],
-    }
-}

--- a/src/unix/notbsd/linux/musl/b32/mod.rs
+++ b/src/unix/notbsd/linux/musl/b32/mod.rs
@@ -2,9 +2,6 @@ pub type c_long = i32;
 pub type c_ulong = u32;
 pub type nlink_t = u32;
 
-pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 32;
-pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 24;
-
 s! {
     pub struct pthread_attr_t {
         __size: [u32; 9]
@@ -24,6 +21,9 @@ s! {
         pub msg_flags: ::c_int,
     }
 }
+
+pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 32;
+pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 24;
 
 cfg_if! {
     if #[cfg(any(target_arch = "x86"))] {

--- a/src/unix/notbsd/linux/musl/b32/x86.rs
+++ b/src/unix/notbsd/linux/musl/b32/x86.rs
@@ -1,6 +1,83 @@
 pub type c_char = i8;
 pub type wchar_t = i32;
 
+s! {
+    pub struct stat {
+        pub st_dev: ::dev_t,
+        __st_dev_padding: ::c_int,
+        __st_ino_truncated: ::c_long,
+        pub st_mode: ::mode_t,
+        pub st_nlink: ::nlink_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        __st_rdev_padding: ::c_int,
+        pub st_size: ::off_t,
+        pub st_blksize: ::blksize_t,
+        pub st_blocks: ::blkcnt_t,
+        pub st_atim: ::timespec,
+        pub st_mtim: ::timespec,
+        pub st_ctim: ::timespec,
+        pub st_ino: ::ino_t,
+    }
+
+    pub struct stat64 {
+        pub st_dev: ::dev_t,
+        __st_dev_padding: ::c_int,
+        __st_ino_truncated: ::c_long,
+        pub st_mode: ::mode_t,
+        pub st_nlink: ::nlink_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        __st_rdev_padding: ::c_int,
+        pub st_size: ::off_t,
+        pub st_blksize: ::blksize_t,
+        pub st_blocks: ::blkcnt_t,
+        pub st_atim: ::timespec,
+        pub st_mtim: ::timespec,
+        pub st_ctim: ::timespec,
+        pub st_ino: ::ino_t,
+    }
+
+    pub struct stack_t {
+        pub ss_sp: *mut ::c_void,
+        pub ss_flags: ::c_int,
+        pub ss_size: ::size_t
+    }
+
+    pub struct shmid_ds {
+        pub shm_perm: ::ipc_perm,
+        pub shm_segsz: ::size_t,
+        pub shm_atime: ::time_t,
+        __unused1: ::c_int,
+        pub shm_dtime: ::time_t,
+        __unused2: ::c_int,
+        pub shm_ctime: ::time_t,
+        __unused3: ::c_int,
+        pub shm_cpid: ::pid_t,
+        pub shm_lpid: ::pid_t,
+        pub shm_nattch: ::c_ulong,
+        __pad1: ::c_ulong,
+        __pad2: ::c_ulong,
+    }
+
+    pub struct statfs {
+        pub f_type: ::c_ulong,
+        pub f_bsize: ::c_ulong,
+        pub f_blocks: ::fsblkcnt_t,
+        pub f_bfree: ::fsblkcnt_t,
+        pub f_bavail: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
+        pub f_fsid: ::fsid_t,
+        pub f_namelen: ::c_ulong,
+        pub f_frsize: ::c_ulong,
+        pub f_flags: ::c_ulong,
+        pub f_spare: [::c_ulong; 4],
+    }
+}
+
 pub const O_DIRECT: ::c_int = 0x4000;
 pub const O_DIRECTORY: ::c_int = 0x10000;
 pub const O_NOFOLLOW: ::c_int = 0x20000;
@@ -174,6 +251,7 @@ pub const SIG_UNBLOCK: ::c_int = 0x01;
 pub const EXTPROC: ::tcflag_t = 0x00010000;
 
 pub const MAP_HUGETLB: ::c_int = 0x040000;
+pub const MAP_32BIT: ::c_int = 0x0040;
 
 pub const F_GETLK: ::c_int = 12;
 pub const F_GETOWN: ::c_int = 9;
@@ -219,80 +297,3 @@ pub const TIOCMBIC: ::c_ulong = 0x5417;
 pub const TIOCMSET: ::c_ulong = 0x5418;
 pub const FIONREAD: ::c_ulong = 0x541B;
 pub const TIOCCONS: ::c_ulong = 0x541D;
-
-s! {
-    pub struct stat {
-        pub st_dev: ::dev_t,
-        __st_dev_padding: ::c_int,
-        __st_ino_truncated: ::c_long,
-        pub st_mode: ::mode_t,
-        pub st_nlink: ::nlink_t,
-        pub st_uid: ::uid_t,
-        pub st_gid: ::gid_t,
-        pub st_rdev: ::dev_t,
-        __st_rdev_padding: ::c_int,
-        pub st_size: ::off_t,
-        pub st_blksize: ::blksize_t,
-        pub st_blocks: ::blkcnt_t,
-        pub st_atim: ::timespec,
-        pub st_mtim: ::timespec,
-        pub st_ctim: ::timespec,
-        pub st_ino: ::ino_t,
-    }
-
-    pub struct stat64 {
-        pub st_dev: ::dev_t,
-        __st_dev_padding: ::c_int,
-        __st_ino_truncated: ::c_long,
-        pub st_mode: ::mode_t,
-        pub st_nlink: ::nlink_t,
-        pub st_uid: ::uid_t,
-        pub st_gid: ::gid_t,
-        pub st_rdev: ::dev_t,
-        __st_rdev_padding: ::c_int,
-        pub st_size: ::off_t,
-        pub st_blksize: ::blksize_t,
-        pub st_blocks: ::blkcnt_t,
-        pub st_atim: ::timespec,
-        pub st_mtim: ::timespec,
-        pub st_ctim: ::timespec,
-        pub st_ino: ::ino_t,
-    }
-
-    pub struct stack_t {
-        pub ss_sp: *mut ::c_void,
-        pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
-    }
-
-    pub struct shmid_ds {
-        pub shm_perm: ::ipc_perm,
-        pub shm_segsz: ::size_t,
-        pub shm_atime: ::time_t,
-        __unused1: ::c_int,
-        pub shm_dtime: ::time_t,
-        __unused2: ::c_int,
-        pub shm_ctime: ::time_t,
-        __unused3: ::c_int,
-        pub shm_cpid: ::pid_t,
-        pub shm_lpid: ::pid_t,
-        pub shm_nattch: ::c_ulong,
-        __pad1: ::c_ulong,
-        __pad2: ::c_ulong,
-    }
-
-    pub struct statfs {
-        pub f_type: ::c_ulong,
-        pub f_bsize: ::c_ulong,
-        pub f_blocks: ::fsblkcnt_t,
-        pub f_bfree: ::fsblkcnt_t,
-        pub f_bavail: ::fsblkcnt_t,
-        pub f_files: ::fsfilcnt_t,
-        pub f_ffree: ::fsfilcnt_t,
-        pub f_fsid: ::fsid_t,
-        pub f_namelen: ::c_ulong,
-        pub f_frsize: ::c_ulong,
-        pub f_flags: ::c_ulong,
-        pub f_spare: [::c_ulong; 4],
-    }
-}

--- a/src/unix/notbsd/linux/musl/b64/mod.rs
+++ b/src/unix/notbsd/linux/musl/b64/mod.rs
@@ -4,6 +4,104 @@ pub type c_long = i64;
 pub type c_ulong = u64;
 pub type nlink_t = u64;
 
+s! {
+    pub struct stat {
+        pub st_dev: ::dev_t,
+        pub st_ino: ::ino_t,
+        pub st_nlink: ::nlink_t,
+        pub st_mode: ::mode_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        __pad0: ::c_int,
+        pub st_rdev: ::dev_t,
+        pub st_size: ::off_t,
+        pub st_blksize: ::blksize_t,
+        pub st_blocks: ::blkcnt_t,
+        pub st_atime: ::time_t,
+        pub st_atime_nsec: ::c_long,
+        pub st_mtime: ::time_t,
+        pub st_mtime_nsec: ::c_long,
+        pub st_ctime: ::time_t,
+        pub st_ctime_nsec: ::c_long,
+        __unused: [::c_long; 3],
+    }
+
+    pub struct stat64 {
+        pub st_dev: ::dev_t,
+        pub st_ino: ::ino64_t,
+        pub st_nlink: ::nlink_t,
+        pub st_mode: ::mode_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        __pad0: ::c_int,
+        pub st_rdev: ::dev_t,
+        pub st_size: ::off_t,
+        pub st_blksize: ::blksize_t,
+        pub st_blocks: ::blkcnt64_t,
+        pub st_atime: ::time_t,
+        pub st_atime_nsec: ::c_long,
+        pub st_mtime: ::time_t,
+        pub st_mtime_nsec: ::c_long,
+        pub st_ctime: ::time_t,
+        pub st_ctime_nsec: ::c_long,
+        __reserved: [::c_long; 3],
+    }
+
+    pub struct stack_t {
+        pub ss_sp: *mut ::c_void,
+        pub ss_flags: ::c_int,
+        pub ss_size: ::size_t
+    }
+
+    pub struct pthread_attr_t {
+        __size: [u64; 7]
+    }
+
+    pub struct sigset_t {
+        __val: [::c_ulong; 16],
+    }
+
+    pub struct shmid_ds {
+        pub shm_perm: ::ipc_perm,
+        pub shm_segsz: ::size_t,
+        pub shm_atime: ::time_t,
+        pub shm_dtime: ::time_t,
+        pub shm_ctime: ::time_t,
+        pub shm_cpid: ::pid_t,
+        pub shm_lpid: ::pid_t,
+        pub shm_nattch: ::c_ulong,
+        __pad1: ::c_ulong,
+        __pad2: ::c_ulong,
+    }
+
+    pub struct statfs {
+        pub f_type: ::c_ulong,
+        pub f_bsize: ::c_ulong,
+        pub f_blocks: ::fsblkcnt_t,
+        pub f_bfree: ::fsblkcnt_t,
+        pub f_bavail: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
+        pub f_fsid: ::fsid_t,
+        pub f_namelen: ::c_ulong,
+        pub f_frsize: ::c_ulong,
+        pub f_flags: ::c_ulong,
+        pub f_spare: [::c_ulong; 4],
+    }
+
+    pub struct msghdr {
+        pub msg_name: *mut ::c_void,
+        pub msg_namelen: ::socklen_t,
+        pub msg_iov: *mut ::iovec,
+        pub msg_iovlen: ::c_int,
+        __pad1: ::c_int,
+        pub msg_control: *mut ::c_void,
+        pub msg_controllen: ::socklen_t,
+        __pad2: ::socklen_t,
+        pub msg_flags: ::c_int,
+    }
+}
+
 pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 56;
 pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
 
@@ -41,6 +139,7 @@ pub const MAP_NORESERVE: ::c_int = 0x04000;
 pub const MAP_POPULATE: ::c_int = 0x08000;
 pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
+pub const MAP_32BIT: ::c_int = 0x0040;
 
 pub const SOCK_STREAM: ::c_int = 1;
 pub const SOCK_DGRAM: ::c_int = 2;
@@ -225,101 +324,3 @@ pub const TIOCMBIC: ::c_ulong = 0x5417;
 pub const TIOCMSET: ::c_ulong = 0x5418;
 pub const FIONREAD: ::c_ulong = 0x541B;
 pub const TIOCCONS: ::c_ulong = 0x541D;
-
-s! {
-    pub struct stat {
-        pub st_dev: ::dev_t,
-        pub st_ino: ::ino_t,
-        pub st_nlink: ::nlink_t,
-        pub st_mode: ::mode_t,
-        pub st_uid: ::uid_t,
-        pub st_gid: ::gid_t,
-        __pad0: ::c_int,
-        pub st_rdev: ::dev_t,
-        pub st_size: ::off_t,
-        pub st_blksize: ::blksize_t,
-        pub st_blocks: ::blkcnt_t,
-        pub st_atime: ::time_t,
-        pub st_atime_nsec: ::c_long,
-        pub st_mtime: ::time_t,
-        pub st_mtime_nsec: ::c_long,
-        pub st_ctime: ::time_t,
-        pub st_ctime_nsec: ::c_long,
-        __unused: [::c_long; 3],
-    }
-
-    pub struct stat64 {
-        pub st_dev: ::dev_t,
-        pub st_ino: ::ino64_t,
-        pub st_nlink: ::nlink_t,
-        pub st_mode: ::mode_t,
-        pub st_uid: ::uid_t,
-        pub st_gid: ::gid_t,
-        __pad0: ::c_int,
-        pub st_rdev: ::dev_t,
-        pub st_size: ::off_t,
-        pub st_blksize: ::blksize_t,
-        pub st_blocks: ::blkcnt64_t,
-        pub st_atime: ::time_t,
-        pub st_atime_nsec: ::c_long,
-        pub st_mtime: ::time_t,
-        pub st_mtime_nsec: ::c_long,
-        pub st_ctime: ::time_t,
-        pub st_ctime_nsec: ::c_long,
-        __reserved: [::c_long; 3],
-    }
-
-    pub struct stack_t {
-        pub ss_sp: *mut ::c_void,
-        pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
-    }
-
-    pub struct pthread_attr_t {
-        __size: [u64; 7]
-    }
-
-    pub struct sigset_t {
-        __val: [::c_ulong; 16],
-    }
-
-    pub struct shmid_ds {
-        pub shm_perm: ::ipc_perm,
-        pub shm_segsz: ::size_t,
-        pub shm_atime: ::time_t,
-        pub shm_dtime: ::time_t,
-        pub shm_ctime: ::time_t,
-        pub shm_cpid: ::pid_t,
-        pub shm_lpid: ::pid_t,
-        pub shm_nattch: ::c_ulong,
-        __pad1: ::c_ulong,
-        __pad2: ::c_ulong,
-    }
-
-    pub struct statfs {
-        pub f_type: ::c_ulong,
-        pub f_bsize: ::c_ulong,
-        pub f_blocks: ::fsblkcnt_t,
-        pub f_bfree: ::fsblkcnt_t,
-        pub f_bavail: ::fsblkcnt_t,
-        pub f_files: ::fsfilcnt_t,
-        pub f_ffree: ::fsfilcnt_t,
-        pub f_fsid: ::fsid_t,
-        pub f_namelen: ::c_ulong,
-        pub f_frsize: ::c_ulong,
-        pub f_flags: ::c_ulong,
-        pub f_spare: [::c_ulong; 4],
-    }
-
-    pub struct msghdr {
-        pub msg_name: *mut ::c_void,
-        pub msg_namelen: ::socklen_t,
-        pub msg_iov: *mut ::iovec,
-        pub msg_iovlen: ::c_int,
-        __pad1: ::c_int,
-        pub msg_control: *mut ::c_void,
-        pub msg_controllen: ::socklen_t,
-        __pad2: ::socklen_t,
-        pub msg_flags: ::c_int,
-    }
-}

--- a/src/unix/notbsd/linux/other/b32/mod.rs
+++ b/src/unix/notbsd/linux/other/b32/mod.rs
@@ -13,17 +13,6 @@ pub type __fsword_t = i32;
 pub type blksize_t = i32;
 pub type nlink_t = u32;
 
-pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 24;
-pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 32;
-pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
-
-pub const PTRACE_GETFPREGS: ::c_uint = 14;
-pub const PTRACE_SETFPREGS: ::c_uint = 15;
-pub const PTRACE_GETFPXREGS: ::c_uint = 18;
-pub const PTRACE_SETFPXREGS: ::c_uint = 19;
-pub const PTRACE_GETREGS: ::c_uint = 12;
-pub const PTRACE_SETREGS: ::c_uint = 13;
-
 s! {
     pub struct stat {
         pub st_dev: ::dev_t,
@@ -78,6 +67,17 @@ s! {
         __val: [::c_ulong; 32],
     }
 }
+
+pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 24;
+pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 32;
+pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
+
+pub const PTRACE_GETFPREGS: ::c_uint = 14;
+pub const PTRACE_SETFPREGS: ::c_uint = 15;
+pub const PTRACE_GETFPXREGS: ::c_uint = 18;
+pub const PTRACE_SETFPXREGS: ::c_uint = 19;
+pub const PTRACE_GETREGS: ::c_uint = 12;
+pub const PTRACE_SETREGS: ::c_uint = 13;
 
 cfg_if! {
     if #[cfg(target_arch = "x86")] {

--- a/src/unix/notbsd/linux/other/b32/x86.rs
+++ b/src/unix/notbsd/linux/other/b32/x86.rs
@@ -1,26 +1,7 @@
 pub type c_char = i8;
 pub type wchar_t = i32;
 
-pub const O_DIRECT: ::c_int = 0x4000;
-pub const O_DIRECTORY: ::c_int = 0x10000;
-pub const O_NOFOLLOW: ::c_int = 0x20000;
-
-pub const MAP_LOCKED: ::c_int = 0x02000;
-pub const MAP_NORESERVE: ::c_int = 0x04000;
-
-pub const EDEADLOCK: ::c_int = 35;
-
-pub const SO_PEERCRED: ::c_int = 17;
-pub const SO_RCVLOWAT: ::c_int = 18;
-pub const SO_SNDLOWAT: ::c_int = 19;
-pub const SO_RCVTIMEO: ::c_int = 20;
-pub const SO_SNDTIMEO: ::c_int = 21;
-
-pub const FIOCLEX: ::c_ulong = 0x5451;
-pub const FIONBIO: ::c_ulong = 0x5421;
-
 s! {
-
     pub struct mcontext_t {
         __private: [u32; 22]
     }
@@ -33,12 +14,33 @@ s! {
         pub uc_sigmask: ::sigset_t,
         __private: [u8; 112],
     }
-
 }
+
+pub const O_DIRECT: ::c_int = 0x4000;
+pub const O_DIRECTORY: ::c_int = 0x10000;
+pub const O_NOFOLLOW: ::c_int = 0x20000;
+
+pub const MAP_LOCKED: ::c_int = 0x02000;
+pub const MAP_NORESERVE: ::c_int = 0x04000;
+pub const MAP_32BIT: ::c_int = 0x0040;
+
+pub const EDEADLOCK: ::c_int = 35;
+
+pub const SO_PEERCRED: ::c_int = 17;
+pub const SO_RCVLOWAT: ::c_int = 18;
+pub const SO_SNDLOWAT: ::c_int = 19;
+pub const SO_RCVTIMEO: ::c_int = 20;
+pub const SO_SNDTIMEO: ::c_int = 21;
+
+pub const FIOCLEX: ::c_ulong = 0x5451;
+pub const FIONBIO: ::c_ulong = 0x5421;
 
 extern {
     pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;
     pub fn setcontext(ucp: *const ucontext_t) -> ::c_int;
-    pub fn makecontext(ucp: *mut ucontext_t, func:  extern fn (), argc: ::c_int, ...);
-    pub fn swapcontext(uocp: *mut ucontext_t, ucp: *const ucontext_t) -> ::c_int;
+    pub fn makecontext(ucp: *mut ucontext_t,
+                       func:  extern fn (),
+                       argc: ::c_int, ...);
+    pub fn swapcontext(uocp: *mut ucontext_t,
+                       ucp: *const ucontext_t) -> ::c_int;
 }

--- a/src/unix/notbsd/linux/other/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/other/b64/aarch64.rs
@@ -5,27 +5,6 @@ pub type wchar_t = u32;
 pub type nlink_t = u32;
 pub type blksize_t = i32;
 
-pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 48;
-pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 8;
-
-pub const O_DIRECT: ::c_int = 0x10000;
-pub const O_DIRECTORY: ::c_int = 0x4000;
-pub const O_NOFOLLOW: ::c_int = 0x8000;
-
-pub const MAP_LOCKED: ::c_int = 0x02000;
-pub const MAP_NORESERVE: ::c_int = 0x04000;
-
-pub const EDEADLOCK: ::c_int = 35;
-
-pub const SO_PEERCRED: ::c_int = 17;
-pub const SO_RCVLOWAT: ::c_int = 18;
-pub const SO_SNDLOWAT: ::c_int = 19;
-pub const SO_RCVTIMEO: ::c_int = 20;
-pub const SO_SNDTIMEO: ::c_int = 21;
-
-pub const FIOCLEX: ::c_ulong = 0x5451;
-pub const FIONBIO: ::c_ulong = 0x5421;
-
 s! {
     pub struct stat {
         pub st_dev: ::dev_t,
@@ -75,3 +54,24 @@ s! {
         __size: [u64; 8]
     }
 }
+
+pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 48;
+pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 8;
+
+pub const O_DIRECT: ::c_int = 0x10000;
+pub const O_DIRECTORY: ::c_int = 0x4000;
+pub const O_NOFOLLOW: ::c_int = 0x8000;
+
+pub const MAP_LOCKED: ::c_int = 0x02000;
+pub const MAP_NORESERVE: ::c_int = 0x04000;
+
+pub const EDEADLOCK: ::c_int = 35;
+
+pub const SO_PEERCRED: ::c_int = 17;
+pub const SO_RCVLOWAT: ::c_int = 18;
+pub const SO_SNDLOWAT: ::c_int = 19;
+pub const SO_RCVTIMEO: ::c_int = 20;
+pub const SO_SNDTIMEO: ::c_int = 21;
+
+pub const FIOCLEX: ::c_ulong = 0x5451;
+pub const FIONBIO: ::c_ulong = 0x5421;

--- a/src/unix/notbsd/linux/other/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/other/b64/powerpc64.rs
@@ -5,27 +5,6 @@ pub type wchar_t = i32;
 pub type nlink_t = u64;
 pub type blksize_t = i64;
 
-pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
-pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
-
-pub const O_DIRECTORY: ::c_int = 0x4000;
-pub const O_NOFOLLOW: ::c_int = 0x8000;
-pub const O_DIRECT: ::c_int = 0x20000;
-
-pub const MAP_LOCKED: ::c_int = 0x00080;
-pub const MAP_NORESERVE: ::c_int = 0x00040;
-
-pub const EDEADLOCK: ::c_int = 58;
-
-pub const SO_PEERCRED: ::c_int = 21;
-pub const SO_RCVLOWAT: ::c_int = 16;
-pub const SO_SNDLOWAT: ::c_int = 17;
-pub const SO_RCVTIMEO: ::c_int = 18;
-pub const SO_SNDTIMEO: ::c_int = 19;
-
-pub const FIOCLEX: ::c_ulong = 0x20006601;
-pub const FIONBIO: ::c_ulong = 0x8004667e;
-
 s! {
     pub struct stat {
         pub st_dev: ::dev_t,
@@ -73,3 +52,24 @@ s! {
         __size: [u64; 7]
     }
 }
+
+pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
+pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
+
+pub const O_DIRECTORY: ::c_int = 0x4000;
+pub const O_NOFOLLOW: ::c_int = 0x8000;
+pub const O_DIRECT: ::c_int = 0x20000;
+
+pub const MAP_LOCKED: ::c_int = 0x00080;
+pub const MAP_NORESERVE: ::c_int = 0x00040;
+
+pub const EDEADLOCK: ::c_int = 58;
+
+pub const SO_PEERCRED: ::c_int = 21;
+pub const SO_RCVLOWAT: ::c_int = 16;
+pub const SO_SNDLOWAT: ::c_int = 17;
+pub const SO_RCVTIMEO: ::c_int = 18;
+pub const SO_SNDTIMEO: ::c_int = 19;
+
+pub const FIOCLEX: ::c_ulong = 0x20006601;
+pub const FIONBIO: ::c_ulong = 0x8004667e;

--- a/src/unix/notbsd/linux/other/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/other/b64/x86_64.rs
@@ -5,34 +5,6 @@ pub type wchar_t = i32;
 pub type nlink_t = u64;
 pub type blksize_t = i64;
 
-pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
-pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
-
-pub const O_DIRECT: ::c_int = 0x4000;
-pub const O_DIRECTORY: ::c_int = 0x10000;
-pub const O_NOFOLLOW: ::c_int = 0x20000;
-
-pub const MAP_LOCKED: ::c_int = 0x02000;
-pub const MAP_NORESERVE: ::c_int = 0x04000;
-
-pub const EDEADLOCK: ::c_int = 35;
-
-pub const SO_PEERCRED: ::c_int = 17;
-pub const SO_RCVLOWAT: ::c_int = 18;
-pub const SO_SNDLOWAT: ::c_int = 19;
-pub const SO_RCVTIMEO: ::c_int = 20;
-pub const SO_SNDTIMEO: ::c_int = 21;
-
-pub const FIOCLEX: ::c_ulong = 0x5451;
-pub const FIONBIO: ::c_ulong = 0x5421;
-
-pub const PTRACE_GETFPREGS: ::c_uint = 14;
-pub const PTRACE_SETFPREGS: ::c_uint = 15;
-pub const PTRACE_GETFPXREGS: ::c_uint = 18;
-pub const PTRACE_SETFPXREGS: ::c_uint = 19;
-pub const PTRACE_GETREGS: ::c_uint = 12;
-pub const PTRACE_SETREGS: ::c_uint = 13;
-
 s! {
     pub struct stat {
         pub st_dev: ::dev_t,
@@ -80,10 +52,6 @@ s! {
         __size: [u64; 7]
     }
 
-}
-
-s! {
-
     pub struct mcontext_t {
         __private: [u64; 32],
     }
@@ -96,12 +64,43 @@ s! {
         pub uc_sigmask: ::sigset_t,
         __private: [u8; 512],
     }
-
 }
+
+pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
+pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
+
+pub const O_DIRECT: ::c_int = 0x4000;
+pub const O_DIRECTORY: ::c_int = 0x10000;
+pub const O_NOFOLLOW: ::c_int = 0x20000;
+
+pub const MAP_LOCKED: ::c_int = 0x02000;
+pub const MAP_NORESERVE: ::c_int = 0x04000;
+pub const MAP_32BIT: ::c_int = 0x0040;
+
+pub const EDEADLOCK: ::c_int = 35;
+
+pub const SO_PEERCRED: ::c_int = 17;
+pub const SO_RCVLOWAT: ::c_int = 18;
+pub const SO_SNDLOWAT: ::c_int = 19;
+pub const SO_RCVTIMEO: ::c_int = 20;
+pub const SO_SNDTIMEO: ::c_int = 21;
+
+pub const FIOCLEX: ::c_ulong = 0x5451;
+pub const FIONBIO: ::c_ulong = 0x5421;
+
+pub const PTRACE_GETFPREGS: ::c_uint = 14;
+pub const PTRACE_SETFPREGS: ::c_uint = 15;
+pub const PTRACE_GETFPXREGS: ::c_uint = 18;
+pub const PTRACE_SETFPXREGS: ::c_uint = 19;
+pub const PTRACE_GETREGS: ::c_uint = 12;
+pub const PTRACE_SETREGS: ::c_uint = 13;
 
 extern {
     pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;
     pub fn setcontext(ucp: *const ucontext_t) -> ::c_int;
-    pub fn makecontext(ucp: *mut ucontext_t, func:  extern fn (), argc: ::c_int, ...);
-    pub fn swapcontext(uocp: *mut ucontext_t, ucp: *const ucontext_t) -> ::c_int;
+    pub fn makecontext(ucp: *mut ucontext_t,
+                       func:  extern fn (),
+                       argc: ::c_int, ...);
+    pub fn swapcontext(uocp: *mut ucontext_t,
+                       ucp: *const ucontext_t) -> ::c_int;
 }

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -37,7 +37,6 @@ s! {
         __unused5: *mut ::c_void,
     }
 
-
     pub struct ucred {
         pub pid: ::pid_t,
         pub uid: ::uid_t,
@@ -87,6 +86,39 @@ s! {
         pub l_start: ::off_t,
         pub l_len: ::off_t,
         pub l_pid: ::pid_t,
+    }
+
+    pub struct ipc_perm {
+        pub __key: ::key_t,
+        pub uid: ::uid_t,
+        pub gid: ::gid_t,
+        pub cuid: ::uid_t,
+        pub cgid: ::gid_t,
+        pub mode: ::c_ushort,
+        __pad1: ::c_ushort,
+        pub __seq: ::c_ushort,
+        __pad2: ::c_ushort,
+        __unused1: ::c_ulong,
+        __unused2: ::c_ulong
+    }
+
+    pub struct shmid_ds {
+        pub shm_perm: ::ipc_perm,
+        pub shm_segsz: ::size_t,
+        pub shm_atime: ::time_t,
+        #[cfg(target_pointer_width = "32")]
+        __unused1: ::c_ulong,
+        pub shm_dtime: ::time_t,
+        #[cfg(target_pointer_width = "32")]
+        __unused2: ::c_ulong,
+        pub shm_ctime: ::time_t,
+        #[cfg(target_pointer_width = "32")]
+        __unused3: ::c_ulong,
+        pub shm_cpid: ::pid_t,
+        pub shm_lpid: ::pid_t,
+        pub shm_nattch: ::shmatt_t,
+        __unused4: ::c_ulong,
+        __unused5: ::c_ulong
     }
 }
 
@@ -425,8 +457,9 @@ extern {
                      sz: ::c_int) -> ::c_int;
     pub fn glob64(pattern: *const ::c_char,
                   flags: ::c_int,
-                  errfunc: ::dox::Option<extern "C" fn(epath: *const ::c_char,
-                                                       errno: ::c_int) -> ::c_int>,
+                  errfunc: ::dox::Option<extern fn(epath: *const ::c_char,
+                                                   errno: ::c_int)
+                                                   -> ::c_int>,
                   pglob: *mut glob64_t) -> ::c_int;
     pub fn globfree64(pglob: *mut glob64_t);
     pub fn getnameinfo(sa: *const ::sockaddr,
@@ -459,40 +492,5 @@ cfg_if! {
         pub use self::b64::*;
     } else {
         // ...
-    }
-}
-
-s! {
-    pub struct ipc_perm {
-        pub __key: ::key_t,
-        pub uid: ::uid_t,
-        pub gid: ::gid_t,
-        pub cuid: ::uid_t,
-        pub cgid: ::gid_t,
-        pub mode: ::c_ushort,
-        __pad1: ::c_ushort,
-        pub __seq: ::c_ushort,
-        __pad2: ::c_ushort,
-        __unused1: ::c_ulong,
-        __unused2: ::c_ulong
-    }
-
-    pub struct shmid_ds {
-        pub shm_perm: ::ipc_perm,
-        pub shm_segsz: ::size_t,
-        pub shm_atime: ::time_t,
-        #[cfg(target_pointer_width = "32")]
-        __unused1: ::c_ulong,
-        pub shm_dtime: ::time_t,
-        #[cfg(target_pointer_width = "32")]
-        __unused2: ::c_ulong,
-        pub shm_ctime: ::time_t,
-        #[cfg(target_pointer_width = "32")]
-        __unused3: ::c_ulong,
-        pub shm_cpid: ::pid_t,
-        pub shm_lpid: ::pid_t,
-        pub shm_nattch: ::shmatt_t,
-        __unused4: ::c_ulong,
-        __unused5: ::c_ulong
     }
 }

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -127,10 +127,14 @@ s! {
 }
 
 // intentionally not public, only used for fd_set
-#[cfg(target_pointer_width = "32")]
-const ULONG_SIZE: usize = 32;
-#[cfg(target_pointer_width = "64")]
-const ULONG_SIZE: usize = 64;
+cfg_if! {
+    if #[cfg(target_pointer_width = "32")] {
+        const ULONG_SIZE: usize = 32;
+    } else if #[cfg(target_pointer_width = "64")] {
+        const ULONG_SIZE: usize = 64;
+    } else {
+    }
+}
 
 pub const EXIT_FAILURE: ::c_int = 1;
 pub const EXIT_SUCCESS: ::c_int = 0;
@@ -605,7 +609,9 @@ extern {
     pub fn memalign(align: ::size_t, size: ::size_t) -> *mut ::c_void;
     pub fn setgroups(ngroups: ::size_t,
                      ptr: *const ::gid_t) -> ::c_int;
-    pub fn sched_setscheduler(pid: ::pid_t, policy: ::c_int, param: *const sched_param) -> ::c_int;
+    pub fn sched_setscheduler(pid: ::pid_t,
+                              policy: ::c_int,
+                              param: *const sched_param) -> ::c_int;
     pub fn sched_getscheduler(pid: ::pid_t) -> ::c_int;
     pub fn sched_get_priority_max(policy: ::c_int) -> ::c_int;
     pub fn sched_get_priority_min(policy: ::c_int) -> ::c_int;
@@ -632,7 +638,9 @@ extern {
                  arg: *mut ::c_void, ...) -> ::c_int;
     pub fn statfs(path: *const ::c_char, buf: *mut statfs) -> ::c_int;
     pub fn fstatfs(fd: ::c_int, buf: *mut statfs) -> ::c_int;
-    pub fn memrchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
+    pub fn memrchr(cx: *const ::c_void,
+                   c: ::c_int,
+                   n: ::size_t) -> *mut ::c_void;
     pub fn syscall(num: ::c_long, ...) -> ::c_long;
     pub fn sendfile(out_fd: ::c_int,
                     in_fd: ::c_int,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -96,7 +96,7 @@ pub const S_IEXEC: ::c_int = 64;
 pub const S_IWRITE: ::c_int = 128;
 pub const S_IREAD: ::c_int = 256;
 
-#[cfg(target_env = "msvc")]
+#[cfg(target_env = "msvc")] // " if " -- appease style checker
 #[link(name = "msvcrt")]
 extern {}
 
@@ -160,7 +160,9 @@ extern {
     #[link_name = "_lseek"]
     pub fn lseek(fd: ::c_int, offset: c_long, origin: ::c_int) -> c_long;
     #[link_name = "_pipe"]
-    pub fn pipe(fds: *mut ::c_int, psize: ::c_uint, textmode: ::c_int) -> ::c_int;
+    pub fn pipe(fds: *mut ::c_int,
+                psize: ::c_uint,
+                textmode: ::c_int) -> ::c_int;
     #[link_name = "_read"]
     pub fn read(fd: ::c_int, buf: *mut ::c_void, count: ::c_uint) -> ::c_int;
     #[link_name = "_rmdir"]


### PR DESCRIPTION
It's tough to have PRs bounce or to have a back and forth with contributors
about minor style quibbles. Sometimes it ends up just being easier to fix style
after the fact, but let's add some automation to help this!

This commit adds a script to run on CI and locally to verify the style of this
repository. There's a few stylistic guidelines to ensure that definitions are
understandable across the jungle of modules. This consistency should help assist
readability for any future readers!