### PR TITLE
i686-unknown-openbsd libc correction

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
@@ -1,5 +1,5 @@
 pub type clock_t = i64;
-pub type suseconds_t = i64;
+pub type suseconds_t = ::c_long;
 pub type dev_t = i32;
 pub type sigset_t = ::c_uint;
 pub type blksize_t = ::int32_t;

--- a/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
@@ -108,6 +108,9 @@ s! {
         pub si_code: ::c_int,
         pub si_errno: ::c_int,
         pub si_addr: *mut ::c_char,
+        #[cfg(target_pointer_width = "32")]
+        __pad: [u8; 112],
+        #[cfg(target_pointer_width = "64")]
         __pad: [u8; 108],
     }
 


### PR DESCRIPTION
Now I had been able to run testsuite on i686-unknown-openbsd, here a batch of corrections.

- `suseconds_t` is `c_long` (`i64` or `i32` depending the arch)
- struct siginfo_t padding adjustment (the pointer `si_addr` makes the pad to change depending pointer size)

I tested the PR on i686-unknown-openbsd and x86_64-unknown-openbsd.