### PR TITLE
L4Re improvements

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -230,8 +230,10 @@ pub const INADDR_BROADCAST: in_addr_t = 4294967295;
 pub const INADDR_NONE: in_addr_t = 4294967295;
 
 cfg_if! {
-    if #[cfg(any(dox, target_os = "l4re"))] {
+    if #[cfg(dox)] {
         // on dox builds don't pull in anything
+    } else if #[cfg(target_os = "l4re")] {
+        // required libraries for L4Re are linked externally, ATM
     } else if #[cfg(all(not(stdbuild), feature = "use_std"))] {
         // cargo build, don't pull in anything extra as the libstd  dep
         // already pulls in all libs.

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -232,7 +232,6 @@ pub const INADDR_NONE: in_addr_t = 4294967295;
 cfg_if! {
     if #[cfg(any(dox, target_os = "l4re"))] {
         // on dox builds don't pull in anything
-        // L4Re builds pass the required libs using -Z to the compiler.
     } else if #[cfg(all(not(stdbuild), feature = "use_std"))] {
         // cargo build, don't pull in anything extra as the libstd  dep
         // already pulls in all libs.

--- a/src/unix/uclibc/x86_64/l4re.rs
+++ b/src/unix/uclibc/x86_64/l4re.rs
@@ -1,7 +1,7 @@
 /// L4Re specifics
 /// This module contains definitions required by various L4Re libc backends.
-/// Some of them are formally not part of the libc, but are a dependency of the libc and hence we
-/// should provide them here.
+/// Some of them are formally not part of the libc, but are a dependency of the
+/// libc and hence we should provide them here.
 
 pub type l4_umword_t = ::c_ulong; // Unsigned machine word.
 
@@ -41,3 +41,6 @@ pub struct pthread_attr_t {
     pub create_flags: ::c_uint,
 }
 
+// L4Re requires a min stack size of 64k; that isn't defined in uClibc, but
+// somewhere in the core libraries. uClibc wants 16k, but that's not enough.
+pub const PTHREAD_STACK_MIN: usize = 65536;

--- a/src/unix/uclibc/x86_64/l4re.rs
+++ b/src/unix/uclibc/x86_64/l4re.rs
@@ -1,7 +1,7 @@
 /// L4Re specifics
 /// This module contains definitions required by various L4Re libc backends.
-/// These are formally not part of the libc, but are a dependency of the libc
-/// and hence we should provide them here.
+/// Some of them are formally not part of the libc, but are a dependency of the libc and hence we
+/// should provide them here.
 
 pub type l4_umword_t = ::c_ulong; // Unsigned machine word.
 

--- a/src/unix/uclibc/x86_64/mod.rs
+++ b/src/unix/uclibc/x86_64/mod.rs
@@ -139,8 +139,8 @@ s! {
     pub struct stat {
         pub st_dev: ::c_ulong,
         pub st_ino: ::ino_t,
-        // According to uclibc/libc/sysdeps/linux/x86_64/bits/stat.h, order of nlink and mode are
-        // swapped on 64 bit systems.
+        // According to uclibc/libc/sysdeps/linux/x86_64/bits/stat.h, order of
+        // nlink and mode are swapped on 64 bit systems.
         pub st_nlink: ::nlink_t,
         pub st_mode: ::mode_t,
         pub st_uid: ::uid_t,
@@ -323,8 +323,8 @@ pub const O_EXCL: ::c_int = 0200;
 pub const O_NONBLOCK: ::c_int = 04000;
 pub const O_TRUNC: ::c_int = 01000;
 pub const NCCS: usize = 32;
-pub const PTHREAD_STACK_MIN: usize = 16384;
 pub const SIG_SETMASK: ::c_int = 2; // Set the set of blocked signals
+pub const PTHREAD_STACK_MIN: usize = 16384;
 pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
 pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
 pub const PTHREAD_MUTEX_NORMAL: ::c_int = 0;


### PR DESCRIPTION
This commit improves the x86_64 uClibc port and splits of L4Re-specific structs into a separate submodule. It defines additional constants and fixes some unfinished structs.