### PR TITLE
linux: Move namespace clone flags up one level

### DIFF
--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -378,13 +378,6 @@ pub const EFD_SEMAPHORE: ::c_int = 0x1;
 
 pub const NCCS: usize = 32;
 
-pub const CLONE_NEWUTS: ::c_int = 0x04000000;
-pub const CLONE_NEWIPC: ::c_int = 0x08000000;
-pub const CLONE_NEWUSER: ::c_int = 0x10000000;
-pub const CLONE_NEWPID: ::c_int = 0x20000000;
-pub const CLONE_NEWNET: ::c_int = 0x40000000;
-pub const CLONE_IO: ::c_int = 0x80000000;
-
 pub const AF_NETLINK: ::c_int = 16;
 
 f! {

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -539,6 +539,12 @@ pub const CLONE_CHILD_CLEARTID: ::c_int = 0x200000;
 pub const CLONE_DETACHED: ::c_int = 0x400000;
 pub const CLONE_UNTRACED: ::c_int = 0x800000;
 pub const CLONE_CHILD_SETTID: ::c_int = 0x01000000;
+pub const CLONE_NEWUTS: ::c_int = 0x04000000;
+pub const CLONE_NEWIPC: ::c_int = 0x08000000;
+pub const CLONE_NEWUSER: ::c_int = 0x10000000;
+pub const CLONE_NEWPID: ::c_int = 0x20000000;
+pub const CLONE_NEWNET: ::c_int = 0x40000000;
+pub const CLONE_IO: ::c_int = 0x80000000;
 
 pub const WNOHANG: ::c_int = 1;
 


### PR DESCRIPTION
The flags are available in Android, and should be defined higher up.