### PR TITLE
add tmpnam and pthread_exit

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -549,6 +549,7 @@ extern {
                link_name = "pthread_join$UNIX2003")]
     pub fn pthread_join(native: ::pthread_t,
                         value: *mut *mut ::c_void) -> ::c_int;
+    pub fn pthread_exit(value: *mut c_void);
     pub fn pthread_attr_init(attr: *mut ::pthread_attr_t) -> ::c_int;
     pub fn pthread_attr_destroy(attr: *mut ::pthread_attr_t) -> ::c_int;
     pub fn pthread_attr_setstacksize(attr: *mut ::pthread_attr_t,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -543,7 +543,7 @@ extern {
     pub fn pthread_self() -> ::pthread_t;
     pub fn pthread_create(native: *mut ::pthread_t,
                           attr: *const ::pthread_attr_t,
-                          f: extern fn(*mut ::c_void) -> *mut ::c_void,
+                          f: unsafe extern fn(*mut ::c_void) -> *mut ::c_void,
                           value: *mut ::c_void) -> ::c_int;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "pthread_join$UNIX2003")]

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -843,6 +843,7 @@ extern {
     pub fn mkstemp(template: *mut ::c_char) -> ::c_int;
     pub fn mkstemps(template: *mut ::c_char, suffixlen: ::c_int) -> ::c_int;
     pub fn mkdtemp(template: *mut ::c_char) -> *mut ::c_char;
+    pub fn tmpnam(ptr: *mut ::c_char) -> *mut ::c_char;
     pub fn futimes(fd: ::c_int, times: *const ::timeval) -> ::c_int;
     pub fn nl_langinfo(item: ::nl_item) -> *mut ::c_char;
 

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -358,9 +358,6 @@ extern {
     #[cfg_attr(target_os = "solaris", link_name = "__posix_readdir_r")]
     pub fn readdir_r(dirp: *mut ::DIR, entry: *mut ::dirent,
                      result: *mut *mut ::dirent) -> ::c_int;
-    #[cfg_attr(target_os = "macos", link_name = "readdir$INODE64")]
-    #[cfg_attr(target_os = "netbsd", link_name = "__readdir30")]
-    pub fn readdir(arg1: *mut ::DIR) -> *mut ::dirent;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "closedir$UNIX2003")]
     pub fn closedir(dirp: *mut ::DIR) -> ::c_int;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -354,6 +354,9 @@ extern {
     #[cfg_attr(target_os = "netbsd", link_name = "__readdir_r30")]
     pub fn readdir_r(dirp: *mut ::DIR, entry: *mut ::dirent,
                      result: *mut *mut ::dirent) -> ::c_int;
+    #[cfg_attr(target_os = "macos", link_name = "readdir$INODE64")]
+    #[cfg_attr(target_os = "netbsd", link_name = "__readdir30")]
+    pub fn readdir(arg1: *mut DIR) -> *mut dirent;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "closedir$UNIX2003")]
     pub fn closedir(dirp: *mut ::DIR) -> ::c_int;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -543,7 +543,7 @@ extern {
     pub fn pthread_self() -> ::pthread_t;
     pub fn pthread_create(native: *mut ::pthread_t,
                           attr: *const ::pthread_attr_t,
-                          f: unsafe extern fn(*mut ::c_void) -> *mut ::c_void,
+                          f: extern fn(*mut ::c_void) -> *mut ::c_void,
                           value: *mut ::c_void) -> ::c_int;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "pthread_join$UNIX2003")]

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -356,7 +356,7 @@ extern {
                      result: *mut *mut ::dirent) -> ::c_int;
     #[cfg_attr(target_os = "macos", link_name = "readdir$INODE64")]
     #[cfg_attr(target_os = "netbsd", link_name = "__readdir30")]
-    pub fn readdir(arg1: *mut DIR) -> *mut dirent;
+    pub fn readdir(arg1: *mut ::DIR) -> *mut ::dirent;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "closedir$UNIX2003")]
     pub fn closedir(dirp: *mut ::DIR) -> ::c_int;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -549,7 +549,7 @@ extern {
                link_name = "pthread_join$UNIX2003")]
     pub fn pthread_join(native: ::pthread_t,
                         value: *mut *mut ::c_void) -> ::c_int;
-    pub fn pthread_exit(value: *mut c_void);
+    pub fn pthread_exit(value: *mut ::c_void);
     pub fn pthread_attr_init(attr: *mut ::pthread_attr_t) -> ::c_int;
     pub fn pthread_attr_destroy(attr: *mut ::pthread_attr_t) -> ::c_int;
     pub fn pthread_attr_setstacksize(attr: *mut ::pthread_attr_t,

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -997,7 +997,6 @@ extern {
                       buflen: ::c_int) -> *const passwd;
     pub fn setpwent();
     pub fn getpwent() -> *mut passwd;
-    pub fn readdir(dirp: *mut ::DIR) -> *const ::dirent;
     pub fn fdatasync(fd: ::c_int) -> ::c_int;
     pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t) -> *mut ::c_char;
     pub fn duplocale(base: ::locale_t) -> ::locale_t;


### PR DESCRIPTION
tmpnam and readdir are trivial IMO.

About the `pthread_create` change: It needs `unsafe` for passing `C` functions to pthread_create (with rust functions the omission of `unsafe` is working of course).

`bindgen` produces this function definition:

```
pub fn pthread_create(arg1: *mut pthread_t,
                      arg2: *const pthread_attr_t,
                      arg3: Option<unsafe extern "C" fn(arg1: *mut c_void) -> *mut c_void>,
                      arg4: *mut c_void) -> c_int;
```

So it would add an additional `Option` around the function. But that would break existing code which uses `libc::pthread_create` and what use is it to call pthread_create without any function pointer, so I left `Option` out.

For reference: I also opened a [stackoverflow question](http://stackoverflow.com/questions/42284562) where the answers were also suggesting adding `unsafe` to the function definition.