### PR TITLE
Add missing constants for mac

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -155,6 +155,7 @@ fn main() {
         if target.starts_with("x86") {
             cfg.header("crt_externs.h");
         }
+	cfg.header("net/route.h");
     }
 
     if bsdlike {

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1538,6 +1538,9 @@ pub const XATTR_NOSECURITY: ::c_int = 0x0008;
 pub const XATTR_NODEFAULT: ::c_int = 0x0010;
 pub const XATTR_SHOWCOMPRESSION: ::c_int = 0x0020;
 
+pub const NET_RT_IFLIST2: ::c_int = 0x0006;
+pub const RTM_IFINFO2: ::c_int = 0x0012;
+
 f! {
     pub fn WSTOPSIG(status: ::c_int) -> ::c_int {
         status >> 8


### PR DESCRIPTION
I didn't find these constants on other systems than mac so only mac is updated...