### PR TITLE
Make cfg_if uses more explicit and consistent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,8 +258,10 @@ cfg_if! {
     if #[cfg(windows)] {
         mod windows;
         pub use windows::*;
-    } else {
+    } else if #[cfg(unix)] {
         mod unix;
         pub use unix::*;
+    } else {
+        // Unknown target_family
     }
 }

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -946,6 +946,6 @@ cfg_if! {
         mod b64;
         pub use self::b64::*;
     } else {
-        // unknown arch...
+        // Unknown target_arch
     }
 }

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -86,6 +86,6 @@ cfg_if! {
         mod x86_64;
         pub use self::x86_64::*;
     } else {
-        // ...
+        // Unknown target_arch
     }
 }

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -350,6 +350,6 @@ cfg_if! {
         mod freebsdlike;
         pub use self::freebsdlike::*;
     } else {
-        // ...
+        // Unknown target_os
     }
 }

--- a/src/unix/bsd/openbsdlike/mod.rs
+++ b/src/unix/bsd/openbsdlike/mod.rs
@@ -402,8 +402,10 @@ cfg_if! {
     } else if #[cfg(target_os = "netbsd")] {
         mod netbsd;
         pub use self::netbsd::*;
-    } else {
+    } else if #[cfg(target_os = "openbsd")] {
         mod openbsd;
         pub use self::openbsd::*;
+    } else {
+        // Unknown target_os
     }
 }

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -733,6 +733,6 @@ cfg_if! {
         mod solaris;
         pub use self::solaris::*;
     } else {
-        // ...
+        // Unknown target_os
     }
 }

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -657,6 +657,6 @@ cfg_if! {
         mod b64;
         pub use self::b64::*;
     } else {
-        // ...
+        // Unknown target_pointer_width
     }
 }

--- a/src/unix/notbsd/linux/musl/b32/mod.rs
+++ b/src/unix/notbsd/linux/musl/b32/mod.rs
@@ -38,5 +38,7 @@ cfg_if! {
     } else if #[cfg(any(target_arch = "asmjs"))] {
         mod asmjs;
         pub use self::asmjs::*;
-    } else { }
+    } else {
+        // Unknown target_arch
+    }
 }

--- a/src/unix/notbsd/linux/other/b32/mod.rs
+++ b/src/unix/notbsd/linux/other/b32/mod.rs
@@ -90,6 +90,6 @@ cfg_if! {
         mod powerpc;
         pub use self::powerpc::*;
     } else {
-        // ...
+        // Unknown target_arch
     }
 }

--- a/src/unix/notbsd/linux/other/b64/mod.rs
+++ b/src/unix/notbsd/linux/other/b64/mod.rs
@@ -25,8 +25,10 @@ cfg_if! {
     } else if #[cfg(any(target_arch = "powerpc64"))] {
         mod powerpc64;
         pub use self::powerpc64::*;
-    } else {
+    } else if #[cfg(any(target_arch = "x86_64"))] {
         mod x86_64;
         pub use self::x86_64::*;
+    } else {
+        // Unknown target_arch
     }
 }

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -491,6 +491,6 @@ cfg_if! {
         mod b64;
         pub use self::b64::*;
     } else {
-        // ...
+        // Unknown target_arch
     }
 }

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -133,6 +133,7 @@ cfg_if! {
     } else if #[cfg(target_pointer_width = "64")] {
         const ULONG_SIZE: usize = 64;
     } else {
+        // Unknown target_pointer_width
     }
 }
 
@@ -680,6 +681,6 @@ cfg_if! {
         mod android;
         pub use self::android::*;
     } else {
-        // ...
+        // Unknown target_os
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -72,9 +72,11 @@ cfg_if! {
     if #[cfg(all(target_env = "gnu"))] {
         pub const L_tmpnam: ::c_uint = 14;
         pub const TMP_MAX: ::c_uint = 0x7fff;
-    } else {
+    } else if #[cfg(all(target_env = "msvc"))] {
         pub const L_tmpnam: ::c_uint = 260;
         pub const TMP_MAX: ::c_uint = 0x7fff_ffff;
+    } else {
+        // Unknown target_env
     }
 }
 


### PR DESCRIPTION
This commit changes most uses of cfg_if as follows:
- fallthrough `else` usage is avoided for architecture or OS specific
  items
- a comment is added in the final `else` clause to signal intent someone
  modifying

It is safer to omit items than include ones for the wrong platform or
architecture.