### PR TITLE
Add the family of printf, scanf functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,16 +166,6 @@ extern {
                    mode: c_int,
                    size: size_t) -> c_int;
     pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
-
-    pub fn fprintf(stream: *mut FILE, format: *const c_char, ...) -> c_int;
-    pub fn printf(format: *const c_char, ...) -> c_int;
-    pub fn snprintf(s: *mut c_char, n: size_t,
-                    format: *const c_char, ...) -> c_int;
-    pub fn sprintf(s: *mut c_char, format: *const c_char, ...) -> c_int;
-    pub fn fscanf(stream: *mut FILE, format: *const c_char, ...) -> c_int;
-    pub fn scanf(format: *const c_char, ...) -> c_int;
-    pub fn sscanf(s: *const c_char, format: *const c_char, ...) -> c_int;
-
     pub fn fgetc(stream: *mut FILE) -> c_int;
     pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
     pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,16 @@ extern {
                    mode: c_int,
                    size: size_t) -> c_int;
     pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
+
+    pub fn fprintf(stream: *mut FILE, format: *const c_char, ...) -> c_int;
+    pub fn printf(format: *const c_char, ...) -> c_int;
+    pub fn snprintf(s: *mut c_char, n: size_t,
+                    format: *const c_char, ...) -> c_int;
+    pub fn sprintf(s: *mut c_char, format: *const c_char, ...) -> c_int;
+    pub fn fscanf(stream: *mut FILE, format: *const c_char, ...) -> c_int;
+    pub fn scanf(format: *const c_char, ...) -> c_int;
+    pub fn sscanf(s: *const c_char, format: *const c_char, ...) -> c_int;
+
     pub fn fgetc(stream: *mut FILE) -> c_int;
     pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
     pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -179,6 +179,15 @@ cfg_if! {
 }
 
 extern {
+    pub fn fprintf(stream: *mut ::FILE, format: *const ::c_char, ...) -> ::c_int;
+    pub fn printf(format: *const ::c_char, ...) -> ::c_int;
+    pub fn snprintf(s: *mut ::c_char, n: ::size_t,
+                    format: *const ::c_char, ...) -> ::c_int;
+    pub fn sprintf(s: *mut ::c_char, format: *const ::c_char, ...) -> ::c_int;
+    pub fn fscanf(stream: *mut ::FILE, format: *const ::c_char, ...) -> ::c_int;
+    pub fn scanf(format: *const ::c_char, ...) -> ::c_int;
+    pub fn sscanf(s: *const ::c_char, format: *const ::c_char, ...) -> ::c_int;
+
     #[cfg_attr(target_os = "netbsd", link_name = "__socket30")]
     pub fn socket(domain: ::c_int, ty: ::c_int, protocol: ::c_int) -> ::c_int;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -179,7 +179,8 @@ cfg_if! {
 }
 
 extern {
-    pub fn fprintf(stream: *mut ::FILE, format: *const ::c_char, ...) -> ::c_int;
+    pub fn fprintf(stream: *mut ::FILE,
+                   format: *const ::c_char, ...) -> ::c_int;
     pub fn printf(format: *const ::c_char, ...) -> ::c_int;
     pub fn snprintf(s: *mut ::c_char, n: ::size_t,
                     format: *const ::c_char, ...) -> ::c_int;


### PR DESCRIPTION
snprintf is apparently supported in MSVC since version 14. I'm curious to take the tests for a spin.