### PR TITLE
epoll: Add EPOLLEXCLUSIVE

### DIFF
--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -501,6 +501,7 @@ pub const EPOLLMSG: ::c_int = 0x400;
 pub const EPOLLERR: ::c_int = 0x8;
 pub const EPOLLHUP: ::c_int = 0x10;
 pub const EPOLLET: ::c_int = 0x80000000;
+pub const EPOLLEXCLUSIVE: ::c_int = 0x10000000;
 
 pub const EPOLL_CTL_ADD: ::c_int = 1;
 pub const EPOLL_CTL_MOD: ::c_int = 3;


### PR DESCRIPTION
This flag was added in Linux 4.5.