### PR TITLE
Fix doc generation on travis.

### DIFF
--- a/ci/dox.sh
+++ b/ci/dox.sh
@@ -27,7 +27,7 @@ cat ci/landing-page-footer.html >> target/doc/index.html
 
 # If we're on travis, not a PR, and on the right branch, publish!
 if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
-  pip install ghp-import --user $USER
+  pip install ghp_import --install-option="--prefix=$HOME/.local"
   $HOME/.local/bin/ghp-import -n target/doc
   git push -qf https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
 fi


### PR DESCRIPTION
Documentation generation appears to be failing on master (https://travis-ci.org/rust-lang/libc/jobs/183483333):

```
Collecting ghp-import
  Downloading ghp-import-0.4.1.tar.gz
Collecting travis
  Could not find a version that satisfies the requirement travis (from versions: )
No matching distribution found for travis
```

Basically `--user` doesn't appear to take an option, so `pip install ghp_import --user $USER` makes pip think the user is a package that needs to be installed (in this case `travis`). As there is no `travis` package, it dies.