### PR TITLE
epoll: Change type of EPOLL flags to uint32_t

### DIFF
--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -495,9 +495,9 @@ pub const SHM_UNLOCK: ::c_int = 12;
 pub const SHM_HUGETLB: ::c_int = 0o4000;
 pub const SHM_NORESERVE: ::c_int = 0o10000;
 
-pub const EPOLLRDHUP: ::c_int = 0x2000;
-pub const EPOLLEXCLUSIVE: ::c_int = 0x10000000;
-pub const EPOLLONESHOT: ::c_int = 0x40000000;
+pub const EPOLLRDHUP: ::uint32_t = 0x2000;
+pub const EPOLLEXCLUSIVE: ::uint32_t = 0x10000000;
+pub const EPOLLONESHOT: ::uint32_t = 0x40000000;
 
 pub const QFMT_VFS_OLD: ::c_int = 1;
 pub const QFMT_VFS_V0: ::c_int = 2;

--- a/src/unix/notbsd/linux/musl/mod.rs
+++ b/src/unix/notbsd/linux/musl/mod.rs
@@ -199,7 +199,7 @@ pub const PTRACE_O_SUSPEND_SECCOMP: ::c_int = 2097152;
 pub const MADV_DODUMP: ::c_int = 17;
 pub const MADV_DONTDUMP: ::c_int = 16;
 
-pub const EPOLLWAKEUP: ::c_int = 0x20000000;
+pub const EPOLLWAKEUP: ::uint32_t = 0x20000000;
 
 pub const POLLRDNORM: ::c_short = 0x040;
 pub const POLLRDBAND: ::c_short = 0x080;

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -334,7 +334,7 @@ pub const PTRACE_PEEKSIGINFO: ::c_uint = 0x4209;
 pub const MADV_DODUMP: ::c_int = 17;
 pub const MADV_DONTDUMP: ::c_int = 16;
 
-pub const EPOLLWAKEUP: ::c_int = 0x20000000;
+pub const EPOLLWAKEUP: ::uint32_t = 0x20000000;
 
 pub const MADV_HUGEPAGE: ::c_int = 14;
 pub const MADV_NOHUGEPAGE: ::c_int = 15;

--- a/src/unix/notbsd/linux/s390x.rs
+++ b/src/unix/notbsd/linux/s390x.rs
@@ -615,7 +615,7 @@ pub const PTRACE_PEEKSIGINFO: ::c_uint = 0x4209;
 pub const MADV_DODUMP: ::c_int = 17;
 pub const MADV_DONTDUMP: ::c_int = 16;
 
-pub const EPOLLWAKEUP: ::c_int = 0x20000000;
+pub const EPOLLWAKEUP: ::uint32_t = 0x20000000;
 
 pub const MADV_HUGEPAGE: ::c_int = 14;
 pub const MADV_NOHUGEPAGE: ::c_int = 15;

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -490,17 +490,17 @@ pub const PATH_MAX: ::c_int = 4096;
 
 pub const FD_SETSIZE: usize = 1024;
 
-pub const EPOLLIN: ::c_int = 0x1;
-pub const EPOLLPRI: ::c_int = 0x2;
-pub const EPOLLOUT: ::c_int = 0x4;
-pub const EPOLLRDNORM: ::c_int = 0x40;
-pub const EPOLLRDBAND: ::c_int = 0x80;
-pub const EPOLLWRNORM: ::c_int = 0x100;
-pub const EPOLLWRBAND: ::c_int = 0x200;
-pub const EPOLLMSG: ::c_int = 0x400;
-pub const EPOLLERR: ::c_int = 0x8;
-pub const EPOLLHUP: ::c_int = 0x10;
-pub const EPOLLET: ::c_int = 0x80000000;
+pub const EPOLLIN: ::uint32_t = 0x1;
+pub const EPOLLPRI: ::uint32_t = 0x2;
+pub const EPOLLOUT: ::uint32_t = 0x4;
+pub const EPOLLRDNORM: ::uint32_t = 0x40;
+pub const EPOLLRDBAND: ::uint32_t = 0x80;
+pub const EPOLLWRNORM: ::uint32_t = 0x100;
+pub const EPOLLWRBAND: ::uint32_t = 0x200;
+pub const EPOLLMSG: ::uint32_t = 0x400;
+pub const EPOLLERR: ::uint32_t = 0x8;
+pub const EPOLLHUP: ::uint32_t = 0x10;
+pub const EPOLLET: ::uint32_t = 0x80000000;
 
 pub const EPOLL_CTL_ADD: ::c_int = 1;
 pub const EPOLL_CTL_MOD: ::c_int = 3;


### PR DESCRIPTION
These flags are used the `events` field of `struct epoll_event`, which
has that type.

    pub struct epoll_event {
        pub events: ::uint32_t,
        pub u64: ::uint64_t,
    }