### PR TITLE
Rename epoll_event data member name

### DIFF
--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -122,7 +122,7 @@ s! {
                repr(packed))]
     pub struct epoll_event {
         pub events: ::uint32_t,
-        pub u64: ::uint64_t,
+        pub data: ::uint64_t,
     }
 
     pub struct utsname {


### PR DESCRIPTION
Just a nit. Rename the [`epoll_event` data member](https://github.com/rust-lang/libc/blob/master/src/unix/notbsd/mod.rs#L125) to `data` (http://man7.org/linux/man-pages/man2/epoll_ctl.2.html).

If it is in fact "rusty" to name struct members that are unions after their largest member, please close this PR.