### PR TITLE
Use cfg_attr to gate musl linking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ services:
 install:
   - if [ -z "$NO_ADD" ]; then rustup target add $TARGET; fi
 script:
-  - cargo build
-  - cargo build --no-default-features
+  - cargo build --target=$TARGET
+  - cargo build --no-default-features --target=$TARGET
   - cargo generate-lockfile --manifest-path libc-test/Cargo.toml
   - if [[ $TRAVIS_OS_NAME = "linux" ]]; then
       sh ci/run-docker.sh $TARGET;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -236,8 +236,8 @@ cfg_if! {
         // cargo build, don't pull in anything extra as the libstd  dep
         // already pulls in all libs.
     } else if #[cfg(any(all(target_env = "musl", not(target_arch = "mips"))))] {
-        #[link(name = "c", kind = "static", cfg(target_feature = "crt-static"))]
-        #[link(name = "c", cfg(not(target_feature = "crt-static")))]
+        #[cfg_attr(stdbuild, link(name = "c", kind = "static", cfg(target_feature = "crt-static")))]
+        #[cfg_attr(stdbuild, link(name = "c", cfg(not(target_feature = "crt-static"))))]
         extern {}
     } else if #[cfg(target_os = "emscripten")] {
         #[link(name = "c")]

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -232,16 +232,12 @@ pub const INADDR_NONE: in_addr_t = 4294967295;
 cfg_if! {
     if #[cfg(dox)] {
         // on dox builds don't pull in anything
-    } else if #[cfg(all(not(stdbuild), feature = "use_std"))] {
+    } else if #[cfg(any(not(stdbuild), feature = "use_std"))] {
         // cargo build, don't pull in anything extra as the libstd  dep
         // already pulls in all libs.
     } else if #[cfg(any(all(target_env = "musl", not(target_arch = "mips"))))] {
-        #[cfg_attr(stdbuild,
-                   link(name = "c",
-                        kind = "static", cfg(target_feature = "crt-static")))]
-        #[cfg_attr(stdbuild,
-                   link(name = "c",
-                        cfg(not(target_feature = "crt-static"))))]
+        #[link(name = "c", kind = "static", cfg(target_feature = "crt-static"))]
+        #[link(name = "c", cfg(not(target_feature = "crt-static")))]
         extern {}
     } else if #[cfg(target_os = "emscripten")] {
         #[link(name = "c")]

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -236,8 +236,12 @@ cfg_if! {
         // cargo build, don't pull in anything extra as the libstd  dep
         // already pulls in all libs.
     } else if #[cfg(any(all(target_env = "musl", not(target_arch = "mips"))))] {
-        #[cfg_attr(stdbuild, link(name = "c", kind = "static", cfg(target_feature = "crt-static")))]
-        #[cfg_attr(stdbuild, link(name = "c", cfg(not(target_feature = "crt-static"))))]
+        #[cfg_attr(stdbuild,
+                   link(name = "c",
+                        kind = "static", cfg(target_feature = "crt-static")))]
+        #[cfg_attr(stdbuild,
+                   link(name = "c",
+                        cfg(not(target_feature = "crt-static"))))]
         extern {}
     } else if #[cfg(target_os = "emscripten")] {
         #[link(name = "c")]


### PR DESCRIPTION
Fixes #684. Previously building libc for musl would fail, because we don't want to use #[link(...)] outside a stdbuild. This commit fixes that issue. (Although it may leave other targets broken, I'm not sure.)