### PR TITLE
haiku: Add missing signals

### DIFF
--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -332,8 +332,6 @@ pub const F_SETFD: ::c_int = 0x0004;
 pub const F_GETFL: ::c_int = 0x0008;
 pub const F_SETFL: ::c_int = 0x0010;
 
-pub const SIGTRAP: ::c_int = 22;
-
 pub const PTHREAD_CREATE_JOINABLE: ::c_int = 0;
 pub const PTHREAD_CREATE_DETACHED: ::c_int = 1;
 
@@ -402,17 +400,37 @@ pub const X_OK: ::c_int = 1;
 pub const STDIN_FILENO: ::c_int = 0;
 pub const STDOUT_FILENO: ::c_int = 1;
 pub const STDERR_FILENO: ::c_int = 2;
+
 pub const SIGHUP: ::c_int = 1;
 pub const SIGINT: ::c_int = 2;
 pub const SIGQUIT: ::c_int = 3;
 pub const SIGILL: ::c_int = 4;
+pub const SIGCHLD: ::c_int = 5;
 pub const SIGABRT: ::c_int = 6;
+pub const SIGPIPE: ::c_int = 7;
 pub const SIGFPE: ::c_int = 8;
 pub const SIGKILL: ::c_int = 9;
+pub const SIGSTOP: ::c_int = 10;
 pub const SIGSEGV: ::c_int = 11;
-pub const SIGPIPE: ::c_int = 7;
+pub const SIGCONT: ::c_int = 12;
+pub const SIGTSTP: ::c_int = 13;
 pub const SIGALRM: ::c_int = 14;
 pub const SIGTERM: ::c_int = 15;
+pub const SIGTTIN: ::c_int = 16;
+pub const SIGTTOU: ::c_int = 17;
+pub const SIGUSR1: ::c_int = 18;
+pub const SIGUSR2: ::c_int = 19;
+pub const SIGWINCH: ::c_int = 20;
+pub const SIGKILLTHR: ::c_int = 21;
+pub const SIGTRAP: ::c_int = 22;
+pub const SIGPOLL: ::c_int = 23;
+pub const SIGPROF: ::c_int = 24;
+pub const SIGSYS: ::c_int = 25;
+pub const SIGURG: ::c_int = 26;
+pub const SIGVTALRM: ::c_int = 27;
+pub const SIGXCPU: ::c_int = 28;
+pub const SIGXFSZ: ::c_int = 29;
+pub const SIGBUS: ::c_int = 30;
 
 pub const EAI_SYSTEM: ::c_int = 11;
 
@@ -638,8 +656,6 @@ pub const SA_ONSTACK: c_ulong = 0x20;
 pub const SA_SIGINFO: c_ulong = 0x40;
 pub const SA_NOCLDWAIT: c_ulong = 0x02;
 
-pub const SIGCHLD: ::c_int = 5;
-pub const SIGBUS: ::c_int = 30;
 pub const SIG_SETMASK: ::c_int = 3;
 
 pub const RUSAGE_CHILDREN: ::c_int = -1;


### PR DESCRIPTION
* Now a complete signal list on Haiku minus reserved.
* Fixes build failure due to missing SIGUSR1