### PR TITLE
Add getpeereid function

### DIFF
--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -355,6 +355,10 @@ extern {
     pub fn getloadavg(loadavg: *mut ::c_double, nelem: ::c_int) -> ::c_int;
     pub fn if_nameindex() -> *mut if_nameindex;
     pub fn if_freenameindex(ptr: *mut if_nameindex);
+
+    pub fn getpeereid(socket: ::c_int,
+                      euid: *mut ::uid_t,
+                      egid: *mut ::gid_t) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
This is a wrapper around getsockopt() for getting the uid/gid of a remote Unix domain socket peer. It was added in FreeBSD 4.6 and present in all modern BSDs I checked (including Mac OS X).