### PR TITLE
Add sem_timedwait for unix platforms

### DIFF
--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -844,6 +844,8 @@ extern {
     pub fn pthread_condattr_setclock(attr: *mut pthread_condattr_t,
                                      clock_id: clockid_t) -> ::c_int;
     pub fn sethostname(name: *const ::c_char, len: ::c_int) -> ::c_int;
+    pub fn sem_timedwait(sem: *mut sem_t,
+                         abstime: *const ::timespec) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/bsd/openbsdlike/mod.rs
+++ b/src/unix/bsd/openbsdlike/mod.rs
@@ -525,8 +525,10 @@ extern {
                    flags: ::c_int) -> ::c_int;
    pub fn mkfifoat(dirfd: ::c_int, pathname: *const ::c_char,
                    mode: ::mode_t) -> ::c_int;
-    pub fn pthread_condattr_setclock(attr: *mut pthread_condattr_t,
-                                     clock_id: clockid_t) -> ::c_int;
+   pub fn sem_timedwait(sem: *mut sem_t,
+                        abstime: *const ::timespec) -> ::c_int;
+   pub fn pthread_condattr_setclock(attr: *mut pthread_condattr_t,
+                                    clock_id: clockid_t) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -710,8 +710,6 @@ extern {
                link_name = "sem_wait$UNIX2003")]
     pub fn sem_wait(sem: *mut sem_t) -> ::c_int;
     pub fn sem_trywait(sem: *mut sem_t) -> ::c_int;
-    pub fn sem_timedwait(sem: *mut sem_t,
-                         abstime: *const ::timespec) -> ::c_int;
     pub fn sem_post(sem: *mut sem_t) -> ::c_int;
     pub fn sem_init(sem: *mut sem_t,
                     pshared: ::c_int,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -710,6 +710,8 @@ extern {
                link_name = "sem_wait$UNIX2003")]
     pub fn sem_wait(sem: *mut sem_t) -> ::c_int;
     pub fn sem_trywait(sem: *mut sem_t) -> ::c_int;
+    pub fn sem_timedwait(sem: *mut sem_t,
+                         abstime: *const ::timespec) -> ::c_int;
     pub fn sem_post(sem: *mut sem_t) -> ::c_int;
     pub fn sem_init(sem: *mut sem_t,
                     pshared: ::c_int,

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -889,6 +889,8 @@ extern {
                              cpuset: *const cpu_set_t) -> ::c_int;
     pub fn unshare(flags: ::c_int) -> ::c_int;
     pub fn setns(fd: ::c_int, nstype: ::c_int) -> ::c_int;
+    pub fn sem_timedwait(sem: *mut sem_t,
+                         abstime: *const ::timespec) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -1033,4 +1033,6 @@ extern {
                                      clock_id: *mut clockid_t) -> ::c_int;
     pub fn pthread_condattr_setclock(attr: *mut pthread_condattr_t,
                                      clock_id: clockid_t) -> ::c_int;
+    pub fn sem_timedwait(sem: *mut sem_t,
+                         abstime: *const ::timespec) -> ::c_int;
 }


### PR DESCRIPTION
We can almost implement synchronization mechanisms in pure-rust using
just pthread semaphores as the primitive but sem_timedwait is necessary for
implementing timeout-based functions.