### PR TITLE
Fix android SA_* constants

### DIFF
--- a/src/unix/notbsd/android/b32/mod.rs
+++ b/src/unix/notbsd/android/b32/mod.rs
@@ -161,6 +161,15 @@ s! {
     }
 }
 
+// These constants must be of the same type of sigaction.sa_flags
+pub const SA_NOCLDSTOP: ::c_ulong = 0x00000001;
+pub const SA_NOCLDWAIT: ::c_ulong = 0x00000002;
+pub const SA_NODEFER: ::c_ulong = 0x40000000;
+pub const SA_ONSTACK: ::c_ulong = 0x08000000;
+pub const SA_RESETHAND: ::c_ulong = 0x80000000;
+pub const SA_RESTART: ::c_ulong = 0x10000000;
+pub const SA_SIGINFO: ::c_ulong = 0x00000004;
+
 pub const RTLD_GLOBAL: ::c_int = 2;
 pub const RTLD_NOW: ::c_int = 0;
 pub const RTLD_DEFAULT: *mut ::c_void = -1isize as *mut ::c_void;

--- a/src/unix/notbsd/android/b64/mod.rs
+++ b/src/unix/notbsd/android/b64/mod.rs
@@ -231,6 +231,15 @@ cfg_if! {
     }
 }
 
+// These constants must be of the same type of sigaction.sa_flags
+pub const SA_NOCLDSTOP: ::c_uint = 0x00000001;
+pub const SA_NOCLDWAIT: ::c_uint = 0x00000002;
+pub const SA_NODEFER: ::c_uint = 0x40000000;
+pub const SA_ONSTACK: ::c_uint = 0x08000000;
+pub const SA_RESETHAND: ::c_uint = 0x80000000;
+pub const SA_RESTART: ::c_uint = 0x10000000;
+pub const SA_SIGINFO: ::c_uint = 0x00000004;
+
 pub const RTLD_GLOBAL: ::c_int = 0x00100;
 pub const RTLD_NOW: ::c_int = 2;
 pub const RTLD_DEFAULT: *mut ::c_void = 0i64 as *mut ::c_void;

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -560,11 +560,6 @@ pub const ECOMM: ::c_int = 70;
 pub const EPROTO: ::c_int = 71;
 pub const EDOTDOT: ::c_int = 73;
 
-pub const SA_NODEFER: ::c_int = 0x40000000;
-pub const SA_RESETHAND: ::c_int = 0x80000000;
-pub const SA_RESTART: ::c_int = 0x10000000;
-pub const SA_NOCLDSTOP: ::c_int = 0x00000001;
-
 pub const EPOLL_CLOEXEC: ::c_int = 0x80000;
 pub const EPOLLONESHOT: ::c_int = 0x40000000;
 pub const EPOLLRDHUP: ::c_int = 0x00002000;
@@ -745,9 +740,6 @@ pub const PTHREAD_MUTEX_DEFAULT: ::c_int = PTHREAD_MUTEX_NORMAL;
 
 pub const FIOCLEX: ::c_int = 0x5451;
 
-pub const SA_ONSTACK: ::c_ulong = 0x08000000;
-pub const SA_SIGINFO: ::c_ulong = 0x00000004;
-pub const SA_NOCLDWAIT: ::c_ulong = 0x00000002;
 pub const SIGCHLD: ::c_int = 17;
 pub const SIGBUS: ::c_int = 7;
 pub const SIGUSR1: ::c_int = 10;


### PR DESCRIPTION
Trying to crosscompile wait-timeout to armv7-linux-androideabi I found that SA_* had different types in libc, but they have to be the same because they are used in bitwise operations. 