### PR TITLE
Add SIGCHLD and other signals

### DIFF
--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -316,6 +316,7 @@ pub const SIGINT: ::c_int = 2;
 pub const SIGQUIT: ::c_int = 3;
 pub const SIGILL: ::c_int = 4;
 pub const SIGABRT: ::c_int = 6;
+pub const SIGEMT: ::c_int = 7;
 pub const SIGFPE: ::c_int = 8;
 pub const SIGKILL: ::c_int = 9;
 pub const SIGSEGV: ::c_int = 11;

--- a/src/unix/bsd/openbsdlike/mod.rs
+++ b/src/unix/bsd/openbsdlike/mod.rs
@@ -181,6 +181,7 @@ pub const SIGINT : ::c_int = 2;
 pub const SIGQUIT : ::c_int = 3;
 pub const SIGILL : ::c_int = 4;
 pub const SIGABRT : ::c_int = 6;
+pub const SIGEMT: ::c_int = 7;
 pub const SIGFPE : ::c_int = 8;
 pub const SIGKILL : ::c_int = 9;
 pub const SIGSEGV : ::c_int = 11;

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -506,6 +506,7 @@ pub const SIGINT: ::c_int = 2;
 pub const SIGQUIT: ::c_int = 3;
 pub const SIGILL: ::c_int = 4;
 pub const SIGABRT: ::c_int = 6;
+pub const SIGEMT: ::c_int = 7;
 pub const SIGFPE: ::c_int = 8;
 pub const SIGKILL: ::c_int = 9;
 pub const SIGSEGV: ::c_int = 11;


### PR DESCRIPTION
Add `SIGCHLD`, `SIGSTOP`, `SIGTSTP`, `SIGCONT`, `SIGTTIN`, `SIGTTOU`. Improve
consistency across oses, by adding `SIGEMT` to relevant oses.

Note: there are still many lesser known signals missing (`SIGXCPU`, `SIGPROF`, etc)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rust-lang/libc/330)
<!-- Reviewable:end -->
