### PR TITLE
Fix SYS_gettid type to match first argument of syscall.

### DIFF
--- a/src/unix/notbsd/android/b32.rs
+++ b/src/unix/notbsd/android/b32.rs
@@ -9,4 +9,4 @@ s! {
     }
 }
 
-pub const SYS_gettid: ::c_int = 224;
+pub const SYS_gettid: ::c_long = 224;

--- a/src/unix/notbsd/android/b64.rs
+++ b/src/unix/notbsd/android/b64.rs
@@ -9,4 +9,4 @@ s! {
     }
 }
 
-pub const SYS_gettid: ::c_int = 178;
+pub const SYS_gettid: ::c_long = 178;

--- a/src/unix/notbsd/linux/mips.rs
+++ b/src/unix/notbsd/linux/mips.rs
@@ -472,7 +472,7 @@ pub const RTLD_DEEPBIND: ::c_int = 0x10;
 pub const RTLD_GLOBAL: ::c_int = 0x4;
 pub const RTLD_NOLOAD: ::c_int = 0x8;
 
-pub const SYS_gettid: ::c_int = 4222;   // Valid for O32
+pub const SYS_gettid: ::c_long = 4222;   // Valid for O32
 
 extern {
     pub fn sysctl(name: *mut ::c_int,

--- a/src/unix/notbsd/linux/musl/b32/arm.rs
+++ b/src/unix/notbsd/linux/musl/b32/arm.rs
@@ -303,4 +303,4 @@ pub const TIOCMSET: ::c_ulong = 0x5418;
 pub const FIONREAD: ::c_ulong = 0x541B;
 pub const TIOCCONS: ::c_ulong = 0x541D;
 
-pub const SYS_gettid: ::c_int = 224;
+pub const SYS_gettid: ::c_long = 224;

--- a/src/unix/notbsd/linux/musl/b32/asmjs.rs
+++ b/src/unix/notbsd/linux/musl/b32/asmjs.rs
@@ -303,4 +303,4 @@ pub const TIOCMSET: ::c_ulong = 0x5418;
 pub const FIONREAD: ::c_ulong = 0x541B;
 pub const TIOCCONS: ::c_ulong = 0x541D;
 
-pub const SYS_gettid: ::c_int = 224; // Valid for arm (32-bit) and x86 (32-bit)
+pub const SYS_gettid: ::c_long = 224; // Valid for arm (32-bit) and x86 (32-bit)

--- a/src/unix/notbsd/linux/musl/b32/mips.rs
+++ b/src/unix/notbsd/linux/musl/b32/mips.rs
@@ -302,4 +302,4 @@ pub const TIOCMSET: ::c_ulong = 0x741D;
 pub const FIONREAD: ::c_ulong = 0x467F;
 pub const TIOCCONS: ::c_ulong = 0x80047478;
 
-pub const SYS_gettid: ::c_int = 4222;   // Valid for O32
+pub const SYS_gettid: ::c_long = 4222;   // Valid for O32

--- a/src/unix/notbsd/linux/musl/b32/x86.rs
+++ b/src/unix/notbsd/linux/musl/b32/x86.rs
@@ -304,4 +304,4 @@ pub const TIOCMSET: ::c_ulong = 0x5418;
 pub const FIONREAD: ::c_ulong = 0x541B;
 pub const TIOCCONS: ::c_ulong = 0x541D;
 
-pub const SYS_gettid: ::c_int = 224;
+pub const SYS_gettid: ::c_long = 224;

--- a/src/unix/notbsd/linux/musl/b64/mod.rs
+++ b/src/unix/notbsd/linux/musl/b64/mod.rs
@@ -325,4 +325,4 @@ pub const TIOCMSET: ::c_ulong = 0x5418;
 pub const FIONREAD: ::c_ulong = 0x541B;
 pub const TIOCCONS: ::c_ulong = 0x541D;
 
-pub const SYS_gettid: ::c_int = 186;    // Valid for x86_64
+pub const SYS_gettid: ::c_long = 186;    // Valid for x86_64

--- a/src/unix/notbsd/linux/other/b32/arm.rs
+++ b/src/unix/notbsd/linux/other/b32/arm.rs
@@ -19,4 +19,4 @@ pub const SO_SNDTIMEO: ::c_int = 21;
 pub const FIOCLEX: ::c_ulong = 0x5451;
 pub const FIONBIO: ::c_ulong = 0x5421;
 
-pub const SYS_gettid: ::c_int = 224;
+pub const SYS_gettid: ::c_long = 224;

--- a/src/unix/notbsd/linux/other/b32/powerpc.rs
+++ b/src/unix/notbsd/linux/other/b32/powerpc.rs
@@ -19,4 +19,4 @@ pub const SO_SNDTIMEO: ::c_int = 19;
 pub const FIOCLEX: ::c_ulong = 0x20006601;
 pub const FIONBIO: ::c_ulong = 0x8004667e;
 
-pub const SYS_gettid: ::c_int = 207;
+pub const SYS_gettid: ::c_long = 207;

--- a/src/unix/notbsd/linux/other/b32/x86.rs
+++ b/src/unix/notbsd/linux/other/b32/x86.rs
@@ -35,7 +35,7 @@ pub const SO_SNDTIMEO: ::c_int = 21;
 pub const FIOCLEX: ::c_ulong = 0x5451;
 pub const FIONBIO: ::c_ulong = 0x5421;
 
-pub const SYS_gettid: ::c_int = 224;
+pub const SYS_gettid: ::c_long = 224;
 
 extern {
     pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;

--- a/src/unix/notbsd/linux/other/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/other/b64/aarch64.rs
@@ -76,4 +76,4 @@ pub const SO_SNDTIMEO: ::c_int = 21;
 pub const FIOCLEX: ::c_ulong = 0x5451;
 pub const FIONBIO: ::c_ulong = 0x5421;
 
-pub const SYS_gettid: ::c_int = 178;
+pub const SYS_gettid: ::c_long = 178;

--- a/src/unix/notbsd/linux/other/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/other/b64/powerpc64.rs
@@ -74,4 +74,4 @@ pub const SO_SNDTIMEO: ::c_int = 19;
 pub const FIOCLEX: ::c_ulong = 0x20006601;
 pub const FIONBIO: ::c_ulong = 0x8004667e;
 
-pub const SYS_gettid: ::c_int = 207;
+pub const SYS_gettid: ::c_long = 207;

--- a/src/unix/notbsd/linux/other/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/other/b64/x86_64.rs
@@ -95,7 +95,7 @@ pub const PTRACE_SETFPXREGS: ::c_uint = 19;
 pub const PTRACE_GETREGS: ::c_uint = 12;
 pub const PTRACE_SETREGS: ::c_uint = 13;
 
-pub const SYS_gettid: ::c_int = 186;
+pub const SYS_gettid: ::c_long = 186;
 
 extern {
     pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;


### PR DESCRIPTION
My apoogies - I should have picked this up on the first PR