### PR TITLE
OS X: add various process status tests defined by wait.h

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1032,20 +1032,20 @@ f! {
         status >> 8
     }
 
-    pub fn WSTATUS(status: ::c_int) -> ::c_int {
+    pub fn _WSTATUS(status: ::c_int) -> ::c_int {
         status & 0x7f
     }
 
     pub fn WIFCONTINUED(status: ::c_int) -> bool {
-        WSTATUS(status) == _WSTOPPED && WSTOPSIG(status) == 0x13
+        _WSTATUS(status) == _WSTOPPED && WSTOPSIG(status) == 0x13
     }
 
     pub fn WIFSIGNALED(status: ::c_int) -> bool {
-        WSTATUS(status) != _WSTOPPED && WSTATUS(status) != 0
+        _WSTATUS(status) != _WSTOPPED && _WSTATUS(status) != 0
     }
 
     pub fn WIFSTOPPED(status: ::c_int) -> bool {
-        WSTATUS(status) == _WSTOPPED && WSTOPSIG(status) != 0x13
+        _WSTATUS(status) == _WSTOPPED && WSTOPSIG(status) != 0x13
     }
 }
 

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1025,6 +1025,30 @@ pub const RTLD_NODELETE: ::c_int = 0x80;
 pub const RTLD_NOLOAD: ::c_int = 0x10;
 pub const RTLD_GLOBAL: ::c_int = 0x8;
 
+pub const _WSTOPPED: ::c_int = 0o177;
+
+f! {
+    pub fn WSTOPSIG(status: ::c_int) -> ::c_int {
+        status >> 8
+    }
+
+    pub fn WSTATUS(status: ::c_int) -> ::c_int {
+        status & 0x7f
+    }
+
+    pub fn WIFCONTINUED(status: ::c_int) -> bool {
+        WSTATUS(status) == _WSTOPPED && WSTOPSIG(status) == 0x13
+    }
+
+    pub fn WIFSIGNALED(status: ::c_int) -> bool {
+        WSTATUS(status) != _WSTOPPED && WSTATUS(status) != 0
+    }
+
+    pub fn WIFSTOPPED(status: ::c_int) -> bool {
+        WSTATUS(status) == _WSTOPPED && WSTOPSIG(status) != 0x13
+    }
+}
+
 extern {
     pub fn getnameinfo(sa: *const ::sockaddr,
                        salen: ::socklen_t,

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -330,6 +330,11 @@ f! {
     pub fn WTERMSIG(status: ::c_int) -> ::c_int {
         status & 0o177
     }
+
+    pub fn WCOREDUMP(status: ::c_int) -> bool {
+        (status & 0o200) != 0
+    }
+
 }
 
 extern {


### PR DESCRIPTION
Adds the various process test macros specified in the wait(2) manpage on OS X. ```WCOREDUMP``` is implemented BSD-wide as it seems to be the only macro whose definition is constant across the BSDs.