### PR TITLE
Make utmp(x) support more platforms

### DIFF
--- a/libc-test/build-generated.rs
+++ b/libc-test/build-generated.rs
@@ -10,6 +10,7 @@ fn main() {
         .flag("-Wall")
         .flag("-Wextra")
         .flag("-Werror")
+        .flag("-Wno-deprecated-declarations")
         .flag("-Wno-type-limits")
         .compile("liball.a");
 }

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -283,6 +283,11 @@ fn main() {
         match ty {
             "sockaddr_nl" => musl,
 
+            // On Linux, the type of `ut_tv` field of `struct utmpx`
+            // can be an anonymous struct, so an extra struct,
+            // which is absent in glibc, has to be defined.
+            "__timeval" if linux => true,
+
             // The alignment of this is 4 on 64-bit OSX...
             "kevent" if apple && x86_64 => true,
 
@@ -431,7 +436,9 @@ fn main() {
         // This is a weird union, don't check the type.
         (struct_ == "ifaddrs" && field == "ifa_ifu") ||
         // sighandler_t type is super weird
-        (struct_ == "sigaction" && field == "sa_sigaction")
+        (struct_ == "sigaction" && field == "sa_sigaction") ||
+        // __timeval type is a patch which doesn't exist in glibc
+        (linux && struct_ == "utmpx" && field == "ut_tv")
     });
 
     cfg.skip_field(move |struct_, field| {

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -64,6 +64,8 @@ fn main() {
             cfg.header("ws2tcpip.h");
         }
     } else {
+        cfg.flag("-Wno-deprecated-declarations");
+
         cfg.header("ctype.h");
         cfg.header("dirent.h");
         if openbsd {

--- a/libc-test/generate-files/Cargo.lock
+++ b/libc-test/generate-files/Cargo.lock
@@ -22,7 +22,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ctest"
 version = "0.1.0"
-source = "git+https://github.com/alexcrichton/ctest#7703b51086cce2d9a703b103d0695b36653b8cab"
+source = "git+https://github.com/alexcrichton/ctest#a6becb6d7fd23d9863cba86eac31d1ffc4082734"
 dependencies = [
  "gcc 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_syntax 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -25,6 +25,17 @@ pub type sem_t = ::c_int;
 pub enum timezone {}
 
 s! {
+    pub struct utmpx {
+        pub ut_user: [::c_char; _UTX_USERSIZE],
+        pub ut_id: [::c_char; _UTX_IDSIZE],
+        pub ut_line: [::c_char; _UTX_LINESIZE],
+        pub ut_pid: ::pid_t,
+        pub ut_type: ::c_short,
+        pub ut_tv: ::timeval,
+        pub ut_host: [::c_char; _UTX_HOSTSIZE],
+        ut_pad: [::uint32_t; 16],
+    }
+
     pub struct glob_t {
         pub gl_pathc:  ::size_t,
         __unused1: ::c_int,
@@ -293,6 +304,24 @@ s! {
         pub int_n_sign_posn: ::c_char,
     }
 }
+
+pub const _UTX_USERSIZE: usize = 256;
+pub const _UTX_LINESIZE: usize = 32;
+pub const _UTX_IDSIZE: usize = 4;
+pub const _UTX_HOSTSIZE: usize = 256;
+
+pub const EMPTY: ::c_short = 0;
+pub const RUN_LVL: ::c_short = 1;
+pub const BOOT_TIME: ::c_short = 2;
+pub const OLD_TIME: ::c_short = 3;
+pub const NEW_TIME: ::c_short = 4;
+pub const INIT_PROCESS: ::c_short = 5;
+pub const LOGIN_PROCESS: ::c_short = 6;
+pub const USER_PROCESS: ::c_short = 7;
+pub const DEAD_PROCESS: ::c_short = 8;
+pub const ACCOUNTING: ::c_short = 9;
+pub const SIGNATURE: ::c_short = 10;
+pub const SHUTDOWN_TIME: ::c_short = 11;
 
 pub const LC_COLLATE_MASK: ::c_int = (1 << 0);
 pub const LC_CTYPE_MASK: ::c_int = (1 << 1);
@@ -1286,6 +1315,14 @@ f! {
 }
 
 extern {
+    pub fn getutxent() -> *mut utmpx;
+    pub fn getutxid(ut: *const utmpx) -> *mut utmpx;
+    pub fn getutxline(ut: *const utmpx) -> *mut utmpx;
+    pub fn pututxline(ut: *const utmpx) -> *mut utmpx;
+    pub fn setutxent();
+    pub fn endutxent();
+    pub fn utmpxname(file: *const ::c_char) -> ::c_int;
+
     pub fn getnameinfo(sa: *const ::sockaddr,
                        salen: ::socklen_t,
                        host: *mut ::c_char,

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -17,6 +17,17 @@ pub type sem_t = _sem;
 pub enum timezone {}
 
 s! {
+    pub struct utmpx {
+        pub ut_type: ::c_short,
+        pub ut_tv: ::timeval,
+        pub ut_id: [::c_char; 8],
+        pub ut_pid: ::pid_t,
+        pub ut_user: [::c_char; 32],
+        pub ut_line: [::c_char; 16],
+        pub ut_host: [::c_char; 128],
+        pub __ut_spare: [::c_char; 64],
+    }
+
     pub struct glob_t {
         pub gl_pathc: ::size_t,
         __unused1: ::size_t,
@@ -157,6 +168,16 @@ s! {
         data: [u32; 4],
     }
 }
+
+pub const EMPTY: ::c_short = 0;
+pub const BOOT_TIME: ::c_short = 1;
+pub const OLD_TIME: ::c_short = 2;
+pub const NEW_TIME: ::c_short = 3;
+pub const USER_PROCESS: ::c_short = 4;
+pub const INIT_PROCESS: ::c_short = 5;
+pub const LOGIN_PROCESS: ::c_short = 6;
+pub const DEAD_PROCESS: ::c_short = 7;
+pub const SHUTDOWN_TIME: ::c_short = 8;
 
 pub const LC_COLLATE_MASK: ::c_int = (1 << 0);
 pub const LC_CTYPE_MASK: ::c_int = (1 << 1);
@@ -699,6 +720,17 @@ f! {
     pub fn WIFSTOPPED(status: ::c_int) -> bool {
         (status & 0o177) == 0o177
     }
+}
+
+extern {
+    pub fn endutxent();
+    pub fn getutxent() -> *mut utmpx;
+    pub fn getutxid(ut: *const utmpx) -> *mut utmpx;
+    pub fn getutxline(ut: *const utmpx) -> *mut utmpx;
+    pub fn pututxline(ut: *const utmpx) -> *mut utmpx;
+    pub fn setutxent();
+    pub fn getutxuser(user: *const ::c_char) -> *mut utmpx;
+    pub fn setutxdb(_type: ::c_int, file: *const ::c_char) -> ::c_int;
 }
 
 #[link(name = "util")]

--- a/src/unix/notbsd/linux/other/b32/mod.rs
+++ b/src/unix/notbsd/linux/other/b32/mod.rs
@@ -83,27 +83,6 @@ s! {
         pub mem_unit: ::c_uint,
         pub _f: [::c_char; 8],
     }
-
-    pub struct __exit_status {
-        pub e_termination: ::c_short,
-        pub e_exit: ::c_short,
-    }
-
-    pub struct utmpx {
-        pub ut_type: ::c_short,
-        pub ut_pid: ::pid_t,
-        pub ut_line: [::c_char; __UT_LINESIZE],
-        pub ut_id: [::c_char; 4],
-
-        pub ut_user: [::c_char; __UT_NAMESIZE],
-        pub ut_host: [::c_char; __UT_HOSTSIZE],
-        pub ut_exit: __exit_status,
-        pub ut_session: ::c_long,
-        pub ut_tv: ::timeval,
-
-        pub ut_addr_v6: [::int32_t; 4],
-        __glibc_reserved: [::c_char; 20],
-    }
 }
 
 pub const __SIZEOF_PTHREAD_CONDATTR_T: usize = 4;
@@ -117,29 +96,6 @@ pub const PTRACE_GETFPXREGS: ::c_uint = 18;
 pub const PTRACE_SETFPXREGS: ::c_uint = 19;
 pub const PTRACE_GETREGS: ::c_uint = 12;
 pub const PTRACE_SETREGS: ::c_uint = 13;
-
-pub const __UT_LINESIZE: usize = 32;
-pub const __UT_NAMESIZE: usize = 32;
-pub const __UT_HOSTSIZE: usize = 256;
-pub const EMPTY: ::c_short = 0;
-pub const RUN_LVL: ::c_short = 1;
-pub const BOOT_TIME: ::c_short = 2;
-pub const NEW_TIME: ::c_short = 3;
-pub const OLD_TIME: ::c_short = 4;
-pub const INIT_PROCESS: ::c_short = 5;
-pub const LOGIN_PROCESS: ::c_short = 6;
-pub const USER_PROCESS: ::c_short = 7;
-pub const DEAD_PROCESS: ::c_short = 8;
-pub const ACCOUNTING: ::c_short = 9;
-
-extern {
-    pub fn getutxent() -> *mut utmpx;
-    pub fn getutxid(ut: *const utmpx) -> *mut utmpx;
-    pub fn getutxline(ut: *const utmpx) -> *mut utmpx;
-    pub fn pututxline(ut: *const utmpx) -> *mut utmpx;
-    pub fn setutxent();
-    pub fn endutxent();
-}
 
 cfg_if! {
     if #[cfg(target_arch = "x86")] {


### PR DESCRIPTION
Also ignored deprecated functions `readdir_r` and `readdir64_r` that fail the tests.