### PR TITLE
Mac OS X specific pthread and Mach thread functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
 os:
   - linux
   - osx
+osx_image: xcode6.4
 env:
   matrix:
     - ARCH=x86_64

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -125,6 +125,9 @@ fn main() {
     if apple {
         cfg.header("mach-o/dyld.h");
         cfg.header("mach/mach_time.h");
+        cfg.header("mach/thread_policy.h");
+        cfg.header("mach/thread_act.h");
+        cfg.header("mach/task_info.h");
         cfg.header("malloc/malloc.h");
         cfg.header("util.h");
         if target.starts_with("x86") {

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -288,6 +288,9 @@ fn main() {
             // uuid_t is a struct, not an integer.
             "uuid_t" if dragonfly => true,
             n if n.starts_with("pthread") => true,
+			
+			// Mac OS X
+			n if n.starts_with("thread_") => true,
 
             // windows-isms
             n if n.starts_with("P") => true,

--- a/src/unix/bsd/apple/b32.rs
+++ b/src/unix/bsd/apple/b32.rs
@@ -2,6 +2,7 @@
 
 pub type c_long = i32;
 pub type c_ulong = u32;
+pub type boolean_t = ::c_int;
 
 s! {
     pub struct pthread_attr_t {

--- a/src/unix/bsd/apple/b64.rs
+++ b/src/unix/bsd/apple/b64.rs
@@ -2,6 +2,7 @@
 
 pub type c_long = i64;
 pub type c_ulong = u64;
+pub type boolean_t = ::c_uint;
 
 s! {
     pub struct pthread_attr_t {

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -29,25 +29,28 @@ pub type kern_return_t = ::c_int;
 pub type thread_latency_qos_t = ::integer_t;
 pub type thread_throughput_qos_t = ::integer_t;
 // libc-test does not like structs
-//pub type thread_policy_t = *mut integer_t;
-//pub type thread_standard_policy_data_t = thread_standard_policy;
-//pub type thread_extended_policy_data_t = thread_extended_policy;
-//pub type thread_time_constraint_policy_data_t = thread_time_constraint_policy;
-//pub type thread_precedence_policy_data_t = thread_precedence_policy;
-//pub type thread_affinity_policy_data_t = thread_affinity_policy;
-//pub type thread_background_policy_data_t = thread_background_policy;
-//pub type thread_latency_qos_policy_data_t = thread_latency_qos_policy;
-//pub type thread_throughput_qos_policy_data_t = thread_throughput_qos_policy;
+// pub type thread_standard_policy_data_t = thread_standard_policy;
+// pub type thread_extended_policy_data_t = thread_extended_policy;
+// pub type thread_time_constraint_policy_data_t =
+// thread_time_constraint_policy;
+// pub type thread_precedence_policy_data_t = thread_precedence_policy;
+// pub type thread_affinity_policy_data_t = thread_affinity_policy;
+// pub type thread_background_policy_data_t = thread_background_policy;
+// pub type thread_latency_qos_policy_data_t = thread_latency_qos_policy;
+// pub type thread_throughput_qos_policy_data_t = thread_throughput_qos_policy;
 // libc-test does not like mutable pointers
-//pub type thread_standard_policy_t = * mut thread_standard_policy_data_t;
-//pub type thread_extended_policy_t = * mut thread_extended_policy_data_t;
-//pub type thread_time_constraint_policy_t =
-//* mut thread_time_constraint_policy_data_t;
-//pub type thread_precedence_policy_t = * mut thread_precedence_policy_data_t;
-//pub type thread_affinity_policy_t = * mut thread_affinity_policy_data_t;
-//pub type thread_background_policy_t = * mut thread_background_policy_data_t;
-//pub type thread_latency_qos_policy_t = * mut thread_latency_qos_policy_data_t;
-//pub type thread_throughput_qos_policy_t = * mut thread_throughput_qos_policy_data_t;
+// pub type thread_policy_t = *mut integer_t;
+// pub type thread_standard_policy_t = * mut thread_standard_policy_data_t;
+// pub type thread_extended_policy_t = * mut thread_extended_policy_data_t;
+// pub type thread_time_constraint_policy_t =
+// * mut thread_time_constraint_policy_data_t;
+// pub type thread_precedence_policy_t = * mut thread_precedence_policy_data_t;
+// pub type thread_affinity_policy_t = * mut thread_affinity_policy_data_t;
+// pub type thread_background_policy_t =* mut thread_background_policy_data_t;
+// pub type thread_latency_qos_policy_t =
+// * mut thread_latency_qos_policy_data_t;
+// pub type thread_throughput_qos_policy_t =
+// * mut thread_throughput_qos_policy_data_t;
 
 pub enum timezone {}
 

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -19,6 +19,35 @@ pub type fsfilcnt_t = ::c_uint;
 pub type speed_t = ::c_ulong;
 pub type tcflag_t = ::c_ulong;
 pub type nl_item = ::c_int;
+pub type natural_t = ::c_uint;
+pub type integer_t = ::c_int;
+pub type mach_port_t = ::natural_t;
+pub type thread_t = ::mach_port_t;
+pub type mach_msg_type_number_t = ::natural_t;
+pub type thread_policy_flavor_t = ::natural_t;
+pub type kern_return_t = ::c_int;
+pub type thread_latency_qos_t = ::integer_t;
+pub type thread_throughput_qos_t = ::integer_t;
+// libc-test does not like structs
+//pub type thread_policy_t = *mut integer_t;
+//pub type thread_standard_policy_data_t = thread_standard_policy;
+//pub type thread_extended_policy_data_t = thread_extended_policy;
+//pub type thread_time_constraint_policy_data_t = thread_time_constraint_policy;
+//pub type thread_precedence_policy_data_t = thread_precedence_policy;
+//pub type thread_affinity_policy_data_t = thread_affinity_policy;
+//pub type thread_background_policy_data_t = thread_background_policy;
+//pub type thread_latency_qos_policy_data_t = thread_latency_qos_policy;
+//pub type thread_throughput_qos_policy_data_t = thread_throughput_qos_policy;
+// libc-test does not like mutable pointers
+//pub type thread_standard_policy_t = * mut thread_standard_policy_data_t;
+//pub type thread_extended_policy_t = * mut thread_extended_policy_data_t;
+//pub type thread_time_constraint_policy_t =
+//* mut thread_time_constraint_policy_data_t;
+//pub type thread_precedence_policy_t = * mut thread_precedence_policy_data_t;
+//pub type thread_affinity_policy_t = * mut thread_affinity_policy_data_t;
+//pub type thread_background_policy_t = * mut thread_background_policy_data_t;
+//pub type thread_latency_qos_policy_t = * mut thread_latency_qos_policy_data_t;
+//pub type thread_throughput_qos_policy_t = * mut thread_throughput_qos_policy_data_t;
 
 pub enum timezone {}
 
@@ -284,6 +313,41 @@ s! {
         pub int_n_sep_by_space: ::c_char,
         pub int_p_sign_posn: ::c_char,
         pub int_n_sign_posn: ::c_char,
+    }
+
+    pub struct thread_standard_policy {
+        pub no_data: ::natural_t,
+    }
+
+    pub struct thread_extended_policy {
+        pub timeshare: ::boolean_t,
+    }
+
+    pub struct thread_time_constraint_policy {
+        pub period: ::uint32_t,
+        pub computation: ::uint32_t,
+        pub constraint: ::uint32_t,
+        pub preemptible: ::boolean_t,
+    }
+
+    pub struct thread_precedence_policy {
+        pub importance: ::integer_t,
+    }
+
+    pub struct thread_affinity_policy {
+        pub affinity_tag: integer_t,
+    }
+
+    pub struct thread_background_policy {
+        pub priority: integer_t,
+    }
+
+    pub struct thread_latency_qos_policy {
+        pub thread_latency_qos_tier: thread_latency_qos_t,
+    }
+
+    pub struct thread_throughput_qos_policy {
+        pub thread_throughput_qos_tier: thread_throughput_qos_t,
     }
 }
 
@@ -1238,6 +1302,30 @@ pub const CTL_DEBUG_NAME: ::c_int = 0;
 pub const CTL_DEBUG_VALUE: ::c_int = 1;
 pub const CTL_DEBUG_MAXID: ::c_int = 20;
 
+pub const SCHED_OTHER: ::c_int = 1;
+pub const SCHED_FIFO: ::c_int = 4;
+pub const SCHED_RR: ::c_int = 2;
+
+pub const THREAD_STANDARD_POLICY: ::thread_policy_flavor_t = 1;
+pub const THREAD_EXTENDED_POLICY: ::thread_policy_flavor_t = 1;
+pub const THREAD_TIME_CONSTRAINT_POLICY: ::thread_policy_flavor_t = 2;
+pub const THREAD_PRECEDENCE_POLICY: ::thread_policy_flavor_t = 3;
+pub const THREAD_AFFINITY_POLICY: ::thread_policy_flavor_t = 4;
+pub const THREAD_BACKGROUND_POLICY: ::thread_policy_flavor_t = 5;
+pub const THREAD_LATENCY_QOS_POLICY: ::thread_policy_flavor_t = 7;
+pub const THREAD_THROUGHPUT_QOS_POLICY: ::thread_policy_flavor_t = 8;
+
+pub const THREAD_STANDARD_POLICY_COUNT: ::mach_msg_type_number_t = 0;
+pub const THREAD_EXTENDED_POLICY_COUNT: ::mach_msg_type_number_t = 1;
+pub const THREAD_TIME_CONSTRAINT_POLICY_COUNT: ::mach_msg_type_number_t = 4;
+pub const THREAD_PRECEDENCE_POLICY_COUNT: ::mach_msg_type_number_t = 1;
+pub const THREAD_AFFINITY_POLICY_COUNT: ::mach_msg_type_number_t = 1;
+pub const THREAD_LATENCY_QOS_POLICY_COUNT: ::mach_msg_type_number_t = 1;
+pub const THREAD_BACKGROUND_POLICY_COUNT: ::mach_msg_type_number_t = 1;
+pub const THREAD_THROUGHPUT_QOS_POLICY_COUNT: ::mach_msg_type_number_t = 1;
+
+pub const THREAD_AFFINITY_TAG_NULL: ::integer_t = 0;
+
 f! {
     pub fn WSTOPSIG(status: ::c_int) -> ::c_int {
         status >> 8
@@ -1353,6 +1441,25 @@ extern {
                      base: ::locale_t) -> ::locale_t;
     pub fn uselocale(loc: ::locale_t) -> ::locale_t;
     pub fn querylocale(mask: ::c_int, loc: ::locale_t) -> *const ::c_char;
+    pub fn pthread_is_threaded_np() -> ::c_int;
+    pub fn pthread_threadid_np(thread: ::pthread_t,
+                     thread_id: *mut ::uint64_t) -> ::c_int;
+    pub fn pthread_getname_np(thread: ::pthread_t, name: *mut ::c_char,
+                     size: ::size_t) -> ::c_int;
+    pub fn pthread_main_np() -> ::c_int;
+    pub fn pthread_mach_thread_np(pthread: ::pthread_t) -> ::mach_port_t;
+    pub fn pthread_from_mach_thread_np(mach_thread: ::mach_port_t)
+                     -> ::pthread_t;
+    pub fn pthread_yield_np() -> ::c_void;
+    pub fn thread_policy_set(thread: ::thread_t,
+                     flavor: ::thread_policy_flavor_t,
+                     policy_info: *mut integer_t /*thread_policy_t*/,
+                     count: ::mach_msg_type_number_t) -> ::kern_return_t;
+    pub fn thread_policy_get(thread: ::thread_t,
+                     flavor: ::thread_policy_flavor_t,
+                     policy_info: *mut integer_t /*thread_policy_t*/,
+                     count: *mut ::mach_msg_type_number_t,
+                     get_default: *mut ::boolean_t) -> ::kern_return_t;
 }
 
 cfg_if! {

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -29,29 +29,27 @@ pub type thread_policy_flavor_t = ::natural_t;
 pub type kern_return_t = ::c_int;
 pub type thread_latency_qos_t = ::integer_t;
 pub type thread_throughput_qos_t = ::integer_t;
-// libc-test does not like structs
-// pub type thread_standard_policy_data_t = thread_standard_policy;
-// pub type thread_extended_policy_data_t = thread_extended_policy;
-// pub type thread_time_constraint_policy_data_t =
-// thread_time_constraint_policy;
-// pub type thread_precedence_policy_data_t = thread_precedence_policy;
-// pub type thread_affinity_policy_data_t = thread_affinity_policy;
-// pub type thread_background_policy_data_t = thread_background_policy;
-// pub type thread_latency_qos_policy_data_t = thread_latency_qos_policy;
-// pub type thread_throughput_qos_policy_data_t = thread_throughput_qos_policy;
-// libc-test does not like mutable pointers
-// pub type thread_policy_t = *mut integer_t;
-// pub type thread_standard_policy_t = * mut thread_standard_policy_data_t;
-// pub type thread_extended_policy_t = * mut thread_extended_policy_data_t;
-// pub type thread_time_constraint_policy_t =
-// * mut thread_time_constraint_policy_data_t;
-// pub type thread_precedence_policy_t = * mut thread_precedence_policy_data_t;
-// pub type thread_affinity_policy_t = * mut thread_affinity_policy_data_t;
-// pub type thread_background_policy_t =* mut thread_background_policy_data_t;
-// pub type thread_latency_qos_policy_t =
-// * mut thread_latency_qos_policy_data_t;
-// pub type thread_throughput_qos_policy_t =
-// * mut thread_throughput_qos_policy_data_t;
+pub type thread_standard_policy_data_t = thread_standard_policy;
+pub type thread_extended_policy_data_t = thread_extended_policy;
+pub type thread_time_constraint_policy_data_t =
+thread_time_constraint_policy;
+pub type thread_precedence_policy_data_t = thread_precedence_policy;
+pub type thread_affinity_policy_data_t = thread_affinity_policy;
+pub type thread_background_policy_data_t = thread_background_policy;
+pub type thread_latency_qos_policy_data_t = thread_latency_qos_policy;
+pub type thread_throughput_qos_policy_data_t = thread_throughput_qos_policy;
+pub type thread_policy_t = *mut integer_t;
+pub type thread_standard_policy_t = * mut thread_standard_policy_data_t;
+pub type thread_extended_policy_t = * mut thread_extended_policy_data_t;
+pub type thread_time_constraint_policy_t =
+* mut thread_time_constraint_policy_data_t;
+pub type thread_precedence_policy_t = * mut thread_precedence_policy_data_t;
+pub type thread_affinity_policy_t = * mut thread_affinity_policy_data_t;
+pub type thread_background_policy_t = * mut thread_background_policy_data_t;
+pub type thread_latency_qos_policy_t =
+* mut thread_latency_qos_policy_data_t;
+pub type thread_throughput_qos_policy_t =
+* mut thread_throughput_qos_policy_data_t;
 
 pub enum timezone {}
 
@@ -1465,13 +1463,15 @@ extern {
     pub fn pthread_from_mach_thread_np(mach_thread: ::mach_port_t)
                      -> ::pthread_t;
     pub fn pthread_yield_np() -> ::c_void;
+    pub fn pthread_cond_signal_thread_np(cond: * mut pthread_cond_t,
+                     pthread: ::pthread_t) -> ::c_int;
     pub fn thread_policy_set(thread: ::thread_t,
                      flavor: ::thread_policy_flavor_t,
-                     policy_info: *mut integer_t /*thread_policy_t*/,
+                     policy_info: thread_policy_t,
                      count: ::mach_msg_type_number_t) -> ::kern_return_t;
     pub fn thread_policy_get(thread: ::thread_t,
                      flavor: ::thread_policy_flavor_t,
-                     policy_info: *mut integer_t /*thread_policy_t*/,
+                     policy_info: thread_policy_t,
                      count: *mut ::mach_msg_type_number_t,
                      get_default: *mut ::boolean_t) -> ::kern_return_t;
 }

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1309,8 +1309,11 @@ pub const USER_MAXID: ::c_int = 21;
 pub const CTL_DEBUG_NAME: ::c_int = 0;
 pub const CTL_DEBUG_VALUE: ::c_int = 1;
 pub const CTL_DEBUG_MAXID: ::c_int = 20;
+pub const PRIO_DARWIN_THREAD: ::c_int = 3;
+pub const PRIO_DARWIN_PROCESS: ::c_int = 4;
+pub const PRIO_DARWIN_BG: ::c_int = 0x1000;
+pub const PRIO_DARWIN_NONUI: ::c_int = 0x1001;
 
-<<<<<<< HEAD
 pub const SCHED_OTHER: ::c_int = 1;
 pub const SCHED_FIFO: ::c_int = 4;
 pub const SCHED_RR: ::c_int = 2;
@@ -1334,12 +1337,6 @@ pub const THREAD_BACKGROUND_POLICY_COUNT: ::mach_msg_type_number_t = 1;
 pub const THREAD_THROUGHPUT_QOS_POLICY_COUNT: ::mach_msg_type_number_t = 1;
 
 pub const THREAD_AFFINITY_TAG_NULL: ::integer_t = 0;
-=======
-pub const PRIO_DARWIN_THREAD: ::c_int = 3;
-pub const PRIO_DARWIN_PROCESS: ::c_int = 4;
-pub const PRIO_DARWIN_BG: ::c_int = 0x1000;
-pub const PRIO_DARWIN_NONUI: ::c_int = 0x1001;
->>>>>>> upstream/master
 
 f! {
     pub fn WSTOPSIG(status: ::c_int) -> ::c_int {
@@ -1456,7 +1453,8 @@ extern {
                      base: ::locale_t) -> ::locale_t;
     pub fn uselocale(loc: ::locale_t) -> ::locale_t;
     pub fn querylocale(mask: ::c_int, loc: ::locale_t) -> *const ::c_char;
-<<<<<<< HEAD
+    pub fn getpriority(which: ::c_int, who: ::id_t) -> ::c_int;
+    pub fn setpriority(which: ::c_int, who: ::id_t, prio: ::c_int) -> ::c_int;
     pub fn pthread_is_threaded_np() -> ::c_int;
     pub fn pthread_threadid_np(thread: ::pthread_t,
                      thread_id: *mut ::uint64_t) -> ::c_int;
@@ -1476,10 +1474,6 @@ extern {
                      policy_info: *mut integer_t /*thread_policy_t*/,
                      count: *mut ::mach_msg_type_number_t,
                      get_default: *mut ::boolean_t) -> ::kern_return_t;
-=======
-    pub fn getpriority(which: ::c_int, who: ::id_t) -> ::c_int;
-    pub fn setpriority(which: ::c_int, who: ::id_t, prio: ::c_int) -> ::c_int;
->>>>>>> upstream/master
 }
 
 cfg_if! {


### PR DESCRIPTION
Also includes `SCHED_*` definitions. Tested locally.

The commented pub type definitions are because these cause breakage of the libc tests - I suspect it's in the test logic, but I'm not able to deduce how this code works.