### PR TITLE
Add Solaris constants for fcntl-style advisory locking

### DIFF
--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -812,6 +812,10 @@ pub const LOCK_EX: ::c_int = 2;
 pub const LOCK_NB: ::c_int = 4;
 pub const LOCK_UN: ::c_int = 8;
 
+pub const F_RDLCK: ::c_int = 1;
+pub const F_WRLCK: ::c_int = 2;
+pub const F_UNLCK: ::c_int = 3;
+
 pub const O_SYNC: ::c_int = 16;
 pub const O_NONBLOCK: ::c_int = 128;
 

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -812,9 +812,9 @@ pub const LOCK_EX: ::c_int = 2;
 pub const LOCK_NB: ::c_int = 4;
 pub const LOCK_UN: ::c_int = 8;
 
-pub const F_RDLCK: ::c_int = 1;
-pub const F_WRLCK: ::c_int = 2;
-pub const F_UNLCK: ::c_int = 3;
+pub const F_RDLCK: ::c_short = 1;
+pub const F_WRLCK: ::c_short = 2;
+pub const F_UNLCK: ::c_short = 3;
 
 pub const O_SYNC: ::c_int = 16;
 pub const O_NONBLOCK: ::c_int = 128;


### PR DESCRIPTION
Solaris doesn't implement flock(), so any Rust implementation of flock()
will need to implement it using fcntl(), using the F_RDLCK, F_WRLCK, and
F_UNLCK constants.