### PR TITLE
64-bit Android timegm fix

### DIFF
--- a/src/unix/notbsd/android/b32.rs
+++ b/src/unix/notbsd/android/b32.rs
@@ -10,3 +10,7 @@ s! {
 }
 
 pub const SYS_gettid: ::c_long = 224;
+
+extern {
+    pub fn timegm64(tm: *const ::tm) -> ::time64_t;
+}

--- a/src/unix/notbsd/android/b64.rs
+++ b/src/unix/notbsd/android/b64.rs
@@ -10,3 +10,7 @@ s! {
 }
 
 pub const SYS_gettid: ::c_long = 178;
+
+extern {
+    pub fn timegm(tm: *const ::tm) -> ::time64_t;
+}

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -648,7 +648,6 @@ extern {
                        serv: *mut ::c_char,
                        sevlen: ::size_t,
                        flags: ::c_int) -> ::c_int;
-    pub fn timegm64(tm: *const ::tm) -> time64_t;
     pub fn eventfd(init: ::c_uint, flags: ::c_int) -> ::c_int;
     pub fn ptrace(request: ::c_int, ...) -> ::c_long;
     pub fn fstat64(fildes: ::c_int, buf: *mut stat64) -> ::c_int;


### PR DESCRIPTION
On aarch64 and x86_64, `timegm64` does not exist (see [time64.h](https://android.googlesource.com/platform/development/+/797351fd3bbb8fe517afafdd5095fd740387e7a4/ndk/platforms/android-L/include/time64.h)).

See rust-lang-deprecated/time#118 for usage. Since that patch, the time library switched to using libc for `timegm` (rust-lang-deprecated/time@51c0019), and it doesn't build on 64-bit Android. This PR fixes that.