### PR TITLE
unix: Add openpty(3) and forkpty(3) for non-Apple platforms

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -130,6 +130,12 @@ fn main() {
 
     if bsdlike {
         cfg.header("sys/event.h");
+
+        if freebsd {
+            cfg.header("libutil.h");
+        } else {
+            cfg.header("util.h");
+        }
     }
 
     if linux {
@@ -139,6 +145,7 @@ fn main() {
         cfg.header("sys/xattr.h");
         cfg.header("sys/ipc.h");
         cfg.header("sys/shm.h");
+        cfg.header("pty.h");
     }
 
     if linux || android {

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -568,6 +568,7 @@ pub const RTLD_NODELETE: ::c_int = 0x1000;
 pub const RTLD_NOLOAD: ::c_int = 0x2000;
 pub const RTLD_GLOBAL: ::c_int = 0x100;
 
+#[link(name = "util")]
 extern {
     pub fn getnameinfo(sa: *const ::sockaddr,
                        salen: ::socklen_t,
@@ -617,6 +618,15 @@ extern {
                         timeout: *const ::timespec) -> ::c_int;
     pub fn sigwaitinfo(set: *const sigset_t,
                        info: *mut siginfo_t) -> ::c_int;
+    pub fn openpty(amaster: *mut ::c_int,
+                   aslave: *mut ::c_int,
+                   name: *mut ::c_char,
+                   termp: *mut termios,
+                   winp: *mut ::winsize) -> ::c_int;
+    pub fn forkpty(amaster: *mut ::c_int,
+                   name: *mut ::c_char,
+                   termp: *mut termios,
+                   winp: *mut ::winsize) -> ::pid_t;
 }
 
 cfg_if! {

--- a/src/unix/bsd/openbsdlike/mod.rs
+++ b/src/unix/bsd/openbsdlike/mod.rs
@@ -376,6 +376,7 @@ pub const Q_SETQUOTA: ::c_int = 0x400;
 
 pub const RTLD_GLOBAL: ::c_int = 0x100;
 
+#[link(name = "util")]
 extern {
     pub fn mincore(addr: *mut ::c_void, len: ::size_t,
                    vec: *mut ::c_char) -> ::c_int;
@@ -393,6 +394,15 @@ extern {
                      flags: ::c_int) -> ::c_int;
     pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
     pub fn fdatasync(fd: ::c_int) -> ::c_int;
+    pub fn openpty(amaster: *mut ::c_int,
+                   aslave: *mut ::c_int,
+                   name: *mut ::c_char,
+                   termp: *mut termios,
+                   winp: *mut ::winsize) -> ::c_int;
+    pub fn forkpty(amaster: *mut ::c_int,
+                   name: *mut ::c_char,
+                   termp: *mut termios,
+                   winp: *mut ::winsize) -> ::pid_t;
 }
 
 cfg_if! {

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -398,6 +398,7 @@ f! {
     }
 }
 
+#[link(name = "util")]
 extern {
     pub fn shm_open(name: *const c_char, oflag: ::c_int,
                     mode: mode_t) -> ::c_int;
@@ -531,6 +532,15 @@ extern {
                         timeout: *const ::timespec) -> ::c_int;
     pub fn sigwaitinfo(set: *const sigset_t,
                        info: *mut siginfo_t) -> ::c_int;
+    pub fn openpty(amaster: *mut ::c_int,
+                   aslave: *mut ::c_int,
+                   name: *mut ::c_char,
+                   termp: *const termios,
+                   winp: *const ::winsize) -> ::c_int;
+    pub fn forkpty(amaster: *mut ::c_int,
+                   name: *mut ::c_char,
+                   termp: *const termios,
+                   winp: *const ::winsize) -> ::pid_t;
 }
 
 cfg_if! {


### PR DESCRIPTION
The functions were added for Apple in #202. Adding them to other
platforms was pending an amendment to RFC 1291 to expand the scope of
libc to include libutil. The amendment was merged as
  https://github.com/rust-lang/rfcs/pull/1529