### PR TITLE
DragonFly - Change PTHREAD_STACK_MIN from 1 to 16k

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -134,7 +134,7 @@ s! {
 }
 
 pub const RAND_MAX: ::c_int = 0x7fff_ffff;
-pub const PTHREAD_STACK_MIN: ::size_t = 1024;
+pub const PTHREAD_STACK_MIN: ::size_t = 16384;
 pub const SIGSTKSZ: ::size_t = 40960;
 pub const MADV_INVAL: ::c_int = 10;
 pub const O_CLOEXEC: ::c_int = 0x00020000;


### PR DESCRIPTION
This is probably related to cargo failing on DragonFly when running with
multiple jobs.

The minimum pthread stack size has been increase as shown here [1],
which was needed to fix nodejs.

[1]: http://gitweb.dragonflybsd.org/dragonfly.git/commitdiff/592912cde1dc358bf080ae9aff3eca491688f47c