### PR TITLE
Issue #450 fix stack_t errors on FreeBSD 11 and later

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -442,7 +442,9 @@ fn main() {
         // sighandler_t type is super weird
         (struct_ == "sigaction" && field == "sa_sigaction") ||
         // __timeval type is a patch which doesn't exist in glibc
-        (linux && struct_ == "utmpx" && field == "ut_tv")
+        (linux && struct_ == "utmpx" && field == "ut_tv") ||
+        // stack_t.ss_sp changed from FreeBSD 10 to 11 in svn r294930
+        (freebsd && struct_ == "stack_t" && field == "ss_sp")
     });
 
     cfg.skip_field(move |struct_, field| {

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -92,6 +92,7 @@ s! {
     }
 
     pub struct stack_t {
+        // In FreeBSD 11 and later, ss_sp is a void*
         pub ss_sp: *mut ::c_char,
         pub ss_size: ::size_t,
         pub ss_flags: ::c_int,


### PR DESCRIPTION
stack_t.ss_sp changed from a char* to a void* in FreeBSD 11.  This commit suppresses
the error generated by libc-test on FreeBSD 11.