### PR TITLE
Run CI on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,3 @@ notifications:
   email:
     on_success: never
   webhooks: http://buildbot.rust-lang.org/homu/travis
-branches:
-  only:
-    - auto-libc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,3 @@ build: false
 test_script:
   - cargo test
   - cargo run --manifest-path libc-test/Cargo.toml
-
-branches:
-  only:
-    - auto-libc


### PR DESCRIPTION
Only running them against auto-libc unfortunately means that PRs don't run CI.