### PR TITLE
aarch64: test against Ubuntu 16.04

### DIFF
--- a/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
   gcc libc6-dev ca-certificates \

--- a/src/unix/notbsd/linux/other/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/other/b64/aarch64.rs
@@ -60,10 +60,9 @@ s! {
         pub gid: ::gid_t,
         pub cuid: ::uid_t,
         pub cgid: ::gid_t,
-        pub mode: ::c_ushort,
-        __pad1: ::c_ushort,
+        pub mode: ::c_uint,
         pub __seq: ::c_ushort,
-        __pad2: ::c_ushort,
+        __pad1: ::c_ushort,
         __unused1: ::c_ulong,
         __unused2: ::c_ulong
     }
@@ -110,7 +109,7 @@ pub const SYS_perf_event_open: ::c_long = 241;
 pub const MCL_CURRENT: ::c_int = 0x0001;
 pub const MCL_FUTURE: ::c_int = 0x0002;
 
-pub const SIGSTKSZ: ::size_t = 8192;
+pub const SIGSTKSZ: ::size_t = 16384;
 pub const CBAUD: ::tcflag_t = 0o0010017;
 pub const TAB1: ::c_int = 0x00000800;
 pub const TAB2: ::c_int = 0x00001000;


### PR DESCRIPTION
also "backport" two glibc fixes:

- ipc_perm.mode is c_uint. [commit][1] [discussion][2]
- bump SIGSTKSZ to 16384. [commit][3] [discussion][4]

so libc-test passes.

[1]: https://sourceware.org/git/?p=glibc.git;a=commit;h=5c40c3bab2
[2]: https://www.sourceware.org/ml/libc-alpha/2014-10/msg00446.html
[3]: https://sourceware.org/git/?p=glibc.git;a=commit;h=b763f6ae859ecea70a5dacb8ad45c71d5f667e2e
[4]: https://sourceware.org/ml/libc-alpha/2015-04/msg00033.html

closes #231 

r? @alexcrichton 