### PR TITLE
Add missing Android constant

### DIFF
--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -254,6 +254,7 @@ pub const _SC_THREAD_PRIORITY_SCHEDULING: ::c_int = 82;
 pub const _SC_THREAD_PRIO_INHERIT: ::c_int = 83;
 pub const _SC_THREAD_PRIO_PROTECT: ::c_int = 84;
 pub const _SC_THREAD_SAFE_FUNCTIONS: ::c_int = 85;
+pub const _SC_NPROCESSORS_CONF: ::c_int = 96;
 pub const _SC_NPROCESSORS_ONLN: ::c_int = 97;
 
 pub const PTHREAD_MUTEX_NORMAL: ::c_int = 0;


### PR DESCRIPTION
This pull requests add the `_SC_NPROCESSORS_CONF` constant to `libc` for Android targets. The similar `_SC_NPROCESSORS_ONLN` already existed.

The reason for adding only this constant is to help fix an [issue with `num_cpus`](https://github.com/seanmonstar/num_cpus/issues/34).