### PR TITLE
Add missing flags in glibc arm

### DIFF
--- a/src/unix/notbsd/android/b32/x86.rs
+++ b/src/unix/notbsd/android/b32/x86.rs
@@ -4,3 +4,5 @@ pub type wchar_t = i32;
 pub const O_DIRECT: ::c_int = 0x4000;
 pub const O_DIRECTORY: ::c_int = 0x10000;
 pub const O_NOFOLLOW: ::c_int = 0x20000;
+
+pub const MAP_32BIT: ::c_int = 0x40;

--- a/src/unix/notbsd/android/b64/x86_64.rs
+++ b/src/unix/notbsd/android/b64/x86_64.rs
@@ -51,3 +51,5 @@ pub const SYS_gettid: ::c_long = 186;
 
 pub const SIGSTKSZ: ::size_t = 8192;
 pub const MINSIGSTKSZ: ::size_t = 2048;
+
+pub const MAP_32BIT: ::c_int = 0x40;

--- a/src/unix/notbsd/linux/other/b32/arm.rs
+++ b/src/unix/notbsd/linux/other/b32/arm.rs
@@ -81,11 +81,13 @@ pub const MAP_NORESERVE: ::c_int = 0x04000;
 
 pub const EDEADLOCK: ::c_int = 35;
 
+pub const SO_PASSCRED: ::c_int = 16;
 pub const SO_PEERCRED: ::c_int = 17;
 pub const SO_RCVLOWAT: ::c_int = 18;
 pub const SO_SNDLOWAT: ::c_int = 19;
 pub const SO_RCVTIMEO: ::c_int = 20;
 pub const SO_SNDTIMEO: ::c_int = 21;
+pub const SO_SNDBUFFORCE: ::c_int = 32;
 
 pub const FIOCLEX: ::c_ulong = 0x5451;
 pub const FIONBIO: ::c_ulong = 0x5421;


### PR DESCRIPTION
Adds two missing flags that are defined everywhere except for arm-linux-gnueabi for some reason : SO_PASSCRED and SO_SNDBUFFORCE.

Also adds MAP_32BIT on x86_64-linux-android and i686-linux-android.