### PR TITLE
Add wcstombs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,7 @@ extern {
     pub fn strtok(s: *mut c_char, t: *const c_char) -> *mut c_char;
     pub fn strxfrm(s: *mut c_char, ct: *const c_char, n: size_t) -> size_t;
     pub fn wcslen(buf: *const wchar_t) -> size_t;
+    pub fn wcstombs(dest: *mut c_char, src: *const wchar_t, n: size_t) -> ::size_t;
 
     pub fn memchr(cx: *const c_void, c: c_int, n: size_t) -> *mut c_void;
     pub fn memcmp(cx: *const c_void, ct: *const c_void, n: size_t) -> c_int;


### PR DESCRIPTION
Add `wcstombs` function to convert from wide chars to multibyte chars.

The `wcstombs(`) function conforms to ISO/IEC 9899:1999 (ISO C99)