### PR TITLE
When checking the status from waitpid on a kill -STOP <child_pid> WIFSIGNALED returns true

### DIFF
--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -685,7 +685,7 @@ f! {
     }
 
     pub fn WIFSIGNALED(status: ::c_int) -> bool {
-        (status & 0x7f) + 1 >= 2
+        ((status & 0x7f) + 1) as i8 >= 2
     }
 
     pub fn WTERMSIG(status: ::c_int) -> ::c_int {


### PR DESCRIPTION
Currently in WIFSIGNALED rust is doing:
(status & 0x7f) + 1
where status is i32

As defined in /usr/include/x86_64-linux-gnu/bits/waitstatus.h
#define __WIFSIGNALED(status) \
  (((signed char) (((status) & 0x7f) + 1) >> 1) > 0)

Here is an example of the issue:
http://paste2.org/fXc8BxJ0

Run it, and it'll print the child pid then:
kill -STOP <child_pid>

Expect:
  Stopped by signal print statement
Results:
  Killed by signal print statement

Using the i32, it wont overflow leaving you with 128 returning true, using the waitstatus define you'll end up with -64 (since it shifts 1 right) which would return false. Though the C version shifts right once not really sure *why* but theres most likely a reason somewhere.

For the fix, just cast to i8 (signed char pretty much) as the C version is doing.

RUNNING ALL TESTS
PASSED 7356 tests