### PR TITLE
Correct solaris libc definitions:

### DIFF
--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -453,10 +453,13 @@ pub const SIG_SETMASK: ::c_int = 3;
 pub const IPV6_MULTICAST_LOOP: ::c_int = 0x8;
 pub const IPV6_V6ONLY: ::c_int = 0x27;
 
-#[cfg(target_pointer_width = "64")]
-pub const FD_SETSIZE: usize = 65536;
-#[cfg(target_pointer_width = "32")]
-pub const FD_SETSIZE: usize = 1024;
+cfg_if! {
+    if #[cfg(target_pointer_width = "64")] {
+        pub const FD_SETSIZE: usize = 65536;
+    } else {
+        pub const FD_SETSIZE: usize = 1024;
+    }
+}
 
 pub const ST_RDONLY: ::c_ulong = 1;
 pub const ST_NOSUID: ::c_ulong = 2;


### PR DESCRIPTION
* pthread_t is defined as uint_t, so must be c_uint, not uintptr_t, just
  as pthread_key_t is already defined
* fd_set is defined as long, so must be i32/i64 based on
  target_pointer_width; this also fixes an indirect endianness issue
  encountered on sparc
* FD_SETSIZE should be defined as 65536 when target_pointer_width = 64

Fixes #515