### PR TITLE
Add sigprocmask function

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -780,6 +780,12 @@ extern {
     #[cfg_attr(target_os = "netbsd", link_name = "__sigismember14")]
     pub fn sigismember(set: *const sigset_t, signum: ::c_int) -> ::c_int;
 
+    #[cfg_attr(target_os = "netbsd", link_name = "__sigprocmask14")]
+    pub fn sigprocmask(how: ::c_int,
+                       set: *const sigset_t,
+                       oldset: *mut sigset_t)
+                       -> ::c_int;
+
     #[cfg_attr(target_os = "netbsd", link_name = "__timegm50")]
     pub fn timegm(tm: *mut ::tm) -> time_t;
 


### PR DESCRIPTION
sigprocmask is currently missing, this adds the definition for sigprocmask into the main list of Unix functions. This should be standard across all the Unix-like systems supported.

Note that the constants for 'how' (SIG_SETMASK, SIG_BLOCK, SIG_UNBLOCK) are already defined, it is only this function that is missing.