### PR TITLE
Pull sockaddr_nl up a layer as it is present for Android

### DIFF
--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -126,13 +126,6 @@ s! {
         __f_spare: [::c_int; 6],
     }
 
-    pub struct sockaddr_nl {
-        pub nl_family: ::sa_family_t,
-        nl_pad: ::c_ushort,
-        pub nl_pid: u32,
-        pub nl_groups: u32
-    }
-
     pub struct dqblk {
         pub dqb_bhardlimit: ::uint64_t,
         pub dqb_bsoftlimit: ::uint64_t,

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -61,6 +61,13 @@ s! {
         pub ai_next: *mut addrinfo,
     }
 
+    pub struct sockaddr_nl {
+        pub nl_family: ::sa_family_t,
+        nl_pad: ::c_ushort,
+        pub nl_pid: u32,
+        pub nl_groups: u32
+    }
+
     pub struct sockaddr_ll {
         pub sll_family: ::c_ushort,
         pub sll_protocol: ::c_ushort,


### PR DESCRIPTION
The addition of sockaddr_nl seems to be a fairly recent
addition to bionic, although it would appear that its lack
of presence in previous versions is more of an oversight than
anything else.

https://github.com/android/platform_bionic/blob/831c8a52498d3c7be204a00847275f6e9163626f/libc/kernel/uapi/linux/netlink.h#L54
