### PR TITLE
Add structs defined in linux/input.h

### DIFF
--- a/ci/docker/i686-unknown-linux-musl/Dockerfile
+++ b/ci/docker/i686-unknown-linux-musl/Dockerfile
@@ -18,6 +18,13 @@ RUN curl https://www.musl-libc.org/releases/musl-1.1.15.tar.gz | \
     CC=gcc CFLAGS=-m32 ./configure --prefix=/musl-i686 --disable-shared --target=i686 && \
     make CROSS_COMPILE= install -j4 && \
     cd .. && \
-    rm -rf musl-1.1.15
+    rm -rf musl-1.1.15 && \
+# Install linux kernel headers sanitized for use with musl
+    curl -L  https://github.com/sabotage-linux/kernel-headers/archive/v3.12.6-5.tar.gz | \
+    tar xzf - && \
+    cd kernel-headers-3.12.6-5 && \
+    make ARCH=i386 prefix=/musl-i686 install -j4 && \
+    cd .. && \
+    rm -rf kernel-headers-3.12.6-5
 ENV PATH=$PATH:/musl-i686/bin:/rust/bin \
     CC_i686_unknown_linux_musl=musl-gcc

--- a/ci/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -9,5 +9,12 @@ RUN curl https://www.musl-libc.org/releases/musl-1.1.15.tar.gz | \
     ./configure --prefix=/musl-x86_64 && \
     make install -j4 && \
     cd .. && \
-    rm -rf musl-1.1.15
+    rm -rf musl-1.1.15 && \
+# Install linux kernel headers sanitized for use with musl
+    curl -L  https://github.com/sabotage-linux/kernel-headers/archive/v3.12.6-5.tar.gz | \
+    tar xzf - && \
+    cd kernel-headers-3.12.6-5 && \
+    make ARCH=x86_64 prefix=/musl-x86_64 install -j4 && \
+    cd .. && \
+    rm -rf kernel-headers-3.12.6-5
 ENV PATH=$PATH:/musl-x86_64/bin:/rust/bin

--- a/src/unix/notbsd/linux/mips/mips32.rs
+++ b/src/unix/notbsd/linux/mips/mips32.rs
@@ -13,6 +13,7 @@ pub type nlink_t = u32;
 pub type fsblkcnt_t = ::c_ulong;
 pub type fsfilcnt_t = ::c_ulong;
 pub type rlim_t = c_ulong;
