### PR TITLE
Use `#[link(cfg(..))]` in preparation for libstd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@
 
 // Attributes needed when building as part of the standard library
 #![cfg_attr(stdbuild, feature(no_std, core, core_slice_ext, staged_api, custom_attribute, cfg_target_vendor))]
+#![cfg_attr(stdbuild, feature(link_cfg))]
 #![cfg_attr(stdbuild, no_std)]
 #![cfg_attr(stdbuild, staged_api)]
 #![cfg_attr(stdbuild, allow(warnings))]

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -205,7 +205,8 @@ cfg_if! {
         // cargo build, don't pull in anything extra as the libstd  dep
         // already pulls in all libs.
     } else if #[cfg(any(all(target_env = "musl", not(target_arch = "mips"))))] {
-        #[link(name = "c", kind = "static")]
+        #[link(name = "c", kind = "static", cfg(target_feature = "crt-static"))]
+        #[link(name = "c", cfg(not(target_feature = "crt-static")))]
         extern {}
     } else if #[cfg(target_os = "emscripten")] {
         #[link(name = "c")]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -146,8 +146,9 @@ pub const ENOTEMPTY: ::c_int = 41;
 pub const EILSEQ: ::c_int = 42;
 pub const STRUNCATE: ::c_int = 80;
 
-#[cfg(target_env = "msvc")] // " if " -- appease style checker
-#[link(name = "msvcrt")]
+#[cfg(all(target_env = "msvc", stdbuild))] // " if " -- appease style checker
+#[link(name = "msvcrt", cfg(not(target_feature = "crt-static")))]
+#[link(name = "libcmt", cfg(target_feature = "crt-static"))]
 extern {}
 
 extern {


### PR DESCRIPTION
In preparation for rust-lang/rust#37545 this is adding the appropriate
directives to libc to get included.