### PR TITLE
Fix size of sigset_t structure

### DIFF
--- a/src/unix/notbsd/android/b64/mod.rs
+++ b/src/unix/notbsd/android/b64/mod.rs
@@ -7,9 +7,11 @@ pub type mode_t = u32;
 pub type off64_t = i64;
 pub type socklen_t = u32;
 
+pub const _NSIG: ::size_t = 64;
+
 s! {
     pub struct sigset_t {
-        __val: [::c_ulong; 1],
+        sig: [u32; _NSIG / 32],
     }
 
     pub struct sigaction {

--- a/src/unix/notbsd/linux/mips/mips32.rs
+++ b/src/unix/notbsd/linux/mips/mips32.rs
@@ -14,6 +14,8 @@ pub type fsblkcnt_t = ::c_ulong;
 pub type fsfilcnt_t = ::c_ulong;
 pub type rlim_t = c_ulong;
 
+pub const _NSIG: ::size_t = 128;
+
 s! {
     pub struct aiocb {
         pub aio_fildes: ::c_int,
@@ -97,7 +99,7 @@ s! {
     }
 
     pub struct sigset_t {
-        __val: [::c_ulong; 32],
+        sig: [u32; _NSIG / 32],
     }
 
     pub struct siginfo_t {

--- a/src/unix/notbsd/linux/mips/mips64.rs
+++ b/src/unix/notbsd/linux/mips/mips64.rs
@@ -13,6 +13,8 @@ pub type suseconds_t = i64;
 pub type time_t = i64;
 pub type wchar_t = i32;
 
+pub const _NSIG: ::size_t = 128;
+
 s! {
     pub struct aiocb {
         pub aio_fildes: ::c_int,
@@ -95,7 +97,7 @@ s! {
     }
 
     pub struct sigset_t {
-        __size: [::c_ulong; 16],
+        sig: [u32; _NSIG / 32],
     }
 
     pub struct siginfo_t {

--- a/src/unix/notbsd/linux/musl/b32/mod.rs
+++ b/src/unix/notbsd/linux/musl/b32/mod.rs
@@ -2,13 +2,15 @@ pub type c_long = i32;
 pub type c_ulong = u32;
 pub type nlink_t = u32;
 
+pub const _NSIG: ::size_t = 64;
+
 s! {
     pub struct pthread_attr_t {
         __size: [u32; 9]
     }
 
     pub struct sigset_t {
-        __val: [::c_ulong; 32],
+        sig: [u32; _NSIG / 32],
     }
 
     pub struct msghdr {

--- a/src/unix/notbsd/linux/musl/b64/mod.rs
+++ b/src/unix/notbsd/linux/musl/b64/mod.rs
@@ -3,6 +3,8 @@ pub type c_long = i64;
 pub type c_ulong = u64;
 pub type nlink_t = u64;
 
+pub const _NSIG: ::size_t = 64;
+
 s! {
     pub struct stat {
         pub st_dev: ::dev_t,
@@ -57,7 +59,7 @@ s! {
     }
 
     pub struct sigset_t {
-        __val: [::c_ulong; 16],
+        sig: [u32; _NSIG / 32],
     }
 
     pub struct shmid_ds {

--- a/src/unix/notbsd/linux/other/b32/mod.rs
+++ b/src/unix/notbsd/linux/other/b32/mod.rs
@@ -13,6 +13,8 @@ pub type __fsword_t = i32;
 pub type blksize_t = i32;
 pub type nlink_t = u32;
 
+pub const _NSIG: ::size_t = 64;
+
 s! {
     pub struct stat {
         pub st_dev: ::dev_t,
@@ -42,7 +44,7 @@ s! {
     }
 
     pub struct sigset_t {
-        __val: [::c_ulong; 32],
+        sig: [u32; _NSIG / 32],
     }
 
     pub struct sysinfo {

--- a/src/unix/notbsd/linux/other/b64/mod.rs
+++ b/src/unix/notbsd/linux/other/b64/mod.rs
@@ -9,9 +9,11 @@ pub type off_t = i64;
 pub type blkcnt_t = i64;
 pub type __fsword_t = ::c_long;
 
+pub const _NSIG: ::size_t = 64;
+
 s! {
     pub struct sigset_t {
-        __val: [::c_ulong; 16],
+        sig: [u32; _NSIG / 32],
     }
 
     pub struct sysinfo {

--- a/src/unix/notbsd/linux/s390x.rs
+++ b/src/unix/notbsd/linux/s390x.rs
@@ -17,6 +17,8 @@ pub type clock_t = i64;
 pub type __fsword_t = ::c_long;
 pub type __priority_which_t = ::c_uint;
 
+pub const _NSIG: ::size_t = 64;
+
 s! {
     pub struct aiocb {
         pub aio_fildes: ::c_int,
@@ -97,7 +99,7 @@ s! {
     }
 
     pub struct sigset_t {
-        __size: [::c_ulong; 16],
+        sig: [u32; _NSIG / 32],
     }
 
     pub struct siginfo_t {


### PR DESCRIPTION
Linux uapi defines sigset_t as an array that contains NUMBER_OF_SIGNALS bits.
Number of signals is 64 at all hardware platforms except mips where it is 128.
Linux uapi (and musl) provides a const for number of signals called _NSIG, introduce one
in rust's libc.