### PR TITLE
Add ENOATTR for Linux

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -404,6 +404,10 @@ fn main() {
             "MADV_MERGEABLE" | "MADV_UNMERGEABLE" | "MADV_HWPOISON" | "IPV6_ADD_MEMBERSHIP" | "IPV6_DROP_MEMBERSHIP" | "IPV6_MULTICAST_LOOP" | "IPV6_V6ONLY" |
             "MAP_STACK" | "RTLD_DEEPBIND" | "SOL_IPV6" | "SOL_ICMPV6" if uclibc => true,
 
+            // Defined by libattr not libc on linux (hard to test).
+            // See constant definition for more details.
+            "ENOATTR" if linux => true,
+
             _ => false,
         }
     });

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -700,6 +700,11 @@ pub const PR_CAP_AMBIENT_CLEAR_ALL: ::c_int = 4;
 pub const XATTR_CREATE: ::c_int = 0x1;
 pub const XATTR_REPLACE: ::c_int = 0x2;
 
+// On Linux, libc doesn't define this constant, libattr does instead.
+// We still define it for Linux as it's defined by libc on other platforms,
+// and it's mentioned in the man pages for getxattr and setxattr.
+pub const ENOATTR: ::c_int = ::ENODATA;
+
 f! {
     pub fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {
         for slot in cpuset.bits.iter_mut() {


### PR DESCRIPTION
It's defined differently for OSX and *BSD, so having a Linux definition is helpful for cross-platform code.