### PR TITLE
Added strnlen function to all platforms.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,6 +232,7 @@ extern {
     pub fn strpbrk(cs: *const c_char, ct: *const c_char) -> *mut c_char;
     pub fn strstr(cs: *const c_char, ct: *const c_char) -> *mut c_char;
     pub fn strlen(cs: *const c_char) -> size_t;
+    pub fn strnlen(cs: *const c_char, maxlen: size_t) -> size_t;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "strerror$UNIX2003")]
     pub fn strerror(n: c_int) -> *mut c_char;


### PR DESCRIPTION
strnlen is used to find the length of a C string that may be
lacking a terminal NUL character. Whilst it is possible to
implement the equivalent functionality in rust code, it is
cleaner, simpler and removes the need for duplication of tricky
functionality to get right. It also makes it easier to port
C code snippets to rust. In my case, it's needed for dealing with
the result of `gethostname`.

Note that strnlen is not part of POSIX or C99, but is present on all major platforms.