### PR TITLE
Add prelimenary wasm32 support

### DIFF
--- a/src/unix/notbsd/linux/musl/b32/mod.rs
+++ b/src/unix/notbsd/linux/musl/b32/mod.rs
@@ -39,7 +39,9 @@ cfg_if! {
     } else if #[cfg(any(target_arch = "arm"))] {
         mod arm;
         pub use self::arm::*;
-    } else if #[cfg(any(target_arch = "asmjs"))] {
+    } else if #[cfg(any(target_arch = "asmjs", target_arch = "wasm32"))] {
+        // For the time being asmjs and wasm32 are the same, and both
+        // backed by identical emscripten runtimes
         mod asmjs;
         pub use self::asmjs::*;
     } else {

--- a/src/unix/notbsd/linux/musl/mod.rs
+++ b/src/unix/notbsd/linux/musl/mod.rs
@@ -235,7 +235,8 @@ cfg_if! {
     } else if #[cfg(any(target_arch = "x86",
                         target_arch = "mips",
                         target_arch = "arm",
-                        target_arch = "asmjs"))] {
+                        target_arch = "asmjs",
+                        target_arch = "wasm32"))] {
         mod b32;
         pub use self::b32::*;
     } else { }


### PR DESCRIPTION
For the moment there's nothing different about the emscripten libc implementations for asmjs and wasm32.