+pub type __u64 = ::c_ulonglong;
 
 s! {
     pub struct aiocb {

--- a/src/unix/notbsd/linux/mips/mips64.rs
+++ b/src/unix/notbsd/linux/mips/mips64.rs
@@ -13,6 +13,7 @@ pub type suseconds_t = i64;
 pub type time_t = i64;
 pub type wchar_t = i32;
 pub type clock_t = i64;
+pub type __u64 = ::c_ulong;
 
 s! {
     pub struct aiocb {

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -19,6 +19,12 @@ pub type nfds_t = ::c_ulong;
 pub type nl_item = ::c_int;
 pub type idtype_t = ::c_uint;
 
+pub type __u8 = ::c_uchar;
+pub type __u16 = ::c_ushort;
+pub type __s16 = ::c_short;
+pub type __u32 = ::c_uint;
+pub type __s32 = ::c_int;
+
 pub enum fpos64_t {} // TODO: fill this out with a struct
 
 s! {
@@ -230,6 +236,113 @@ s! {
         pub sem_num: ::c_ushort,
         pub sem_op: ::c_short,
         pub sem_flg: ::c_short,
+    }
+
+    pub struct input_event {
+        pub time: ::timeval,
+        pub type_: ::__u16,
+        pub code: ::__u16,
+        pub value: ::__s32,
+    }
+
+    pub struct input_id {
+        pub bustype: ::__u16,
+        pub vendor: ::__u16,
+        pub product: ::__u16,
+        pub version: ::__u16,
+    }
+
+    pub struct input_absinfo {
+        pub value: ::__s32,
+        pub minimum: ::__s32,
+        pub maximum: ::__s32,
+        pub fuzz: ::__s32,
+        pub flat: ::__s32,
+        pub resolution: ::__s32,
+    }
+
+    pub struct input_keymap_entry {
+        pub flags: ::__u8,
+        pub len: ::__u8,
+        pub index: ::__u16,
+        pub keycode: ::__u32,
+        pub scancode: [::__u8; 32],
+    }
+
+    pub struct input_mask {
+        pub type_: ::__u32,
+        pub codes_size: ::__u32,
+        pub codes_ptr: ::__u64,
+    }
+
+    pub struct ff_replay {
+        pub length: ::__u16,
+        pub delay: ::__u16,
+    }
+
+    pub struct ff_trigger {
+        pub button: ::__u16,
+        pub interval: ::__u16,
+    }
+
+    pub struct ff_envelope {
+        pub attack_length: ::__u16,
+        pub attack_level: ::__u16,
+        pub fade_length: ::__u16,
+        pub fade_level: ::__u16,
+    }
+
+    pub struct ff_constant_effect {
+        pub level: ::__s16,
+        pub envelope: ff_envelope,
+    }
+
+    pub struct ff_ramp_effect {
+        pub start_level: ::__s16,
+        pub end_level: ::__s16,
+        pub envelope: ff_envelope,
+    }
+
+    pub struct ff_condition_effect {
+        pub right_saturation: ::__u16,
+        pub left_saturation: ::__u16,
+
+        pub right_coeff: ::__s16,
+        pub left_coeff: ::__s16,
+
+        pub deadband: ::__u16,
+        pub center: ::__s16,
+    }
+
+    pub struct ff_periodic_effect {
+        pub waveform: ::__u16,
+        pub period: ::__u16,
+        pub magnitude: ::__s16,
+        pub offset: ::__s16,
+        pub phase: ::__u16,
+
+        pub envelope: ff_envelope,
+
+        pub custom_len: ::__u32,
+        pub custom_data: *mut ::__s16,
+    }
+
+    pub struct ff_rumble_effect {
+        pub strong_magnitude: ::__u16,
+        pub weak_magnitude: ::__u16,
+    }
+
+    pub struct ff_effect {
+        pub type_: ::__u16,
+        pub id: ::__s16,
+        pub direction: ::__u16,
+        pub trigger: ff_trigger,
+        pub replay: ff_replay,
+        // FIXME this is actually a union
+        #[cfg(target_pointer_width = "64")]
+        pub u: [u64; 4],
+        #[cfg(target_pointer_width = "32")]
+        pub u: [u32; 7],
     }
 }
 

--- a/src/unix/notbsd/linux/musl/b32/mod.rs
+++ b/src/unix/notbsd/linux/musl/b32/mod.rs
@@ -1,6 +1,7 @@
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type nlink_t = u32;
+pub type __u64 = ::c_ulonglong;
 
 s! {
     pub struct pthread_attr_t {

--- a/src/unix/notbsd/linux/musl/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/musl/b64/aarch64.rs
@@ -1,3 +1,4 @@
 pub type c_char = u8;
+pub type __u64 = ::c_ulonglong;
 
 pub const SYS_perf_event_open: ::c_long = 241;

--- a/src/unix/notbsd/linux/musl/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/musl/b64/powerpc64.rs
@@ -1,3 +1,4 @@
 pub type c_char = u8;
+pub type __u64 = ::c_ulong;
 
 pub const SYS_perf_event_open: ::c_long = 319;

--- a/src/unix/notbsd/linux/musl/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/musl/b64/x86_64.rs
@@ -1,4 +1,5 @@
 pub type c_char = i8;
+pub type __u64 = ::c_ulonglong;
 
 s! {
     pub struct mcontext_t {

--- a/src/unix/notbsd/linux/other/b32/mod.rs
+++ b/src/unix/notbsd/linux/other/b32/mod.rs
@@ -12,6 +12,7 @@ pub type __fsword_t = i32;
 
 pub type blksize_t = i32;
 pub type nlink_t = u32;
+pub type __u64 = ::c_ulonglong;
 
 s! {
     pub struct stat {

--- a/src/unix/notbsd/linux/other/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/other/b64/aarch64.rs
@@ -5,6 +5,7 @@ pub type wchar_t = u32;
 pub type nlink_t = u32;
 pub type blksize_t = i32;
 pub type suseconds_t = i64;
+pub type __u64 = ::c_ulonglong;
 
 s! {
     pub struct stat {

--- a/src/unix/notbsd/linux/other/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/other/b64/powerpc64.rs
@@ -5,6 +5,7 @@ pub type wchar_t = i32;
 pub type nlink_t = u64;
 pub type blksize_t = i64;
 pub type suseconds_t = i64;
+pub type __u64 = ::c_ulong;
 
 s! {
     pub struct stat {

--- a/src/unix/notbsd/linux/other/b64/sparc64.rs
+++ b/src/unix/notbsd/linux/other/b64/sparc64.rs
@@ -5,6 +5,7 @@ pub type wchar_t = i32;
 pub type nlink_t = u32;
 pub type blksize_t = i64;
 pub type suseconds_t = i32;
+pub type __u64 = ::c_ulonglong;
 
 s! {
     pub struct stat {

--- a/src/unix/notbsd/linux/other/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/other/b64/x86_64.rs
@@ -6,6 +6,7 @@ pub type nlink_t = u64;
 pub type blksize_t = i64;
 pub type greg_t = i64;
 pub type suseconds_t = i64;
+pub type __u64 = ::c_ulonglong;
 
 s! {
     pub struct stat {


### PR DESCRIPTION
I was using definitions for these structs from `ioctl` but because @cmr decide to deprecate his crate (and yanked all versions :() I think that `libc` is the best place for them.

In original C header, primitive types uses aliases like `__u16` or `__s32`; for now I replaced them with Rust's counterparts but I'm not sure if it is ok, especially because tests were failing for `u64` (`unsigned long long` vs `unsigned long` on x86_64). Also, should I do something special with union in `ff_effect`?

I would like also to add all constants form `linux/input.h` and `linux/input-event-codes.h` if this PR will be accepted.