### PR TITLE
Link libc and libm in Redox [critical]

### DIFF
--- a/src/redox.rs
+++ b/src/redox.rs
@@ -51,3 +51,7 @@ s! {
 extern {
     pub fn memalign(align: ::size_t, size: ::size_t) -> *mut ::c_void;
 }
+
+#[link(name = "c", kind = "static")]
+#[link(name = "m", kind = "static")]
+extern {}


### PR DESCRIPTION
This is critical to being able to set up a proper cross compilation setup for Redox. Due to the way libc is vendored, I have to have this change merged in and have liblibc updated in the Rust repository as well before I can have a working buildbot for Redox.