### PR TITLE
added getchar and putchar

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,8 @@ extern {
                    mode: c_int,
                    size: size_t) -> c_int;
     pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
+    pub fn getchar() -> c_int;
+    pub fn putchar(c: c_int) -> c_int;
     pub fn fgetc(stream: *mut FILE) -> c_int;
     pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
     pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;


### PR DESCRIPTION
Not sure why they were not in the repo until now, but they are both part of POSIX.1-2008: [getchar](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getchar.html), [putchar](http://pubs.opengroup.org/onlinepubs/9699919799/functions/putchar.html)