### PR TITLE
Add cfmakeraw and cfsetspeed

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -835,8 +835,10 @@ extern {
     pub fn tcdrain(fd: ::c_int) -> ::c_int;
     pub fn cfgetispeed(termios: *const ::termios) -> ::speed_t;
     pub fn cfgetospeed(termios: *const ::termios) -> ::speed_t;
+    pub fn cfmakeraw(termios: *mut ::termios);
     pub fn cfsetispeed(termios: *mut ::termios, speed: ::speed_t) -> ::c_int;
     pub fn cfsetospeed(termios: *mut ::termios, speed: ::speed_t) -> ::c_int;
+    pub fn cfsetspeed(termios: *mut ::termios, speed: ::speed_t) -> ::c_int;
     pub fn tcgetattr(fd: ::c_int, termios: *mut ::termios) -> ::c_int;
     pub fn tcsetattr(fd: ::c_int,
                      optional_actions: ::c_int,

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -752,12 +752,27 @@ f! {
     pub fn cfgetospeed(termios: *const ::termios) -> ::speed_t {
         (*termios).c_cflag & ::CBAUD
     }
+    pub fn cfmakeraw(termios: *mut ::termios) -> () {
+        (*termios).c_iflag &= !(::IGNBRK | ::BRKINT | ::PARMRK | ::ISTRIP |
+                              ::INLCR | ::IGNCR | ::ICRNL | ::IXON);
+        (*termios).c_oflag &= !::OPOST;
+        (*termios).c_lflag &= !(::ECHO | ::ECHONL | ::ICANON | ::ISIG |
+                              ::IEXTEN);
+        (*termios).c_cflag &= !(::CSIZE | ::PARENB);
+        (*termios).c_cflag |= ::CS8;
+        ()
+    }
     pub fn cfsetispeed(termios: *mut ::termios, speed: ::speed_t) -> ::c_int {
         let cbaud = ::CBAUD;
         (*termios).c_cflag = ((*termios).c_cflag & !cbaud) | (speed & cbaud);
         return 0
     }
     pub fn cfsetospeed(termios: *mut ::termios, speed: ::speed_t) -> ::c_int {
+        let cbaud = ::CBAUD;
+        (*termios).c_cflag = ((*termios).c_cflag & !cbaud) | (speed & cbaud);
+        return 0
+    }
+    pub fn cfsetspeed(termios: *mut ::termios, speed: ::speed_t) -> ::c_int {
         let cbaud = ::CBAUD;
         (*termios).c_cflag = ((*termios).c_cflag & !cbaud) | (speed & cbaud);
         return 0


### PR DESCRIPTION
This includes implementations for Android. `cfsetspeed` is basically just a back-to-back call to `cfsetispeed` and `cfsetospeed`, both of which seem to do the same thing here, so I just copied that body as well for `cfsetspeed`. The implementation for `cfmakeraw` was taken from the man pages for `termios(3)`.