### PR TITLE
Add missing consts on Solaris

### DIFF
--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -432,6 +432,7 @@ pub const FIONBIO: ::c_int = 0x8004667e;
 
 pub const SIGCHLD: ::c_int = 18;
 pub const SIGBUS: ::c_int = 10;
+pub const SIGINFO: ::c_int = 41;
 pub const SIG_BLOCK: ::c_int = 1;
 pub const SIG_UNBLOCK: ::c_int = 2;
 pub const SIG_SETMASK: ::c_int = 3;
@@ -541,6 +542,7 @@ pub const SIGXCPU: ::c_int = 30;
 pub const SIGXFSZ: ::c_int = 31;
 
 pub const WNOHANG: ::c_int = 0x40;
+pub const WUNTRACED: ::c_int = 0x04;
 
 pub const PROT_NONE: ::c_int = 0;
 pub const PROT_READ: ::c_int = 1;


### PR DESCRIPTION
These are required for [nix](https://github.com/nix-rust/nix).