### PR TITLE
Use now available link name "signal" instead of "bsd_signal"

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -385,12 +385,6 @@ fn main() {
 
     cfg.skip_fn_ptrcheck(move |name| {
         match name {
-            // This used to be called bsd_signal in rev 18 of the android
-            // platform and is now just called signal, the old `bsd_signal`
-            // symbol, however, still remains, just gives a different function
-            // pointer.
-            "signal" if android => true,
-
             // dllimport weirdness?
             _ if windows => true,
 

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -408,7 +408,6 @@ extern {
 
     pub fn ftruncate(fd: ::c_int, length: off_t) -> ::c_int;
 
-    #[cfg_attr(target_os = "android", link_name = "bsd_signal")]
     pub fn signal(signum: ::c_int, handler: sighandler_t) -> sighandler_t;
 
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),


### PR DESCRIPTION
On android, the `bsd_signal` is gone, the `signal` is available.

While this is the most obvious solution, I am not sure of a few things:
- How are we going to keep compatibility with older NDKs where `signal` does not exist;
- Was something dependent on this being different on android and thus would break (for example, the rust compiler uses this function, so it may break somewhere).

Fixes #236.