### PR TITLE
Fix semaphores on Solaris/Illumos

### DIFF
--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -300,6 +300,14 @@ s! {
         pub int_p_sign_posn: ::c_char,
         pub int_n_sign_posn: ::c_char,
     }
+
+    pub struct sem_t {
+        pub sem_count: u32,
+        pub sem_type: u16,
+        pub sem_magic: u16,
+        pub sem_pad1: [u64; 3],
+        pub sem_pad2: [u64; 2]
+    }
 }
 
 pub const LC_CTYPE: ::c_int = 0;


### PR DESCRIPTION
This adds `sem_t` structure introduced in https://github.com/rust-lang/libc/pull/309 and fixes compilation on Solaris.