### PR TITLE
Fix broken html_root_url link

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,58 +19,58 @@
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico")]
 
 #![cfg_attr(all(target_os = "linux", target_arch = "x86_64"), doc(
-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-linux-gnu"
+    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-linux-gnu/libc"
 ))]
 #![cfg_attr(all(target_os = "linux", target_arch = "x86"), doc(
-    html_root_url = "https://doc.rust-lang.org/libc/i686-unknown-linux-gnu"
+    html_root_url = "https://doc.rust-lang.org/libc/i686-unknown-linux-gnu/libc"
 ))]
 #![cfg_attr(all(target_os = "linux", target_arch = "arm"), doc(
-    html_root_url = "https://doc.rust-lang.org/libc/arm-unknown-linux-gnueabihf"
+    html_root_url = "https://doc.rust-lang.org/libc/arm-unknown-linux-gnueabihf/libc"
 ))]
 #![cfg_attr(all(target_os = "linux", target_arch = "mips"), doc(
-    html_root_url = "https://doc.rust-lang.org/libc/mips-unknown-linux-gnu"
+    html_root_url = "https://doc.rust-lang.org/libc/mips-unknown-linux-gnu/libc"
 ))]
 #![cfg_attr(all(target_os = "linux", target_arch = "aarch64"), doc(
-    html_root_url = "https://doc.rust-lang.org/libc/aarch64-unknown-linux-gnu"
+    html_root_url = "https://doc.rust-lang.org/libc/aarch64-unknown-linux-gnu/libc"
 ))]
 #![cfg_attr(all(target_os = "linux", target_env = "musl"), doc(
-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-linux-musl"
+    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-linux-musl/libc"
 ))]
 #![cfg_attr(all(target_os = "macos", target_arch = "x86_64"), doc(
-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-apple-darwin"
+    html_root_url = "https://doc.rust-lang.org/libc/x86_64-apple-darwin/libc"
 ))]
 #![cfg_attr(all(target_os = "macos", target_arch = "x86"), doc(
-    html_root_url = "https://doc.rust-lang.org/libc/i686-apple-darwin"
+    html_root_url = "https://doc.rust-lang.org/libc/i686-apple-darwin/libc"
 ))]
 #![cfg_attr(all(windows, target_arch = "x86_64", target_env = "gnu"), doc(
-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-pc-windows-gnu"
+    html_root_url = "https://doc.rust-lang.org/libc/x86_64-pc-windows-gnu/libc"
 ))]
 #![cfg_attr(all(windows, target_arch = "x86", target_env = "gnu"), doc(
-    html_root_url = "https://doc.rust-lang.org/libc/i686-pc-windows-gnu"
+    html_root_url = "https://doc.rust-lang.org/libc/i686-pc-windows-gnu/libc"
 ))]
 #![cfg_attr(all(windows, target_arch = "x86_64", target_env = "msvc"), doc(
-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-pc-windows-msvc"
+    html_root_url = "https://doc.rust-lang.org/libc/x86_64-pc-windows-msvc/libc"
 ))]
 #![cfg_attr(all(windows, target_arch = "x86", target_env = "msvc"), doc(
-    html_root_url = "https://doc.rust-lang.org/libc/i686-pc-windows-msvc"
+    html_root_url = "https://doc.rust-lang.org/libc/i686-pc-windows-msvc/libc"
 ))]
 #![cfg_attr(target_os = "android", doc(
-    html_root_url = "https://doc.rust-lang.org/libc/arm-linux-androideabi"
+    html_root_url = "https://doc.rust-lang.org/libc/arm-linux-androideabi/libc"
 ))]
 #![cfg_attr(target_os = "freebsd", doc(
-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-freebsd"
+    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-freebsd/libc"
 ))]
 #![cfg_attr(target_os = "openbsd", doc(
-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-openbsd"
+    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-openbsd/libc"
 ))]
 #![cfg_attr(target_os = "bitrig", doc(
-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-bitrig"
+    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-bitrig/libc"
 ))]
 #![cfg_attr(target_os = "netbsd", doc(
-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-netbsd"
+    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-netbsd/libc"
 ))]
 #![cfg_attr(target_os = "dragonfly", doc(
-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-dragonfly"
+    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-dragonfly/libc"
 ))]
 
 // Attributes needed when building as part of the standard library


### PR DESCRIPTION
All `html_root_url` redirect to 404 github page. I fixed this with add path `/libc`.