### PR TITLE
Various MIPS cleanups

### DIFF
--- a/src/unix/notbsd/linux/mips/mips32.rs
+++ b/src/unix/notbsd/linux/mips/mips32.rs
@@ -10,9 +10,6 @@ pub type ino_t = u32;
 pub type blkcnt_t = i32;
 pub type blksize_t = i32;
 pub type nlink_t = u32;
-pub type fsblkcnt_t = ::c_ulong;
-pub type fsfilcnt_t = ::c_ulong;
-pub type rlim_t = c_ulong;
 
 s! {
     pub struct aiocb {
@@ -105,19 +102,6 @@ s! {
         pub si_code: ::c_int,
         pub si_errno: ::c_int,
         pub _pad: [::c_int; 29],
-    }
-
-    pub struct glob64_t {
-        pub gl_pathc: ::size_t,
-        pub gl_pathv: *mut *mut ::c_char,
-        pub gl_offs: ::size_t,
-        pub gl_flags: ::c_int,
-
-        __unused1: *mut ::c_void,
-        __unused2: *mut ::c_void,
-        __unused3: *mut ::c_void,
-        __unused4: *mut ::c_void,
-        __unused5: *mut ::c_void,
     }
 
     pub struct ipc_perm {
@@ -237,15 +221,6 @@ s! {
         pub freehigh: ::c_ulong,
         pub mem_unit: ::c_uint,
         pub _f: [::c_char; 8],
-    }
-
-    // FIXME this is actually a union
-    pub struct sem_t {
-        #[cfg(target_pointer_width = "32")]
-        __size: [::c_char; 16],
-        #[cfg(target_pointer_width = "64")]
-        __size: [::c_char; 32],
-        __align: [::c_long; 0],
     }
 }
 

--- a/src/unix/notbsd/linux/mips/mips32.rs
+++ b/src/unix/notbsd/linux/mips/mips32.rs
@@ -232,31 +232,3 @@ pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
 pub const RLIM_INFINITY: ::rlim_t = 0x7fffffff;
 
 pub const SYS_gettid: ::c_long = 4222;   // Valid for O32
-
-#[link(name = "util")]
-extern {
-    pub fn sysctl(name: *mut ::c_int,
-                  namelen: ::c_int,
-                  oldp: *mut ::c_void,
-                  oldlenp: *mut ::size_t,
-                  newp: *mut ::c_void,
-                  newlen: ::size_t)
-                  -> ::c_int;
-    pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
-    pub fn backtrace(buf: *mut *mut ::c_void,
-                     sz: ::c_int) -> ::c_int;
-    pub fn glob64(pattern: *const ::c_char,
-                  flags: ::c_int,
-                  errfunc: ::dox::Option<extern fn(epath: *const ::c_char,
-                                                   errno: ::c_int)
-                                                   -> ::c_int>,
-                  pglob: *mut glob64_t) -> ::c_int;
-    pub fn globfree64(pglob: *mut glob64_t);
-    pub fn ptrace(request: ::c_uint, ...) -> ::c_long;
-    pub fn pthread_attr_getaffinity_np(attr: *const ::pthread_attr_t,
-                                       cpusetsize: ::size_t,
-                                       cpuset: *mut ::cpu_set_t) -> ::c_int;
-    pub fn pthread_attr_setaffinity_np(attr: *mut ::pthread_attr_t,
-                                       cpusetsize: ::size_t,
-                                       cpuset: *const ::cpu_set_t) -> ::c_int;
-}

--- a/src/unix/notbsd/linux/mips/mips64.rs
+++ b/src/unix/notbsd/linux/mips/mips64.rs
@@ -184,6 +184,14 @@ s! {
         pub c_cc: [::cc_t; ::NCCS],
     }
 
+    pub struct flock {
+        pub l_type: ::c_short,
+        pub l_whence: ::c_short,
+        pub l_start: ::off_t,
+        pub l_len: ::off_t,
+        pub l_pid: ::pid_t,
+    }
+
     pub struct sysinfo {
         pub uptime: ::c_long,
         pub loads: [::c_ulong; 3],

--- a/src/unix/notbsd/linux/mips/mips64.rs
+++ b/src/unix/notbsd/linux/mips/mips64.rs
@@ -210,8 +210,3 @@ pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 56;
 pub const RLIM_INFINITY: ::rlim_t = 0xffff_ffff_ffff_ffff;
 
 pub const SYS_gettid: ::c_long = 5178;   // Valid for n64
-
-#[link(name = "util")]
-extern {
-    pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
-}

--- a/src/unix/notbsd/linux/mips/mips64.rs
+++ b/src/unix/notbsd/linux/mips/mips64.rs
@@ -3,12 +3,9 @@ pub type blksize_t = i64;
 pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type fsblkcnt_t = ::c_ulong;
-pub type fsfilcnt_t = ::c_ulong;
 pub type ino_t = u64;
 pub type nlink_t = u64;
 pub type off_t = i64;
-pub type rlim_t = ::c_ulong;
 pub type suseconds_t = i64;
 pub type time_t = i64;
 pub type wchar_t = i32;
@@ -202,12 +199,6 @@ s! {
         pub freehigh: ::c_ulong,
         pub mem_unit: ::c_uint,
         pub _f: [::c_char; 0],
-    }
-
-    // FIXME this is actually a union
-    pub struct sem_t {
-        __size: [::c_char; 32],
-        __align: [::c_long; 0],
     }
 }
 

--- a/src/unix/notbsd/linux/mips/mod.rs
+++ b/src/unix/notbsd/linux/mips/mod.rs
@@ -1,6 +1,7 @@
 pub type fsblkcnt_t = ::c_ulong;
 pub type fsfilcnt_t = ::c_ulong;
 pub type rlim_t = c_ulong;
+pub type __priority_which_t = ::c_uint;
 
 s! {
     pub struct glob64_t {
@@ -523,6 +524,44 @@ pub const B2500000: ::speed_t = 0o010014;
 pub const B3000000: ::speed_t = 0o010015;
 pub const B3500000: ::speed_t = 0o010016;
 pub const B4000000: ::speed_t = 0o010017;
+
+#[link(name = "util")]
+extern {
+    pub fn sysctl(name: *mut ::c_int,
+                  namelen: ::c_int,
+                  oldp: *mut ::c_void,
+                  oldlenp: *mut ::size_t,
+                  newp: *mut ::c_void,
+                  newlen: ::size_t)
+                  -> ::c_int;
+    pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
+    pub fn backtrace(buf: *mut *mut ::c_void,
+                     sz: ::c_int) -> ::c_int;
+    pub fn glob64(pattern: *const ::c_char,
+                  flags: ::c_int,
+                  errfunc: ::dox::Option<extern fn(epath: *const ::c_char,
+                                                   errno: ::c_int)
+                                                   -> ::c_int>,
+                  pglob: *mut glob64_t) -> ::c_int;
+    pub fn globfree64(pglob: *mut glob64_t);
+    pub fn ptrace(request: ::c_uint, ...) -> ::c_long;
+    pub fn pthread_attr_getaffinity_np(attr: *const ::pthread_attr_t,
+                                       cpusetsize: ::size_t,
+                                       cpuset: *mut ::cpu_set_t) -> ::c_int;
+    pub fn pthread_attr_setaffinity_np(attr: *mut ::pthread_attr_t,
+                                       cpusetsize: ::size_t,
+                                       cpuset: *const ::cpu_set_t) -> ::c_int;
+    pub fn getpriority(which: ::__priority_which_t, who: ::id_t) -> ::c_int;
+    pub fn setpriority(which: ::__priority_which_t, who: ::id_t,
+                                       prio: ::c_int) -> ::c_int;
+    pub fn pthread_getaffinity_np(thread: ::pthread_t,
+                                  cpusetsize: ::size_t,
+                                  cpuset: *mut ::cpu_set_t) -> ::c_int;
+    pub fn pthread_setaffinity_np(thread: ::pthread_t,
+                                  cpusetsize: ::size_t,
+                                  cpuset: *const ::cpu_set_t) -> ::c_int;
+    pub fn sched_getcpu() -> ::c_int;
+}
 
 cfg_if! {
     if #[cfg(target_arch = "mips")] {

--- a/src/unix/notbsd/linux/mips/mod.rs
+++ b/src/unix/notbsd/linux/mips/mod.rs
@@ -1,3 +1,31 @@
+pub type fsblkcnt_t = ::c_ulong;
+pub type fsfilcnt_t = ::c_ulong;
+pub type rlim_t = c_ulong;
+
+s! {
+    pub struct glob64_t {
+        pub gl_pathc: ::size_t,
+        pub gl_pathv: *mut *mut ::c_char,
+        pub gl_offs: ::size_t,
+        pub gl_flags: ::c_int,
+
+        __unused1: *mut ::c_void,
+        __unused2: *mut ::c_void,
+        __unused3: *mut ::c_void,
+        __unused4: *mut ::c_void,
+        __unused5: *mut ::c_void,
+    }
+
+    // FIXME this is actually a union
+    pub struct sem_t {
+        #[cfg(target_pointer_width = "32")]
+        __size: [::c_char; 16],
+        #[cfg(target_pointer_width = "64")]
+        __size: [::c_char; 32],
+        __align: [::c_long; 0],
+    }
+}
+
 pub const CLONE_NEWCGROUP: ::c_int = 0x02000000;
 
 pub const SFD_CLOEXEC: ::c_int = 0x080000;


### PR DESCRIPTION
This PR contains a few cleanups to the MIPS part of the bindings. It mostly moves stuff out of `mips/mips32.rs` into `mips/mod.rs` which is identical between mips32 and mips64, mostly because mips64 is missing a number of syscalls. In addition, I add `struct flock` which was missing on mips64.