### PR TITLE
Adding accept4 function

### DIFF
--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -843,6 +843,8 @@ extern {
     pub fn setns(fd: ::c_int, nstype: ::c_int) -> ::c_int;
     pub fn sem_timedwait(sem: *mut sem_t,
                          abstime: *const ::timespec) -> ::c_int;
+    pub fn accept4(fd: ::c_int, addr: *mut ::sockaddr, len: *mut ::socklen_t,
+                   flg: ::c_int) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
accept4 is a version of accept that takes flags.
It is more efficient for certain use cases, and has
a more modern path inside the kernel.