### PR TITLE
Add support for Fuchsia

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -231,7 +231,6 @@ cfg_if! {
     } else if #[cfg(target_os = "fuchsia")] {
         #[link(name = "c")]
         #[link(name = "mxio")]
-        #[link(name = "unwind")]
         extern {}
     } else {
         #[link(name = "c")]

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -228,6 +228,11 @@ cfg_if! {
         #[link(name = "root")]
         #[link(name = "network")]
         extern {}
+    } else if #[cfg(target_os = "fuchsia")] {
+        #[link(name = "c")]
+        #[link(name = "mxio")]
+        #[link(name = "unwind")]
+        extern {}
     } else {
         #[link(name = "c")]
         #[link(name = "m")]
@@ -843,7 +848,8 @@ extern {
 cfg_if! {
     if #[cfg(any(target_os = "linux",
                  target_os = "android",
-                 target_os = "emscripten"))] {
+                 target_os = "emscripten",
+                 target_os = "fuchsia"))] {
         mod notbsd;
         pub use self::notbsd::*;
     } else if #[cfg(any(target_os = "macos",

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -728,6 +728,7 @@ extern {
 
 cfg_if! {
     if #[cfg(any(target_env = "musl",
+                 target_os = "fuchsia",
                  target_os = "emscripten"))] {
         mod musl;
         pub use self::musl::*;

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -53,7 +53,7 @@ s! {
         pub ai_protocol: ::c_int,
         pub ai_addrlen: socklen_t,
 
-        #[cfg(any(target_os = "linux", target_os = "emscripten"))]
+        #[cfg(any(target_os = "linux", target_os = "emscripten", target_os = "fuchsia"))]
         pub ai_addr: *mut ::sockaddr,
 
         pub ai_canonname: *mut c_char,
@@ -858,7 +858,8 @@ extern {
 
 cfg_if! {
     if #[cfg(any(target_os = "linux",
-                 target_os = "emscripten"))] {
+                 target_os = "emscripten",
+                 target_os = "fuchsia"))] {
         mod linux;
         pub use self::linux::*;
     } else if #[cfg(target_os = "android")] {

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -54,12 +54,14 @@ s! {
         pub ai_addrlen: socklen_t,
 
         #[cfg(any(target_os = "linux",
-                  target_os = "android",
                   target_os = "emscripten",
                   target_os = "fuchsia"))]
         pub ai_addr: *mut ::sockaddr,
 
         pub ai_canonname: *mut c_char,
+
+        #[cfg(target_os = "android")]
+        pub ai_addr: *mut ::sockaddr,
 
         pub ai_next: *mut addrinfo,
     }

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -54,14 +54,12 @@ s! {
         pub ai_addrlen: socklen_t,
 
         #[cfg(any(target_os = "linux",
+                  target_os = "android",
                   target_os = "emscripten",
                   target_os = "fuchsia"))]
         pub ai_addr: *mut ::sockaddr,
 
         pub ai_canonname: *mut c_char,
-
-        #[cfg(target_os = "android")]
-        pub ai_addr: *mut ::sockaddr,
 
         pub ai_next: *mut addrinfo,
     }

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -53,7 +53,9 @@ s! {
         pub ai_protocol: ::c_int,
         pub ai_addrlen: socklen_t,
 
-        #[cfg(any(target_os = "linux", target_os = "emscripten", target_os = "fuchsia"))]
+        #[cfg(any(target_os = "linux",
+                  target_os = "emscripten",
+                  target_os = "fuchsia"))]
         pub ai_addr: *mut ::sockaddr,
 
         pub ai_canonname: *mut c_char,


### PR DESCRIPTION
These patches add support for the Fuchsia operating system. For the
time being, it shares a lot of infrastructure with the Linux target,
because of the use of a musl-based libc.