### PR TITLE
Unify some BSD flags

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -448,14 +448,8 @@ pub const _PC_PIPE_BUF: ::c_int = 6;
 pub const _PC_CHOWN_RESTRICTED: ::c_int = 7;
 pub const _PC_NO_TRUNC: ::c_int = 8;
 pub const _PC_VDISABLE: ::c_int = 9;
-pub const O_RDONLY: ::c_int = 0;
-pub const O_WRONLY: ::c_int = 1;
-pub const O_RDWR: ::c_int = 2;
-pub const O_APPEND: ::c_int = 8;
-pub const O_CREAT: ::c_int = 512;
-pub const O_EXCL: ::c_int = 2048;
-pub const O_NOCTTY: ::c_int = 131072;
-pub const O_TRUNC: ::c_int = 1024;
+pub const O_DSYNC: ::c_int = 0x400000;
+pub const O_NOCTTY: ::c_int = 0x20000;
 pub const O_CLOEXEC: ::c_int = 0x1000000;
 pub const O_DIRECTORY: ::c_int = 0x100000;
 pub const S_IFIFO: mode_t = 4096;
@@ -670,8 +664,6 @@ pub const AT_EACCESS: ::c_int = 0x0010;
 pub const AT_SYMLINK_NOFOLLOW: ::c_int = 0x0020;
 pub const AT_SYMLINK_FOLLOW: ::c_int = 0x0040;
 pub const AT_REMOVEDIR: ::c_int = 0x0080;
-
-pub const O_ACCMODE: ::c_int = 3;
 
 pub const TIOCMODG: ::c_ulong = 0x40047403;
 pub const TIOCMODS: ::c_ulong = 0x80047404;
@@ -1023,10 +1015,6 @@ pub const LOCK_SH: ::c_int = 1;
 pub const LOCK_EX: ::c_int = 2;
 pub const LOCK_NB: ::c_int = 4;
 pub const LOCK_UN: ::c_int = 8;
-
-pub const O_DSYNC: ::c_int = 4194304;
-pub const O_SYNC: ::c_int = 128;
-pub const O_NONBLOCK: ::c_int = 4;
 
 pub const MAP_COPY: ::c_int = 0x0002;
 pub const MAP_RENAME: ::c_int = 0x0020;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -272,15 +272,7 @@ pub const FILENAME_MAX: ::c_uint = 1024;
 pub const L_tmpnam: ::c_uint = 1024;
 pub const TMP_MAX: ::c_uint = 308915776;
 
-pub const O_RDONLY: ::c_int = 0;
-pub const O_WRONLY: ::c_int = 1;
-pub const O_RDWR: ::c_int = 2;
-pub const O_ACCMODE: ::c_int = 3;
-pub const O_APPEND: ::c_int = 8;
-pub const O_CREAT: ::c_int = 512;
-pub const O_EXCL: ::c_int = 2048;
 pub const O_NOCTTY: ::c_int = 32768;
-pub const O_TRUNC: ::c_int = 1024;
 pub const S_IFIFO: mode_t = 4096;
 pub const S_IFCHR: mode_t = 8192;
 pub const S_IFBLK: mode_t = 24576;
@@ -681,9 +673,6 @@ pub const LOCK_SH: ::c_int = 1;
 pub const LOCK_EX: ::c_int = 2;
 pub const LOCK_NB: ::c_int = 4;
 pub const LOCK_UN: ::c_int = 8;
-
-pub const O_SYNC: ::c_int = 128;
-pub const O_NONBLOCK: ::c_int = 4;
 
 pub const MAP_COPY: ::c_int = 0x0002;
 pub const MAP_RENAME: ::c_int = 0x0020;

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -187,10 +187,22 @@ pub const ST_RDONLY: ::c_ulong = 1;
 
 pub const NCCS: usize = 20;
 
+pub const O_ACCMODE: ::c_int = 0x3;
+pub const O_RDONLY: ::c_int = 0;
+pub const O_WRONLY: ::c_int = 1;
+pub const O_RDWR: ::c_int = 2;
+pub const O_APPEND: ::c_int = 8;
+pub const O_CREAT: ::c_int = 512;
+pub const O_TRUNC: ::c_int = 1024;
+pub const O_EXCL: ::c_int = 2048;
 pub const O_ASYNC: ::c_int = 0x40;
-pub const O_FSYNC: ::c_int = 0x80;
-pub const O_NDELAY: ::c_int = 0x4;
+pub const O_SYNC: ::c_int = 0x80;
+pub const O_NONBLOCK: ::c_int = 0x4;
 pub const O_NOFOLLOW: ::c_int = 0x100;
+pub const O_SHLOCK: ::c_int = 0x10;
+pub const O_EXLOCK: ::c_int = 0x20;
+pub const O_FSYNC: ::c_int = O_SYNC;
+pub const O_NDELAY: ::c_int = O_NONBLOCK;
 
 pub const F_GETOWN: ::c_int = 5;
 pub const F_SETOWN: ::c_int = 6;

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -127,16 +127,7 @@ pub const BUFSIZ : ::c_uint = 1024;
 pub const FOPEN_MAX : ::c_uint = 20;
 pub const FILENAME_MAX : ::c_uint = 1024;
 pub const L_tmpnam : ::c_uint = 1024;
-pub const O_RDONLY : ::c_int = 0;
-pub const O_WRONLY : ::c_int = 1;
-pub const O_RDWR : ::c_int = 2;
-pub const O_ACCMODE : ::c_int = 3;
-pub const O_APPEND : ::c_int = 8;
-pub const O_CREAT : ::c_int = 512;
-pub const O_EXCL : ::c_int = 2048;
 pub const O_NOCTTY : ::c_int = 32768;
-pub const O_TRUNC : ::c_int = 1024;
-pub const O_SYNC : ::c_int = 128;
 pub const S_IFIFO : mode_t = 4096;
 pub const S_IFCHR : mode_t = 8192;
 pub const S_IFBLK : mode_t = 24576;
@@ -477,8 +468,6 @@ pub const LOCK_SH: ::c_int = 1;
 pub const LOCK_EX: ::c_int = 2;
 pub const LOCK_NB: ::c_int = 4;
 pub const LOCK_UN: ::c_int = 8;
-
-pub const O_NONBLOCK : ::c_int = 4;
 
 pub const IPPROTO_RAW : ::c_int = 255;
 

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -270,8 +270,6 @@ pub const O_CLOEXEC: ::c_int = 0x400000;
 pub const O_ALT_IO: ::c_int = 0x40000;
 pub const O_NOSIGPIPE: ::c_int = 0x1000000;
 pub const O_SEARCH: ::c_int = 0x800000;
-pub const O_EXLOCK: ::c_int = 0x20;
-pub const O_SHLOCK: ::c_int = 0x10;
 pub const O_DIRECTORY: ::c_int = 0x200000;
 
 pub const MS_SYNC : ::c_int = 0x4;


### PR DESCRIPTION
These BSD flags have common value in all OSes, so I've merged them into root `mod.rs`.
- `O_ACCMODE`
- `O_RDONLY`
- `O_WRONLY`
- `O_RDWR`
- `O_APPEND`
- `O_CREAT`
- `O_TRUNC`
- `O_EXCL`
- `O_SYNC`
- `O_NONBLOCK`
- `O_SHLOCK`
- `O_EXLOCK`
- `O_FSYNC`
- `O_NDELAY`
