### PR TITLE
Add timerfd API on Linux

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -188,6 +188,7 @@ fn main() {
         cfg.header("sys/shm.h");
         cfg.header("sys/user.h");
         cfg.header("sys/fsuid.h");
+        cfg.header("sys/timerfd.h");
         cfg.header("shadow.h");
         if !emscripten {
             cfg.header("linux/input.h");

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -200,6 +200,11 @@ s! {
         _pad: [::uint8_t; 48],
     }
 
+    pub struct itimerspec {
+        pub it_interval: ::timespec,
+        pub it_value: ::timespec,
+    }
+
     pub struct fsid_t {
         __val: [::c_int; 2],
     }
@@ -900,6 +905,10 @@ pub const ITIMER_REAL: ::c_int = 0;
 pub const ITIMER_VIRTUAL: ::c_int = 1;
 pub const ITIMER_PROF: ::c_int = 2;
 
+pub const TFD_CLOEXEC: ::c_int = 0o2000000;
+pub const TFD_NONBLOCK: ::c_int = 0o4000;
+pub const TFD_TIMER_ABSTIME: ::c_int = 1;
+
 pub const XATTR_CREATE: ::c_int = 0x1;
 pub const XATTR_REPLACE: ::c_int = 0x2;
 
@@ -1074,6 +1083,13 @@ extern {
     pub fn signalfd(fd: ::c_int,
                     mask: *const ::sigset_t,
                     flags: ::c_int) -> ::c_int;
+    pub fn timerfd_create(clockid: ::c_int, flags: ::c_int) -> ::c_int;
+    pub fn timerfd_gettime(fd: ::c_int,
+                           curr_value: *mut itimerspec) -> ::c_int;
+    pub fn timerfd_settime(fd: ::c_int,
+                           flags: ::c_int,
+                           new_value: *const itimerspec,
+                           old_value: *mut itimerspec) -> ::c_int;
     pub fn pwritev(fd: ::c_int,
                    iov: *const ::iovec,
                    iovcnt: ::c_int,

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -905,8 +905,8 @@ pub const ITIMER_REAL: ::c_int = 0;
 pub const ITIMER_VIRTUAL: ::c_int = 1;
 pub const ITIMER_PROF: ::c_int = 2;
 
-pub const TFD_CLOEXEC: ::c_int = 0o2000000;
-pub const TFD_NONBLOCK: ::c_int = 0o4000;
+pub const TFD_CLOEXEC: ::c_int = O_CLOEXEC;
+pub const TFD_NONBLOCK: ::c_int = O_NONBLOCK;
 pub const TFD_TIMER_ABSTIME: ::c_int = 1;
 
 pub const XATTR_CREATE: ::c_int = 0x1;


### PR DESCRIPTION
This change adds the Linux-specific timerfd API to libc.

```C
#include <sys/timerfd.h>

int timerfd_create(int clockid, int flags);
int timerfd_gettime(int fd, struct itimerspec *curr_value);
int timerfd_settime(int fd, int flags, 
                    const struct itimerspec *new_value, 
                    struct itimerspec *old_value);
```

The timerfd API has been available since kernel 2.6.25 and in glibc since version 2.8. 

I'm not sure if I put the changes in the right places, so please review with great care. 
