### PR TITLE
musl: opt for dynamic linking for arm arch

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -139,7 +139,8 @@ cfg_if! {
     if #[cfg(not(stdbuild))] {
         // cargo build, don't pull in anything extra as the libstd  dep
         // already pulls in all libs.
-    } else if #[cfg(all(target_env = "musl", not(target_arch = "mips")))] {
+    } else if #[cfg(all(target_env = "musl", not(any(target_arch = "mips",
+                                                     target_arch = "arm"))))] {
         #[link(name = "c", kind = "static")]
         extern {}
     } else if #[cfg(target_os = "emscripten")] {


### PR DESCRIPTION
When building with musl for an arm target link with a shared libc (like mips already does).