### PR TITLE
posix definitions should be used on Solaris

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -352,6 +352,7 @@ extern {
     pub fn opendir(dirname: *const c_char) -> *mut ::DIR;
     #[cfg_attr(target_os = "macos", link_name = "readdir_r$INODE64")]
     #[cfg_attr(target_os = "netbsd", link_name = "__readdir_r30")]
+    #[cfg_attr(target_os = "solaris", link_name = "__posix_readdir_r")]
     pub fn readdir_r(dirp: *mut ::DIR, entry: *mut ::dirent,
                      result: *mut *mut ::dirent) -> ::c_int;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
@@ -638,6 +639,7 @@ extern {
                        oss: *mut stack_t) -> ::c_int;
     #[cfg_attr(all(target_os = "macos", target_arch ="x86"),
                link_name = "sigwait$UNIX2003")]
+    #[cfg_attr(target_os = "solaris", link_name = "__posix_sigwait")]
     pub fn sigwait(set: *const sigset_t,
                    sig: *mut ::c_int) -> ::c_int;
 

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -1023,14 +1023,19 @@ extern {
                        serv: *mut ::c_char,
                        sevlen: ::socklen_t,
                        flags: ::c_int) -> ::c_int;
+    #[link_name = "__posix_getpwnam_r"]
     pub fn getpwnam_r(name: *const ::c_char,
                       pwd: *mut passwd,
                       buf: *mut ::c_char,
-                      buflen: ::c_int) -> *const passwd;
+                      buflen: ::size_t,
+                      result: *mut *mut passwd) -> ::c_int;
+
+    #[link_name = "__posix_getpwuid_r"]
     pub fn getpwuid_r(uid: ::uid_t,
                       pwd: *mut passwd,
                       buf: *mut ::c_char,
-                      buflen: ::c_int) -> *const passwd;
+                      buflen: ::size_t,
+                      result: *mut *mut passwd) -> ::c_int;
     pub fn setpwent();
     pub fn getpwent() -> *mut passwd;
     pub fn readdir(dirp: *mut ::DIR) -> *const ::dirent;


### PR DESCRIPTION
For compatibility reasons, Solaris historically had its header files
setup so that, unless specifically requested through specific header
defines, either the old pre-POSIX interfaces or POSIX.1c Draft 6
interfaces were used. However, in the case of rust, since these symbols
are linked directly instead of via system header files, the underlying
posix symbol name can be used directly instead.

These definitions should be corrected to match what they do on almost
every other platform.

Be aware this is a breaking change in terms of interface for any crates
/ consumers of these interfaces for Solaris.

Fixes #522