### PR TITLE
Added _SC_HOST_NAME_MAX for FreeBSD, DragonFly, BitRig and Linux (glibc and musl)

### DIFF
--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -643,6 +643,7 @@ pub const _SC_SEM_NSEMS_MAX: ::c_int = 49;
 pub const _SC_SEM_VALUE_MAX: ::c_int = 50;
 pub const _SC_SIGQUEUE_MAX: ::c_int = 51;
 pub const _SC_TIMER_MAX: ::c_int = 52;
+pub const _SC_HOST_NAME_MAX: ::c_int = 72;
 
 pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = 0 as *mut _;
 pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = 0 as *mut _;

--- a/src/unix/bsd/openbsdlike/bitrig.rs
+++ b/src/unix/bsd/openbsdlike/bitrig.rs
@@ -262,6 +262,7 @@ pub const _SC_REALTIME_SIGNALS : ::c_int = 64;
 pub const _SC_RTSIG_MAX : ::c_int = 66;
 pub const _SC_SIGQUEUE_MAX : ::c_int = 70;
 pub const _SC_TIMER_MAX : ::c_int = 93;
+pub const _SC_HOST_NAME_MAX: ::c_int = 33;
 
 pub const FD_SETSIZE: usize = 1024;
 

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -339,6 +339,7 @@ pub const _SC_XBS5_LPBIG_OFFBIG: ::c_int = 128;
 pub const _SC_XOPEN_LEGACY: ::c_int = 129;
 pub const _SC_XOPEN_REALTIME: ::c_int = 130;
 pub const _SC_XOPEN_REALTIME_THREADS: ::c_int = 131;
+pub const _SC_HOST_NAME_MAX: ::c_int = 180;
 
 pub const RLIM_SAVED_MAX: ::rlim_t = RLIM_INFINITY;
 pub const RLIM_SAVED_CUR: ::rlim_t = RLIM_INFINITY;


### PR DESCRIPTION
I'd have liked to also add NetBSD and OpenBSD, but I can't find where _SC_HOST_NAME_MAX is defined.