### PR TITLE
Use NOCANCEL variants for close on Mac

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -500,7 +500,7 @@ fn main() {
             "backtrace" |
             "sysinfo" | "newlocale" | "duplocale" | "freelocale" | "uselocale" |
             "nl_langinfo_l" | "wcslen" | "wcstombs" if uclibc => true,
-          
+
             // Apparently res_init exists on Android, but isn't defined in a header:
             // https://mail.gnome.org/archives/commits-list/2013-May/msg01329.html
             "res_init" if android => true,
@@ -510,6 +510,9 @@ fn main() {
             // See discussion for skipping here:
             // https://github.com/rust-lang/libc/pull/585#discussion_r114561460
             "res_init" if apple => true,
+
+            // On Mac we don't use the default `close()`, instead using their $NOCANCEL variants.
+            "close" if apple => true,
 
             _ => false,
         }

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -405,7 +405,9 @@ extern {
     pub fn lchown(path: *const c_char, uid: uid_t,
                   gid: gid_t) -> ::c_int;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
-               link_name = "close$UNIX2003")]
+               link_name = "close$NOCANCEL$UNIX2003")]
+    #[cfg_attr(all(target_os = "macos", target_arch = "x86_64"),
+               link_name = "close$NOCANCEL")]
     pub fn close(fd: ::c_int) -> ::c_int;
     pub fn dup(fd: ::c_int) -> ::c_int;
     pub fn dup2(src: ::c_int, dst: ::c_int) -> ::c_int;


### PR DESCRIPTION
The default `close()` on OS X does not provide clear errors, instead the `$NOCANCEL` variants should be used. These are available as of OS X 10.6 onwards.

Fixes #595.