### PR TITLE
Added Ptrace option parameters

### DIFF
--- a/src/unix/notbsd/linux/musl/mod.rs
+++ b/src/unix/notbsd/linux/musl/mod.rs
@@ -138,6 +138,20 @@ pub const PTRACE_INTERRUPT: ::c_int = 0x4207;
 pub const PTRACE_LISTEN: ::c_int = 0x4208;
 pub const PTRACE_PEEKSIGINFO: ::c_int = 0x4209;
 
+pub const PTRACE_PEEKSIGINFO: ::c_int = 0x4209;
+pub const PTRACE_PEEKSIGINFO: ::c_int = 0x4209;
+pub const PTRACE_PEEKSIGINFO: ::c_int = 0x4209;
+
+pub const PTRACE_O_EXITKILL: ::c_int = 1048576;
+pub const PTRACE_O_TRACECLONE: ::c_int = 8;
+pub const PTRACE_O_TRACEEXEC: ::c_int = 16;
+pub const PTRACE_O_TRACEEXIT: ::c_int = 64;
+pub const PTRACE_O_TRACEFORK: ::c_int = 2;
+pub const PTRACE_O_TRACESYSGOOD: ::c_int = 1;
+pub const PTRACE_O_TRACEVFORK: ::c_int = 4;
+pub const PTRACE_O_TRACEVFORKDONE: ::c_int = 32;
+pub const PTRACE_O_SUSPEND_SECCOMP: ::c_int = 2097152;
+
 pub const MADV_DODUMP: ::c_int = 17;
 pub const MADV_DONTDUMP: ::c_int = 16;
 

--- a/src/unix/notbsd/linux/musl/mod.rs
+++ b/src/unix/notbsd/linux/musl/mod.rs
@@ -138,10 +138,6 @@ pub const PTRACE_INTERRUPT: ::c_int = 0x4207;
 pub const PTRACE_LISTEN: ::c_int = 0x4208;
 pub const PTRACE_PEEKSIGINFO: ::c_int = 0x4209;
 
-pub const PTRACE_PEEKSIGINFO: ::c_int = 0x4209;
-pub const PTRACE_PEEKSIGINFO: ::c_int = 0x4209;
-pub const PTRACE_PEEKSIGINFO: ::c_int = 0x4209;
-
 pub const PTRACE_O_EXITKILL: ::c_int = 1048576;
 pub const PTRACE_O_TRACECLONE: ::c_int = 8;
 pub const PTRACE_O_TRACEEXEC: ::c_int = 16;


### PR DESCRIPTION
When the tracer process (often parent, but not necessarily) starts tracing it needs to pass the kernel options about what it is trying to accomplish. These constants were not defined in this document, so I'm attempting to add them.