### PR TITLE
Added SSIZE_MAX for all platforms. It's always isize::MAX

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,9 @@ pub type ssize_t = isize;
 pub enum FILE {}
 pub enum fpos_t {} // TODO: fill this out with a struct
 
+#[cfg(not(any(dox, target_env = "msvc")))]
+pub const SSIZE_MAX: ssize_t = core::isize::MAX as ::ssize_t;
+
 extern {
     pub fn isalnum(c: c_int) -> c_int;
     pub fn isalpha(c: c_int) -> c_int;


### PR DESCRIPTION
This is a new PR, which replaces the previous one which
became polluted with non-relevant changes.
