### PR TITLE
Add shadow password bindings

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -163,6 +163,7 @@ fn main() {
         cfg.header("sys/msg.h");
         cfg.header("sys/shm.h");
         cfg.header("pty.h");
+        cfg.header("shadow.h");
     }
 
     if linux || android {

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -117,6 +117,18 @@ s! {
         pub pw_shell: *mut ::c_char,
     }
 
+    pub struct spwd {
+        pub sp_namp: *mut ::c_char,
+        pub sp_pwdp: *mut ::c_char,
+        pub sp_lstchg: ::c_long,
+        pub sp_min: ::c_long,
+        pub sp_max: ::c_long,
+        pub sp_warn: ::c_long,
+        pub sp_inact: ::c_long,
+        pub sp_expire: ::c_long,
+        pub sp_flag: ::c_ulong,
+    }
+
     pub struct statvfs {
         pub f_bsize: ::c_ulong,
         pub f_frsize: ::c_ulong,
@@ -520,6 +532,11 @@ extern {
 
     pub fn setpwent();
     pub fn getpwent() -> *mut passwd;
+    pub fn setspent();
+    pub fn endspent();
+    pub fn getspent() -> *mut spwd;
+    pub fn getspnam(__name: *const ::c_char) -> *mut spwd;
+
     pub fn shm_open(name: *const c_char, oflag: ::c_int,
                     mode: mode_t) -> ::c_int;
     pub fn shmget(key: ::key_t, size: ::size_t, shmflg: ::c_int) -> ::c_int;


### PR DESCRIPTION
Add shadow password bindings: setspent, endspent, getspent, getspnam plus spwd, the corresponding struct.

[Example code](https://github.com/philippkeller/apue-rust/blob/master/src/bin/e06-01-shadow-pw.rs) (tested on Linux 4.4.0-21-generic)