### PR TITLE
Add QCMD() for available platforms

### DIFF
--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -360,6 +360,10 @@ f! {
     pub fn WCOREDUMP(status: ::c_int) -> bool {
         (status & 0o200) != 0
     }
+
+    pub fn QCMD(cmd: ::c_int, type_: ::c_int) -> ::c_int {
+        (cmd << 8) | (type_ & 0x00ff)
+    }
 }
 
 extern {

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -856,6 +856,10 @@ f! {
     pub fn WCOREDUMP(status: ::c_int) -> bool {
         (status & 0x80) != 0
     }
+
+    pub fn QCMD(cmd: ::c_int, type_: ::c_int) -> ::c_int {
+        (cmd << 8) | (type_ & 0x00ff)
+    }
 }
 
 extern {

--- a/src/unix/uclibc/mod.rs
+++ b/src/unix/uclibc/mod.rs
@@ -1419,6 +1419,10 @@ f! {
     pub fn CPU_EQUAL(set1: &cpu_set_t, set2: &cpu_set_t) -> bool {
         set1.bits == set2.bits
     }
+
+    pub fn QCMD(cmd: ::c_int, type_: ::c_int) -> ::c_int {
+        (cmd << 8) | (type_ & 0x00ff)
+    }
 }
 
 extern {


### PR DESCRIPTION
Exists where `Q_QUOTAON` also exists, so added it for those same platforms.