### PR TITLE
Link to libraries when disabling `use_std`

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -143,7 +143,9 @@ pub const IF_NAMESIZE: ::size_t = 16;
 pub const RTLD_LAZY: ::c_int = 0x1;
 
 cfg_if! {
-    if #[cfg(not(stdbuild))] {
+    if #[cfg(dox)] {
+        // on dox builds don't pull in anything
+    } else if #[cfg(all(not(stdbuild), feature = "use_std"))] {
         // cargo build, don't pull in anything extra as the libstd  dep
         // already pulls in all libs.
     } else if #[cfg(all(target_env = "musl", not(any(target_arch = "mips",


### PR DESCRIPTION
This crate currently relies on libraries being linked to come from libstd, but
if `use_std` is disabled that's not true! In that case we need to pull in the
libraries ourselves.

Closes rust-lang/rust#32661