### PR TITLE
WIFCONTINUED function on Linux and FreeBSD

### DIFF
--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -756,8 +756,8 @@ pub const NETGRAPHDISC: ::c_int = 0x6;
 pub const SEM_FAILED: *mut sem_t = 0 as *mut sem_t;
 
 f! {
-    pub fn WIFCONTINUED(status: ::c_int) -> ::c_int {
-        status & 0o23
+    pub fn WIFCONTINUED(status: ::c_int) -> bool {
+        status == 0x13
     }
 
     pub fn WSTOPSIG(status: ::c_int) -> ::c_int {

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -667,6 +667,10 @@ f! {
         (status >> 8) & 0xff
     }
 
+    pub fn WIFCONTINUED(status: ::c_int) -> bool {
+        status == 0xffff
+    }
+
     pub fn WIFSIGNALED(status: ::c_int) -> bool {
         ((status & 0x7f) + 1) as i8 >= 2
     }


### PR DESCRIPTION
* Adds the missing WIFCONTINUED function to Linux (in `src/unix/notbsd/mod.rs`).
* Modifies the signature of WIFCONTINUED on FreeBSD (`src/unix/bsd/freebsdlike/mod.rs`) to be consistent with the ones on MacOS and Linux.