### PR TITLE
unix: add fexecve()

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -457,7 +457,8 @@ fn main() {
             "execv" |       // crazy stuff with const/mut
             "execve" |
             "execvp" |
-            "execvpe" => true,
+            "execvpe" |
+            "fexecve" => true,
 
             "getrlimit" | "getrlimit64" |    // non-int in 1st arg
             "setrlimit" | "setrlimit64" |    // non-int in 1st arg

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -449,6 +449,9 @@ extern {
                   -> ::c_int;
     pub fn execvp(c: *const c_char,
                   argv: *const *const c_char) -> ::c_int;
+    pub fn fexecve(fd: ::c_int, argv: *const *const c_char,
+                   envp: *const *const c_char)
+                   -> ::c_int;
     pub fn fork() -> pid_t;
     pub fn fpathconf(filedes: ::c_int, name: ::c_int) -> c_long;
     pub fn getcwd(buf: *mut c_char, size: ::size_t) -> *mut c_char;


### PR DESCRIPTION
Add missing fexecve() - execute program specified via file descriptor.

Reference: http://pubs.opengroup.org/onlinepubs/9699919799/functions/fexecve.html