### PR TITLE
linux: Add SYS_perf_event_open syscall numbers

### DIFF
--- a/src/unix/notbsd/linux/musl/b32/arm.rs
+++ b/src/unix/notbsd/linux/musl/b32/arm.rs
@@ -304,3 +304,4 @@ pub const FIONREAD: ::c_ulong = 0x541B;
 pub const TIOCCONS: ::c_ulong = 0x541D;
 
 pub const SYS_gettid: ::c_long = 224;
+pub const SYS_perf_event_open: ::c_long = 364;

--- a/src/unix/notbsd/linux/musl/b32/mips.rs
+++ b/src/unix/notbsd/linux/musl/b32/mips.rs
@@ -303,3 +303,4 @@ pub const FIONREAD: ::c_ulong = 0x467F;
 pub const TIOCCONS: ::c_ulong = 0x80047478;
 
 pub const SYS_gettid: ::c_long = 4222;   // Valid for O32
+pub const SYS_perf_event_open: ::c_long = 4333;  // Valid for O32

--- a/src/unix/notbsd/linux/musl/b32/x86.rs
+++ b/src/unix/notbsd/linux/musl/b32/x86.rs
@@ -305,3 +305,4 @@ pub const FIONREAD: ::c_ulong = 0x541B;
 pub const TIOCCONS: ::c_ulong = 0x541D;
 
 pub const SYS_gettid: ::c_long = 224;
+pub const SYS_perf_event_open: ::c_long = 336;

--- a/src/unix/notbsd/linux/musl/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/musl/b64/aarch64.rs
@@ -1,0 +1,1 @@
+pub const SYS_perf_event_open: ::c_long = 241;

--- a/src/unix/notbsd/linux/musl/b64/mod.rs
+++ b/src/unix/notbsd/linux/musl/b64/mod.rs
@@ -325,4 +325,17 @@ pub const TIOCMSET: ::c_ulong = 0x5418;
 pub const FIONREAD: ::c_ulong = 0x541B;
 pub const TIOCCONS: ::c_ulong = 0x541D;
 
-pub const SYS_gettid: ::c_long = 186;    // Valid for x86_64
+cfg_if! {
+    if #[cfg(target_arch = "aarch64")] {
+        mod aarch64;
+        pub use self::aarch64::*;
+    } else if #[cfg(any(target_arch = "powerpc64"))] {
+        mod powerpc64;
+        pub use self::powerpc64::*;
+    } else if #[cfg(any(target_arch = "x86_64"))] {
+        mod x86_64;
+        pub use self::x86_64::*;
+    } else {
+        // Unknown target_arch
+    }
+}

--- a/src/unix/notbsd/linux/musl/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/musl/b64/powerpc64.rs
@@ -1,0 +1,1 @@
+pub const SYS_perf_event_open: ::c_long = 319;

--- a/src/unix/notbsd/linux/musl/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/musl/b64/x86_64.rs
@@ -1,1 +1,3 @@
 pub const SYS_gettid: ::c_long = 186;
+
+pub const SYS_perf_event_open: ::c_long = 298;

--- a/src/unix/notbsd/linux/musl/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/musl/b64/x86_64.rs
@@ -1,0 +1,1 @@
+pub const SYS_gettid: ::c_long = 186;

--- a/src/unix/notbsd/linux/other/b32/arm.rs
+++ b/src/unix/notbsd/linux/other/b32/arm.rs
@@ -20,3 +20,4 @@ pub const FIOCLEX: ::c_ulong = 0x5451;
 pub const FIONBIO: ::c_ulong = 0x5421;
 
 pub const SYS_gettid: ::c_long = 224;
+pub const SYS_perf_event_open: ::c_long = 364;

--- a/src/unix/notbsd/linux/other/b32/powerpc.rs
+++ b/src/unix/notbsd/linux/other/b32/powerpc.rs
@@ -20,3 +20,4 @@ pub const FIOCLEX: ::c_ulong = 0x20006601;
 pub const FIONBIO: ::c_ulong = 0x8004667e;
 
 pub const SYS_gettid: ::c_long = 207;
+pub const SYS_perf_event_open: ::c_long = 319;

--- a/src/unix/notbsd/linux/other/b32/x86.rs
+++ b/src/unix/notbsd/linux/other/b32/x86.rs
@@ -36,6 +36,7 @@ pub const FIOCLEX: ::c_ulong = 0x5451;
 pub const FIONBIO: ::c_ulong = 0x5421;
 
 pub const SYS_gettid: ::c_long = 224;
+pub const SYS_perf_event_open: ::c_long = 336;
 
 extern {
     pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;

--- a/src/unix/notbsd/linux/other/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/other/b64/aarch64.rs
@@ -77,3 +77,4 @@ pub const FIOCLEX: ::c_ulong = 0x5451;
 pub const FIONBIO: ::c_ulong = 0x5421;
 
 pub const SYS_gettid: ::c_long = 178;
+pub const SYS_perf_event_open: ::c_long = 241;

--- a/src/unix/notbsd/linux/other/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/other/b64/powerpc64.rs
@@ -75,3 +75,4 @@ pub const FIOCLEX: ::c_ulong = 0x20006601;
 pub const FIONBIO: ::c_ulong = 0x8004667e;
 
 pub const SYS_gettid: ::c_long = 207;
+pub const SYS_perf_event_open: ::c_long = 319;

--- a/src/unix/notbsd/linux/other/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/other/b64/x86_64.rs
@@ -96,6 +96,7 @@ pub const PTRACE_GETREGS: ::c_uint = 12;
 pub const PTRACE_SETREGS: ::c_uint = 13;
 
 pub const SYS_gettid: ::c_long = 186;
+pub const SYS_perf_event_open: ::c_long = 298;
 
 extern {
     pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;


### PR DESCRIPTION
There is no glibc wrapper for this system call; it must be called as
`syscall(__NR_perf_event_open, ...)`.
    
The associated `perf_event_attr` struct has several unions and one
set of bitfields. These are currently represented as padding.
