### PR TITLE
Add support for arm-unknown-linux-musleabi{,hf} targets.

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -55,7 +55,9 @@ s! {
         pub ru_nvcsw: c_long,
         pub ru_nivcsw: c_long,
 
-        #[cfg(target_env = "musl")]
+        #[cfg(any(target_env = "musl",
+                  target_env = "musleabi",
+                  target_env = "musleabihf"))]
         __reserved: [c_long; 16],
     }
 
@@ -149,8 +151,9 @@ cfg_if! {
     } else if #[cfg(all(not(stdbuild), feature = "use_std"))] {
         // cargo build, don't pull in anything extra as the libstd  dep
         // already pulls in all libs.
-    } else if #[cfg(all(target_env = "musl", not(any(target_arch = "mips",
-                                                     target_arch = "arm"))))] {
+    } else if #[cfg(any(all(target_env = "musl", not(target_arch = "mips")),
+                        target_env = "musleabi",
+                        target_env = "musleabihf"))] {
         #[link(name = "c", kind = "static")]
         extern {}
     } else if #[cfg(target_os = "emscripten")] {

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -93,9 +93,13 @@ s! {
     }
 
     pub struct pthread_cond_t {
-        #[cfg(target_env = "musl")]
+        #[cfg(any(target_env = "musl",
+                  target_env = "musleabi",
+                  target_env = "musleabihf"))]
         __align: [*const ::c_void; 0],
-        #[cfg(not(target_env = "musl"))]
+        #[cfg(not(any(target_env = "musl",
+                      target_env = "musleabi",
+                      target_env = "musleabihf")))]
         __align: [::c_longlong; 0],
         size: [u8; __SIZEOF_PTHREAD_COND_T],
     }
@@ -615,6 +619,8 @@ extern {
 
 cfg_if! {
     if #[cfg(any(target_env = "musl",
+                 target_env = "musleabi",
+                 target_env = "musleabihf",
                  target_os = "emscripten"))] {
         mod musl;
         pub use self::musl::*;

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -99,13 +99,21 @@ s! {
 
     pub struct sched_param {
         pub sched_priority: ::c_int,
-        #[cfg(target_env = "musl")]
+        #[cfg(any(target_env = "musl",
+                  target_env = "musleabi",
+                  target_env = "musleabihf"))]
         pub sched_ss_low_priority: ::c_int,
-        #[cfg(target_env = "musl")]
+        #[cfg(any(target_env = "musl",
+                  target_env = "musleabi",
+                  target_env = "musleabihf"))]
         pub sched_ss_repl_period: ::timespec,
-        #[cfg(target_env = "musl")]
+        #[cfg(any(target_env = "musl",
+                  target_env = "musleabi",
+                  target_env = "musleabihf"))]
         pub sched_ss_init_budget: ::timespec,
-        #[cfg(target_env = "musl")]
+        #[cfg(any(target_env = "musl",
+                  target_env = "musleabi",
+                  target_env = "musleabihf"))]
         pub sched_ss_max_repl: ::c_int,
     }
 


### PR DESCRIPTION
These targets will be similar to the x86_64-unknown-linux-musl
target, in that they'll use MUSL libc to allow fully static binaries
to be generated. To remain consistent with the naming of existing
ARM targets, as well as with the standard naming of MUSL toolchains,
we'll use `musleabi` and `musleabihf` as the target environment
names (analogous to `gnueabi` and `gnueabihf`).

Most of these changes just extend the special casing for x86_64 MUSL
targets to the ARM ones as well.