### PR TITLE
Make openbsdlike to support 64 and 32 bits archs

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
@@ -1,5 +1,3 @@
-pub type c_long = i64;
-pub type c_ulong = u64;
 pub type clock_t = i64;
 pub type suseconds_t = i64;
 pub type dev_t = i32;
@@ -448,3 +446,6 @@ cfg_if! {
         // Unknown target_os
     }
 }
+
+mod other;
+pub use self::other::*;

--- a/src/unix/bsd/netbsdlike/openbsdlike/other/b32/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/other/b32/mod.rs
@@ -1,0 +1,2 @@
+pub type c_long = i32;
+pub type c_ulong = u32;

--- a/src/unix/bsd/netbsdlike/openbsdlike/other/b64/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/other/b64/mod.rs
@@ -1,0 +1,2 @@
+pub type c_long = i64;
+pub type c_ulong = u64;

--- a/src/unix/bsd/netbsdlike/openbsdlike/other/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/other/mod.rs
@@ -1,0 +1,11 @@
+cfg_if! {
+    if #[cfg(target_arch = "x86_64")] {
+        mod b64;
+        pub use self::b64::*;
+    } else if #[cfg(target_arch = "x86")] {
+        mod b32;
+        pub use self::b32::*;
+    } else {
+        // Unknown target_arch
+    }
+}


### PR DESCRIPTION
It is a preliminary work to add a new target `i686-unknown-openbsd`.