### PR TITLE
Add missing SO_TIMESTAMP constant for OpenBSD like OSes

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
@@ -210,6 +210,7 @@ pub const AT_REMOVEDIR: ::c_int = 0x08;
 
 pub const RLIM_NLIMITS: ::c_int = 9;
 
+pub const SO_TIMESTAMP: ::c_int = 0x0800;
 pub const SO_SNDTIMEO: ::c_int = 0x1005;
 pub const SO_RCVTIMEO: ::c_int = 0x1006;
 pub const SO_BINDANY: ::c_int = 0x1000;


### PR DESCRIPTION
Added to mod.rs as both [OpenBSD](https://github.com/openbsd/src/blob/e35050970e3e2b822e383a5e844e4c4402eebccc/sys/sys/socket.h#L97) and [Bitrig](https://github.com/bitrig/bitrig/blob/a15267d8249fe8d329eb34048605c59a394a02ac/sys/sys/socket.h#L100) have it.

Required for https://github.com/nix-rust/nix/pull/688