### PR TITLE
Remove mipsel target_arches

### DIFF
--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -66,21 +66,21 @@ s! {
     }
 
     pub struct pthread_mutex_t {
-        #[cfg(any(target_arch = "mips", target_arch = "mipsel",
-                  target_arch = "arm", target_arch = "powerpc"))]
+        #[cfg(any(target_arch = "mips", target_arch = "arm",
+                  target_arch = "powerpc"))]
         __align: [::c_long; 0],
-        #[cfg(not(any(target_arch = "mips", target_arch = "mipsel",
-                      target_arch = "arm", target_arch = "powerpc")))]
+        #[cfg(not(any(target_arch = "mips", target_arch = "arm",
+                      target_arch = "powerpc")))]
         __align: [::c_longlong; 0],
         size: [u8; __SIZEOF_PTHREAD_MUTEX_T],
     }
 
     pub struct pthread_rwlock_t {
-        #[cfg(any(target_arch = "mips", target_arch = "mipsel",
-                  target_arch = "arm", target_arch = "powerpc"))]
+        #[cfg(any(target_arch = "mips", target_arch = "arm",
+                  target_arch = "powerpc"))]
         __align: [::c_long; 0],
-        #[cfg(not(any(target_arch = "mips", target_arch = "mipsel",
-                      target_arch = "arm", target_arch = "powerpc")))]
+        #[cfg(not(any(target_arch = "mips", target_arch = "arm",
+                      target_arch = "powerpc")))]
         __align: [::c_longlong; 0],
         size: [u8; __SIZEOF_PTHREAD_RWLOCK_T],
     }
@@ -736,7 +736,7 @@ cfg_if! {
                  target_os = "emscripten"))] {
         mod musl;
         pub use self::musl::*;
-    } else if #[cfg(any(target_arch = "mips", target_arch = "mipsel"))] {
+    } else if #[cfg(any(target_arch = "mips"))] {
         mod mips;
         pub use self::mips::*;
     } else if #[cfg(any(target_arch = "s390x"))] {


### PR DESCRIPTION
The `mipsel` `target_arch` was introduced with the initial MIPSel support (rust-lang/rust@82ec1aef293ddc5c6373bd7f5ec323fafbdf7901), but was subsequently removed with implementation of the Flexible Target Specification (Rust RFC 0131, rust-lang/rust@3a8f4ec32a80d372db2d02c76acba0276c4effd0). Remove these to be consistent with other arches and reduce confusion.

I've very slightly formatted the deletions so as to not require a style cleanup later and obscure `git blame` output.