### PR TITLE
Add the TIOCGWINSZ and TIOCSWINSZ constants

### DIFF
--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -668,6 +668,9 @@ pub const LOG_SECURITY: ::c_int = 13 << 3;
 pub const LOG_CONSOLE: ::c_int = 14 << 3;
 pub const LOG_NFACILITIES: ::c_int = 24;
 
+pub const TIOCGWINSZ: ::c_ulong = 0x40087468;
+pub const TIOCSWINSZ: ::c_ulong = 0x80087467;
+
 #[link(name = "util")]
 extern {
     pub fn getnameinfo(sa: *const ::sockaddr,


### PR DESCRIPTION
I've added the `TIOCGWINSZ` and `TIOCSWINSZ` constants/ioctl control codes. I wasn't quite sure where to put them, so hopefully they're in the right place.

As of now it's set to compile on 'FreeBSD-like' platforms, so it will compile on both FreeBSD *and* DragonflyBSD. I've only tested it on FreeBSD though, but it should also work on DragonflyBSD AFAIK.

Fixes #292.