### PR TITLE
Add definitions to Android to allow fs2 crate compile

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -101,6 +101,7 @@ fn main() {
         cfg.header("poll.h");
         cfg.header("syslog.h");
         cfg.header("semaphore.h");
+        cfg.header("sys/statvfs.h");
     }
 
     if android {
@@ -111,7 +112,6 @@ fn main() {
     } else if !windows {
         cfg.header("glob.h");
         cfg.header("ifaddrs.h");
-        cfg.header("sys/statvfs.h");
         cfg.header("langinfo.h");
 
         if !openbsd && !freebsd && !dragonfly {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -745,6 +745,8 @@ extern {
                     pshared: ::c_int,
                     value: ::c_uint)
                     -> ::c_int;
+    pub fn statvfs(path: *const c_char, buf: *mut statvfs) -> ::c_int;
+    pub fn fstatvfs(fd: ::c_int, buf: *mut statvfs) -> ::c_int;
 }
 
 // TODO: get rid of this cfg(not(...))
@@ -824,8 +826,6 @@ extern {
     pub fn ftello(stream: *mut ::FILE) -> ::off_t;
     #[cfg_attr(target_os = "netbsd", link_name = "__timegm50")]
     pub fn timegm(tm: *mut ::tm) -> time_t;
-    pub fn statvfs(path: *const c_char, buf: *mut statvfs) -> ::c_int;
-    pub fn fstatvfs(fd: ::c_int, buf: *mut statvfs) -> ::c_int;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "tcdrain$UNIX2003")]
     pub fn tcdrain(fd: ::c_int) -> ::c_int;

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -136,6 +136,20 @@ s! {
         pub ut_addr_v6: [::int32_t; 4],
         unused: [::c_char; 20],
     }
+
+    pub struct statvfs {
+        pub f_bsize: ::c_ulong,
+        pub f_frsize: ::c_ulong,
+        pub f_blocks: ::fsblkcnt_t,
+        pub f_bfree: ::fsblkcnt_t,
+        pub f_bavail: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
+        pub f_favail: ::fsfilcnt_t,
+        pub f_fsid: ::c_ulong,
+        pub f_flag: ::c_ulong,
+        pub f_namemax: ::c_ulong,
+    }
 }
 
 pub const O_TRUNC: ::c_int = 512;
@@ -801,6 +815,9 @@ extern {
     pub fn utmpname(name: *const ::c_char) -> ::c_int;
     pub fn setutent();
     pub fn getutent() -> *mut utmp;
+
+    pub fn posix_fallocate(fd: ::c_int, offset: ::off_t,
+                           len: ::off_t) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
This is the only missing part to allow cargo to compile on android.