### PR TITLE
Add Linux-specific recvmmsg(2) and sendmmsg(2)

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -404,6 +404,11 @@ fn main() {
             "prlimit" | "prlimit64" |        // non-int in 2nd arg
             "strerror_r" if linux => true,   // actually xpg-something-or-other
 
+            // int vs uint. Sorry musl, your prototype declarations are "correct" in the sense that
+            // they match the interface defined by Linux verbatim, but they conflict with other
+            // send*/recv* syscalls
+            "sendmmsg" | "recvmmsg" if musl => true,
+
             // typed 2nd arg on linux and android
             "gettimeofday" if linux || android || freebsd || openbsd || dragonfly => true,
 

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -220,6 +220,11 @@ s! {
         pub msgtql: ::c_int,
         pub msgseg: ::c_ushort,
     }
+
+    pub struct mmsghdr {
+        pub msg_hdr: ::msghdr,
+        pub msg_len: ::c_uint,
+    }
 }
 
 pub const ABDAY_1: ::nl_item = 0x20000;
@@ -981,6 +986,13 @@ extern {
                    flags: ::c_int) -> ::ssize_t;
     pub fn recvmsg(fd: ::c_int, msg: *mut ::msghdr, flags: ::c_int)
                    -> ::ssize_t;
+}
+
+extern {
+    pub fn sendmmsg(sockfd: ::c_int, msgvec: *mut mmsghdr, vlen: ::c_uint,
+                    flags: ::c_int) -> ::c_int;
+    pub fn recvmmsg(sockfd: ::c_int, msgvec: *mut mmsghdr, vlen: ::c_uint,
+                    flags: ::c_int, timeout: *mut ::timespec) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
This is just the patch that @nodakai submitted in #257, updated against current master, but I'm opening this PR as a vehicle for whatever additional changes need to be made to get it merged.  Thanks.