### PR TITLE
Fix platform constants not being exposed on mips64el

### DIFF
--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -742,7 +742,7 @@ cfg_if! {
     } else if #[cfg(any(target_arch = "s390x"))] {
         mod s390x;
         pub use self::s390x::*;
-    } else if #[cfg(any(target_arch = "mips64"))] {
+    } else if #[cfg(any(target_arch = "mips64", target_arch = "mips64el"))] {
         mod mips64;
         pub use self::mips64::*;
     } else {


### PR DESCRIPTION
Just noticed this while trying to bring `rustup` to mips64el, which is almost certainly an oversight.

More work is needed to get `rustup` working on mips64el, but I'm submitting this first. More fixes to come.