### PR TITLE
Add KERN_USERMOUNT and KERN_ARND to don't check list on OpenBSD

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -431,6 +431,11 @@ fn main() {
             "KERN_KDENABLE_BG_TRACE" if apple => true,
             "KERN_KDDISABLE_BG_TRACE" if apple => true,
 
+            // These constants were removed in OpenBSD 6 (https://git.io/v7gBO
+            // https://git.io/v7gBq)
+            "KERN_USERMOUNT" |
+            "KERN_ARND" if openbsd => true,
+
             // These are either unimplemented or optionally built into uClibc
             "LC_CTYPE_MASK" | "LC_NUMERIC_MASK" | "LC_TIME_MASK" | "LC_COLLATE_MASK" | "LC_MONETARY_MASK" | "LC_MESSAGES_MASK" |
             "MADV_MERGEABLE" | "MADV_UNMERGEABLE" | "MADV_HWPOISON" | "IPV6_ADD_MEMBERSHIP" | "IPV6_DROP_MEMBERSHIP" | "IPV6_MULTICAST_LOOP" | "IPV6_V6ONLY" |


### PR DESCRIPTION
These [two constants are no longer in OpenBSD](https://github.com/openbsd/src/blob/3f376b0849a3d7e59ed23ac6dba2b729fc2c7589/sys/sys/sysctl.h#L133-L140). They were preventing the the tests from passing. With this change the test now pass:

```
CC=egcc cargo run
   Compiling libc v0.2.29 (file:///home/vagrant/libc)
   Compiling libc-test v0.1.0 (file:///home/vagrant/libc/libc-test)
    Finished debug [unoptimized + debuginfo] target(s) in 11.7 secs
     Running `/home/vagrant/libc/target/debug/libc-test`
RUNNING ALL TESTS
PASSED 5935 tests
```

They are still present in bitrig so I moved them there.