### PR TITLE
Fix spelling of ptrace's request argument

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1742,7 +1742,7 @@ extern {
                  target: *const ::c_char,
                  flags: ::c_int,
                  data: *mut ::c_void) -> ::c_int;
-    pub fn ptrace(requeset: ::c_int,
+    pub fn ptrace(request: ::c_int,
                   pid: ::pid_t,
                   addr: *mut ::c_char,
                   data: ::c_int) -> ::c_int;

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -798,7 +798,7 @@ extern {
                  flags: ::c_int,
                  data: *mut ::c_void,
                  size: ::size_t) -> ::c_int;
-    pub fn ptrace(requeset: ::c_int,
+    pub fn ptrace(request: ::c_int,
                   pid: ::pid_t,
                   addr: *mut ::c_void,
                   data: ::c_int) -> ::c_int;


### PR DESCRIPTION
Couldn't handle seeing this anymore after working on a ptrace API for `nix`!