### PR TITLE
Add Linux-specific recvmmsg(2) and sendmmsg(2)

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -343,6 +343,11 @@ fn main() {
             "setrlimit" | "setrlimit64" |    // non-int in 1st arg
             "strerror_r" if linux => true,   // actually xpg-something-or-other
 
+            // int vs uint. Sorry musl, your prototype declarations are "correct" in the sense that
+            // they match the interface defined by Linux verbatim, but they conflict with other
+            // send*/recv* syscalls
+            "sendmmsg" | "recvmmsg" if musl => true,
+
             // typed 2nd arg on linux and android
             "gettimeofday" if linux || android || freebsd || openbsd || dragonfly => true,
 

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -181,6 +181,11 @@ s! {
         #[cfg(target_pointer_width = "64")]
         bits: [u64; 16],
     }
+
+    pub struct mmsghdr {
+        pub msg_hdr: ::msghdr,
+        pub msg_len: ::c_uint,
+    }
 }
 
 pub const ABDAY_1: ::nl_item = 0x20000;
@@ -615,6 +620,13 @@ extern {
                    termp: *const termios,
                    winp: *const ::winsize) -> ::pid_t;
     pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t) -> *mut ::c_char;
+}
+
+extern {
+    pub fn sendmmsg(sockfd: ::c_int, msgvec: *mut mmsghdr, vlen: ::c_uint,
+                    flags: ::c_int) -> ::c_int;
+    pub fn recvmmsg(sockfd: ::c_int, msgvec: *mut mmsghdr, vlen: ::c_uint,
+                    flags: ::c_int, timeout: *mut ::timespec) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
glibc has almost harmless bugs in their prototype declarations.