### PR TITLE
added documentation for getcwd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,7 @@ extern {
                    mode: c_int,
                    size: size_t) -> c_int;
     pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
+    pub fn getchar() -> c_int;
     pub fn fgetc(stream: *mut FILE) -> c_int;
     pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
     pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,6 @@ extern {
                    mode: c_int,
                    size: size_t) -> c_int;
     pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
-    pub fn getchar() -> c_int;
     pub fn fgetc(stream: *mut FILE) -> c_int;
     pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
     pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -355,12 +355,12 @@ extern {
     pub fn fpathconf(filedes: ::c_int, name: ::c_int) -> c_long;
 
     /// Retrieves current working directory
-    /// 
+    ///
     /// The result is saved it in `buf`, `size` denotes the buffer size.
     ///
     /// The buffer must be large enough to store the absolute pathname plus
     /// a terminating null byte, or else null is returned.
-    /// To safely handle this either find out PATH_MAX via 
+    /// To safely handle this either find out PATH_MAX via
     /// `libc::pathconf(a_file, libc::_PC_PATH_MAX)` or start with a reasonably
     /// size (e.g. 512) and double the buffer size upon every error
     ///
@@ -369,7 +369,7 @@ extern {
     /// ```
     /// use std::io;
     /// use std::ffi::{CStr,CString};
-    /// 
+    ///
     /// fn main() {
     ///     let buf = unsafe {
     ///         let mut buf = Vec::with_capacity(512);
@@ -382,7 +382,7 @@ extern {
     ///         CString::new(buf)
     ///     };
     ///     let s = buf.expect("Not a C string").into_string().expect("Not UTF-8");
-    ///     println!("getcwd: {}", s);
+    ///     println!("path length: {}, max path: {}", s, path_max);
     /// }
     /// ```
     /// 

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -381,11 +381,11 @@ extern {
     ///         buf.set_len(len);
     ///         CString::new(buf)
     ///     };
-    ///     let s = buf.expect("Not a C string").into_string().expect("Not UTF-8");
-    ///     println!("path length: {}, max path: {}", s, path_max);
+    ///     let s = buf.expect("Not a C string").into_string();
+    ///     println!("getcwd: {}", s.expect("Not UTF-8"));
     /// }
     /// ```
-    /// 
+    ///
     pub fn getcwd(buf: *mut c_char, size: ::size_t) -> *mut c_char;
     pub fn getegid() -> gid_t;
     pub fn geteuid() -> uid_t;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -353,6 +353,39 @@ extern {
                   argv: *const *const c_char) -> ::c_int;
     pub fn fork() -> pid_t;
     pub fn fpathconf(filedes: ::c_int, name: ::c_int) -> c_long;
+
+    /// Retrieves current working directory
+    /// 
+    /// The result is saved it in `buf`, `size` denotes the buffer size.
+    ///
+    /// The buffer must be large enough to store the absolute pathname plus
+    /// a terminating null byte, or else null is returned.
+    /// To safely handle this either find out PATH_MAX via 
+    /// `libc::pathconf(a_file, libc::_PC_PATH_MAX)` or start with a reasonably
+    /// size (e.g. 512) and double the buffer size upon every error
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::io;
+    /// use std::ffi::{CStr,CString};
+    /// 
+    /// fn main() {
+    ///     let buf = unsafe {
+    ///         let mut buf = Vec::with_capacity(512);
+    ///         let ptr = buf.as_mut_ptr() as *mut libc::c_char;
+    ///         if libc::getcwd(ptr, buf.capacity()).is_null() {
+    ///             panic!(io::Error::last_os_error());
+    ///         }
+    ///         let len = CStr::from_ptr(ptr).to_bytes().len();
+    ///         buf.set_len(len);
+    ///         CString::new(buf)
+    ///     };
+    ///     let s = buf.expect("Not a C string").into_string().expect("Not UTF-8");
+    ///     println!("getcwd: {}", s);
+    /// }
+    /// ```
+    /// 
     pub fn getcwd(buf: *mut c_char, size: ::size_t) -> *mut c_char;
     pub fn getegid() -> gid_t;
     pub fn geteuid() -> uid_t;


### PR DESCRIPTION
I'm currently reading through [Advanced Programming in the UNIX Environment](https://www.amazon.com/dp/0321637739) which goes through most of the libc functions, explains them and does some example code. I'm trying to port the code into Rust.

I thought about adding my findings as documentation string into libc. Would that be a thing that would benefit this repo? I've added the documentation for `getcwd` in this PR, would that be good enough? I would add those documentation bits by bits. Is that ok or should I put as much documentation as possible in one huge PR?