### PR TITLE
Added the waitid interface

### DIFF
--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -20,9 +20,9 @@ pub type nl_item = ::c_int;
 pub type idtype_t = ::c_int;
 pub enum fpos64_t {} // TODO: fill this out with a struct
 
-pub const P_PID: ::id_t = 1;
-pub const P_PGID: ::id_t = 2;
-pub const P_ALL: ::id_t = 3;
+pub const P_PID: ::idtype_t = 1;
+pub const P_PGID: ::idtype_t = 2;
+pub const P_ALL: ::idtype_t = 3;
 
 
 s! {

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -17,8 +17,13 @@ pub type msgqnum_t = ::c_ulong;
 pub type msglen_t = ::c_ulong;
 pub type nfds_t = ::c_ulong;
 pub type nl_item = ::c_int;
-
+pub type idtype_t = ::c_int;
 pub enum fpos64_t {} // TODO: fill this out with a struct
+
+pub const P_PID: ::id_t = 1;
+pub const P_PGID: ::id_t = 2;
+pub const P_ALL: ::id_t = 3;
+
 
 s! {
     pub struct dirent {

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -548,13 +548,6 @@ pub const NLA_F_NESTED: ::c_int = 1 << 15;
 pub const NLA_F_NET_BYTEORDER: ::c_int = 1 << 14;
 pub const NLA_TYPE_MASK: ::c_int = !(NLA_F_NESTED | NLA_F_NET_BYTEORDER);
 
-#[repr(C)]
-pub enum idtype_t {
-    P_ALL,
-    P_PID,
-    P_PGID
-}
-
 cfg_if! {
     if #[cfg(any(target_arch = "arm", target_arch = "x86",
                  target_arch = "x86_64"))] {
@@ -611,7 +604,7 @@ extern {
                                   cpuset: *const ::cpu_set_t) -> ::c_int;
     pub fn sched_getcpu() -> ::c_int;
 
-    pub fn waitid(idtype: idtype_t, id: ::id_t, infop: *mut ::siginfo_t,
+    pub fn waitid(idtype: ::idtype_t, id: ::id_t, infop: *mut ::siginfo_t,
                   options: ::c_int) -> ::c_int;
 }
 

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -611,7 +611,7 @@ extern {
                                   cpuset: *const ::cpu_set_t) -> ::c_int;
     pub fn sched_getcpu() -> ::c_int;
 
-    pub fn waitid(idtype: idtype_t, id: ::c_int, infop: *mut ::siginfo_t,
+    pub fn waitid(idtype: idtype_t, id: ::id_t, infop: *mut ::siginfo_t,
                   options: ::c_int) -> ::c_int;
 }
 

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -548,6 +548,13 @@ pub const NLA_F_NESTED: ::c_int = 1 << 15;
 pub const NLA_F_NET_BYTEORDER: ::c_int = 1 << 14;
 pub const NLA_TYPE_MASK: ::c_int = !(NLA_F_NESTED | NLA_F_NET_BYTEORDER);
 
+#[repr(C)]
+pub enum idtype_t {
+    P_ALL,
+    P_PID,
+    P_PGID
+}
+
 cfg_if! {
     if #[cfg(any(target_arch = "arm", target_arch = "x86",
                  target_arch = "x86_64"))] {
@@ -603,6 +610,9 @@ extern {
                                   cpusetsize: ::size_t,
                                   cpuset: *const ::cpu_set_t) -> ::c_int;
     pub fn sched_getcpu() -> ::c_int;
+
+    pub fn waitid(idtype: idtype_t, id: ::c_int, infop: *mut ::siginfo_t,
+                  options: ::c_int) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
Waitid allows for a non-blocking way to check the status of individual threads, groups of threads, or every thread on the system.

Not 100% sure about how the linking is handled. Also can't confirm that it exists for *every* platform currently. I'm more or less gonna use travis for that.