### PR TITLE
Getprogname

### DIFF
--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -358,6 +358,8 @@ extern {
                       buf: *mut ::c_char,
                       buflen: ::size_t,
                       result: *mut *mut passwd) -> ::c_int;
+    pub fn getprogname() -> *const ::c_char;
+    pub fn setprogname(name: *const ::c_char);
 }
 
 cfg_if! {

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -626,6 +626,10 @@ f! {
 }
 
 extern {
+    static mut __progname: *mut ::c_char;
+}
+
+extern {
     pub fn madvise(addr: *const ::c_void, len: ::size_t, advice: ::c_int)
                    -> ::c_int;
     pub fn ioctl(fd: ::c_int, request: ::c_int, ...) -> ::c_int;

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -474,6 +474,10 @@ f! {
     }
 }
 
+extern {
+    static mut program_invocation_short_name: *mut ::c_char;
+}
+
 #[link(name = "util")]
 extern {
     pub fn shm_open(name: *const c_char, oflag: ::c_int,

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -901,5 +901,7 @@ extern {
                      locale: *const ::c_char,
                      base: ::locale_t) -> ::locale_t;
     pub fn uselocale(loc: ::locale_t) -> ::locale_t;
+    pub fn getprogname() -> *const ::c_char;
+    pub fn setprogname(name: *const ::c_char);
 }
 


### PR DESCRIPTION
Added `getprogname()` and `setprogname()` for all BSDs and Solaris (including Mac OS X).

Added `program_invocation_short_name` global, for Linux (glibc and Musl) which is effectively the same thing, and is what compatibility libraries like `libbsd` use to implement `getprogname()`.

Added `__progname` global for Android, which, whilst not quite the same as `getprogname` or `program_invocation_short_name`, is better than using argv[0], as it (a) avoids a common bug with no arguments (b) avoids a common bug with a NULL string in argv[0] and (c) incorporates Android's chosen name for an unknown process.