### PR TITLE
harmonize dirent->d_ino according to posix

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -113,7 +113,7 @@ s! {
     }
 
     pub struct dirent {
-        pub d_ino: u64,
+        pub d_ino: ino_t,
         pub d_seekoff: u64,
         pub d_reclen: u16,
         pub d_namlen: u16,

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -55,7 +55,7 @@ s! {
     }
 
     pub struct dirent {
-        pub d_fileno: ::ino_t,
+        pub d_ino: ::ino_t,
         pub d_namlen: u16,
         pub d_type: u8,
         __unused1: u8,

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -44,7 +44,7 @@ s! {
     }
 
     pub struct dirent {
-        pub d_fileno: u32,
+        pub d_ino: ::ino_t,
         pub d_reclen: u16,
         pub d_type: u8,
         pub d_namlen: u8,

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -21,7 +21,7 @@ s! {
     }
 
     pub struct dirent {
-        pub d_fileno: ::ino_t,
+        pub d_ino: ::ino_t,
         pub d_reclen: u16,
         pub d_namlen: u16,
         pub d_type: u8,


### PR DESCRIPTION
POSIX 2004 states that dirent shall include the field `d_ino` of type `ino_t`:
http://pubs.opengroup.org/onlinepubs/009695399/basedefs/dirent.h.html

Updated darwin/dragonfly/freebsd and netbsd definitions to met POSIX and make
portable use easier.