### PR TITLE
struct addrinfo needs padding on Solaris/SPARC

### DIFF
--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -208,6 +208,8 @@ s! {
         pub ai_family: ::c_int,
         pub ai_socktype: ::c_int,
         pub ai_protocol: ::c_int,
+        #[cfg(target_arch = "sparc64")]
+        __sparcv9_pad: ::c_int,
         pub ai_addrlen: ::socklen_t,
         pub ai_canonname: *mut ::c_char,
         pub ai_addr: *mut ::sockaddr,


### PR DESCRIPTION
64-bit Solaris/SPARC has a 4-byte pad before `ai_addrlen` for historical reasons (`ai_addrlen` used to be defined as a `size_t`, which is 4 bytes in ILP32 and 8 in LP64, but was converted to a 4-byte `socklen_t` in Solaris 10, which necessitated padding for (more or less) binary compatibility).

See rust-lang/rust#43649.