### PR TITLE
unix: Include fdatasync(2) on non-Apple systems

### DIFF
--- a/src/unix/bsd/openbsdlike/mod.rs
+++ b/src/unix/bsd/openbsdlike/mod.rs
@@ -388,6 +388,7 @@ extern {
     pub fn mkostemp(template: *mut ::c_char, flags: ::c_int) -> ::c_int;
     pub fn mkostemps(template: *mut ::c_char, suffixlen: ::c_int, flags: ::c_int) -> ::c_int;
     pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
+    pub fn fdatasync(fd: ::c_int) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -765,5 +765,6 @@ extern {
                       buf: *mut ::c_char,
                       buflen: ::size_t) -> *const passwd;
     pub fn readdir(dirp: *mut ::DIR) -> *const ::dirent;
+    pub fn fdatasync(fd: ::c_int) -> ::c_int;
 }
 


### PR DESCRIPTION
The function is defined in POSIX [0], but according to Gnulib docs [1],
it is missing or not declared on at least some versions of OS X. On
Solaris, it is not a system call but is present as fdatasync(3) [2].

[0] http://www.opengroup.org/onlinepubs/9699919799/functions/fdatasync.html
[1] https://www.gnu.org/software/gnulib/manual/html_node/fdatasync.html
[2] http://docs.oracle.com/cd/E36784_01/html/E36874/fdatasync-3c.html