### PR TITLE
Add res_init

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -77,6 +77,7 @@ fn main() {
         cfg.header("netinet/in.h");
         cfg.header("netinet/ip.h");
         cfg.header("netinet/tcp.h");
+        cfg.header("resolv.h");
         cfg.header("pthread.h");
         cfg.header("dlfcn.h");
         cfg.header("signal.h");

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -469,6 +469,10 @@ fn main() {
             // it's in a header file?
             "endpwent" if android => true,
 
+            // Apparently it exists, but isn't defined in a header:
+            // https://mail.gnome.org/archives/commits-list/2013-May/msg01329.html
+            "res_init" if android => true,
+
             _ => false,
         }
     });

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -469,9 +469,15 @@ fn main() {
             // it's in a header file?
             "endpwent" if android => true,
 
-            // Apparently it exists, but isn't defined in a header:
+            // Apparently res_init exists on Android, but isn't defined in a header:
             // https://mail.gnome.org/archives/commits-list/2013-May/msg01329.html
             "res_init" if android => true,
+
+            // On macOS and iOS, res_init is available, but requires linking with libresolv:
+            // http://blog.achernya.com/2013/03/os-x-has-silly-libsystem.html
+            // See discussion for skipping here:
+            // https://github.com/rust-lang/libc/pull/585#discussion_r114561460
+            "res_init" if apple => true,
 
             _ => false,
         }

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -206,19 +206,9 @@ pub const PRIO_MAX: ::c_int = 20;
 cfg_if! {
     if #[cfg(dox)] {
         // on dox builds don't pull in anything
-    } else if #[cfg(all(not(stdbuild),
-                        feature = "use_std",
-                        not(any(target_os = "macos",
-                                target_os = "ios")
-                        )))] {
+    } else if #[cfg(all(not(stdbuild), feature = "use_std"))] {
         // cargo build, don't pull in anything extra as the libstd  dep
         // already pulls in all libs.
-    } else if #[cfg(all(not(stdbuild), feature = "use_std"))] {
-        // except on macOS and iOS, where we must link with lib resolv
-        // for res_init, despite libsystem_info including it:
-        // http://blog.achernya.com/2013/03/os-x-has-silly-libsystem.html
-        #[link(name = "resolv")]
-        extern {}
     } else if #[cfg(any(all(target_env = "musl", not(target_arch = "mips"))))] {
         #[link(name = "c", kind = "static", cfg(target_feature = "crt-static"))]
         #[link(name = "c", cfg(not(target_feature = "crt-static")))]
@@ -233,12 +223,8 @@ cfg_if! {
         #[link(name = "m")]
         extern {}
     } else if #[cfg(any(target_os = "macos",
-                        target_os = "ios"))] {
-        #[link(name = "c")]
-        #[link(name = "m")]
-        #[link(name = "resolv")]
-        extern {}
-    } else if #[cfg(any(target_os = "android",
+                        target_os = "ios",
+                        target_os = "android",
                         target_os = "openbsd",
                         target_os = "bitrig"))] {
         #[link(name = "c")]

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -210,8 +210,6 @@ cfg_if! {
                         feature = "use_std",
                         not(any(target_os = "macos",
                                 target_os = "ios",
-                                target_os = "android",
-                                target_os = "openbsd",
                                 target_os = "bitrig")
                         )))] {
         // cargo build, don't pull in anything extra as the libstd  dep
@@ -237,12 +235,15 @@ cfg_if! {
         extern {}
     } else if #[cfg(any(target_os = "macos",
                         target_os = "ios",
-                        target_os = "android",
-                        target_os = "openbsd",
                         target_os = "bitrig"))] {
         #[link(name = "c")]
         #[link(name = "m")]
         #[link(name = "resolv")]
+        extern {}
+    } else if #[cfg(any(target_os = "android",
+                        target_os = "openbsd"))] {
+        #[link(name = "c")]
+        #[link(name = "m")]
         extern {}
     } else if #[cfg(target_os = "haiku")] {
         #[link(name = "root")]

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -209,8 +209,7 @@ cfg_if! {
     } else if #[cfg(all(not(stdbuild),
                         feature = "use_std",
                         not(any(target_os = "macos",
-                                target_os = "ios",
-                                target_os = "bitrig")
+                                target_os = "ios")
                         )))] {
         // cargo build, don't pull in anything extra as the libstd  dep
         // already pulls in all libs.
@@ -234,14 +233,14 @@ cfg_if! {
         #[link(name = "m")]
         extern {}
     } else if #[cfg(any(target_os = "macos",
-                        target_os = "ios",
-                        target_os = "bitrig"))] {
+                        target_os = "ios"))] {
         #[link(name = "c")]
         #[link(name = "m")]
         #[link(name = "resolv")]
         extern {}
     } else if #[cfg(any(target_os = "android",
