### PR TITLE
Minimal liblibc for Redox

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,7 @@ cfg_if! {
     if #[cfg(windows)] {
         mod windows;
         pub use windows::*;
-    } else if #[cfg(redox)] {
+    } else if #[cfg(target_os = "redox")] {
         mod redox;
         pub use redox::*;
     } else if #[cfg(unix)] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,9 @@ cfg_if! {
     if #[cfg(windows)] {
         mod windows;
         pub use windows::*;
+    } else if #[cfg(redox)] {
+        mod redox;
+        pub use redox::*;
     } else if #[cfg(unix)] {
         mod unix;
         pub use unix::*;

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -1,0 +1,57 @@
+pub type c_char = i8;
+pub type c_long = i64;
+pub type c_ulong = u64;
+
+pub type wchar_t = i16;
+
+pub type off_t = usize;
+pub type mode_t = u16;
+pub type time_t = i64;
+pub type pid_t = usize;
+pub type gid_t = usize;
+pub type uid_t = usize;
+
+pub type in_addr_t = u32;
+pub type in_port_t = u16;
+
+pub type socklen_t = u32;
+pub type sa_family_t = u16;
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct in_addr {
+    pub s_addr: in_addr_t,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct in6_addr {
+    pub s6_addr: [u8; 16],
+    __align: [u32; 0],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct sockaddr {
+    pub sa_family: sa_family_t,
+    pub sa_data: [::c_char; 14],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct sockaddr_in {
+    pub sin_family: sa_family_t,
+    pub sin_port: ::in_port_t,
+    pub sin_addr: ::in_addr,
+    pub sin_zero: [u8; 8],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct sockaddr_in6 {
+    pub sin6_family: sa_family_t,
+    pub sin6_port: in_port_t,
+    pub sin6_flowinfo: u32,
+    pub sin6_addr: ::in6_addr,
+    pub sin6_scope_id: u32,
+}

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -17,41 +17,33 @@ pub type in_port_t = u16;
 pub type socklen_t = u32;
 pub type sa_family_t = u16;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct in_addr {
-    pub s_addr: in_addr_t,
-}
+s! {
+    pub struct in_addr {
+        pub s_addr: in_addr_t,
+    }
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct in6_addr {
-    pub s6_addr: [u8; 16],
-    __align: [u32; 0],
-}
+    pub struct in6_addr {
+        pub s6_addr: [u8; 16],
+        __align: [u32; 0],
+    }
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct sockaddr {
-    pub sa_family: sa_family_t,
-    pub sa_data: [::c_char; 14],
-}
+    pub struct sockaddr {
+        pub sa_family: sa_family_t,
+        pub sa_data: [::c_char; 14],
+    }
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct sockaddr_in {
-    pub sin_family: sa_family_t,
-    pub sin_port: ::in_port_t,
-    pub sin_addr: ::in_addr,
-    pub sin_zero: [u8; 8],
-}
+    pub struct sockaddr_in {
+        pub sin_family: sa_family_t,
+        pub sin_port: ::in_port_t,
+        pub sin_addr: ::in_addr,
+        pub sin_zero: [u8; 8],
+    }
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct sockaddr_in6 {
-    pub sin6_family: sa_family_t,
-    pub sin6_port: in_port_t,
-    pub sin6_flowinfo: u32,
-    pub sin6_addr: ::in6_addr,
-    pub sin6_scope_id: u32,
+    pub struct sockaddr_in6 {
+        pub sin6_family: sa_family_t,
+        pub sin6_port: in_port_t,
+        pub sin6_flowinfo: u32,
+        pub sin6_addr: ::in6_addr,
+        pub sin6_scope_id: u32,
+    }
 }


### PR DESCRIPTION
This implements a minimal liblibc for Redox. Previously, this was talked about here: https://internals.rust-lang.org/t/redox-support-in-liblibc-and-libstd/3954

Merging this would allow Redox to port more Rust software, and will also allow libstd to be ported to Redox.

Changes to src/lib.rs are minimal, and the src/redox.rs file is also minimal but may be expanded in the future.