### PR TITLE
Add x86_64-linux-android test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,10 @@ matrix:
     - os: linux
       env: TARGET=i686-linux-android
       rust: stable
+    # as of 2017/05/03 x86_64-linux-android are not on stable
+    - os: linux
+      env: TARGET=x86_64-linux-android
+      rust: beta
     - os: linux
       env: TARGET=x86_64-unknown-linux-musl
       rust: stable

--- a/ci/android-sysimage.sh
+++ b/ci/android-sysimage.sh
@@ -1,0 +1,52 @@
+# Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+set -ex
+
+URL=https://dl.google.com/android/repository/sys-img/android
+
+main() {
+    local arch=$1
+    local name=$2
+    local dest=/system
+    local td=$(mktemp -d)
+
+    apt-get install --no-install-recommends e2tools
+
+    pushd $td
+    curl -O $URL/$name
+    unzip -q $name
+
+    local system=$(find . -name system.img)
+    mkdir -p $dest/{bin,lib,lib64}
+
+    # Extract android linker and libraries to /system
+    # This allows android executables to be run directly (or with qemu)
+    if [ $arch = "x86_64" -o $arch = "arm64" ]; then
+        e2cp -p $system:/bin/linker64 $dest/bin/
+        e2cp -p $system:/lib64/libdl.so $dest/lib64/
+        e2cp -p $system:/lib64/libc.so $dest/lib64/
+        e2cp -p $system:/lib64/libm.so $dest/lib64/
+    else
+        e2cp -p $system:/bin/linker $dest/bin/
+        e2cp -p $system:/lib/libdl.so $dest/lib/
+        e2cp -p $system:/lib/libc.so $dest/lib/
+        e2cp -p $system:/lib/libm.so $dest/lib/
+    fi
+
+    # clean up
+    apt-get purge --auto-remove -y e2tools
+
+    popd
+
+    rm -rf $td
+}
+
+main "${@}"

--- a/ci/docker/x86_64-linux-android/Dockerfile
+++ b/ci/docker/x86_64-linux-android/Dockerfile
@@ -1,32 +1,26 @@
 FROM ubuntu:16.04
 
-RUN dpkg --add-architecture i386 && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-  file \
-  curl \
   ca-certificates \
-  python \
-  unzip \
-  expect \
-  openjdk-9-jre \
-  libstdc++6:i386 \
-  libpulse0 \
+  curl \
   gcc \
-  libc6-dev
+  libc-dev \
+  python \
+  unzip
 
 WORKDIR /android/
-COPY android* /android/
-
 ENV ANDROID_ARCH=x86_64
-ENV PATH=$PATH:/android/ndk-$ANDROID_ARCH/bin:/android/sdk/tools:/android/sdk/platform-tools
-
+COPY android-install-ndk.sh /android/
 RUN sh /android/android-install-ndk.sh $ANDROID_ARCH
-RUN sh /android/android-install-sdk.sh $ANDROID_ARCH
-RUN mv /root/.android /tmp
-RUN chmod 777 -R /tmp/.android
-RUN chmod 755 /android/sdk/tools/* /android/sdk/tools/qemu/linux-x86_64/*
 
-ENV PATH=$PATH:/rust/bin \
+# We do not run x86_64-linux-android tests on an android emulator.
+# See ci/android-sysimage.sh for informations about how tests are run.
+COPY android-sysimage.sh /android/
+RUN bash /android/android-sysimage.sh x86_64 x86_64-21_r04.zip
+
+ENV PATH=$PATH:/rust/bin:/android/ndk-$ANDROID_ARCH/bin \
     CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=x86_64-linux-android-gcc \
+    CC_x86_64_linux_android=x86_64-linux-android-gcc \
+    CXX_x86_64_linux_android=x86_64-linux-android-g++ \
     HOME=/tmp

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -105,7 +105,10 @@ case "$TARGET" in
 esac
 
 case "$TARGET" in
-  arm-linux-androideabi | aarch64-linux-android | i686-linux-android | x86_64-linux-android)
+  # Android emulator for x86_64 does not work on travis (missing hardware
+  # acceleration). Tests are run on case *). See ci/android-sysimage.sh for
+  # informations about how tests are run.
+  arm-linux-androideabi | aarch64-linux-android | i686-linux-android)
     # set SHELL so android can detect a 64bits system, see
     # http://stackoverflow.com/a/41789144
     # https://issues.jenkins-ci.org/browse/JENKINS-26930?focusedCommentId=230791&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-230791


### PR DESCRIPTION
We extract the linker and some libraries from an android image and copy then to `/system`. This allows the android test to run directly (or with qemu).