### PR TITLE
Diff reduction between OpenBSD and Bitrig

### DIFF
--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -29,14 +29,12 @@ s! {
     }
 
     pub struct glob_t {
-        pub gl_pathc: ::size_t,
-        __unused1: ::size_t,
-        pub gl_offs: ::size_t,
-        __unused2: ::c_int,
+        pub gl_pathc:  ::size_t,
+        pub gl_matchc: ::size_t,
+        pub gl_offs:   ::size_t,
+        pub gl_flags:  ::c_int,
         pub gl_pathv:  *mut *mut ::c_char,
-
         __unused3: *mut ::c_void,
-
         __unused4: *mut ::c_void,
         __unused5: *mut ::c_void,
         __unused6: *mut ::c_void,

--- a/src/unix/bsd/openbsdlike/netbsd.rs
+++ b/src/unix/bsd/openbsdlike/netbsd.rs
@@ -16,9 +16,9 @@ s! {
 
     pub struct glob_t {
         pub gl_pathc:   ::size_t,
-        __unused1:      ::c_int,
+        pub gl_matchc:  ::size_t,
         pub gl_offs:    ::size_t,
-        __unused2:      ::c_int,
+        pub gl_flags:   ::c_int,
         pub gl_pathv:   *mut *mut ::c_char,
 
         __unused3: *mut ::c_void,

--- a/src/unix/bsd/openbsdlike/openbsd.rs
+++ b/src/unix/bsd/openbsdlike/openbsd.rs
@@ -25,19 +25,17 @@ s! {
 
     pub struct glob_t {
         pub gl_pathc:   ::c_int,
-        __unused1:      ::c_int,
+        pub gl_matchc:  ::c_int,
         pub gl_offs:    ::c_int,
-        __unused2:      ::c_int,
+        pub gl_flags:   ::c_int,
         pub gl_pathv:   *mut *mut ::c_char,
-
+        __unused1: *mut ::c_void,
+        __unused2: *mut ::c_void,
         __unused3: *mut ::c_void,
-
         __unused4: *mut ::c_void,
         __unused5: *mut ::c_void,
         __unused6: *mut ::c_void,
         __unused7: *mut ::c_void,
-        __unused8: *mut ::c_void,
-        __unused9: *mut ::c_void,
     }
 
     pub struct kevent {


### PR DESCRIPTION
Bitrig had a number of errors and omissions.
Also, fill out struct glob_t on all BSDs.

A follow-up commit will condense OpenBSD/Bitrig common code into a separate file.