### PR TITLE
Make the AF_NETLINK constant available for Android

### DIFF
--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -506,8 +506,6 @@ pub const EFD_SEMAPHORE: ::c_int = 0x1;
 
 pub const NCCS: usize = 32;
 
-pub const AF_NETLINK: ::c_int = 16;
-
 pub const LOG_NFACILITIES: ::c_int = 24;
 
 pub const SEM_FAILED: *mut ::sem_t = 0 as *mut sem_t;

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -435,6 +435,7 @@ pub const IFF_DYNAMIC: ::c_int = 0x8000;
 pub const AF_UNIX: ::c_int = 1;
 pub const AF_INET: ::c_int = 2;
 pub const AF_INET6: ::c_int = 10;
+pub const AF_NETLINK: ::c_int = 16;
 pub const SOCK_RAW: ::c_int = 3;
 pub const IPPROTO_TCP: ::c_int = 6;
 pub const IPPROTO_IP: ::c_int = 0;


### PR DESCRIPTION
Currently the `AF_NETLINK` constant is not available for Android, but [it has the same value as on Linux](https://android.googlesource.com/kernel/common/+/android-4.4.y/include/linux/socket.h#177). To fix it, this patch moves the definition to the common `notbsd/mod.rs`.

(this fixes an [issue we found in Servo](https://github.com/servo/servo/issues/13154#issuecomment-251325701))