### PR TITLE
Add more s390x definitions

### DIFF
--- a/src/unix/notbsd/linux/s390x.rs
+++ b/src/unix/notbsd/linux/s390x.rs
@@ -621,7 +621,6 @@ pub const LINUX_REBOOT_CMD_KEXEC: ::c_int = 0x45584543;
 pub const SYS_gettid: ::c_long = 236;
 pub const SYS_perf_event_open: ::c_long = 331;
 
-
 #[link(name = "util")]
 extern {
     pub fn sysctl(name: *mut ::c_int,

--- a/src/unix/notbsd/linux/s390x.rs
+++ b/src/unix/notbsd/linux/s390x.rs
@@ -12,6 +12,10 @@ pub type rlim_t = u64;
 pub type suseconds_t = i64;
 pub type time_t = i64;
 pub type wchar_t = i32;
+pub type greg_t = u64;
+pub type clock_t = i64;
+pub type __fsword_t = ::c_long;
+pub type __priority_which_t = ::c_uint;
 
 s! {
     pub struct stat {
@@ -32,12 +36,12 @@ s! {
         pub st_ctime_nsec: ::c_long,
         pub st_blksize: ::blksize_t,
         pub st_blocks: ::blkcnt_t,
-        __glibc_reserved: [::c_int; 5],
+        __glibc_reserved: [::c_long; 3],
     }
 
     pub struct stat64 {
         pub st_dev: ::dev_t,
-        pub st_ino: ::ino_t,
+        pub st_ino: ::ino64_t,
         pub st_nlink: ::nlink_t,
         pub st_mode: ::mode_t,
         pub st_uid: ::uid_t,
@@ -52,8 +56,8 @@ s! {
         pub st_ctime: ::time_t,
         pub st_ctime_nsec: ::c_long,
         pub st_blksize: ::blksize_t,
-        pub st_blocks: ::blkcnt_t,
-        __glibc_reserved: [::c_int; 5],
+        pub st_blocks: ::blkcnt64_t,
+        __glibc_reserved: [::c_long; 3],
     }
 
     pub struct pthread_attr_t {
@@ -62,7 +66,8 @@ s! {
 
     pub struct sigaction {
         pub sa_sigaction: ::sighandler_t,
-        pub sa_flags: ::c_ulong,
+        __glibc_reserved0: ::c_int,
+        pub sa_flags: ::c_int,
         _restorer: *mut ::c_void,
         pub sa_mask: sigset_t,
     }
@@ -91,7 +96,7 @@ s! {
         pub gid: ::gid_t,
         pub cuid: ::uid_t,
         pub cgid: ::gid_t,
-        pub mode: ::c_uint,
+        pub mode: ::mode_t,
         pub __seq: ::c_ushort,
         __pad1: ::c_ushort,
         __unused1: ::c_ulong,
@@ -117,8 +122,8 @@ s! {
         pub f_blocks: ::fsblkcnt_t,
         pub f_bfree: ::fsblkcnt_t,
         pub f_bavail: ::fsblkcnt_t,
-        pub f_files: ::fsblkcnt_t,
-        pub f_ffree: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
         pub f_fsid: ::fsid_t,
         pub f_namelen: ::c_uint,
         pub f_frsize: ::c_uint,
@@ -164,10 +169,69 @@ s! {
         pub _f: [::c_char; 0],
     }
 
+    pub struct glob64_t {
+        pub gl_pathc: ::size_t,
+        pub gl_pathv: *mut *mut ::c_char,
+        pub gl_offs: ::size_t,
+        pub gl_flags: ::c_int,
+
+        __unused1: *mut ::c_void,
+        __unused2: *mut ::c_void,
+        __unused3: *mut ::c_void,
+        __unused4: *mut ::c_void,
+        __unused5: *mut ::c_void,
+    }
+
+    pub struct ucred {
+        pub pid: ::pid_t,
+        pub uid: ::uid_t,
+        pub gid: ::gid_t,
+    }
+
+    pub struct flock {
+        pub l_type: ::c_short,
+        pub l_whence: ::c_short,
+        pub l_start: ::off_t,
+        pub l_len: ::off_t,
+        pub l_pid: ::pid_t,
+    }
+
     // FIXME this is actually a union
     pub struct sem_t {
         __size: [::c_char; 32],
         __align: [::c_long; 0],
+    }
+
+    pub struct __psw_t {
+        pub mask: u64,
+        pub addr: u64,
+    }
+
+    // FIXME: This is actually a union.
+    pub struct fpreg_t {
+        pub d: ::c_double,
+        // f: ::c_float,
+    }
+
+    pub struct fpregset_t {
+        pub fpc: u32,
+        __pad: u32,
+        pub fprs: [fpreg_t; 16],
+    }
+
+    pub struct mcontext_t {
+        pub psw: __psw_t,
+        pub gregs: [u64; 16],
+        pub aregs: [u32; 16],
+        pub fpregs: fpregset_t,
+    }
+
+    pub struct ucontext_t {
+        pub uc_flags: ::c_ulong,
+        pub uc_link: *mut ucontext_t,
+        pub uc_stack: ::stack_t,
+        pub uc_mcontext: mcontext_t,
+        pub uc_sigmask: ::sigset_t,
     }
 }
 
@@ -198,8 +262,9 @@ pub const O_EXCL: ::c_int = 128;
 pub const O_NONBLOCK: ::c_int = 2048;
 pub const PTHREAD_STACK_MIN: ::size_t = 16384;
 pub const RLIM_INFINITY: ::rlim_t = 0xffffffffffffffff;
-pub const SA_ONSTACK: ::c_ulong = 0x08000000;
-pub const SA_SIGINFO: ::c_ulong = 4;
+pub const SA_NOCLDWAIT: ::c_int = 2;
+pub const SA_ONSTACK: ::c_int = 0x08000000;
+pub const SA_SIGINFO: ::c_int = 4;
 pub const SIGBUS: ::c_int = 7;
 pub const SIGSTKSZ: ::size_t = 0x2000;
 pub const SIG_SETMASK: ::c_int = 2;
@@ -212,7 +277,392 @@ pub const SO_RCVTIMEO: ::c_int = 20;
 pub const SO_REUSEADDR: ::c_int = 2;
 pub const SO_SNDTIMEO: ::c_int = 21;
 
+pub const RLIMIT_RSS: ::c_int = 5;
+pub const RLIMIT_NOFILE: ::c_int = 7;
+pub const RLIMIT_AS: ::c_int = 9;
+pub const RLIMIT_NPROC: ::c_int = 6;
+pub const RLIMIT_MEMLOCK: ::c_int = 8;
+pub const RLIMIT_RTTIME: ::c_int = 15;
+pub const RLIMIT_NLIMITS: ::c_int = 16;
+
+pub const O_NOCTTY: ::c_int = 256;
+pub const O_SYNC: ::c_int = 1052672;
+pub const O_RSYNC: ::c_int = 1052672;
+pub const O_DSYNC: ::c_int = 4096;
+pub const O_FSYNC: ::c_int = 0x101000;
+pub const O_DIRECT: ::c_int = 0x4000;
+pub const O_DIRECTORY: ::c_int = 0x10000;
+pub const O_NOFOLLOW: ::c_int = 0x20000;
+
+pub const SOCK_NONBLOCK: ::c_int = O_NONBLOCK;
+
+pub const LC_PAPER: ::c_int = 7;
+pub const LC_NAME: ::c_int = 8;
+pub const LC_ADDRESS: ::c_int = 9;
+pub const LC_TELEPHONE: ::c_int = 10;
+pub const LC_MEASUREMENT: ::c_int = 11;
+pub const LC_IDENTIFICATION: ::c_int = 12;
+pub const LC_PAPER_MASK: ::c_int = (1 << LC_PAPER);
+pub const LC_NAME_MASK: ::c_int = (1 << LC_NAME);
+pub const LC_ADDRESS_MASK: ::c_int = (1 << LC_ADDRESS);
+pub const LC_TELEPHONE_MASK: ::c_int = (1 << LC_TELEPHONE);
+pub const LC_MEASUREMENT_MASK: ::c_int = (1 << LC_MEASUREMENT);
+pub const LC_IDENTIFICATION_MASK: ::c_int = (1 << LC_IDENTIFICATION);
+pub const LC_ALL_MASK: ::c_int = ::LC_CTYPE_MASK
+                               | ::LC_NUMERIC_MASK
+                               | ::LC_TIME_MASK
+                               | ::LC_COLLATE_MASK
+                               | ::LC_MONETARY_MASK
+                               | ::LC_MESSAGES_MASK
+                               | LC_PAPER_MASK
+                               | LC_NAME_MASK
+                               | LC_ADDRESS_MASK
+                               | LC_TELEPHONE_MASK
+                               | LC_MEASUREMENT_MASK
+                               | LC_IDENTIFICATION_MASK;
+
+pub const MAP_ANONYMOUS: ::c_int = 0x0020;
+pub const MAP_GROWSDOWN: ::c_int = 0x0100;
+pub const MAP_DENYWRITE: ::c_int = 0x0800;
+pub const MAP_EXECUTABLE: ::c_int = 0x01000;
+pub const MAP_LOCKED: ::c_int = 0x02000;
+pub const MAP_NORESERVE: ::c_int = 0x04000;
+pub const MAP_POPULATE: ::c_int = 0x08000;
+pub const MAP_NONBLOCK: ::c_int = 0x010000;
+pub const MAP_STACK: ::c_int = 0x020000;
+
+pub const EDEADLOCK: ::c_int = 35;
+pub const ENAMETOOLONG: ::c_int = 36;
+pub const ENOLCK: ::c_int = 37;
+pub const ENOTEMPTY: ::c_int = 39;
+pub const ELOOP: ::c_int = 40;
+pub const ENOMSG: ::c_int = 42;
+pub const EIDRM: ::c_int = 43;
+pub const ECHRNG: ::c_int = 44;
+pub const EL2NSYNC: ::c_int = 45;
+pub const EL3HLT: ::c_int = 46;
+pub const EL3RST: ::c_int = 47;
+pub const ELNRNG: ::c_int = 48;
+pub const EUNATCH: ::c_int = 49;
+pub const ENOCSI: ::c_int = 50;
+pub const EL2HLT: ::c_int = 51;
+pub const EBADE: ::c_int = 52;
+pub const EBADR: ::c_int = 53;
+pub const EXFULL: ::c_int = 54;
+pub const ENOANO: ::c_int = 55;
+pub const EBADRQC: ::c_int = 56;
+pub const EBADSLT: ::c_int = 57;
+pub const EMULTIHOP: ::c_int = 72;
+pub const EOVERFLOW: ::c_int = 75;
+pub const ENOTUNIQ: ::c_int = 76;
+pub const EBADFD: ::c_int = 77;
+pub const EBADMSG: ::c_int = 74;
+pub const EREMCHG: ::c_int = 78;
+pub const ELIBACC: ::c_int = 79;
+pub const ELIBBAD: ::c_int = 80;
+pub const ELIBSCN: ::c_int = 81;
+pub const ELIBMAX: ::c_int = 82;
+pub const ELIBEXEC: ::c_int = 83;
+pub const EILSEQ: ::c_int = 84;
+pub const ERESTART: ::c_int = 85;
+pub const ESTRPIPE: ::c_int = 86;
+pub const EUSERS: ::c_int = 87;
+pub const ENOTSOCK: ::c_int = 88;
+pub const EDESTADDRREQ: ::c_int = 89;
+pub const EMSGSIZE: ::c_int = 90;
+pub const EPROTOTYPE: ::c_int = 91;
+pub const ENOPROTOOPT: ::c_int = 92;
+pub const EPROTONOSUPPORT: ::c_int = 93;
+pub const ESOCKTNOSUPPORT: ::c_int = 94;
+pub const EOPNOTSUPP: ::c_int = 95;
+pub const EPFNOSUPPORT: ::c_int = 96;
+pub const EAFNOSUPPORT: ::c_int = 97;
+pub const ENETDOWN: ::c_int = 100;
+pub const ENETUNREACH: ::c_int = 101;
+pub const ENETRESET: ::c_int = 102;
+pub const ENOBUFS: ::c_int = 105;
+pub const EISCONN: ::c_int = 106;
+pub const ESHUTDOWN: ::c_int = 108;
+pub const ETOOMANYREFS: ::c_int = 109;
+pub const EHOSTDOWN: ::c_int = 112;
+pub const EHOSTUNREACH: ::c_int = 113;
+pub const EALREADY: ::c_int = 114;
+pub const EINPROGRESS: ::c_int = 115;
+pub const ESTALE: ::c_int = 116;
+pub const EUCLEAN: ::c_int = 117;
+pub const ENOTNAM: ::c_int = 118;
+pub const ENAVAIL: ::c_int = 119;
+pub const EISNAM: ::c_int = 120;
+pub const EREMOTEIO: ::c_int = 121;
+pub const EDQUOT: ::c_int = 122;
+pub const ENOMEDIUM: ::c_int = 123;
+pub const EMEDIUMTYPE: ::c_int = 124;
+pub const ECANCELED: ::c_int = 125;
+pub const ENOKEY: ::c_int = 126;
+pub const EKEYEXPIRED: ::c_int = 127;
+pub const EKEYREVOKED: ::c_int = 128;
+pub const EKEYREJECTED: ::c_int = 129;
+pub const EOWNERDEAD: ::c_int = 130;
+pub const ENOTRECOVERABLE: ::c_int = 131;
+pub const EHWPOISON: ::c_int = 133;
+pub const ERFKILL: ::c_int = 132;
+
+pub const SOCK_SEQPACKET: ::c_int = 5;
+
+pub const SO_TYPE: ::c_int = 3;
+pub const SO_DONTROUTE: ::c_int = 5;
+pub const SO_SNDBUF: ::c_int = 7;
+pub const SO_RCVBUF: ::c_int = 8;
+pub const SO_KEEPALIVE: ::c_int = 9;
+pub const SO_OOBINLINE: ::c_int = 10;
+pub const SO_LINGER: ::c_int = 13;
+pub const SO_REUSEPORT: ::c_int = 15;
+pub const SO_PEERCRED: ::c_int = 17;
+pub const SO_RCVLOWAT: ::c_int = 18;
+pub const SO_SNDLOWAT: ::c_int = 19;
+pub const SO_ACCEPTCONN: ::c_int = 30;
+
+pub const TCP_COOKIE_TRANSACTIONS: ::c_int = 15;
+pub const TCP_THIN_LINEAR_TIMEOUTS: ::c_int = 16;
+pub const TCP_THIN_DUPACK: ::c_int = 17;
+pub const TCP_USER_TIMEOUT: ::c_int = 18;
+pub const TCP_REPAIR: ::c_int = 19;
+pub const TCP_REPAIR_QUEUE: ::c_int = 20;
+pub const TCP_QUEUE_SEQ: ::c_int = 21;
+pub const TCP_REPAIR_OPTIONS: ::c_int = 22;
+pub const TCP_FASTOPEN: ::c_int = 23;
+pub const TCP_TIMESTAMP: ::c_int = 24;
+
+pub const SIGCHLD: ::c_int = 17;
+pub const SIGUSR1: ::c_int = 10;
+pub const SIGUSR2: ::c_int = 12;
+pub const SIGCONT: ::c_int = 18;
+pub const SIGSTOP: ::c_int = 19;
+pub const SIGTSTP: ::c_int = 20;
+pub const SIGURG: ::c_int = 23;
+pub const SIGIO: ::c_int = 29;
+pub const SIGSYS: ::c_int = 31;
+pub const SIGSTKFLT: ::c_int = 16;
+pub const SIGUNUSED: ::c_int = 31;
+pub const SIGTTIN: ::c_int = 21;
+pub const SIGTTOU: ::c_int = 22;
+pub const SIGXCPU: ::c_int = 24;
+pub const SIGXFSZ: ::c_int = 25;
+pub const SIGVTALRM: ::c_int = 26;
+pub const SIGPROF: ::c_int = 27;
+pub const SIGWINCH: ::c_int = 28;
+pub const SIGPOLL: ::c_int = 29;
+pub const SIGPWR: ::c_int = 30;
+pub const SIG_BLOCK: ::c_int = 0x000000;
+pub const SIG_UNBLOCK: ::c_int = 0x01;
+
+pub const FALLOC_FL_KEEP_SIZE: ::c_int = 0x01;
+pub const FALLOC_FL_PUNCH_HOLE: ::c_int = 0x02;
+
+pub const BUFSIZ: ::c_uint = 8192;
+pub const TMP_MAX: ::c_uint = 238328;
+pub const FOPEN_MAX: ::c_uint = 16;
+pub const POSIX_MADV_DONTNEED: ::c_int = 4;
+pub const _SC_2_C_VERSION: ::c_int = 96;
+pub const RUSAGE_THREAD: ::c_int = 1;
+pub const O_ASYNC: ::c_int = 0x2000;
+pub const O_NDELAY: ::c_int = 0x800;
+pub const RUSAGE_CHILDREN: ::c_int = -1;
+pub const ST_RELATIME: ::c_ulong = 4096;
+pub const NI_MAXHOST: ::socklen_t = 1025;
+
+pub const ADFS_SUPER_MAGIC: ::c_int = 0x0000adf5;
+pub const AFFS_SUPER_MAGIC: ::c_int = 0x0000adff;
+pub const CODA_SUPER_MAGIC: ::c_int = 0x73757245;
+pub const CRAMFS_MAGIC: ::c_int = 0x28cd3d45;
+pub const EFS_SUPER_MAGIC: ::c_int = 0x00414a53;
+pub const EXT2_SUPER_MAGIC: ::c_int = 0x0000ef53;
+pub const EXT3_SUPER_MAGIC: ::c_int = 0x0000ef53;
+pub const EXT4_SUPER_MAGIC: ::c_int = 0x0000ef53;
+pub const HPFS_SUPER_MAGIC: ::c_int = 0xf995e849;
+pub const HUGETLBFS_MAGIC: ::c_int = 0x958458f6;
+pub const ISOFS_SUPER_MAGIC: ::c_int = 0x00009660;
+pub const JFFS2_SUPER_MAGIC: ::c_int = 0x000072b6;
+pub const MINIX_SUPER_MAGIC: ::c_int = 0x0000137f;
+pub const MINIX_SUPER_MAGIC2: ::c_int = 0x0000138f;
+pub const MINIX2_SUPER_MAGIC: ::c_int = 0x00002468;
+pub const MINIX2_SUPER_MAGIC2: ::c_int = 0x00002478;
+pub const MSDOS_SUPER_MAGIC: ::c_int = 0x00004d44;
+pub const NCP_SUPER_MAGIC: ::c_int = 0x0000564c;
+pub const NFS_SUPER_MAGIC: ::c_int = 0x00006969;
+pub const OPENPROM_SUPER_MAGIC: ::c_int = 0x00009fa1;
+pub const PROC_SUPER_MAGIC: ::c_int = 0x00009fa0;
+pub const QNX4_SUPER_MAGIC: ::c_int = 0x0000002f;
+pub const REISERFS_SUPER_MAGIC: ::c_int = 0x52654973;
+pub const SMB_SUPER_MAGIC: ::c_int = 0x0000517b;
+pub const TMPFS_MAGIC: ::c_int = 0x01021994;
+pub const USBDEVICE_SUPER_MAGIC: ::c_int = 0x00009fa2;
+
+pub const VEOF: usize = 4;
+pub const VEOL: usize = 11;
+pub const VEOL2: usize = 16;
+pub const VMIN: usize = 6;
+pub const IEXTEN: ::tcflag_t = 0x00008000;
+pub const TOSTOP: ::tcflag_t = 0x00000100;
+pub const FLUSHO: ::tcflag_t = 0x00001000;
+pub const IUTF8: ::tcflag_t = 0x00004000;
+
+pub const CPU_SETSIZE: ::c_int = 0x400;
+
+pub const EXTPROC: ::tcflag_t = 0x00010000;
+
+pub const QFMT_VFS_V1: ::c_int = 4;
+
+pub const PTRACE_TRACEME: ::c_uint = 0;
+pub const PTRACE_PEEKTEXT: ::c_uint = 1;
+pub const PTRACE_PEEKDATA: ::c_uint = 2;
+pub const PTRACE_PEEKUSER: ::c_uint = 3;
+pub const PTRACE_POKETEXT: ::c_uint = 4;
+pub const PTRACE_POKEDATA: ::c_uint = 5;
+pub const PTRACE_POKEUSER: ::c_uint = 6;
+pub const PTRACE_CONT: ::c_uint = 7;
+pub const PTRACE_KILL: ::c_uint = 8;
+pub const PTRACE_SINGLESTEP: ::c_uint = 9;
+pub const PTRACE_GETREGS: ::c_uint = 12;
+pub const PTRACE_SETREGS: ::c_uint = 13;
+pub const PTRACE_GETFPREGS: ::c_uint = 14;
+pub const PTRACE_SETFPREGS: ::c_uint = 15;
+pub const PTRACE_ATTACH: ::c_uint = 16;
+pub const PTRACE_DETACH: ::c_uint = 17;
+pub const PTRACE_SYSCALL: ::c_uint = 24;
+pub const PTRACE_SETOPTIONS: ::c_uint = 0x4200;
+pub const PTRACE_GETEVENTMSG: ::c_uint = 0x4201;
+pub const PTRACE_GETSIGINFO: ::c_uint = 0x4202;
+pub const PTRACE_SETSIGINFO: ::c_uint = 0x4203;
+pub const PTRACE_GETREGSET: ::c_uint = 0x4204;
+pub const PTRACE_SETREGSET: ::c_uint = 0x4205;
+pub const PTRACE_SEIZE: ::c_uint = 0x4206;
+pub const PTRACE_INTERRUPT: ::c_uint = 0x4207;
+pub const PTRACE_LISTEN: ::c_uint = 0x4208;
+pub const PTRACE_PEEKSIGINFO: ::c_uint = 0x4209;
+
+pub const MADV_DODUMP: ::c_int = 17;
+pub const MADV_DONTDUMP: ::c_int = 16;
+
+pub const EPOLLWAKEUP: ::c_int = 0x20000000;
+
+pub const MADV_HUGEPAGE: ::c_int = 14;
+pub const MADV_NOHUGEPAGE: ::c_int = 15;
+pub const MAP_HUGETLB: ::c_int = 0x040000;
+
+pub const EFD_NONBLOCK: ::c_int = 0x800;
+
+pub const F_GETLK: ::c_int = 5;
+pub const F_GETOWN: ::c_int = 9;
+pub const F_SETOWN: ::c_int = 8;
+pub const F_SETLK: ::c_int = 6;
+pub const F_SETLKW: ::c_int = 7;
+
+pub const SEEK_DATA: ::c_int = 3;
+pub const SEEK_HOLE: ::c_int = 4;
+
+pub const SFD_NONBLOCK: ::c_int = 0x0800;
+
+pub const TCSANOW: ::c_int = 0;
+pub const TCSADRAIN: ::c_int = 1;
+pub const TCSAFLUSH: ::c_int = 2;
+
+pub const TCGETS: ::c_ulong = 0x5401;
+pub const TCSETS: ::c_ulong = 0x5402;
+pub const TCSETSW: ::c_ulong = 0x5403;
+pub const TCSETSF: ::c_ulong = 0x5404;
+pub const TCGETA: ::c_ulong = 0x5405;
+pub const TCSETA: ::c_ulong = 0x5406;
+pub const TCSETAW: ::c_ulong = 0x5407;
+pub const TCSETAF: ::c_ulong = 0x5408;
+pub const TCSBRK: ::c_ulong = 0x5409;
+pub const TCXONC: ::c_ulong = 0x540A;
+pub const TCFLSH: ::c_ulong = 0x540B;
+pub const TIOCGSOFTCAR: ::c_ulong = 0x5419;
+pub const TIOCSSOFTCAR: ::c_ulong = 0x541A;
+pub const TIOCINQ: ::c_ulong = 0x541B;
+pub const TIOCLINUX: ::c_ulong = 0x541C;
+pub const TIOCGSERIAL: ::c_ulong = 0x541E;
+pub const TIOCEXCL: ::c_ulong = 0x540C;
+pub const TIOCNXCL: ::c_ulong = 0x540D;
+pub const TIOCSCTTY: ::c_ulong = 0x540E;
+pub const TIOCGPGRP: ::c_ulong = 0x540F;
+pub const TIOCSPGRP: ::c_ulong = 0x5410;
+pub const TIOCOUTQ: ::c_ulong = 0x5411;
+pub const TIOCSTI: ::c_ulong = 0x5412;
+pub const TIOCGWINSZ: ::c_ulong = 0x5413;
+pub const TIOCSWINSZ: ::c_ulong = 0x5414;
+pub const TIOCMGET: ::c_ulong = 0x5415;
+pub const TIOCMBIS: ::c_ulong = 0x5416;
+pub const TIOCMBIC: ::c_ulong = 0x5417;
+pub const TIOCMSET: ::c_ulong = 0x5418;
+pub const FIONREAD: ::c_ulong = 0x541B;
+pub const TIOCCONS: ::c_ulong = 0x541D;
+
+pub const RTLD_DEEPBIND: ::c_int = 0x8;
+pub const RTLD_GLOBAL: ::c_int = 0x100;
+pub const RTLD_NOLOAD: ::c_int = 0x4;
+
+pub const LINUX_REBOOT_MAGIC1: ::c_int = 0xfee1dead;
+pub const LINUX_REBOOT_MAGIC2: ::c_int = 672274793;
+pub const LINUX_REBOOT_MAGIC2A: ::c_int = 85072278;
+pub const LINUX_REBOOT_MAGIC2B: ::c_int = 369367448;
+pub const LINUX_REBOOT_MAGIC2C: ::c_int = 537993216;
+
+pub const LINUX_REBOOT_CMD_RESTART: ::c_int = 0x01234567;
+pub const LINUX_REBOOT_CMD_HALT: ::c_int = 0xCDEF0123;
+pub const LINUX_REBOOT_CMD_CAD_ON: ::c_int = 0x89ABCDEF;
+pub const LINUX_REBOOT_CMD_CAD_OFF: ::c_int = 0x00000000;
+pub const LINUX_REBOOT_CMD_POWER_OFF: ::c_int = 0x4321FEDC;
+pub const LINUX_REBOOT_CMD_RESTART2: ::c_int = 0xA1B2C3D4;
+pub const LINUX_REBOOT_CMD_SW_SUSPEND: ::c_int = 0xD000FCE2;
+pub const LINUX_REBOOT_CMD_KEXEC: ::c_int = 0x45584543;
+
+pub const SYS_gettid: ::c_long = 236;
+pub const SYS_perf_event_open: ::c_long = 331;
+
+
 #[link(name = "util")]
 extern {
+    pub fn sysctl(name: *mut ::c_int,
+                  namelen: ::c_int,
+                  oldp: *mut ::c_void,
+                  oldlenp: *mut ::size_t,
+                  newp: *mut ::c_void,
+                  newlen: ::size_t)
+                  -> ::c_int;
     pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
+    pub fn backtrace(buf: *mut *mut ::c_void,
+                     sz: ::c_int) -> ::c_int;
+    pub fn glob64(pattern: *const ::c_char,
+                  flags: ::c_int,
+                  errfunc: ::dox::Option<extern fn(epath: *const ::c_char,
+                                                   errno: ::c_int)
+                                                   -> ::c_int>,
+                  pglob: *mut glob64_t) -> ::c_int;
+    pub fn globfree64(pglob: *mut glob64_t);
+    pub fn ptrace(request: ::c_uint, ...) -> ::c_long;
+    pub fn pthread_attr_getaffinity_np(attr: *const ::pthread_attr_t,
+                                       cpusetsize: ::size_t,
+                                       cpuset: *mut ::cpu_set_t) -> ::c_int;
+    pub fn pthread_attr_setaffinity_np(attr: *mut ::pthread_attr_t,
+                                       cpusetsize: ::size_t,
+                                       cpuset: *const ::cpu_set_t) -> ::c_int;
+    pub fn getpriority(which: ::__priority_which_t, who: ::id_t) -> ::c_int;
+    pub fn setpriority(which: ::__priority_which_t, who: ::id_t,
+                                       prio: ::c_int) -> ::c_int;
+    pub fn pthread_getaffinity_np(thread: ::pthread_t,
+                                  cpusetsize: ::size_t,
+                                  cpuset: *mut ::cpu_set_t) -> ::c_int;
+    pub fn pthread_setaffinity_np(thread: ::pthread_t,
+                                  cpusetsize: ::size_t,
+                                  cpuset: *const ::cpu_set_t) -> ::c_int;
+    pub fn sched_getcpu() -> ::c_int;
+    pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;
+    pub fn setcontext(ucp: *const ucontext_t) -> ::c_int;
+    pub fn makecontext(ucp: *mut ucontext_t,
+                       func:  extern fn (),
+                       argc: ::c_int, ...);
+    pub fn swapcontext(uocp: *mut ucontext_t,
+                       ucp: *const ucontext_t) -> ::c_int;
 }


### PR DESCRIPTION
This adds more Linux-specific definitions for s390x, to match the
defines provided for other Linux targets.  Many of these will be
required to build std, rustc, and cargo.

In addition, this changes the type of sigaction.sa_flags to "int"
to match current glibc after this bug fix was applied:
https://sourceware.org/bugzilla/show_bug.cgi?id=16713

Some other (cosmetic) changes to bring types in line with the
exact types used in the glibc headers (e.g. ino64_t instead
of ino_t in statfs64).

Signed-off-by: Ulrich Weigand <ulrich.weigand@de.ibm.com>