### PR TITLE
Add syscall constants to more Android/Linux targets

### DIFF
--- a/src/unix/notbsd/android/b32/arm.rs
+++ b/src/unix/notbsd/android/b32/arm.rs
@@ -6,4 +6,7 @@ pub const O_DIRECTORY: ::c_int = 0x4000;
 pub const O_NOFOLLOW: ::c_int = 0x8000;
 pub const O_LARGEFILE: ::c_int = 0o400000;
 
+pub const SYS_pivot_root: ::c_long = 218;
 pub const SYS_gettid: ::c_long = 224;
+pub const SYS_perf_event_open: ::c_long = 364;
+pub const SYS_memfd_create: ::c_long = 385;

--- a/src/unix/notbsd/android/b64/aarch64.rs
+++ b/src/unix/notbsd/android/b64/aarch64.rs
@@ -54,7 +54,10 @@ pub const O_DIRECTORY: ::c_int = 0x4000;
 pub const O_NOFOLLOW: ::c_int = 0x8000;
 pub const O_LARGEFILE: ::c_int = 0o400000;
 
+pub const SYS_pivot_root: ::c_long = 41;
 pub const SYS_gettid: ::c_long = 178;
+pub const SYS_perf_event_open: ::c_long = 241;
+pub const SYS_memfd_create: ::c_long = 279;
 
 pub const SIGSTKSZ: ::size_t = 16384;
 pub const MINSIGSTKSZ: ::size_t = 5120;

--- a/src/unix/notbsd/linux/mips/mips32.rs
+++ b/src/unix/notbsd/linux/mips/mips32.rs
@@ -269,4 +269,8 @@ pub const O_LARGEFILE: ::c_int = 0x2000;
 
 pub const RLIM_INFINITY: ::rlim_t = 0x7fffffff;
 
-pub const SYS_gettid: ::c_long = 4222;   // Valid for O32
+// Valid for O32
+pub const SYS_pivot_root: ::c_long = 4216;
+pub const SYS_gettid: ::c_long = 4222;
+pub const SYS_perf_event_open: ::c_long = 4333;
+pub const SYS_memfd_create: ::c_long = 4354;

--- a/src/unix/notbsd/linux/mips/mips64.rs
+++ b/src/unix/notbsd/linux/mips/mips64.rs
@@ -251,4 +251,7 @@ pub const O_LARGEFILE: ::c_int = 0;
 
 pub const RLIM_INFINITY: ::rlim_t = 0xffff_ffff_ffff_ffff;
 
-pub const SYS_gettid: ::c_long = 5178;   // Valid for n64
+// Valid for n64
+pub const SYS_pivot_root: ::c_long = 5151;
+pub const SYS_gettid: ::c_long = 5178;
+pub const SYS_memfd_create: ::c_long = 5314;

--- a/src/unix/notbsd/linux/musl/b32/arm.rs
+++ b/src/unix/notbsd/linux/musl/b32/arm.rs
@@ -371,8 +371,10 @@ pub const TIOCMSET: ::c_int = 0x5418;
 pub const FIONREAD: ::c_int = 0x541B;
 pub const TIOCCONS: ::c_int = 0x541D;
 
+pub const SYS_pivot_root: ::c_long = 218;
 pub const SYS_gettid: ::c_long = 224;
 pub const SYS_perf_event_open: ::c_long = 364;
+pub const SYS_memfd_create: ::c_long = 385;
 
 pub const POLLWRNORM: ::c_short = 0x100;
 pub const POLLWRBAND: ::c_short = 0x200;

--- a/src/unix/notbsd/linux/musl/b32/mips.rs
+++ b/src/unix/notbsd/linux/musl/b32/mips.rs
@@ -382,8 +382,11 @@ pub const TIOCMSET: ::c_int = 0x741A;
 pub const FIONREAD: ::c_int = 0x467F;
 pub const TIOCCONS: ::c_int = 0x80047478;
 
-pub const SYS_gettid: ::c_long = 4222;   // Valid for O32
-pub const SYS_perf_event_open: ::c_long = 4333;  // Valid for O32
+// Valid for O32
+pub const SYS_pivot_root: ::c_long = 4216;
+pub const SYS_gettid: ::c_long = 4222;
+pub const SYS_perf_event_open: ::c_long = 4333;
+pub const SYS_memfd_create: ::c_long = 4354;
 
 pub const POLLWRNORM: ::c_short = 0x4;
 pub const POLLWRBAND: ::c_short = 0x100;

--- a/src/unix/notbsd/linux/musl/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/musl/b64/aarch64.rs
@@ -1,4 +1,7 @@
 pub type c_char = u8;
 pub type __u64 = ::c_ulonglong;
 
