### PR TITLE
Add clock_nanosleep for linux and solaris

### DIFF
--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -219,6 +219,7 @@ pub const CLOCK_BOOTTIME_ALARM: clockid_t = 9;
 // 2014.) See also musl/mod.rs
 // pub const CLOCK_SGI_CYCLE: clockid_t = 10;
 // pub const CLOCK_TAI: clockid_t = 11;
+pub const TIMER_ABSTIME: ::c_int = 1;
 
 pub const RLIMIT_CPU: ::c_int = 0;
 pub const RLIMIT_FSIZE: ::c_int = 1;
@@ -730,6 +731,10 @@ extern {
                    vec: *mut ::c_uchar) -> ::c_int;
     pub fn clock_getres(clk_id: clockid_t, tp: *mut ::timespec) -> ::c_int;
     pub fn clock_gettime(clk_id: clockid_t, tp: *mut ::timespec) -> ::c_int;
+    pub fn clock_nanosleep(clk_id: clockid_t,
+                           flags: ::c_int,
+                           rqtp: *const ::timespec,
+                           rmtp:  *mut ::timespec) -> ::c_int;
     pub fn prctl(option: ::c_int, ...) -> ::c_int;
     pub fn pthread_getattr_np(native: ::pthread_t,
                               attr: *mut ::pthread_attr_t) -> ::c_int;

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -724,6 +724,8 @@ pub const SIGSTKSZ: ::size_t = 8192;
 // __CLOCK_REALTIME0==0 is an obsoleted version of CLOCK_REALTIME==3
 pub const CLOCK_REALTIME: clockid_t = 3;
 pub const CLOCK_MONOTONIC: clockid_t = 4;
+pub const TIMER_RELTIME: ::c_int = 0;
+pub const TIMER_ABSTIME: ::c_int = 1;
 
 pub const RLIMIT_CPU: ::c_int = 0;
 pub const RLIMIT_FSIZE: ::c_int = 1;
@@ -959,6 +961,10 @@ extern {
                     -> ::c_int;
     pub fn clock_getres(clk_id: clockid_t, tp: *mut ::timespec) -> ::c_int;
     pub fn clock_gettime(clk_id: clockid_t, tp: *mut ::timespec) -> ::c_int;
+    pub fn clock_nanosleep(clk_id: clockid_t,
+                           flags: ::c_int,
+                           rqtp: *const ::timespec,
+                           rmtp:  *mut ::timespec) -> ::c_int;
     pub fn getnameinfo(sa: *const ::sockaddr,
                        salen: ::socklen_t,
                        host: *mut ::c_char,
@@ -1028,4 +1034,3 @@ extern {
     pub fn pthread_condattr_setclock(attr: *mut pthread_condattr_t,
                                      clock_id: clockid_t) -> ::c_int;
 }
-


### PR DESCRIPTION
Add `clock_nanosleep`.

Support is a bit scarce but it's the only sleep call with options for monotonic clock and absolute time.