### PR TITLE
Add EPOLLEXCLUSIVE that is added in Linux 4.5.

### DIFF
--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -500,6 +500,7 @@ pub const EPOLLWRBAND: ::c_int = 0x200;
 pub const EPOLLMSG: ::c_int = 0x400;
 pub const EPOLLERR: ::c_int = 0x8;
 pub const EPOLLHUP: ::c_int = 0x10;
+pub const EPOLLEXCLUSIVE: ::c_int = 0x10000000;
 pub const EPOLLET: ::c_int = 0x80000000;
 
 pub const EPOLL_CTL_ADD: ::c_int = 1;


### PR DESCRIPTION
Add [EPOLLEXCLUSIVE](https://kernelnewbies.org/Linux_4.5#head-64f3b13b9026133a232a418a27ac029e21fff2ba) that is added in Linux 4.5.