### PR TITLE
Add x86_64-linux-android support

### DIFF
--- a/ci/android-install-sdk.sh
+++ b/ci/android-install-sdk.sh
@@ -37,6 +37,10 @@ case "$1" in
     abi=x86
     ;;
 
+  x86_64)
+    abi=x86_64
+    ;;
+
   *)
     echo "invalid arch: $1"
     exit 1

--- a/ci/docker/x86_64-linux-android/Dockerfile
+++ b/ci/docker/x86_64-linux-android/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:16.04
+
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+  file \
+  curl \
+  ca-certificates \
+  python \
+  unzip \
+  expect \
+  openjdk-9-jre \
+  libstdc++6:i386 \
+  libpulse0 \
+  gcc \
+  libc6-dev
+
+WORKDIR /android/
+COPY android* /android/
+
+ENV ANDROID_ARCH=x86_64
+ENV PATH=$PATH:/android/ndk-$ANDROID_ARCH/bin:/android/sdk/tools:/android/sdk/platform-tools
+
+RUN sh /android/android-install-ndk.sh $ANDROID_ARCH
+RUN sh /android/android-install-sdk.sh $ANDROID_ARCH
+RUN mv /root/.android /tmp
+RUN chmod 777 -R /tmp/.android
+RUN chmod 755 /android/sdk/tools/* /android/sdk/tools/qemu/linux-x86_64/*
+
+ENV PATH=$PATH:/rust/bin \
+    CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=x86_64-linux-android-gcc \
+    HOME=/tmp

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -8,10 +8,14 @@ run() {
     # use -f so we can use ci/ as build context
     docker build -t libc -f ci/docker/$1/Dockerfile ci/
     mkdir -p target
+    if [ -w /dev/kvm ]; then
+      kvm="--volume /dev/kvm:/dev/kvm"
+    fi
     docker run \
       --user `id -u`:`id -g` \
       --rm \
       --volume $HOME/.cargo:/cargo \
+      $kvm \
       --env CARGO_HOME=/cargo \
       --volume `rustc --print sysroot`:/rust:ro \
       --volume `pwd`:/checkout:ro \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -111,7 +111,11 @@ case "$TARGET" in
     # https://issues.jenkins-ci.org/browse/JENKINS-26930?focusedCommentId=230791&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-230791
     export SHELL=/bin/dash
     arch=$(echo $TARGET | cut -d- -f1)
-    emulator @$arch -no-window -no-accel &
+    accel="-no-accel"
+    if emulator -accel-check; then
+      accel=""
+    fi
+    emulator @$arch -no-window $accel &
     adb wait-for-device
     adb push $CARGO_TARGET_DIR/$TARGET/debug/libc-test /data/local/tmp/libc-test
     adb shell /data/local/tmp/libc-test 2>&1 | tee /tmp/out

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -105,7 +105,7 @@ case "$TARGET" in
 esac
 
 case "$TARGET" in
-  arm-linux-androideabi | aarch64-linux-android | i686-linux-android)
+  arm-linux-androideabi | aarch64-linux-android | i686-linux-android | x86_64-linux-android)
     # set SHELL so android can detect a 64bits system, see
     # http://stackoverflow.com/a/41789144
     # https://issues.jenkins-ci.org/browse/JENKINS-26930?focusedCommentId=230791&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-230791

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -106,8 +106,8 @@ fn main() {
     }
 
     if android {
-        if !aarch64 {
-            // time64_t is not define for aarch64
+        if !aarch64 && !x86_64 {
+            // time64_t is not define for aarch64 and x86_64
             // If included it will generate the error 'Your time_t is already 64-bit'
             cfg.header("time64.h");
         }

--- a/src/unix/notbsd/android/b32/mod.rs
+++ b/src/unix/notbsd/android/b32/mod.rs
@@ -1,3 +1,6 @@
+// The following definitions are correct for arm and i686,
+// but may be wrong for mips
+
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type mode_t = u16;

--- a/src/unix/notbsd/android/b64/aarch64.rs
+++ b/src/unix/notbsd/android/b64/aarch64.rs
@@ -1,0 +1,56 @@
+pub type c_char = u8;
+pub type wchar_t = u32;
+
+s! {
+    pub struct stat {
+        pub st_dev: ::dev_t,
+        pub st_ino: ::ino_t,
+        pub st_mode: ::c_uint,
+        pub st_nlink: ::c_uint,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        __pad1: ::c_ulong,
+        pub st_size: ::off64_t,
+        pub st_blksize: ::c_int,
+        __pad2: ::c_int,
+        pub st_blocks: ::c_long,
+        pub st_atime: ::time_t,
+        pub st_atime_nsec: ::c_ulong,
+        pub st_mtime: ::time_t,
+        pub st_mtime_nsec: ::c_ulong,
+        pub st_ctime: ::time_t,
+        pub st_ctime_nsec: ::c_ulong,
+        __unused4: ::c_uint,
+        __unused5: ::c_uint,
+    }
+
+    pub struct stat64 {
+        pub st_dev: ::dev_t,
+        pub st_ino: ::ino_t,
+        pub st_mode: ::c_uint,
+        pub st_nlink: ::c_uint,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        __pad1: ::c_ulong,
+        pub st_size: ::off64_t,
+        pub st_blksize: ::c_int,
+        __pad2: ::c_int,
+        pub st_blocks: ::c_long,
+        pub st_atime: ::time_t,
+        pub st_atime_nsec: ::c_ulong,
+        pub st_mtime: ::time_t,
+        pub st_mtime_nsec: ::c_ulong,
+        pub st_ctime: ::time_t,
+        pub st_ctime_nsec: ::c_ulong,
+        __unused4: ::c_uint,
+        __unused5: ::c_uint,
+    }
+}
+
+pub const O_DIRECT: ::c_int = 0x10000;
+pub const O_DIRECTORY: ::c_int = 0x4000;
+pub const O_NOFOLLOW: ::c_int = 0x8000;
+
+pub const SYS_gettid: ::c_long = 178;

--- a/src/unix/notbsd/android/b64/mod.rs
+++ b/src/unix/notbsd/android/b64/mod.rs
@@ -1,12 +1,11 @@
-// The following definitions are correct for aarch64 and may be wrong for x86_64
+// The following definitions are correct for aarch64 and x86_64,
+// but may be wrong for mips64
 
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type mode_t = u32;
 pub type off64_t = i64;
 pub type socklen_t = u32;
-pub type wchar_t = u32;
 
 s! {
     pub struct sigset_t {
@@ -23,52 +22,6 @@ s! {
     pub struct rlimit64 {
         pub rlim_cur: ::c_ulonglong,
         pub rlim_max: ::c_ulonglong,
-    }
-
-    pub struct stat {
-        pub st_dev: ::dev_t,
-        pub st_ino: ::ino_t,
-        pub st_mode: ::c_uint,
-        pub st_nlink: ::c_uint,
-        pub st_uid: ::uid_t,
-        pub st_gid: ::gid_t,
-        pub st_rdev: ::dev_t,
-        __pad1: ::c_ulong,
-        pub st_size: ::off64_t,
-        pub st_blksize: ::c_int,
-        __pad2: ::c_int,
-        pub st_blocks: ::c_long,
-        pub st_atime: ::time_t,
-        pub st_atime_nsec: ::c_ulong,
-        pub st_mtime: ::time_t,
-        pub st_mtime_nsec: ::c_ulong,
-        pub st_ctime: ::time_t,
-        pub st_ctime_nsec: ::c_ulong,
-        __unused4: ::c_uint,
-        __unused5: ::c_uint,
-    }
-
-    pub struct stat64 {
-        pub st_dev: ::dev_t,
-        pub st_ino: ::ino_t,
-        pub st_mode: ::c_uint,
-        pub st_nlink: ::c_uint,
-        pub st_uid: ::uid_t,
-        pub st_gid: ::gid_t,
-        pub st_rdev: ::dev_t,
-        __pad1: ::c_ulong,
-        pub st_size: ::off64_t,
-        pub st_blksize: ::c_int,
-        __pad2: ::c_int,
-        pub st_blocks: ::c_long,
-        pub st_atime: ::time_t,
-        pub st_atime_nsec: ::c_ulong,
-        pub st_mtime: ::time_t,
-        pub st_mtime_nsec: ::c_ulong,
-        pub st_ctime: ::time_t,
-        pub st_ctime_nsec: ::c_ulong,
-        __unused4: ::c_uint,
-        __unused5: ::c_uint,
     }
 
     pub struct pthread_attr_t {
@@ -143,15 +96,10 @@ s! {
     }
 }
 
-pub const O_DIRECT: ::c_int = 0x10000;
-pub const O_DIRECTORY: ::c_int = 0x4000;
-pub const O_NOFOLLOW: ::c_int = 0x8000;
-
 pub const RTLD_GLOBAL: ::c_int = 0x00100;
 pub const RTLD_NOW: ::c_int = 2;
 pub const RTLD_DEFAULT: *mut ::c_void = 0i64 as *mut ::c_void;
 
-pub const SYS_gettid: ::c_long = 178;
 pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
     value: 0,
     __reserved: [0; 36],
@@ -199,4 +147,16 @@ extern {
 
     // the return type should be ::ssize_t, but it is c_int!
     pub fn recvmsg(fd: ::c_int, msg: *mut ::msghdr, flags: ::c_int) -> ::c_int;
+}
+
+cfg_if! {
+    if #[cfg(target_arch = "x86_64")] {
+        mod x86_64;
+        pub use self::x86_64::*;
+    } else if #[cfg(target_arch = "aarch64")] {
+        mod aarch64;
+        pub use self::aarch64::*;
+    } else {
+        // Unknown target_arch
+    }
 }

--- a/src/unix/notbsd/android/b64/x86_64.rs
+++ b/src/unix/notbsd/android/b64/x86_64.rs
@@ -1,0 +1,50 @@
+pub type c_char = i8;
+pub type wchar_t = i32;
+
+s! {
+    pub struct stat {
+        pub st_dev: ::dev_t,
+        pub st_ino: ::ino_t,
+        pub st_nlink: ::c_ulong,
+        pub st_mode: ::c_uint,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        pub st_size: ::off64_t,
+        pub st_blksize: ::c_long,
+        pub st_blocks: ::c_long,
+        pub st_atime: ::c_ulong,
+        pub st_atime_nsec: ::c_ulong,
+        pub st_mtime: ::c_ulong,
+        pub st_mtime_nsec: ::c_ulong,
+        pub st_ctime: ::c_ulong,
+        pub st_ctime_nsec: ::c_ulong,
+        __unused: [::c_long; 3],
+    }
+
+    pub struct stat64 {
+        pub st_dev: ::dev_t,
+        pub st_ino: ::ino_t,
+        pub st_nlink: ::c_ulong,
+        pub st_mode: ::c_uint,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        pub st_size: ::off64_t,
+        pub st_blksize: ::c_long,
+        pub st_blocks: ::c_long,
+        pub st_atime: ::c_ulong,
+        pub st_atime_nsec: ::c_ulong,
+        pub st_mtime: ::c_ulong,
+        pub st_mtime_nsec: ::c_ulong,
+        pub st_ctime: ::c_ulong,
+        pub st_ctime_nsec: ::c_ulong,
+        __unused: [::c_long; 3],
+    }
+}
+
+pub const O_DIRECT: ::c_int = 0x4000;
+pub const O_DIRECTORY: ::c_int = 0x10000;
+pub const O_NOFOLLOW: ::c_int = 0x20000;
+
+pub const SYS_gettid: ::c_long = 186;


### PR DESCRIPTION
When rust add support for x86_64-linux-android, the tests may be run with:
`rustup target add x86_64-linux-android && bash ci/run-docker.sh x86_64-linux-android`.

Android x86_64 emulator does not work without hardware acceleration, so we are not able to run tests on travis.