-                        target_os = "openbsd"))] {
+                        target_os = "openbsd",
+                        target_os = "bitrig"))] {
         #[link(name = "c")]
         #[link(name = "m")]
         extern {}
@@ -714,6 +713,7 @@ extern {
                    not(target_os = "ios"),
                    not(target_os = "netbsd"),
                    not(target_os = "openbsd"),
+                   not(target_os = "bitrig"),
                    not(target_os = "solaris"),
                    not(target_env = "musl")
                    ),

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -713,6 +713,7 @@ extern {
                    not(target_os = "macos"),
                    not(target_os = "ios"),
                    not(target_os = "netbsd"),
+                   not(target_os = "openbsd"),
                    not(target_os = "solaris"),
                    not(target_env = "musl")
                    ),

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -708,15 +708,10 @@ extern {
                        res: *mut *mut addrinfo) -> ::c_int;
     pub fn freeaddrinfo(res: *mut addrinfo);
     pub fn gai_strerror(errcode: ::c_int) -> *const ::c_char;
-    #[cfg_attr(all(unix,
-                   not(target_os = "macos"),
-                   not(target_os = "ios"),
-                   not(target_os = "netbsd"),
-                   not(target_os = "openbsd"),
-                   not(target_os = "bitrig"),
-                   not(target_os = "solaris"),
-                   not(target_env = "musl")
-                   ),
+    #[cfg_attr(any(
+                   all(target_os = "linux", not(target_env = "musl")),
+                   target_os = "freebsd",
+                   target_os = "dragonfly"),
                link_name = "__res_init")]
     #[cfg_attr(any(target_os = "macos", target_os = "ios"),
                link_name = "res_9_init")]


### PR DESCRIPTION
The `res_init` function, while deprecated, is critical for making networked applications work correctly when switching between networks, or between being offline and online. By default, `getaddrinfo` and friends use a cached version of `/etc/resolv.conf`, which means that network changes are not picked up by applications after they first start up. This has bitten [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=214538), [Pidgin](https://developer.pidgin.im/ticket/2825), [MongoDB](https://jira.mongodb.org/browse/DOCS-5700), and more in the past.

The logic behind exposing only `res_init` is that it is the only `res_*` function that is frequently called directly by user applications. The other `res_*` functions provide low-level access to domain lookups, whereas `res_init` is useful even if the application itself is not concerned with doing lookups.

Behind the scenes, `getaddrinfo` in glibc [ultimately calls](https://github.com/lattera/glibc/blob/a2f34833b1042d5d8eeb263b4cf4caaea138c4ad/resolv/nss_dns/dns-host.c#L196) `res_nsearch` with `&_res`. `res_init` operates directly on this global reference, and is thus more useful to expose for most applications than the non-deprecated `res_ninit` function (which operators on an arbitrary `res_state`).

As far as I can tell, `res_init` is available in [FreeBSD](https://www.freebsd.org/cgi/man.cgi?query=res_init&manpath=SuSE+Linux/i386+11.3), [NetBSD](http://netbsd.gw.com/cgi-bin/man-cgi?res_init+3+NetBSD-6.1), [OpenBSD](http://man.openbsd.org/resolver.3), [Solaris](http://www.polarhome.com/service/man/?qf=res_init&tf=2&of=Solaris&sf=), [Linux](https://linux.die.net/man/3/res_init), and [macOS](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man3/res_init.3.html).