### PR TITLE
Add unix seteuid()

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -472,6 +472,7 @@ extern {
     pub fn read(fd: ::c_int, buf: *mut ::c_void, count: ::size_t)
                 -> ::ssize_t;
     pub fn rmdir(path: *const c_char) -> ::c_int;
+    pub fn seteuid(uid: uid_t) -> ::c_int;
     pub fn setgid(gid: gid_t) -> ::c_int;
     pub fn setpgid(pid: pid_t, pgid: pid_t) -> ::c_int;
     pub fn setsid() -> pid_t;


### PR DESCRIPTION
Adds prototype for unix seteuid() as defined [here](http://pubs.opengroup.org/onlinepubs/009695399/functions/seteuid.html).