### PR TITLE
Add AF_UNSPEC from Apple socket.h

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -819,6 +819,7 @@ pub const MINCORE_MODIFIED: ::c_int = 0x4;
 pub const MINCORE_REFERENCED_OTHER: ::c_int = 0x8;
 pub const MINCORE_MODIFIED_OTHER: ::c_int = 0x10;
 
+pub const AF_UNSPEC: ::c_int = 0;
 pub const AF_UNIX: ::c_int = 1;
 pub const AF_INET: ::c_int = 2;
 pub const AF_INET6: ::c_int = 30;


### PR DESCRIPTION
[socket.h](https://opensource.apple.com/source/xnu/xnu-792.13.8/bsd/sys/socket.h) of Apple contains this definition so i'm not sure why it is missing from libc.
The same goes for other BSD-like OSes...
Is there some particular reasons why it is so?