### PR TITLE
Corrects signedness of c_char for Linux musl Aarch64 & ppc64.

### DIFF
--- a/src/unix/notbsd/linux/musl/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/musl/b64/aarch64.rs
@@ -1,1 +1,3 @@
+pub type c_char = u8;
+
 pub const SYS_perf_event_open: ::c_long = 241;

--- a/src/unix/notbsd/linux/musl/b64/mod.rs
+++ b/src/unix/notbsd/linux/musl/b64/mod.rs
@@ -1,4 +1,3 @@
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/unix/notbsd/linux/musl/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/musl/b64/powerpc64.rs
@@ -1,1 +1,3 @@
+pub type c_char = u8;
+
 pub const SYS_perf_event_open: ::c_long = 319;

--- a/src/unix/notbsd/linux/musl/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/musl/b64/x86_64.rs
@@ -1,3 +1,5 @@
+pub type c_char = i8;
+
 s! {
     pub struct mcontext_t {
         __private: [u64; 32],


### PR DESCRIPTION
Correction for issue #362 (and the same problem for PowerPC64 architecture).