### PR TITLE
Link libc crate against pthread

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -242,6 +242,7 @@ cfg_if! {
         #[link(name = "c")]
         #[link(name = "m")]
         #[link(name = "rt")]
+        #[link(name = "pthread")]
         extern {}
     }
 }


### PR DESCRIPTION
pthread_* functions are defined in libpthread thus we need to link against
this library.