### PR TITLE
enhance pathconf constants to cover the most common constants

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -386,8 +386,15 @@ pub const FOPEN_MAX: ::c_uint = 20;
 pub const FILENAME_MAX: ::c_uint = 1024;
 pub const L_tmpnam: ::c_uint = 1024;
 pub const TMP_MAX: ::c_uint = 308915776;
+pub const _PC_LINK_MAX: ::c_int = 1;
+pub const _PC_MAX_CANON: ::c_int = 2;
+pub const _PC_MAX_INPUT: ::c_int = 3;
 pub const _PC_NAME_MAX: ::c_int = 4;
-
+pub const _PC_PATH_MAX: ::c_int = 5;
+pub const _PC_PIPE_BUF: ::c_int = 6;
+pub const _PC_CHOWN_RESTRICTED: ::c_int = 7;
+pub const _PC_NO_TRUNC: ::c_int = 8;
+pub const _PC_VDISABLE: ::c_int = 9;
 pub const O_RDONLY: ::c_int = 0;
 pub const O_WRONLY: ::c_int = 1;
 pub const O_RDWR: ::c_int = 2;

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -106,7 +106,15 @@ pub const FILENAME_MAX: ::c_uint = 1024;
 pub const FOPEN_MAX: ::c_uint = 20;
 pub const L_tmpnam: ::c_uint = 1024;
 pub const TMP_MAX: ::c_uint = 308915776;
+pub const _PC_LINK_MAX: ::c_int = 1;
+pub const _PC_MAX_CANON: ::c_int = 2;
+pub const _PC_MAX_INPUT: ::c_int = 3;
 pub const _PC_NAME_MAX: ::c_int = 4;
+pub const _PC_PATH_MAX: ::c_int = 5;
+pub const _PC_PIPE_BUF: ::c_int = 6;
+pub const _PC_CHOWN_RESTRICTED: ::c_int = 14;
+pub const _PC_NO_TRUNC: ::c_int = 15;
+pub const _PC_VDISABLE: ::c_int = 16;
 
 pub const FIONBIO: ::c_int = 0x5421;
 

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -253,7 +253,15 @@ pub const NOSTR: ::nl_item = 0x50003;
 
 pub const FILENAME_MAX: ::c_uint = 4096;
 pub const L_tmpnam: ::c_uint = 20;
+pub const _PC_LINK_MAX: ::c_int = 0;
+pub const _PC_MAX_CANON: ::c_int = 1;
+pub const _PC_MAX_INPUT: ::c_int = 2;
 pub const _PC_NAME_MAX: ::c_int = 3;
+pub const _PC_PATH_MAX: ::c_int = 4;
+pub const _PC_PIPE_BUF: ::c_int = 5;
+pub const _PC_CHOWN_RESTRICTED: ::c_int = 6;
+pub const _PC_NO_TRUNC: ::c_int = 7;
+pub const _PC_VDISABLE: ::c_int = 8;
 
 pub const _SC_ARG_MAX: ::c_int = 0;
 pub const _SC_CHILD_MAX: ::c_int = 1;


### PR DESCRIPTION
I ran into this issue because I wanted to find out `PATH_MAX` for my OS X, but `_PC_PATH_MAX` was undefined, the only constant available was `_PC_NAME_MAX`. So I enhanced all the platforms for whom `_PC_NAME_MAX` was defined (which was Linux, Apple and Android).

the values taken from:

linux: /usr/include/bits/confname.h (taken from redhat, checked against https://github.com/cpc26/abi_linux/blob/master/linux-abi/branches/IBCS3/cxenix/pathconf.c)
android: https://android.googlesource.com/platform/development/+/android-4.3_r1.1/ndk/platforms/android-3/include/pathconf.h
mac: taken from /usr/include/sys/unistd.h

This is my first PR to a public repo, so if I missed something obvious please tell me.