### PR TITLE
arm-musl targets now use cfg(target_env = "musl")

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -55,9 +55,7 @@ s! {
         pub ru_nvcsw: c_long,
         pub ru_nivcsw: c_long,
 
-        #[cfg(any(target_env = "musl",
-                  target_env = "musleabi",
-                  target_env = "musleabihf"))]
+        #[cfg(any(target_env = "musl"))]
         __reserved: [c_long; 16],
     }
 
@@ -199,9 +197,7 @@ cfg_if! {
     } else if #[cfg(all(not(stdbuild), feature = "use_std"))] {
         // cargo build, don't pull in anything extra as the libstd  dep
         // already pulls in all libs.
-    } else if #[cfg(any(all(target_env = "musl", not(target_arch = "mips")),
-                        target_env = "musleabi",
-                        target_env = "musleabihf"))] {
+    } else if #[cfg(any(all(target_env = "musl", not(target_arch = "mips"))))] {
         #[link(name = "c", kind = "static")]
         extern {}
     } else if #[cfg(target_os = "emscripten")] {

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -93,13 +93,9 @@ s! {
     }
 
     pub struct pthread_cond_t {
-        #[cfg(any(target_env = "musl",
-                  target_env = "musleabi",
-                  target_env = "musleabihf"))]
+        #[cfg(any(target_env = "musl"))]
         __align: [*const ::c_void; 0],
-        #[cfg(not(any(target_env = "musl",
-                      target_env = "musleabi",
-                      target_env = "musleabihf")))]
+        #[cfg(not(any(target_env = "musl")))]
         __align: [::c_longlong; 0],
         size: [u8; __SIZEOF_PTHREAD_COND_T],
     }
@@ -663,8 +659,6 @@ extern {
 
 cfg_if! {
     if #[cfg(any(target_env = "musl",
-                 target_env = "musleabi",
-                 target_env = "musleabihf",
                  target_os = "emscripten"))] {
         mod musl;
         pub use self::musl::*;

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -100,21 +100,13 @@ s! {
 
     pub struct sched_param {
         pub sched_priority: ::c_int,
-        #[cfg(any(target_env = "musl",
-                  target_env = "musleabi",
-                  target_env = "musleabihf"))]
+        #[cfg(any(target_env = "musl"))]
         pub sched_ss_low_priority: ::c_int,
-        #[cfg(any(target_env = "musl",
-                  target_env = "musleabi",
-                  target_env = "musleabihf"))]
+        #[cfg(any(target_env = "musl"))]
         pub sched_ss_repl_period: ::timespec,
-        #[cfg(any(target_env = "musl",
-                  target_env = "musleabi",
-                  target_env = "musleabihf"))]
+        #[cfg(any(target_env = "musl"))]
         pub sched_ss_init_budget: ::timespec,
-        #[cfg(any(target_env = "musl",
-                  target_env = "musleabi",
-                  target_env = "musleabihf"))]
+        #[cfg(any(target_env = "musl"))]
         pub sched_ss_max_repl: ::c_int,
     }
 


### PR DESCRIPTION
As decided on rust-lang/rust#33244, the upcoming ARM musl targets will use musl (instead of musleabi/musleabihf) as their target_env.

r? @alexcrichton 
cc @timonvo 