### PR TITLE
On non-musl Linux, strerror_r should be linked to __xpg_strerror_r

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -312,6 +312,7 @@ fn main() {
 
             // weird signed extension or something like that?
             "MS_NOUSER" => true,
+            "MS_RMT_MASK" => true, // updated in glibc 2.22 and musl 1.1.13
 
             // These OSX constants are flagged as deprecated
             "NOTE_EXIT_REPARENTED" |

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -506,8 +506,8 @@ extern {
     pub fn pthread_sigmask(how: ::c_int, set: *const sigset_t,
                            oldset: *mut sigset_t) -> ::c_int;
     pub fn pthread_kill(thread: ::pthread_t, sig: ::c_int) -> ::c_int;
-
-    // #[cfg_attr(target_os = "linux", link_name = "__xpg_strerror_r")]
+    #[cfg_attr(all(target_os = "linux", not(target_env = "musl")),
+               link_name = "__xpg_strerror_r")]
     pub fn strerror_r(errnum: ::c_int, buf: *mut c_char,
                       buflen: ::size_t) -> ::c_int;
 


### PR DESCRIPTION
Currently `libc::strerror_r()` wrongly returns a `c_char` pointer as a large `c_int`.

Also exclude `MS_RMT_MASK` from `libc-test`.