### PR TITLE
Add support for pthread_condattr_t on Unix platforms.

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -22,9 +22,11 @@ fn main() {
     let bsdlike = freebsd || apple || netbsd || openbsd || dragonfly;
     let mut cfg = ctest::TestGenerator::new();
 
-    // Pull in extra goodies on linux/mingw
+    // Pull in extra goodies
     if linux || android {
         cfg.define("_GNU_SOURCE", None);
+    } else if netbsd {
+        cfg.define("_NETBSD_SOURCE", Some("1"));
     } else if windows {
         cfg.define("_WIN32_WINNT", Some("0x8000"));
     }

--- a/src/unix/bsd/apple/b32.rs
+++ b/src/unix/bsd/apple/b32.rs
@@ -12,6 +12,7 @@ s! {
 
 pub const __PTHREAD_MUTEX_SIZE__: usize = 40;
 pub const __PTHREAD_COND_SIZE__: usize = 24;
+pub const __PTHREAD_CONDATTR_SIZE__: usize = 4;
 pub const __PTHREAD_RWLOCK_SIZE__: usize = 124;
 
 pub const TIOCTIMESTAMP: ::c_ulong = 0x40087459;

--- a/src/unix/bsd/apple/b64.rs
+++ b/src/unix/bsd/apple/b64.rs
@@ -12,6 +12,7 @@ s! {
 
 pub const __PTHREAD_MUTEX_SIZE__: usize = 56;
 pub const __PTHREAD_COND_SIZE__: usize = 40;
+pub const __PTHREAD_CONDATTR_SIZE__: usize = 8;
 pub const __PTHREAD_RWLOCK_SIZE__: usize = 192;
 
 pub const TIOCTIMESTAMP: ::c_ulong = 0x40107459;

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -114,6 +114,11 @@ s! {
         __opaque: [u8; __PTHREAD_COND_SIZE__],
     }
 
+    pub struct pthread_condattr_t {
+        __sig: ::c_long,
+        __opaque: [u8; __PTHREAD_CONDATTR_SIZE__],
+    }
+
     pub struct pthread_rwlock_t {
         __sig: ::c_long,
         __opaque: [u8; __PTHREAD_RWLOCK_SIZE__],

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -5,6 +5,7 @@ pub type rlim_t = i64;
 pub type pthread_mutex_t = *mut ::c_void;
 pub type pthread_mutexattr_t = *mut ::c_void;
 pub type pthread_cond_t = *mut ::c_void;
+pub type pthread_condattr_t = *mut ::c_void;
 pub type pthread_rwlock_t = *mut ::c_void;
 pub type pthread_key_t = ::c_int;
 pub type tcflag_t = ::c_uint;
@@ -806,6 +807,10 @@ extern {
                    flags: ::c_int) -> ::c_int;
    pub fn mkfifoat(dirfd: ::c_int, pathname: *const ::c_char,
                    mode: ::mode_t) -> ::c_int;
+    pub fn pthread_condattr_getclock(attr: *const pthread_condattr_t,
+                                     clock_id: *mut clockid_t) -> ::c_int;
+    pub fn pthread_condattr_setclock(attr: *mut pthread_condattr_t,
+                                     clock_id: clockid_t) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/bsd/openbsdlike/bitrig.rs
+++ b/src/unix/bsd/openbsdlike/bitrig.rs
@@ -9,6 +9,7 @@ pub type pthread_attr_t = *mut ::c_void;
 pub type pthread_mutex_t = *mut ::c_void;
 pub type pthread_mutexattr_t = *mut ::c_void;
 pub type pthread_cond_t = *mut ::c_void;
+pub type pthread_condattr_t = *mut ::c_void;
 pub type pthread_rwlock_t = *mut ::c_void;
 
 s! {

--- a/src/unix/bsd/openbsdlike/mod.rs
+++ b/src/unix/bsd/openbsdlike/mod.rs
@@ -525,6 +525,8 @@ extern {
                    flags: ::c_int) -> ::c_int;
    pub fn mkfifoat(dirfd: ::c_int, pathname: *const ::c_char,
                    mode: ::mode_t) -> ::c_int;
+    pub fn pthread_condattr_setclock(attr: *mut pthread_condattr_t,
+                                     clock_id: clockid_t) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/bsd/openbsdlike/netbsd.rs
+++ b/src/unix/bsd/openbsdlike/netbsd.rs
@@ -152,6 +152,11 @@ s! {
         ptc_private: *mut ::c_void,
     }
 
+    pub struct pthread_condattr_t {
+        ptca_magic: ::c_uint,
+        ptca_private: *mut ::c_void,
+    }
+
     pub struct pthread_rwlock_t {
         ptr_magic: ::c_uint,
         ptr_interlock: ::c_uchar,

--- a/src/unix/bsd/openbsdlike/openbsd.rs
+++ b/src/unix/bsd/openbsdlike/openbsd.rs
@@ -9,6 +9,7 @@ pub type pthread_attr_t = *mut ::c_void;
 pub type pthread_mutex_t = *mut ::c_void;
 pub type pthread_mutexattr_t = *mut ::c_void;
 pub type pthread_cond_t = *mut ::c_void;
+pub type pthread_condattr_t = *mut ::c_void;
 pub type pthread_rwlock_t = *mut ::c_void;
 
 s! {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -539,6 +539,10 @@ extern {
                                      _type: ::c_int) -> ::c_int;
 
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
+               link_name = "pthread_cond_init$UNIX2003")]
+    pub fn pthread_cond_init(cond: *mut pthread_cond_t,
+                             attr: *const pthread_condattr_t) -> ::c_int;
+    #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "pthread_cond_wait$UNIX2003")]
     pub fn pthread_cond_wait(cond: *mut pthread_cond_t,
                              lock: *mut pthread_mutex_t) -> ::c_int;
@@ -550,6 +554,8 @@ extern {
     pub fn pthread_cond_signal(cond: *mut pthread_cond_t) -> ::c_int;
     pub fn pthread_cond_broadcast(cond: *mut pthread_cond_t) -> ::c_int;
     pub fn pthread_cond_destroy(cond: *mut pthread_cond_t) -> ::c_int;
+    pub fn pthread_condattr_init(attr: *mut pthread_condattr_t) -> ::c_int;
+    pub fn pthread_condattr_destroy(attr: *mut pthread_condattr_t) -> ::c_int;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "pthread_rwlock_destroy$UNIX2003")]
     pub fn pthread_rwlock_destroy(lock: *mut pthread_rwlock_t) -> ::c_int;

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -13,6 +13,7 @@ pub type useconds_t = u32;
 pub type socklen_t = i32;
 pub type pthread_t = ::c_long;
 pub type pthread_mutexattr_t = ::c_long;
+pub type pthread_condattr_t = ::c_long;
 pub type sigset_t = ::c_ulong;
 pub type time64_t = i64; // N/A on android
 pub type fsfilcnt_t = ::c_ulong;

--- a/src/unix/notbsd/linux/mips.rs
+++ b/src/unix/notbsd/linux/mips.rs
@@ -378,6 +378,7 @@ pub const SO_RCVTIMEO: ::c_int = 4102;
 pub const SO_SNDTIMEO: ::c_int = 4101;
 pub const SO_ACCEPTCONN: ::c_int = 4105;
 
+pub const __SIZEOF_PTHREAD_CONDATTR_T: usize = 4;
 pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 24;
 pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 32;
 pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -104,6 +104,11 @@ s! {
         size: [u8; __SIZEOF_PTHREAD_COND_T],
     }
 
+    pub struct pthread_condattr_t {
+        __align: [::c_int; 0],
+        size: [u8; __SIZEOF_PTHREAD_CONDATTR_T],
+    }
+
     pub struct passwd {
         pub pw_name: *mut ::c_char,
         pub pw_passwd: *mut ::c_char,

--- a/src/unix/notbsd/linux/musl/mod.rs
+++ b/src/unix/notbsd/linux/musl/mod.rs
@@ -107,6 +107,7 @@ pub const SIGUNUSED: ::c_int = ::SIGSYS;
 pub const FALLOC_FL_KEEP_SIZE: ::c_int = 0x01;
 pub const FALLOC_FL_PUNCH_HOLE: ::c_int = 0x02;
 
+pub const __SIZEOF_PTHREAD_CONDATTR_T: usize = 4;
 pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
 
 pub const CPU_SETSIZE: ::c_int = 128;

--- a/src/unix/notbsd/linux/other/b32/mod.rs
+++ b/src/unix/notbsd/linux/other/b32/mod.rs
@@ -85,6 +85,7 @@ s! {
     }
 }
 
+pub const __SIZEOF_PTHREAD_CONDATTR_T: usize = 4;
 pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 24;
 pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 32;
 pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;

--- a/src/unix/notbsd/linux/other/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/other/b64/aarch64.rs
@@ -55,6 +55,7 @@ s! {
     }
 }
 
+pub const __SIZEOF_PTHREAD_CONDATTR_T: usize = 8;
 pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 48;
 pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 8;
 

--- a/src/unix/notbsd/linux/other/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/other/b64/powerpc64.rs
@@ -53,6 +53,7 @@ s! {
     }
 }
 
+pub const __SIZEOF_PTHREAD_CONDATTR_T: usize = 4;
 pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
 pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
 

--- a/src/unix/notbsd/linux/other/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/other/b64/x86_64.rs
@@ -93,6 +93,7 @@ s! {
     }
 }
 
+pub const __SIZEOF_PTHREAD_CONDATTR_T: usize = 4;
 pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
 pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
 

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -860,6 +860,10 @@ extern {
                      linkpath: *const ::c_char) -> ::c_int;
     pub fn unlinkat(dirfd: ::c_int, pathname: *const ::c_char,
                     flags: ::c_int) -> ::c_int;
+    pub fn pthread_condattr_getclock(attr: *const pthread_condattr_t,
+                                     clock_id: *mut clockid_t) -> ::c_int;
+    pub fn pthread_condattr_setclock(attr: *mut pthread_condattr_t,
+                                     clock_id: clockid_t) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -143,6 +143,10 @@ s! {
         __pthread_cond_data: u64
     }
 
+    pub struct pthread_condattr_t {
+        __pthread_condattrp: *mut ::c_void,
+    }
+
     pub struct pthread_rwlock_t {
         __pthread_rwlock_readers: i32,
         __pthread_rwlock_type: u16,
@@ -1013,5 +1017,9 @@ extern {
     pub fn sethostname(name: *const ::c_char, len: ::size_t) -> ::c_int;
     pub fn if_nameindex() -> *mut if_nameindex;
     pub fn if_freenameindex(ptr: *mut if_nameindex);
+    pub fn pthread_condattr_getclock(attr: *const pthread_condattr_t,
+                                     clock_id: *mut clockid_t) -> ::c_int;
+    pub fn pthread_condattr_setclock(attr: *mut pthread_condattr_t,
+                                     clock_id: clockid_t) -> ::c_int;
 }
 


### PR DESCRIPTION
Following types and function have been added:
* pthread_cond_init
* pthread_condattr_t
* pthread_condattr_init
* pthread_condattr_destroy
* pthread_condattr_getclock [0]
* pthread_condattr_setclock [0]

[0] Not available on OSX.