### PR TITLE
Make readdir available on all unix targets

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -352,7 +352,7 @@ extern {
     pub fn opendir(dirname: *const c_char) -> *mut ::DIR;
     #[cfg_attr(target_os = "macos", link_name = "readdir$INODE64")]
     #[cfg_attr(target_os = "netbsd", link_name = "__readdir30")]
-    pub fn readdir(dirp: *mut ::DIR) -> *const ::dirent;
+    pub fn readdir(dirp: *mut ::DIR) -> *mut ::dirent;
     #[cfg_attr(target_os = "macos", link_name = "readdir_r$INODE64")]
     #[cfg_attr(target_os = "netbsd", link_name = "__readdir_r30")]
     pub fn readdir_r(dirp: *mut ::DIR, entry: *mut ::dirent,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -350,6 +350,9 @@ extern {
                link_name = "opendir$INODE64$UNIX2003")]
     #[cfg_attr(target_os = "netbsd", link_name = "__opendir30")]
     pub fn opendir(dirname: *const c_char) -> *mut ::DIR;
+    #[cfg_attr(target_os = "macos", link_name = "readdir$INODE64")]
+    #[cfg_attr(target_os = "netbsd", link_name = "__readdir30")]
+    pub fn readdir(dirp: *mut ::DIR) -> *const ::dirent;
     #[cfg_attr(target_os = "macos", link_name = "readdir_r$INODE64")]
     #[cfg_attr(target_os = "netbsd", link_name = "__readdir_r30")]
     pub fn readdir_r(dirp: *mut ::DIR, entry: *mut ::dirent,

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -1017,7 +1017,6 @@ extern {
                       buflen: ::c_int) -> *const passwd;
     pub fn setpwent();
     pub fn getpwent() -> *mut passwd;
-    pub fn readdir(dirp: *mut ::DIR) -> *const ::dirent;
     pub fn fdatasync(fd: ::c_int) -> ::c_int;
     pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t) -> *mut ::c_char;
     pub fn duplocale(base: ::locale_t) -> ::locale_t;


### PR DESCRIPTION
The readdir_r call has problems, and we'll probably want to move to
readdir on many, if not most, unix targets. This patch makes readdir
available in unix, rather than just solaris as before.

See https://github.com/rust-lang/rust/issues/40021