### PR TITLE
Adding syslog functions, constants and structs

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -95,6 +95,7 @@ fn main() {
         cfg.header("sched.h");
         cfg.header("termios.h");
         cfg.header("poll.h");
+        cfg.header("syslog.h");
     }
 
     if android {

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1029,6 +1029,13 @@ pub const RTLD_GLOBAL: ::c_int = 0x8;
 
 pub const _WSTOPPED: ::c_int = 0o177;
 
+pub const LOG_NETINFO: ::c_int = 12 << 3;
+pub const LOG_REMOTEAUTH: ::c_int = 13 << 3;
+pub const LOG_INSTALL: ::c_int = 14 << 3;
+pub const LOG_RAS: ::c_int = 15 << 3;
+pub const LOG_LAUNCHD: ::c_int = 24 << 3;
+pub const LOG_NFACILITIES: ::c_int = 25;
+
 f! {
     pub fn WSTOPSIG(status: ::c_int) -> ::c_int {
         status >> 8

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -112,6 +112,10 @@ pub const CLOCK_SECOND: clockid_t = 13;
 pub const CLOCK_THREAD_CPUTIME_ID: clockid_t = 14;
 pub const CLOCK_PROCESS_CPUTIME_ID: clockid_t = 15;
 
+pub const LOG_NTP: ::c_int = 12 << 3;
+pub const LOG_SECURITY: ::c_int = 13 << 3;
+pub const LOG_CONSOLE: ::c_int = 14 << 3;
+
 extern {
     pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int)
                     -> ::c_int;

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -112,10 +112,6 @@ pub const CLOCK_SECOND: clockid_t = 13;
 pub const CLOCK_THREAD_CPUTIME_ID: clockid_t = 14;
 pub const CLOCK_PROCESS_CPUTIME_ID: clockid_t = 15;
 
-pub const LOG_NTP: ::c_int = 12 << 3;
-pub const LOG_SECURITY: ::c_int = 13 << 3;
-pub const LOG_CONSOLE: ::c_int = 14 << 3;
-
 extern {
     pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int)
                     -> ::c_int;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -665,6 +665,9 @@ pub const RTLD_NODELETE: ::c_int = 0x1000;
 pub const RTLD_NOLOAD: ::c_int = 0x2000;
 pub const RTLD_GLOBAL: ::c_int = 0x100;
 
+pub const LOG_NTP: ::c_int = 12 << 3;
+pub const LOG_SECURITY: ::c_int = 13 << 3;
+pub const LOG_CONSOLE: ::c_int = 14 << 3;
 pub const LOG_NFACILITIES: ::c_int = 24;
 
 #[link(name = "util")]

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -664,6 +664,8 @@ pub const RTLD_NODELETE: ::c_int = 0x1000;
 pub const RTLD_NOLOAD: ::c_int = 0x2000;
 pub const RTLD_GLOBAL: ::c_int = 0x100;
 
+pub const LOG_NFACILITIES: ::c_int = 24;
+
 #[link(name = "util")]
 extern {
     pub fn getnameinfo(sa: *const ::sockaddr,

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -293,6 +293,11 @@ pub const WNOHANG: ::c_int = 1;
 pub const RTLD_NOW: ::c_int = 0x2;
 pub const RTLD_DEFAULT: *mut ::c_void = -2isize as *mut ::c_void;
 
+pub const LOG_CRON: ::c_int = 9 << 3;
+pub const LOG_AUTHPRIV: ::c_int = 10 << 3;
+pub const LOG_FTP: ::c_int = 11 << 3;
+pub const LOG_PERROR: ::c_int = 0x20;
+
 f! {
     pub fn FD_CLR(fd: ::c_int, set: *mut fd_set) -> () {
         let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;

--- a/src/unix/bsd/openbsdlike/mod.rs
+++ b/src/unix/bsd/openbsdlike/mod.rs
@@ -445,6 +445,8 @@ pub const Q_SETQUOTA: ::c_int = 0x400;
 
 pub const RTLD_GLOBAL: ::c_int = 0x100;
 
+pub const LOG_NFACILITIES: ::c_int = 24;
+
 #[link(name = "util")]
 extern {
     pub fn mincore(addr: *mut ::c_void, len: ::size_t,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -109,6 +109,11 @@ s! {
         pub ws_xpixel: ::c_ushort,
         pub ws_ypixel: ::c_ushort,
     }
+
+    pub struct CODE {
+        pub c_name: *mut ::c_char,
+        pub c_val: *mut ::c_int,
+    }
 }
 
 pub const SIG_DFL: sighandler_t = 0 as sighandler_t;
@@ -144,6 +149,47 @@ pub const POLLNVAL: ::c_short = 0x20;
 pub const IF_NAMESIZE: ::size_t = 16;
 
 pub const RTLD_LAZY: ::c_int = 0x1;
+
+pub const LOG_EMERG: ::c_int = 0;
+pub const LOG_ALERT: ::c_int = 1;
+pub const LOG_CRIT: ::c_int = 2;
+pub const LOG_ERR: ::c_int = 3;
+pub const LOG_WARNING: ::c_int = 4;
+pub const LOG_NOTICE: ::c_int = 5;
+pub const LOG_INFO: ::c_int = 6;
+pub const LOG_DEBUG: ::c_int = 7;
+
+pub const LOG_KERN: ::c_int = 0;
+pub const LOG_USER: ::c_int = 1 << 3;
+pub const LOG_MAIL: ::c_int = 2 << 3;
+pub const LOG_DAEMON: ::c_int = 3 << 3;
+pub const LOG_AUTH: ::c_int = 4 << 3;
+pub const LOG_SYSLOG: ::c_int = 5 << 3;
+pub const LOG_LPR: ::c_int = 6 << 3;
+pub const LOG_NEWS: ::c_int = 7 << 3;
+pub const LOG_UUCP: ::c_int = 8 << 3;
+pub const LOG_CRON: ::c_int = 9 << 3;
+pub const LOG_AUTHPRIV: ::c_int = 10 << 3;
+pub const LOG_FTP: ::c_int = 11 << 3;
+pub const LOG_LOCAL0: ::c_int = 16 << 3;
+pub const LOG_LOCAL1: ::c_int = 17 << 3;
+pub const LOG_LOCAL2: ::c_int = 18 << 3;
+pub const LOG_LOCAL3: ::c_int = 19 << 3;
+pub const LOG_LOCAL4: ::c_int = 20 << 3;
+pub const LOG_LOCAL5: ::c_int = 21 << 3;
+pub const LOG_LOCAL6: ::c_int = 22 << 3;
+pub const LOG_LOCAL7: ::c_int = 23 << 3;
+
+pub const LOG_PID: ::c_int = 0x01;
+pub const LOG_CONS: ::c_int = 0x02;
+pub const LOG_ODELAY: ::c_int = 0x04;
+pub const LOG_NDELAY: ::c_int = 0x08;
+pub const LOG_NOWAIT: ::c_int = 0x10;
+pub const LOG_PERROR: ::c_int = 0x20;
+
+pub const LOG_PRIMASK: ::c_int = 7;
+pub const LOG_NFACILITIES: ::c_int = 24;
+pub const LOG_FACMASK: ::c_int = 0x3f8;
 
 cfg_if! {
     if #[cfg(dox)] {
@@ -732,6 +778,11 @@ extern {
     pub fn mkdtemp(template: *mut ::c_char) -> *mut ::c_char;
     pub fn futimes(fd: ::c_int, times: *const ::timeval) -> ::c_int;
     pub fn nl_langinfo(item: ::nl_item) -> *mut ::c_char;
+
+    pub fn openlog(ident: *const ::c_char, logopt: ::c_int, facility: ::c_int);
+    pub fn closelog();
+    pub fn setlogmask(maskpri: ::c_int) -> ::c_int;
+    pub fn syslog(priority: ::c_int, message: *const ::c_char, ...);
 }
 
 cfg_if! {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -109,11 +109,6 @@ s! {
         pub ws_xpixel: ::c_ushort,
         pub ws_ypixel: ::c_ushort,
     }
-
-    pub struct CODE {
-        pub c_name: *mut ::c_char,
-        pub c_val: *mut ::c_int,
-    }
 }
 
 pub const SIG_DFL: sighandler_t = 0 as sighandler_t;
@@ -168,9 +163,6 @@ pub const LOG_SYSLOG: ::c_int = 5 << 3;
 pub const LOG_LPR: ::c_int = 6 << 3;
 pub const LOG_NEWS: ::c_int = 7 << 3;
 pub const LOG_UUCP: ::c_int = 8 << 3;
-pub const LOG_CRON: ::c_int = 9 << 3;
-pub const LOG_AUTHPRIV: ::c_int = 10 << 3;
-pub const LOG_FTP: ::c_int = 11 << 3;
 pub const LOG_LOCAL0: ::c_int = 16 << 3;
 pub const LOG_LOCAL1: ::c_int = 17 << 3;
 pub const LOG_LOCAL2: ::c_int = 18 << 3;
@@ -185,10 +177,8 @@ pub const LOG_CONS: ::c_int = 0x02;
 pub const LOG_ODELAY: ::c_int = 0x04;
 pub const LOG_NDELAY: ::c_int = 0x08;
 pub const LOG_NOWAIT: ::c_int = 0x10;
-pub const LOG_PERROR: ::c_int = 0x20;
 
 pub const LOG_PRIMASK: ::c_int = 7;
-pub const LOG_NFACILITIES: ::c_int = 24;
 pub const LOG_FACMASK: ::c_int = 0x3f8;
 
 cfg_if! {

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -446,6 +446,8 @@ pub const NCCS: usize = 32;
 
 pub const AF_NETLINK: ::c_int = 16;
 
+pub const LOG_NFACILITIES: ::c_int = 24;
+
 f! {
     pub fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {
         for slot in cpuset.bits.iter_mut() {

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -648,7 +648,6 @@ pub const AT_SYMLINK_NOFOLLOW: ::c_int = 0x100;
 pub const LOG_CRON: ::c_int = 9 << 3;
 pub const LOG_AUTHPRIV: ::c_int = 10 << 3;
 pub const LOG_FTP: ::c_int = 11 << 3;
-pub const LOG_NFACILITIES: ::c_int = 24;
 pub const LOG_PERROR: ::c_int = 0x20;
 
 f! {

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -645,6 +645,12 @@ pub const POSIX_FADV_NOREUSE: ::c_int = 5;
 pub const AT_FDCWD: ::c_int = -100;
 pub const AT_SYMLINK_NOFOLLOW: ::c_int = 0x100;
 
+pub const LOG_CRON: ::c_int = 9 << 3;
+pub const LOG_AUTHPRIV: ::c_int = 10 << 3;
+pub const LOG_FTP: ::c_int = 11 << 3;
+pub const LOG_NFACILITIES: ::c_int = 24;
+pub const LOG_PERROR: ::c_int = 0x20;
+
 f! {
     pub fn FD_CLR(fd: ::c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -806,6 +806,8 @@ pub const _RWL_MAGIC: u16 = 0x5257;   // RW
 
 pub const NCCS: usize = 19;
 
+pub const LOG_CRON: ::c_int = 15 << 3;
+
 pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
     __pthread_mutex_flag1: 0,
     __pthread_mutex_flag2: 0,


### PR DESCRIPTION
This commit adds the functions:-
- syslog
- openlog
- closelog
- setlogmask

It adds LOG_* constants.

It adds the `CODE` struct used by the `#define` definitions `prioritynames` and `facilitynames`.

It does not add:-
- the function `vsyslog`; this is an extension to POSIX and uses va_list macros;
- the `#define`s `prioritynames` and `facilitynames`, as usage is not common
- rust functions mirroring the macros:-
  - LOG_PRI
  - LOG_MAKEPRI
  - LOG_MASK
  - LOG_UPTO
  - LOG_FAC
* `CODE` is included in case a third-party unsafe C function returns or takes it.