### PR TITLE
notbsd: Add utimensat

### DIFF
--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -548,6 +548,9 @@ pub const POSIX_FADV_WILLNEED: ::c_int = 3;
 pub const POSIX_FADV_DONTNEED: ::c_int = 4;
 pub const POSIX_FADV_NOREUSE: ::c_int = 5;
 
+pub const AT_FDCWD: ::c_int = -100;
+pub const AT_SYMLINK_NOFOLLOW: ::c_int = 0x100;
+
 f! {
     pub fn FD_CLR(fd: ::c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
@@ -664,6 +667,8 @@ extern {
     pub fn posix_fadvise(fd: ::c_int, offset: ::off_t, len: ::off_t,
                          advise: ::c_int) -> ::c_int;
     pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
+    pub fn utimensat(dirfd: ::c_int, path: *const ::c_char,
+                     times: *const ::timespec, flag: ::c_int) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
This pull request adds the `utimensat` function, which is related to `futimens` (already in the code).  `utimensat` allows modifying the mtime/atime using a path instead of a file descriptor, and it also allows modifying mtime/atime on a symlink (the link's inode, rather than the target inode).

I also added the two constants which can be passed to `utimensat`: `AT_FDCWD` and `AT_SYMLINK_NOFOLLOW`.  I used http://lxr.free-electrons.com/source/include/uapi/linux/fcntl.h#L56 to get the constant values.

I tested `libc::utimensat` on my local system (Ubuntu 15.10).  Not sure if I'm supposed to add any unit tests with this pull request or not.