### PR TITLE
Add setfsgid()/setfsuid() on linux

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -162,6 +162,7 @@ fn main() {
         cfg.header("sys/ipc.h");
         cfg.header("sys/msg.h");
         cfg.header("sys/shm.h");
+        cfg.header("sys/fsuid.h");
         cfg.header("pty.h");
         cfg.header("shadow.h");
     }

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -714,6 +714,8 @@ extern {
                              riovcnt: ::c_ulong,
                              flags: ::c_ulong) -> isize;
     pub fn reboot(how_to: ::c_int) -> ::c_int;
+    pub fn setfsgid(gid: ::gid_t) -> ::c_int;
+    pub fn setfsuid(uid: ::uid_t) -> ::c_int;
     pub fn setresgid(rgid: ::gid_t, egid: ::gid_t, sgid: ::gid_t) -> ::c_int;
     pub fn setresuid(ruid: ::uid_t, euid: ::uid_t, suid: ::uid_t) -> ::c_int;
 


### PR DESCRIPTION
Tested with the following code ran as root and then looking at the owner/group of `/tmp/foo.txt`.
```rust
extern crate libc;

use std::fs::File;

fn main() {
    unsafe {
        libc::setfsuid(1234u32);
        libc::setfsgid(5678u32);
    }
    File::create("/tmp/foo.txt").ok();
}
```
