### PR TITLE
linux: Add missing Linux-specific fcntls

### DIFF
--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -315,8 +315,6 @@ pub const RTLD_NOW: ::c_int = 0x2;
 
 pub const TCP_MD5SIG: ::c_int = 14;
 
-pub const F_DUPFD_CLOEXEC: ::c_int = 1030;
-
 pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
     __align: [],
     size: [0; __SIZEOF_PTHREAD_MUTEX_T],

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -161,6 +161,16 @@ pub const F_SETFD: ::c_int = 2;
 pub const F_GETFL: ::c_int = 3;
 pub const F_SETFL: ::c_int = 4;
 
+// Linux-specific fcntls
+pub const F_SETLEASE: ::c_int = 1024;
+pub const F_GETLEASE: ::c_int = 1025;
+pub const F_NOTIFY: ::c_int = 1026;
+pub const F_DUPFD_CLOEXEC: ::c_int = 1030;
+pub const F_SETPIPE_SZ: ::c_int = 1031;
+pub const F_GETPIPE_SZ: ::c_int = 1032;
+
+// TODO(#235): Include file sealing fcntls once we have a way to verify them.
+
 pub const SIGTRAP: ::c_int = 5;
 
 pub const PTHREAD_CREATE_JOINABLE: ::c_int = 0;


### PR DESCRIPTION
Also move F_DUPFD_CLOEXEC up a level as it is available on Android.