+pub const SYS_pivot_root: ::c_long = 41;
+pub const SYS_gettid: ::c_long = 178;
 pub const SYS_perf_event_open: ::c_long = 241;
+pub const SYS_memfd_create: ::c_long = 279;

--- a/src/unix/notbsd/linux/musl/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/musl/b64/powerpc64.rs
@@ -1,4 +1,7 @@
 pub type c_char = u8;
 pub type __u64 = ::c_ulong;
 
+pub const SYS_pivot_root: ::c_long = 203;
+pub const SYS_gettid: ::c_long = 207;
 pub const SYS_perf_event_open: ::c_long = 319;
+pub const SYS_memfd_create: ::c_long = 360;

--- a/src/unix/notbsd/linux/other/b32/arm.rs
+++ b/src/unix/notbsd/linux/other/b32/arm.rs
@@ -125,8 +125,10 @@ pub const SO_RCVBUFFORCE: ::c_int = 33;
 pub const FIOCLEX: ::c_ulong = 0x5451;
 pub const FIONBIO: ::c_ulong = 0x5421;
 
+pub const SYS_pivot_root: ::c_long = 218;
 pub const SYS_gettid: ::c_long = 224;
 pub const SYS_perf_event_open: ::c_long = 364;
+pub const SYS_memfd_create: ::c_long = 385;
 
 pub const PTRACE_GETFPXREGS: ::c_uint = 18;
 pub const PTRACE_SETFPXREGS: ::c_uint = 19;

--- a/src/unix/notbsd/linux/other/b32/powerpc.rs
+++ b/src/unix/notbsd/linux/other/b32/powerpc.rs
@@ -126,8 +126,10 @@ pub const SO_PEERCRED: ::c_int = 21;
 pub const FIOCLEX: ::c_ulong = 0x20006601;
 pub const FIONBIO: ::c_ulong = 0x8004667e;
 
+pub const SYS_pivot_root: ::c_long = 203;
 pub const SYS_gettid: ::c_long = 207;
 pub const SYS_perf_event_open: ::c_long = 319;
+pub const SYS_memfd_create: ::c_long = 360;
 
 pub const MCL_CURRENT: ::c_int = 0x2000;
 pub const MCL_FUTURE: ::c_int = 0x4000;

--- a/src/unix/notbsd/linux/other/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/other/b64/aarch64.rs
@@ -367,8 +367,10 @@ pub const EDEADLOCK: ::c_int = 35;
 pub const FIOCLEX: ::c_ulong = 0x5451;
 pub const FIONBIO: ::c_ulong = 0x5421;
 
+pub const SYS_pivot_root: ::c_long = 41;
 pub const SYS_gettid: ::c_long = 178;
 pub const SYS_perf_event_open: ::c_long = 241;
+pub const SYS_memfd_create: ::c_long = 279;
 
 pub const MCL_CURRENT: ::c_int = 0x0001;
 pub const MCL_FUTURE: ::c_int = 0x0002;

--- a/src/unix/notbsd/linux/other/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/other/b64/powerpc64.rs
@@ -365,8 +365,10 @@ pub const EDEADLOCK: ::c_int = 58;
 pub const FIOCLEX: ::c_ulong = 0x20006601;
 pub const FIONBIO: ::c_ulong = 0x8004667e;
 
+pub const SYS_pivot_root: ::c_long = 203;
 pub const SYS_gettid: ::c_long = 207;
 pub const SYS_perf_event_open: ::c_long = 319;
+pub const SYS_memfd_create: ::c_long = 360;
 
 pub const MCL_CURRENT: ::c_int = 0x2000;
 pub const MCL_FUTURE: ::c_int = 0x4000;

--- a/src/unix/notbsd/linux/s390x.rs
+++ b/src/unix/notbsd/linux/s390x.rs
@@ -800,8 +800,10 @@ pub const LINUX_REBOOT_CMD_RESTART2: ::c_int = 0xA1B2C3D4;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: ::c_int = 0xD000FCE2;
 pub const LINUX_REBOOT_CMD_KEXEC: ::c_int = 0x45584543;
 
+pub const SYS_pivot_root: ::c_long = 217;
 pub const SYS_gettid: ::c_long = 236;
 pub const SYS_perf_event_open: ::c_long = 331;
+pub const SYS_memfd_create: ::c_long = 350;
 
 pub const VTIME: usize = 5;
 pub const VSWTC: usize = 7;


### PR DESCRIPTION
Primarily adding `SYS_memfd_create` and `SYS_pivot_root` for `nix`. But I also equalized a few constants across platforms so some of the other ones that were defined on some targets are now defined across all linux/android targets.