### PR TITLE
Remove kind='static' from Redox linkage

### DIFF
--- a/src/redox.rs
+++ b/src/redox.rs
@@ -52,6 +52,6 @@ extern {
     pub fn memalign(align: ::size_t, size: ::size_t) -> *mut ::c_void;
 }
 
-#[link(name = "c", kind = "static")]
-#[link(name = "m", kind = "static")]
+#[link(name = "c")]
+#[link(name = "m")]
 extern {}


### PR DESCRIPTION
Our cross compiler links binaries statically, and the rustc target has dynamic linking disabled - adding kind = "static" is not necessary.