### PR TITLE
Add MSG_PEEK socket flag

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -860,6 +860,8 @@ pub const SO_RCVTIMEO: ::c_int = 0x1006;
 pub const SO_ERROR: ::c_int = 0x1007;
 pub const SO_TYPE: ::c_int = 0x1008;
 
+pub const MSG_PEEK: ::c_int = 0x2;
+
 pub const IFF_LOOPBACK: ::c_int = 0x8;
 
 pub const SHUT_RD: ::c_int = 0;

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -344,6 +344,7 @@ pub const NOTE_TRACK: ::uint32_t = 0x00000001;
 pub const NOTE_TRACKERR: ::uint32_t = 0x00000002;
 pub const NOTE_CHILD: ::uint32_t = 0x00000004;
 
+pub const MSG_PEEK: ::c_int = 0x2;
 pub const MSG_NOSIGNAL: ::c_int = 0x400;
 
 pub const EMPTY: ::c_short = 0;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -331,6 +331,7 @@ pub const USER_MAXID: ::c_int = 21;
 #[doc(hidden)]
 pub const CTL_P1003_1B_MAXID: ::c_int = 26;
 
+pub const MSG_PEEK: ::c_int = 0x2;
 pub const MSG_NOSIGNAL: ::c_int = 0x20000;
 
 pub const EMPTY: ::c_short = 0;

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -392,6 +392,7 @@ pub const SO_RCVLOWAT: ::c_int = 0x1004;
 pub const SO_ERROR: ::c_int = 0x1007;
 pub const SO_TYPE: ::c_int = 0x1008;
 
+pub const MSG_PEEK: ::c_int = 0x2;
 pub const MSG_NOSIGNAL: ::c_int = 0x400;
 
 pub const IFF_LOOPBACK: ::c_int = 0x8;

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -556,6 +556,7 @@ pub const IPV6_V6ONLY: ::c_int = 30;
 
 pub const SO_DEBUG: ::c_int = 0x00000004;
 
+pub const MSG_PEEK: ::c_int = 0x2;
 pub const MSG_NOSIGNAL: ::c_int = 0x0800;
 
 pub const SHUT_RD: ::c_int = 0;

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -468,6 +468,7 @@ pub const IPV6_V6ONLY: ::c_int = 26;
 
 pub const SO_DEBUG: ::c_int = 1;
 
+pub const MSG_PEEK: ::c_int = 0x2;
 pub const MSG_NOSIGNAL: ::c_int = 0x4000;
 
 pub const SHUT_RD: ::c_int = 0;


### PR DESCRIPTION
#### MSG_PEEK
This PR exposes a cross-platform `MSG_PEEK` flag that a user may pass into the `flags` parameter for `recv()`, `recvfrom()`, or `recvmsg()` calls.

```
   MSG_PEEK
          This flag causes the receive operation to return data from the
          beginning of the receive queue without removing that data from the
          queue.  Thus, a subsequent receive call will return the same data.
```

In short, users may call `recv()` to "peek" at new data (or a message) without consuming it. Recall that in the normal case, calls to `recv()` consume the data from the socket's receive queue, making it unavailable to future calls.

#### Motivation
This change enables `libc` users, such as the rust standard library, to potentially add peeking functionality to TCP and UDP implementations, like `TcpStream` and `UdpSocket`, without being concerned about the highly platform-dependent nature of the flags.

(In this case, the flag's value `0x2` is very consistent, but that is not the case for many of the `MSG_*` flags. It makes sense to keep these differences confined to `libc`)

#### Reference
[bsd/apple: socket.h](https://opensource.apple.com/source/xnu/xnu-2050.7.9/bsd/sys/socket.h)
[bsd/freebsdlike/freebsd: socket.h](https://github.com/freebsd/freebsd/blob/master/sys/sys/socket.h#L418)
[bsd/freebsdlike/dragonfly: socket.h](https://github.com/DragonFlyBSD/DragonFlyBSD/blob/1f249c981c4e89e7cde1836a75b61cac36dc7ac5/sys/sys/socket.h#L367)
[bsd/netbsdlike: socket.h](https://github.com/IIJ-NetBSD/netbsd-src/blob/af5d253140491f2d1816c59ecb8a4d8a8d927688/sys/sys/socket.h#L517)
[unix/haiku: socket.h](https://github.com/haiku/haiku/blob/b65adbdfbc322bb7d86d74049389c688e9962f15/headers/posix/sys/socket.h#L114)
[unix/notbsd/linux: socket.h](https://github.com/torvalds/linux/blob/5924bbecd0267d87c24110cbe2041b5075173a25/include/linux/socket.h#L264)
[unix/notbsd/android: socket.h](https://android.googlesource.com/platform/development/+/73a5a3baaa5089f1ab2049e5934fa5d8a3f3e76a/ndk/platforms/android-20/include/sys/socket.h#229)
