### PR TITLE
Add SYS_gettid

### DIFF
--- a/src/unix/notbsd/android/b32.rs
+++ b/src/unix/notbsd/android/b32.rs
@@ -1,5 +1,7 @@
 pub type mode_t = u16;
 
+pub const SYS_gettid: ::c_int = 224;
+
 s! {
     pub struct sigaction {
         pub sa_sigaction: ::sighandler_t,

--- a/src/unix/notbsd/android/b64.rs
+++ b/src/unix/notbsd/android/b64.rs
@@ -1,5 +1,7 @@
 pub type mode_t = u32;
 
+pub const SYS_gettid: ::c_int = 178;
+
 s! {
     pub struct sigaction {
         pub sa_flags: ::c_uint,

--- a/src/unix/notbsd/linux/mips.rs
+++ b/src/unix/notbsd/linux/mips.rs
@@ -472,6 +472,8 @@ pub const RTLD_DEEPBIND: ::c_int = 0x10;
 pub const RTLD_GLOBAL: ::c_int = 0x4;
 pub const RTLD_NOLOAD: ::c_int = 0x8;
 
+pub const SYS_gettid: ::c_int = 4222;   // Valid for O32
+
 extern {
     pub fn sysctl(name: *mut ::c_int,
                   namelen: ::c_int,

--- a/src/unix/notbsd/linux/musl/b32/arm.rs
+++ b/src/unix/notbsd/linux/musl/b32/arm.rs
@@ -220,6 +220,8 @@ pub const TIOCMSET: ::c_ulong = 0x5418;
 pub const FIONREAD: ::c_ulong = 0x541B;
 pub const TIOCCONS: ::c_ulong = 0x541D;
 
+pub const SYS_gettid: ::c_int = 224;
+
 s! {
     pub struct stat {
         pub st_dev: ::dev_t,

--- a/src/unix/notbsd/linux/musl/b32/asmjs.rs
+++ b/src/unix/notbsd/linux/musl/b32/asmjs.rs
@@ -220,6 +220,8 @@ pub const TIOCMSET: ::c_ulong = 0x5418;
 pub const FIONREAD: ::c_ulong = 0x541B;
 pub const TIOCCONS: ::c_ulong = 0x541D;
 
+pub const SYS_gettid: ::c_int = 224; // Valid for arm (32-bit) and x86 (32-bit)
+
 s! {
     pub struct stat {
         pub st_dev: ::dev_t,

--- a/src/unix/notbsd/linux/musl/b32/mips.rs
+++ b/src/unix/notbsd/linux/musl/b32/mips.rs
@@ -301,3 +301,5 @@ pub const TIOCMBIC: ::c_ulong = 0x741C;
 pub const TIOCMSET: ::c_ulong = 0x741D;
 pub const FIONREAD: ::c_ulong = 0x467F;
 pub const TIOCCONS: ::c_ulong = 0x80047478;
+
+pub const SYS_gettid: ::c_int = 4222;   // Valid for O32

--- a/src/unix/notbsd/linux/musl/b32/x86.rs
+++ b/src/unix/notbsd/linux/musl/b32/x86.rs
@@ -220,6 +220,8 @@ pub const TIOCMSET: ::c_ulong = 0x5418;
 pub const FIONREAD: ::c_ulong = 0x541B;
 pub const TIOCCONS: ::c_ulong = 0x541D;
 
+pub const SYS_gettid: ::c_int = 224;
+
 s! {
     pub struct stat {
         pub st_dev: ::dev_t,

--- a/src/unix/notbsd/linux/musl/b64/mod.rs
+++ b/src/unix/notbsd/linux/musl/b64/mod.rs
@@ -226,6 +226,8 @@ pub const TIOCMSET: ::c_ulong = 0x5418;
 pub const FIONREAD: ::c_ulong = 0x541B;
 pub const TIOCCONS: ::c_ulong = 0x541D;
 
+pub const SYS_gettid: ::c_int = 186;    // Valid for x86_64
+
 s! {
     pub struct stat {
         pub st_dev: ::dev_t,

--- a/src/unix/notbsd/linux/other/b32/arm.rs
+++ b/src/unix/notbsd/linux/other/b32/arm.rs
@@ -18,3 +18,5 @@ pub const SO_SNDTIMEO: ::c_int = 21;
 
 pub const FIOCLEX: ::c_ulong = 0x5451;
 pub const FIONBIO: ::c_ulong = 0x5421;
+
+pub const SYS_gettid: ::c_int = 224;

--- a/src/unix/notbsd/linux/other/b32/powerpc.rs
+++ b/src/unix/notbsd/linux/other/b32/powerpc.rs
@@ -18,3 +18,5 @@ pub const SO_SNDTIMEO: ::c_int = 19;
 
 pub const FIOCLEX: ::c_ulong = 0x20006601;
 pub const FIONBIO: ::c_ulong = 0x8004667e;
+
+pub const SYS_gettid: ::c_int = 207;

--- a/src/unix/notbsd/linux/other/b32/x86.rs
+++ b/src/unix/notbsd/linux/other/b32/x86.rs
@@ -19,6 +19,8 @@ pub const SO_SNDTIMEO: ::c_int = 21;
 pub const FIOCLEX: ::c_ulong = 0x5451;
 pub const FIONBIO: ::c_ulong = 0x5421;
 
+pub const SYS_gettid: ::c_int = 224;
+
 s! {
 
     pub struct mcontext_t {

--- a/src/unix/notbsd/linux/other/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/other/b64/aarch64.rs
@@ -26,6 +26,8 @@ pub const SO_SNDTIMEO: ::c_int = 21;
 pub const FIOCLEX: ::c_ulong = 0x5451;
 pub const FIONBIO: ::c_ulong = 0x5421;
 
+pub const SYS_gettid: ::c_int = 178;
+
 s! {
     pub struct stat {
         pub st_dev: ::dev_t,

--- a/src/unix/notbsd/linux/other/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/other/b64/powerpc64.rs
@@ -26,6 +26,8 @@ pub const SO_SNDTIMEO: ::c_int = 19;
 pub const FIOCLEX: ::c_ulong = 0x20006601;
 pub const FIONBIO: ::c_ulong = 0x8004667e;
 
+pub const SYS_gettid: ::c_int = 207;
+
 s! {
     pub struct stat {
         pub st_dev: ::dev_t,

--- a/src/unix/notbsd/linux/other/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/other/b64/x86_64.rs
@@ -33,6 +33,8 @@ pub const PTRACE_SETFPXREGS: ::c_uint = 19;
 pub const PTRACE_GETREGS: ::c_uint = 12;
 pub const PTRACE_SETREGS: ::c_uint = 13;
 
+pub const SYS_gettid: ::c_int = 186;
+
 s! {
     pub struct stat {
         pub st_dev: ::dev_t,


### PR DESCRIPTION
I'm trying to get gettid added (either in libc or nix). We discussed things a bit over here:
https://github.com/nix-rust/nix/pull/293 so I thought I would take a stab at adding the SYS_gettid constant into libc.

Should I also add a gettid function here? Or should that go in nix?

I wasn't sure which variant of MIPS was being used, so I didn't add the constant into the mips.rs. The constants are: 4222 for O32, 5178 for N64 and 6178 for N32. Since it seems to be used for OpenWRT, I'd guess O32.

Should this also be added to musl?