### PR TITLE
Fix dev_t minor() bitmasking on Linux

### DIFF
--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -962,7 +962,7 @@ f! {
 
     pub fn minor(dev: ::dev_t) -> ::c_uint {
         let mut minor = 0;
-        minor |= (dev & 0xfffff00000000000) >> 0;
+        minor |= (dev & 0x00000000000000ff) >> 0;
         minor |= (dev & 0x00000ffffff00000) >> 12;
         minor as ::c_uint
     }


### PR DESCRIPTION
This code appears to be modeled on the macros in glibc bits/sysmacros.h
(since Glibc 2.26). Fix the masking of bits for minor() to match that
implementation, which also corresponds with the explanatory comment in
that file.