### PR TITLE
Add FIONREAD for apple/b64

### DIFF
--- a/src/unix/bsd/apple/b64.rs
+++ b/src/unix/bsd/apple/b64.rs
@@ -17,3 +17,5 @@ pub const __PTHREAD_RWLOCK_SIZE__: usize = 192;
 
 pub const TIOCTIMESTAMP: ::c_ulong = 0x40107459;
 pub const TIOCDCDTIMESTAMP: ::c_ulong = 0x40107458;
+
+pub const FIONREAD: ::c_ulong = 0x4004667f;


### PR DESCRIPTION
Adds the FIONREAD constant for macos/x86_64 machines.