### PR TITLE
Add support for the `accept4` system call for FreeBSD* & NetBSD*

### DIFF
--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -980,6 +980,8 @@ extern {
                      base: ::locale_t) -> ::locale_t;
     pub fn uselocale(loc: ::locale_t) -> ::locale_t;
     pub fn querylocale(mask: ::c_int, loc: ::locale_t) -> *const ::c_char;
+    pub fn accept4(s: ::c_int, addr: *mut ::sockaddr,
+                   addrlen: *mut ::socklen_t, flags: ::c_int) -> ::c_int;
     pub fn pthread_set_name_np(tid: ::pthread_t, name: *const ::c_char);
     pub fn pthread_attr_get_np(tid: ::pthread_t,
                                attr: *mut ::pthread_attr_t) -> ::c_int;

--- a/src/unix/bsd/netbsdlike/openbsdlike/openbsd.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/openbsd.rs
@@ -26,3 +26,8 @@ s! {
         pub int_n_sign_posn: ::c_char,
     }
 }
+
+extern {
+    pub fn accept4(s: ::c_int, addr: *mut ::sockaddr,
+                   addrlen: *mut ::socklen_t, flags: ::c_int) -> ::c_int;
+}


### PR DESCRIPTION
As outlined in #540.

However since support for this system call seems to be committed, but not yet released in NetBSD & BitRig (is BitRig actually still be developed at all, btw?), I'm not sure whether it wouldn't be a better idea to only add OpenBSD support instead?
What's the official policy on this?