### PR TITLE
linux: Add prlimit(2) and prlimit64(2)

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -341,6 +341,7 @@ fn main() {
 
             "getrlimit" | "getrlimit64" |    // non-int in 1st arg
             "setrlimit" | "setrlimit64" |    // non-int in 1st arg
+            "prlimit" | "prlimit64" |        // non-int in 2nd arg
             "strerror_r" if linux => true,   // actually xpg-something-or-other
 
             // typed 2nd arg on linux and android

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -599,6 +599,12 @@ extern {
                        serv: *mut ::c_char,
                        sevlen: ::socklen_t,
                        flags: ::c_int) -> ::c_int;
+    pub fn prlimit(pid: ::pid_t, resource: ::c_int, new_limit: *const ::rlimit,
+                   old_limit: *mut ::rlimit) -> ::c_int;
+    pub fn prlimit64(pid: ::pid_t,
+                     resource: ::c_int,
+                     new_limit: *const ::rlimit64,
+                     old_limit: *mut ::rlimit64) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
As with `getrlimit` and `setrlimit`, the glibc wrappers have a non-`int`
for the `resource` argument, eg:

    extern int prlimit (__pid_t __pid, enum __rlimit_resource __resource,
                        const struct rlimit *__new_limit,
                        struct rlimit *__old_limit) __THROW;