### PR TITLE
Define additional IPPROTO_* constants.

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1039,6 +1039,223 @@ pub const MINCORE_MODIFIED: ::c_int = 0x4;
 pub const MINCORE_REFERENCED_OTHER: ::c_int = 0x8;
 pub const MINCORE_MODIFIED_OTHER: ::c_int = 0x10;
 
+//
+// sys/netinet/in.h
+// Protocols (RFC 1700)
+// NOTE: These are in addition to the constants defined in src/unix/mod.rs
+
+// IPPROTO_IP defined in src/unix/mod.rs
+/// IP6 hop-by-hop options
+pub const IPPROTO_HOPOPTS: ::c_int = 0;
+// IPPROTO_ICMP defined in src/unix/mod.rs
+/// group mgmt protocol
+pub const IPPROTO_IGMP: ::c_int = 2;
+/// gateway^2 (deprecated)
+pub const IPPROTO_GGP: ::c_int = 3;
+/// for compatibility
+pub const IPPROTO_IPIP: ::c_int = 4;
+// IPPROTO_TCP defined in src/unix/mod.rs
+/// Stream protocol II.
+pub const IPPROTO_ST: ::c_int = 7;
+/// exterior gateway protocol
+pub const IPPROTO_EGP: ::c_int = 8;
+/// private interior gateway
+pub const IPPROTO_PIGP: ::c_int = 9;
+/// BBN RCC Monitoring
+pub const IPPROTO_RCCMON: ::c_int = 10;
+/// network voice protocol
+pub const IPPROTO_NVPII: ::c_int = 11;
+/// pup
+pub const IPPROTO_PUP: ::c_int = 12;
+/// Argus
+pub const IPPROTO_ARGUS: ::c_int = 13;
+/// EMCON
+pub const IPPROTO_EMCON: ::c_int = 14;
+/// Cross Net Debugger
+pub const IPPROTO_XNET: ::c_int = 15;
+/// Chaos
+pub const IPPROTO_CHAOS: ::c_int = 16;
+// IPPROTO_UDP defined in src/unix/mod.rs
+/// Multiplexing
+pub const IPPROTO_MUX: ::c_int = 18;
+/// DCN Measurement Subsystems
+pub const IPPROTO_MEAS: ::c_int = 19;
+/// Host Monitoring
+pub const IPPROTO_HMP: ::c_int = 20;
+/// Packet Radio Measurement
+pub const IPPROTO_PRM: ::c_int = 21;
+/// xns idp
+pub const IPPROTO_IDP: ::c_int = 22;
+/// Trunk-1
+pub const IPPROTO_TRUNK1: ::c_int = 23;
+/// Trunk-2
+pub const IPPROTO_TRUNK2: ::c_int = 24;
+/// Leaf-1
+pub const IPPROTO_LEAF1: ::c_int = 25;
+/// Leaf-2
+pub const IPPROTO_LEAF2: ::c_int = 26;
+/// Reliable Data
+pub const IPPROTO_RDP: ::c_int = 27;
+/// Reliable Transaction
+pub const IPPROTO_IRTP: ::c_int = 28;
+/// tp-4 w/ class negotiation
+pub const IPPROTO_TP: ::c_int = 29;
+/// Bulk Data Transfer
+pub const IPPROTO_BLT: ::c_int = 30;
+/// Network Services
+pub const IPPROTO_NSP: ::c_int = 31;
+/// Merit Internodal
+pub const IPPROTO_INP: ::c_int = 32;
+/// Sequential Exchange
+pub const IPPROTO_SEP: ::c_int = 33;
+/// Third Party Connect
+pub const IPPROTO_3PC: ::c_int = 34;
+/// InterDomain Policy Routing
+pub const IPPROTO_IDPR: ::c_int = 35;
+/// XTP
+pub const IPPROTO_XTP: ::c_int = 36;
+/// Datagram Delivery
+pub const IPPROTO_DDP: ::c_int = 37;
+/// Control Message Transport
+pub const IPPROTO_CMTP: ::c_int = 38;
+/// TP++ Transport
+pub const IPPROTO_TPXX: ::c_int = 39;
+/// IL transport protocol
+pub const IPPROTO_IL: ::c_int = 40;
+// IPPROTO_IPV6 defined in src/unix/mod.rs
+/// Source Demand Routing
+pub const IPPROTO_SDRP: ::c_int = 42;
+/// IP6 routing header
+pub const IPPROTO_ROUTING: ::c_int = 43;
+/// IP6 fragmentation header
+pub const IPPROTO_FRAGMENT: ::c_int = 44;
+/// InterDomain Routing
+pub const IPPROTO_IDRP: ::c_int = 45;
+/// resource reservation
+pub const IPPROTO_RSVP: ::c_int = 46;
+/// General Routing Encap.
+pub const IPPROTO_GRE: ::c_int = 47;
+/// Mobile Host Routing
+pub const IPPROTO_MHRP: ::c_int = 48;
+/// BHA
+pub const IPPROTO_BHA: ::c_int = 49;
+/// IP6 Encap Sec. Payload
+pub const IPPROTO_ESP: ::c_int = 50;
+/// IP6 Auth Header
+pub const IPPROTO_AH: ::c_int = 51;
+/// Integ. Net Layer Security
+pub const IPPROTO_INLSP: ::c_int = 52;
+/// IP with encryption
+pub const IPPROTO_SWIPE: ::c_int = 53;
+/// Next Hop Resolution
+pub const IPPROTO_NHRP: ::c_int = 54;
+/* 55-57: Unassigned */
+// IPPROTO_ICMPV6 defined in src/unix/mod.rs
+/// IP6 no next header
+pub const IPPROTO_NONE: ::c_int = 59;
+/// IP6 destination option
+pub const IPPROTO_DSTOPTS: ::c_int = 60;
+/// any host internal protocol
+pub const IPPROTO_AHIP: ::c_int = 61;
+/// CFTP
+pub const IPPROTO_CFTP: ::c_int = 62;
+/// "hello" routing protocol
+pub const IPPROTO_HELLO: ::c_int = 63;
+/// SATNET/Backroom EXPAK
+pub const IPPROTO_SATEXPAK: ::c_int = 64;
+/// Kryptolan
+pub const IPPROTO_KRYPTOLAN: ::c_int = 65;
+/// Remote Virtual Disk
+pub const IPPROTO_RVD: ::c_int = 66;
+/// Pluribus Packet Core
+pub const IPPROTO_IPPC: ::c_int = 67;
+/// Any distributed FS
+pub const IPPROTO_ADFS: ::c_int = 68;
+/// Satnet Monitoring
+pub const IPPROTO_SATMON: ::c_int = 69;
+/// VISA Protocol
+pub const IPPROTO_VISA: ::c_int = 70;
+/// Packet Core Utility
+pub const IPPROTO_IPCV: ::c_int = 71;
+/// Comp. Prot. Net. Executive
+pub const IPPROTO_CPNX: ::c_int = 72;
+/// Comp. Prot. HeartBeat
+pub const IPPROTO_CPHB: ::c_int = 73;
+/// Wang Span Network
+pub const IPPROTO_WSN: ::c_int = 74;
+/// Packet Video Protocol
+pub const IPPROTO_PVP: ::c_int = 75;
+/// BackRoom SATNET Monitoring
+pub const IPPROTO_BRSATMON: ::c_int = 76;
+/// Sun net disk proto (temp.)
+pub const IPPROTO_ND: ::c_int = 77;
+/// WIDEBAND Monitoring
+pub const IPPROTO_WBMON: ::c_int = 78;
+/// WIDEBAND EXPAK
+pub const IPPROTO_WBEXPAK: ::c_int = 79;
+/// ISO cnlp
+pub const IPPROTO_EON: ::c_int = 80;
+/// VMTP
+pub const IPPROTO_VMTP: ::c_int = 81;
+/// Secure VMTP
+pub const IPPROTO_SVMTP: ::c_int = 82;
+/// Banyon VINES
+pub const IPPROTO_VINES: ::c_int = 83;
+/// TTP
+pub const IPPROTO_TTP: ::c_int = 84;
+/// NSFNET-IGP
+pub const IPPROTO_IGP: ::c_int = 85;
+/// dissimilar gateway prot.
+pub const IPPROTO_DGP: ::c_int = 86;
+/// TCF
+pub const IPPROTO_TCF: ::c_int = 87;
+/// Cisco/GXS IGRP
+pub const IPPROTO_IGRP: ::c_int = 88;
+/// OSPFIGP
+pub const IPPROTO_OSPFIGP: ::c_int = 89;
+/// Strite RPC protocol
+pub const IPPROTO_SRPC: ::c_int = 90;
+/// Locus Address Resoloution
+pub const IPPROTO_LARP: ::c_int = 91;
+/// Multicast Transport
+pub const IPPROTO_MTP: ::c_int = 92;
+/// AX.25 Frames
+pub const IPPROTO_AX25: ::c_int = 93;
+/// IP encapsulated in IP
+pub const IPPROTO_IPEIP: ::c_int = 94;
+/// Mobile Int.ing control
+pub const IPPROTO_MICP: ::c_int = 95;
+/// Semaphore Comm. security
+pub const IPPROTO_SCCSP: ::c_int = 96;
+/// Ethernet IP encapsulation
+pub const IPPROTO_ETHERIP: ::c_int = 97;
+/// encapsulation header
+pub const IPPROTO_ENCAP: ::c_int = 98;
+/// any private encr. scheme
+pub const IPPROTO_APES: ::c_int = 99;
+/// GMTP
+pub const IPPROTO_GMTP: ::c_int = 100;
+
+/* 101-254: Partly Unassigned */
+/// Protocol Independent Mcast
+pub const IPPROTO_PIM: ::c_int = 103;
+/// payload compression (IPComp)
+pub const IPPROTO_IPCOMP: ::c_int = 108;
+/// PGM
+pub const IPPROTO_PGM: ::c_int = 113;
+/// SCTP
+pub const IPPROTO_SCTP: ::c_int = 132;
+
+/* 255: Reserved */
+/* BSD Private, local use, namespace incursion */
+/// divert pseudo-protocol
+pub const IPPROTO_DIVERT: ::c_int = 254;
+/// raw IP packet
+pub const IPPROTO_RAW: ::c_int = 255;
+pub const IPPROTO_MAX: ::c_int = 256;
+/// last return value of *_input(), meaning "all job for this pkt is done".
+pub const IPPROTO_DONE: ::c_int = 257;
+
 pub const AF_UNSPEC: ::c_int = 0;
 pub const AF_LOCAL: ::c_int = 1;
 pub const AF_UNIX: ::c_int = AF_LOCAL;
@@ -1222,8 +1439,6 @@ pub const MAP_NOEXTEND: ::c_int = 0x0100;
 pub const MAP_HASSEMAPHORE: ::c_int = 0x0200;
 pub const MAP_NOCACHE: ::c_int = 0x0400;
 pub const MAP_JIT: ::c_int = 0x0800;
-
-pub const IPPROTO_RAW: ::c_int = 255;
 
 pub const _SC_ARG_MAX: ::c_int = 1;
 pub const _SC_CHILD_MAX: ::c_int = 2;

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -386,6 +386,231 @@ pub const NOTE_CHILD: ::uint32_t = 0x00000004;
 pub const SO_SNDSPACE: ::c_int = 0x100a;
 pub const SO_CPUHINT: ::c_int = 0x1030;
 
+//
+// sys/netinet/in.h
+// Protocols (RFC 1700)
+// NOTE: These are in addition to the constants defined in src/unix/mod.rs
+
+// IPPROTO_IP defined in src/unix/mod.rs
+/// IP6 hop-by-hop options
+pub const IPPROTO_HOPOPTS: ::c_int = 0;
+// IPPROTO_ICMP defined in src/unix/mod.rs
+/// group mgmt protocol
+pub const IPPROTO_IGMP: ::c_int = 2;
+/// gateway^2 (deprecated)
+pub const IPPROTO_GGP: ::c_int = 3;
+/// for compatibility
+pub const IPPROTO_IPIP: ::c_int = 4;
+// IPPROTO_TCP defined in src/unix/mod.rs
+/// Stream protocol II.
+pub const IPPROTO_ST: ::c_int = 7;
+/// exterior gateway protocol
+pub const IPPROTO_EGP: ::c_int = 8;
+/// private interior gateway
+pub const IPPROTO_PIGP: ::c_int = 9;
+/// BBN RCC Monitoring
+pub const IPPROTO_RCCMON: ::c_int = 10;
+/// network voice protocol
+pub const IPPROTO_NVPII: ::c_int = 11;
+/// pup
+pub const IPPROTO_PUP: ::c_int = 12;
+/// Argus
+pub const IPPROTO_ARGUS: ::c_int = 13;
+/// EMCON
+pub const IPPROTO_EMCON: ::c_int = 14;
+/// Cross Net Debugger
+pub const IPPROTO_XNET: ::c_int = 15;
+/// Chaos
+pub const IPPROTO_CHAOS: ::c_int = 16;
+// IPPROTO_UDP defined in src/unix/mod.rs
+/// Multiplexing
+pub const IPPROTO_MUX: ::c_int = 18;
+/// DCN Measurement Subsystems
+pub const IPPROTO_MEAS: ::c_int = 19;
+/// Host Monitoring
+pub const IPPROTO_HMP: ::c_int = 20;
+/// Packet Radio Measurement
+pub const IPPROTO_PRM: ::c_int = 21;
+/// xns idp
+pub const IPPROTO_IDP: ::c_int = 22;
+/// Trunk-1
+pub const IPPROTO_TRUNK1: ::c_int = 23;
+/// Trunk-2
+pub const IPPROTO_TRUNK2: ::c_int = 24;
+/// Leaf-1
+pub const IPPROTO_LEAF1: ::c_int = 25;
+/// Leaf-2
+pub const IPPROTO_LEAF2: ::c_int = 26;
+/// Reliable Data
+pub const IPPROTO_RDP: ::c_int = 27;
+/// Reliable Transaction
+pub const IPPROTO_IRTP: ::c_int = 28;
+/// tp-4 w/ class negotiation
+pub const IPPROTO_TP: ::c_int = 29;
+/// Bulk Data Transfer
+pub const IPPROTO_BLT: ::c_int = 30;
+/// Network Services
+pub const IPPROTO_NSP: ::c_int = 31;
+/// Merit Internodal
+pub const IPPROTO_INP: ::c_int = 32;
+/// Sequential Exchange
+pub const IPPROTO_SEP: ::c_int = 33;
+/// Third Party Connect
+pub const IPPROTO_3PC: ::c_int = 34;
+/// InterDomain Policy Routing
+pub const IPPROTO_IDPR: ::c_int = 35;
+/// XTP
+pub const IPPROTO_XTP: ::c_int = 36;
+/// Datagram Delivery
+pub const IPPROTO_DDP: ::c_int = 37;
+/// Control Message Transport
+pub const IPPROTO_CMTP: ::c_int = 38;
+/// TP++ Transport
+pub const IPPROTO_TPXX: ::c_int = 39;
+/// IL transport protocol
+pub const IPPROTO_IL: ::c_int = 40;
+// IPPROTO_IPV6 defined in src/unix/mod.rs
+/// Source Demand Routing
+pub const IPPROTO_SDRP: ::c_int = 42;
+/// IP6 routing header
+pub const IPPROTO_ROUTING: ::c_int = 43;
+/// IP6 fragmentation header
+pub const IPPROTO_FRAGMENT: ::c_int = 44;
+/// InterDomain Routing
+pub const IPPROTO_IDRP: ::c_int = 45;
+/// resource reservation
+pub const IPPROTO_RSVP: ::c_int = 46;
+/// General Routing Encap.
+pub const IPPROTO_GRE: ::c_int = 47;
+/// Mobile Host Routing
+pub const IPPROTO_MHRP: ::c_int = 48;
+/// BHA
+pub const IPPROTO_BHA: ::c_int = 49;
+/// IP6 Encap Sec. Payload
+pub const IPPROTO_ESP: ::c_int = 50;
+/// IP6 Auth Header
+pub const IPPROTO_AH: ::c_int = 51;
+/// Integ. Net Layer Security
+pub const IPPROTO_INLSP: ::c_int = 52;
+/// IP with encryption
+pub const IPPROTO_SWIPE: ::c_int = 53;
+/// Next Hop Resolution
+pub const IPPROTO_NHRP: ::c_int = 54;
+/// IP Mobility
+pub const IPPROTO_MOBILE: ::c_int = 55;
+/// Transport Layer Security
+pub const IPPROTO_TLSP: ::c_int = 56;
+/// SKIP
+pub const IPPROTO_SKIP: ::c_int = 57;
+// IPPROTO_ICMPV6 defined in src/unix/mod.rs
+/// IP6 no next header
+pub const IPPROTO_NONE: ::c_int = 59;
+/// IP6 destination option
+pub const IPPROTO_DSTOPTS: ::c_int = 60;
+/// any host internal protocol
+pub const IPPROTO_AHIP: ::c_int = 61;
+/// CFTP
+pub const IPPROTO_CFTP: ::c_int = 62;
+/// "hello" routing protocol
+pub const IPPROTO_HELLO: ::c_int = 63;
+/// SATNET/Backroom EXPAK
+pub const IPPROTO_SATEXPAK: ::c_int = 64;
+/// Kryptolan
+pub const IPPROTO_KRYPTOLAN: ::c_int = 65;
+/// Remote Virtual Disk
+pub const IPPROTO_RVD: ::c_int = 66;
+/// Pluribus Packet Core
+pub const IPPROTO_IPPC: ::c_int = 67;
+/// Any distributed FS
+pub const IPPROTO_ADFS: ::c_int = 68;
+/// Satnet Monitoring
+pub const IPPROTO_SATMON: ::c_int = 69;
+/// VISA Protocol
+pub const IPPROTO_VISA: ::c_int = 70;
+/// Packet Core Utility
+pub const IPPROTO_IPCV: ::c_int = 71;
+/// Comp. Prot. Net. Executive
+pub const IPPROTO_CPNX: ::c_int = 72;
+/// Comp. Prot. HeartBeat
+pub const IPPROTO_CPHB: ::c_int = 73;
+/// Wang Span Network
+pub const IPPROTO_WSN: ::c_int = 74;
+/// Packet Video Protocol
+pub const IPPROTO_PVP: ::c_int = 75;
+/// BackRoom SATNET Monitoring
+pub const IPPROTO_BRSATMON: ::c_int = 76;
+/// Sun net disk proto (temp.)
+pub const IPPROTO_ND: ::c_int = 77;
+/// WIDEBAND Monitoring
+pub const IPPROTO_WBMON: ::c_int = 78;
+/// WIDEBAND EXPAK
+pub const IPPROTO_WBEXPAK: ::c_int = 79;
+/// ISO cnlp
+pub const IPPROTO_EON: ::c_int = 80;
+/// VMTP
+pub const IPPROTO_VMTP: ::c_int = 81;
+/// Secure VMTP
+pub const IPPROTO_SVMTP: ::c_int = 82;
+/// Banyon VINES
+pub const IPPROTO_VINES: ::c_int = 83;
+/// TTP
+pub const IPPROTO_TTP: ::c_int = 84;
+/// NSFNET-IGP
+pub const IPPROTO_IGP: ::c_int = 85;
+/// dissimilar gateway prot.
+pub const IPPROTO_DGP: ::c_int = 86;
+/// TCF
+pub const IPPROTO_TCF: ::c_int = 87;
+/// Cisco/GXS IGRP
+pub const IPPROTO_IGRP: ::c_int = 88;
+/// OSPFIGP
+pub const IPPROTO_OSPFIGP: ::c_int = 89;
+/// Strite RPC protocol
+pub const IPPROTO_SRPC: ::c_int = 90;
+/// Locus Address Resoloution
+pub const IPPROTO_LARP: ::c_int = 91;
+/// Multicast Transport
+pub const IPPROTO_MTP: ::c_int = 92;
+/// AX.25 Frames
+pub const IPPROTO_AX25: ::c_int = 93;
+/// IP encapsulated in IP
+pub const IPPROTO_IPEIP: ::c_int = 94;
+/// Mobile Int.ing control
+pub const IPPROTO_MICP: ::c_int = 95;
+/// Semaphore Comm. security
+pub const IPPROTO_SCCSP: ::c_int = 96;
+/// Ethernet IP encapsulation
+pub const IPPROTO_ETHERIP: ::c_int = 97;
+/// encapsulation header
+pub const IPPROTO_ENCAP: ::c_int = 98;
+/// any private encr. scheme
+pub const IPPROTO_APES: ::c_int = 99;
+/// GMTP
+pub const IPPROTO_GMTP: ::c_int = 100;
+/// payload compression (IPComp)
+pub const IPPROTO_IPCOMP: ::c_int = 108;
+
+/* 101-254: Partly Unassigned */
+/// Protocol Independent Mcast
+pub const IPPROTO_PIM: ::c_int = 103;
+/// CARP
+pub const IPPROTO_CARP: ::c_int = 112;
+/// PGM
+pub const IPPROTO_PGM: ::c_int = 113;
+/// PFSYNC
+pub const IPPROTO_PFSYNC: ::c_int = 240;
+
+/* 255: Reserved */
+/* BSD Private, local use, namespace incursion, no longer used */
+/// divert pseudo-protocol
+pub const IPPROTO_DIVERT: ::c_int = 254;
+pub const IPPROTO_MAX: ::c_int = 256;
+/// last return value of *_input(), meaning "all job for this pkt is done".
+pub const IPPROTO_DONE: ::c_int = 257;
+
+/// Used by RSS: the layer3 protocol is unknown
+pub const IPPROTO_UNKNOWN: ::c_int = 258;
+
 pub const AF_BLUETOOTH: ::c_int = 33;
 pub const AF_MPLS: ::c_int = 34;
 pub const AF_IEEE80211: ::c_int = 35;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -412,7 +412,244 @@ pub const AF_INET6_SDP: ::c_int = 42;
 #[doc(hidden)]
 pub const AF_MAX: ::c_int = 42;
 
+// sys/netinet/in.h
+// Protocols (RFC 1700)
+// NOTE: These are in addition to the constants defined in src/unix/mod.rs
+
+// IPPROTO_IP defined in src/unix/mod.rs
+/// IP6 hop-by-hop options
+pub const IPPROTO_HOPOPTS: ::c_int = 0;
+// IPPROTO_ICMP defined in src/unix/mod.rs
+/// group mgmt protocol
+pub const IPPROTO_IGMP: ::c_int = 2;
+/// gateway^2 (deprecated)
+pub const IPPROTO_GGP: ::c_int = 3;
+/// for compatibility
+pub const IPPROTO_IPIP: ::c_int = 4;
+// IPPROTO_TCP defined in src/unix/mod.rs
+/// Stream protocol II.
+pub const IPPROTO_ST: ::c_int = 7;
+/// exterior gateway protocol
+pub const IPPROTO_EGP: ::c_int = 8;
+/// private interior gateway
+pub const IPPROTO_PIGP: ::c_int = 9;
+/// BBN RCC Monitoring
+pub const IPPROTO_RCCMON: ::c_int = 10;
+/// network voice protocol
+pub const IPPROTO_NVPII: ::c_int = 11;
+/// pup
+pub const IPPROTO_PUP: ::c_int = 12;
+/// Argus
+pub const IPPROTO_ARGUS: ::c_int = 13;
+/// EMCON
+pub const IPPROTO_EMCON: ::c_int = 14;
+/// Cross Net Debugger
+pub const IPPROTO_XNET: ::c_int = 15;
+/// Chaos
+pub const IPPROTO_CHAOS: ::c_int = 16;
+// IPPROTO_UDP defined in src/unix/mod.rs
+/// Multiplexing
+pub const IPPROTO_MUX: ::c_int = 18;
+/// DCN Measurement Subsystems
+pub const IPPROTO_MEAS: ::c_int = 19;
+/// Host Monitoring
+pub const IPPROTO_HMP: ::c_int = 20;
+/// Packet Radio Measurement
+pub const IPPROTO_PRM: ::c_int = 21;
+/// xns idp
+pub const IPPROTO_IDP: ::c_int = 22;
+/// Trunk-1
+pub const IPPROTO_TRUNK1: ::c_int = 23;
+/// Trunk-2
+pub const IPPROTO_TRUNK2: ::c_int = 24;
+/// Leaf-1
+pub const IPPROTO_LEAF1: ::c_int = 25;
+/// Leaf-2
+pub const IPPROTO_LEAF2: ::c_int = 26;
+/// Reliable Data
+pub const IPPROTO_RDP: ::c_int = 27;
+/// Reliable Transaction
+pub const IPPROTO_IRTP: ::c_int = 28;
+/// tp-4 w/ class negotiation
+pub const IPPROTO_TP: ::c_int = 29;
+/// Bulk Data Transfer
+pub const IPPROTO_BLT: ::c_int = 30;
+/// Network Services
+pub const IPPROTO_NSP: ::c_int = 31;
+/// Merit Internodal
+pub const IPPROTO_INP: ::c_int = 32;
+/// Sequential Exchange
+pub const IPPROTO_SEP: ::c_int = 33;
+/// Third Party Connect
+pub const IPPROTO_3PC: ::c_int = 34;
+/// InterDomain Policy Routing
+pub const IPPROTO_IDPR: ::c_int = 35;
+/// XTP
+pub const IPPROTO_XTP: ::c_int = 36;
+/// Datagram Delivery
+pub const IPPROTO_DDP: ::c_int = 37;
+/// Control Message Transport
+pub const IPPROTO_CMTP: ::c_int = 38;
+/// TP++ Transport
+pub const IPPROTO_TPXX: ::c_int = 39;
+/// IL transport protocol
+pub const IPPROTO_IL: ::c_int = 40;
+// IPPROTO_IPV6 defined in src/unix/mod.rs
+/// Source Demand Routing
+pub const IPPROTO_SDRP: ::c_int = 42;
+/// IP6 routing header
+pub const IPPROTO_ROUTING: ::c_int = 43;
+/// IP6 fragmentation header
+pub const IPPROTO_FRAGMENT: ::c_int = 44;
+/// InterDomain Routing
+pub const IPPROTO_IDRP: ::c_int = 45;
+/// resource reservation
+pub const IPPROTO_RSVP: ::c_int = 46;
+/// General Routing Encap.
+pub const IPPROTO_GRE: ::c_int = 47;
+/// Mobile Host Routing
+pub const IPPROTO_MHRP: ::c_int = 48;
+/// BHA
+pub const IPPROTO_BHA: ::c_int = 49;
+/// IP6 Encap Sec. Payload
+pub const IPPROTO_ESP: ::c_int = 50;
+/// IP6 Auth Header
+pub const IPPROTO_AH: ::c_int = 51;
+/// Integ. Net Layer Security
+pub const IPPROTO_INLSP: ::c_int = 52;
+/// IP with encryption
+pub const IPPROTO_SWIPE: ::c_int = 53;
+/// Next Hop Resolution
+pub const IPPROTO_NHRP: ::c_int = 54;
+/// IP Mobility
+pub const IPPROTO_MOBILE: ::c_int = 55;
+/// Transport Layer Security
+pub const IPPROTO_TLSP: ::c_int = 56;
+/// SKIP
+pub const IPPROTO_SKIP: ::c_int = 57;
+// IPPROTO_ICMPV6 defined in src/unix/mod.rs
+/// IP6 no next header
+pub const IPPROTO_NONE: ::c_int = 59;
+/// IP6 destination option
+pub const IPPROTO_DSTOPTS: ::c_int = 60;
+/// any host internal protocol
+pub const IPPROTO_AHIP: ::c_int = 61;
+/// CFTP
+pub const IPPROTO_CFTP: ::c_int = 62;
+/// "hello" routing protocol
+pub const IPPROTO_HELLO: ::c_int = 63;
+/// SATNET/Backroom EXPAK
+pub const IPPROTO_SATEXPAK: ::c_int = 64;
+/// Kryptolan
+pub const IPPROTO_KRYPTOLAN: ::c_int = 65;
+/// Remote Virtual Disk
+pub const IPPROTO_RVD: ::c_int = 66;
+/// Pluribus Packet Core
+pub const IPPROTO_IPPC: ::c_int = 67;
+/// Any distributed FS
+pub const IPPROTO_ADFS: ::c_int = 68;
+/// Satnet Monitoring
+pub const IPPROTO_SATMON: ::c_int = 69;
+/// VISA Protocol
+pub const IPPROTO_VISA: ::c_int = 70;
+/// Packet Core Utility
+pub const IPPROTO_IPCV: ::c_int = 71;
+/// Comp. Prot. Net. Executive
+pub const IPPROTO_CPNX: ::c_int = 72;
+/// Comp. Prot. HeartBeat
+pub const IPPROTO_CPHB: ::c_int = 73;
+/// Wang Span Network
+pub const IPPROTO_WSN: ::c_int = 74;
+/// Packet Video Protocol
+pub const IPPROTO_PVP: ::c_int = 75;
+/// BackRoom SATNET Monitoring
+pub const IPPROTO_BRSATMON: ::c_int = 76;
+/// Sun net disk proto (temp.)
+pub const IPPROTO_ND: ::c_int = 77;
+/// WIDEBAND Monitoring
+pub const IPPROTO_WBMON: ::c_int = 78;
+/// WIDEBAND EXPAK
+pub const IPPROTO_WBEXPAK: ::c_int = 79;
+/// ISO cnlp
+pub const IPPROTO_EON: ::c_int = 80;
+/// VMTP
+pub const IPPROTO_VMTP: ::c_int = 81;
+/// Secure VMTP
+pub const IPPROTO_SVMTP: ::c_int = 82;
+/// Banyon VINES
+pub const IPPROTO_VINES: ::c_int = 83;
+/// TTP
+pub const IPPROTO_TTP: ::c_int = 84;
+/// NSFNET-IGP
+pub const IPPROTO_IGP: ::c_int = 85;
+/// dissimilar gateway prot.
+pub const IPPROTO_DGP: ::c_int = 86;
+/// TCF
+pub const IPPROTO_TCF: ::c_int = 87;
+/// Cisco/GXS IGRP
+pub const IPPROTO_IGRP: ::c_int = 88;
+/// OSPFIGP
+pub const IPPROTO_OSPFIGP: ::c_int = 89;
+/// Strite RPC protocol
+pub const IPPROTO_SRPC: ::c_int = 90;
+/// Locus Address Resoloution
+pub const IPPROTO_LARP: ::c_int = 91;
+/// Multicast Transport
+pub const IPPROTO_MTP: ::c_int = 92;
+/// AX.25 Frames
+pub const IPPROTO_AX25: ::c_int = 93;
+/// IP encapsulated in IP
+pub const IPPROTO_IPEIP: ::c_int = 94;
+/// Mobile Int.ing control
+pub const IPPROTO_MICP: ::c_int = 95;
+/// Semaphore Comm. security
+pub const IPPROTO_SCCSP: ::c_int = 96;
+/// Ethernet IP encapsulation
+pub const IPPROTO_ETHERIP: ::c_int = 97;
+/// encapsulation header
+pub const IPPROTO_ENCAP: ::c_int = 98;
+/// any private encr. scheme
+pub const IPPROTO_APES: ::c_int = 99;
+/// GMTP
+pub const IPPROTO_GMTP: ::c_int = 100;
+/// payload compression (IPComp)
+pub const IPPROTO_IPCOMP: ::c_int = 108;
+/// SCTP
+pub const IPPROTO_SCTP: ::c_int = 132;
+/// IPv6 Mobility Header
+pub const IPPROTO_MH: ::c_int = 135;
+/// UDP-Lite
+pub const IPPROTO_UDPLITE: ::c_int = 136;
+/// IP6 Host Identity Protocol
+pub const IPPROTO_HIP: ::c_int = 139;
+/// IP6 Shim6 Protocol
+pub const IPPROTO_SHIM6: ::c_int = 140;
+
+/* 101-254: Partly Unassigned */
+/// Protocol Independent Mcast
+pub const IPPROTO_PIM: ::c_int = 103;
+/// CARP
+pub const IPPROTO_CARP: ::c_int = 112;
+/// PGM
+pub const IPPROTO_PGM: ::c_int = 113;
+/// MPLS-in-IP
+pub const IPPROTO_MPLS: ::c_int = 137;
+/// PFSYNC
+pub const IPPROTO_PFSYNC: ::c_int = 240;
+
+/* 255: Reserved */
+/* BSD Private, local use, namespace incursion, no longer used */
+/// OLD divert pseudo-proto
+pub const IPPROTO_OLD_DIVERT: ::c_int = 254;
+pub const IPPROTO_MAX: ::c_int = 256;
+/// last return value of *_input(), meaning "all job for this pkt is done".
+pub const IPPROTO_DONE: ::c_int = 257;
+
+/* Only used internally, so can be outside the range of valid IP protocols. */
+/// divert pseudo-protocol
 pub const IPPROTO_DIVERT: ::c_int = 258;
+/// SeND pseudo-protocol
+pub const IPPROTO_SEND: ::c_int = 259;
 
 pub const PF_SLOW: ::c_int = AF_SLOW;
 pub const PF_SCLUSTER: ::c_int = AF_SCLUSTER;

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -346,6 +346,85 @@ pub const SO_TIMESTAMP: ::c_int = 0x2000;
 pub const SO_OVERFLOWED: ::c_int = 0x1009;
 pub const SO_NOHEADER: ::c_int = 0x100a;
 
+// sys/netinet/in.h
+// Protocols (RFC 1700)
+// NOTE: These are in addition to the constants defined in src/unix/mod.rs
+
+// IPPROTO_IP defined in src/unix/mod.rs
+/// Hop-by-hop option header
+pub const IPPROTO_HOPOPTS: ::c_int = 0;
+// IPPROTO_ICMP defined in src/unix/mod.rs
+/// group mgmt protocol
+pub const IPPROTO_IGMP: ::c_int = 2;
+/// gateway^2 (deprecated)
+pub const IPPROTO_GGP: ::c_int = 3;
+/// for compatibility
+pub const IPPROTO_IPIP: ::c_int = 4;
+// IPPROTO_TCP defined in src/unix/mod.rs
+/// exterior gateway protocol
+pub const IPPROTO_EGP: ::c_int = 8;
+/// pup
+pub const IPPROTO_PUP: ::c_int = 12;
+// IPPROTO_UDP defined in src/unix/mod.rs
+/// xns idp
+pub const IPPROTO_IDP: ::c_int = 22;
+/// tp-4 w/ class negotiation
+pub const IPPROTO_TP: ::c_int = 29;
+/// DCCP
+pub const IPPROTO_DCCP: ::c_int = 33;
+// IPPROTO_IPV6 defined in src/unix/mod.rs
+/// IP6 routing header
+pub const IPPROTO_ROUTING: ::c_int = 43;
+/// IP6 fragmentation header
+pub const IPPROTO_FRAGMENT: ::c_int = 44;
+/// resource reservation
+pub const IPPROTO_RSVP: ::c_int = 46;
+/// General Routing Encap.
+pub const IPPROTO_GRE: ::c_int = 47;
+/// IP6 Encap Sec. Payload
+pub const IPPROTO_ESP: ::c_int = 50;
+/// IP6 Auth Header
+pub const IPPROTO_AH: ::c_int = 51;
+/// IP Mobility RFC 2004
+pub const IPPROTO_MOBILE: ::c_int = 55;
+/// IPv6 ICMP
+pub const IPPROTO_IPV6_ICMP: ::c_int = 58;
+// IPPROTO_ICMPV6 defined in src/unix/mod.rs
+/// IP6 no next header
+pub const IPPROTO_NONE: ::c_int = 59;
+/// IP6 destination option
+pub const IPPROTO_DSTOPTS: ::c_int = 60;
+/// ISO cnlp
+pub const IPPROTO_EON: ::c_int = 80;
+/// Ethernet-in-IP
+pub const IPPROTO_ETHERIP: ::c_int = 97;
+/// encapsulation header
+pub const IPPROTO_ENCAP: ::c_int = 98;
+/// Protocol indep. multicast
+pub const IPPROTO_PIM: ::c_int = 103;
+/// IP Payload Comp. Protocol
+pub const IPPROTO_IPCOMP: ::c_int = 108;
+/// VRRP RFC 2338
+pub const IPPROTO_VRRP: ::c_int = 112;
+/// Common Address Resolution Protocol
+pub const IPPROTO_CARP: ::c_int = 112;
+/// L2TPv3
+// TEMP: Disabled for now; this constant was added to NetBSD on 2017-02-16,
+// but isn't yet supported by the NetBSD rumprun kernel image used for
+// libc testing.
+//pub const IPPROTO_L2TP: ::c_int = 115;
+/// SCTP
+pub const IPPROTO_SCTP: ::c_int = 132;
+/// PFSYNC
+pub const IPPROTO_PFSYNC: ::c_int = 240;
+pub const IPPROTO_MAX: ::c_int = 256;
+
+/// last return value of *_input(), meaning "all job for this pkt is done".
+pub const IPPROTO_DONE: ::c_int = 257;
+
+/// sysctl placeholder for (FAST_)IPSEC
+pub const CTL_IPPROTO_IPSEC: ::c_int = 258;
+
 pub const AF_OROUTE: ::c_int = 17;
 pub const AF_ARP: ::c_int = 28;
 pub const pseudo_AF_KEY: ::c_int = 29;

--- a/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
@@ -221,6 +221,72 @@ pub const SO_RTABLE: ::c_int = 0x1021;
 pub const SO_PEERCRED: ::c_int = 0x1022;
 pub const SO_SPLICE: ::c_int = 0x1023;
 
+// sys/netinet/in.h
+// Protocols (RFC 1700)
+// NOTE: These are in addition to the constants defined in src/unix/mod.rs
+
+// IPPROTO_IP defined in src/unix/mod.rs
+/// Hop-by-hop option header
+pub const IPPROTO_HOPOPTS: ::c_int = 0;
+// IPPROTO_ICMP defined in src/unix/mod.rs
+/// group mgmt protocol
+pub const IPPROTO_IGMP: ::c_int = 2;
+/// gateway^2 (deprecated)
+pub const IPPROTO_GGP: ::c_int = 3;
+/// for compatibility
+pub const IPPROTO_IPIP: ::c_int = 4;
+// IPPROTO_TCP defined in src/unix/mod.rs
+/// exterior gateway protocol
+pub const IPPROTO_EGP: ::c_int = 8;
+/// pup
+pub const IPPROTO_PUP: ::c_int = 12;
+// IPPROTO_UDP defined in src/unix/mod.rs
+/// xns idp
+pub const IPPROTO_IDP: ::c_int = 22;
+/// tp-4 w/ class negotiation
+pub const IPPROTO_TP: ::c_int = 29;
+// IPPROTO_IPV6 defined in src/unix/mod.rs
+/// IP6 routing header
+pub const IPPROTO_ROUTING: ::c_int = 43;
+/// IP6 fragmentation header
+pub const IPPROTO_FRAGMENT: ::c_int = 44;
+/// resource reservation
+pub const IPPROTO_RSVP: ::c_int = 46;
+/// General Routing Encap.
+pub const IPPROTO_GRE: ::c_int = 47;
+/// IP6 Encap Sec. Payload
+pub const IPPROTO_ESP: ::c_int = 50;
+/// IP6 Auth Header
+pub const IPPROTO_AH: ::c_int = 51;
+/// IP Mobility RFC 2004
+pub const IPPROTO_MOBILE: ::c_int = 55;
+// IPPROTO_ICMPV6 defined in src/unix/mod.rs
+/// IP6 no next header
+pub const IPPROTO_NONE: ::c_int = 59;
+/// IP6 destination option
+pub const IPPROTO_DSTOPTS: ::c_int = 60;
+/// ISO cnlp
+pub const IPPROTO_EON: ::c_int = 80;
+/// Ethernet-in-IP
+pub const IPPROTO_ETHERIP: ::c_int = 97;
+/// encapsulation header
+pub const IPPROTO_ENCAP: ::c_int = 98;
+/// Protocol indep. multicast
+pub const IPPROTO_PIM: ::c_int = 103;
+/// IP Payload Comp. Protocol
+pub const IPPROTO_IPCOMP: ::c_int = 108;
+/// CARP
+pub const IPPROTO_CARP: ::c_int = 112;
+/// unicast MPLS packet
+pub const IPPROTO_MPLS: ::c_int = 137;
+/// PFSYNC
+pub const IPPROTO_PFSYNC: ::c_int = 240;
+pub const IPPROTO_MAX: ::c_int = 256;
+
+/* Only used internally, so it can be outside the range of valid IP protocols */
+/// Divert sockets
+pub const IPPROTO_DIVERT: ::c_int = 258;
+
 pub const AF_ECMA: ::c_int = 8;
 pub const AF_ROUTE: ::c_int = 17;
 pub const AF_ENCAP: ::c_int = 28;

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -671,6 +671,64 @@ pub const SCHED_RR: ::c_int = 2;
 pub const SCHED_BATCH: ::c_int = 3;
 pub const SCHED_IDLE: ::c_int = 5;
 
+// netinet/in.h
+// NOTE: These are in addition to the constants defined in src/unix/mod.rs
+
+// IPPROTO_IP defined in src/unix/mod.rs
+/// Hop-by-hop option header
+pub const IPPROTO_HOPOPTS: ::c_int = 0;
+// IPPROTO_ICMP defined in src/unix/mod.rs
+/// group mgmt protocol
+pub const IPPROTO_IGMP: ::c_int = 2;
+/// for compatibility
+pub const IPPROTO_IPIP: ::c_int = 4;
+// IPPROTO_TCP defined in src/unix/mod.rs
+/// exterior gateway protocol
+pub const IPPROTO_EGP: ::c_int = 8;
+/// pup
+pub const IPPROTO_PUP: ::c_int = 12;
+// IPPROTO_UDP defined in src/unix/mod.rs
+/// xns idp
+pub const IPPROTO_IDP: ::c_int = 22;
+/// tp-4 w/ class negotiation
+pub const IPPROTO_TP: ::c_int = 29;
+/// DCCP
+pub const IPPROTO_DCCP: ::c_int = 33;
+// IPPROTO_IPV6 defined in src/unix/mod.rs
+/// IP6 routing header
+pub const IPPROTO_ROUTING: ::c_int = 43;
+/// IP6 fragmentation header
+pub const IPPROTO_FRAGMENT: ::c_int = 44;
+/// resource reservation
+pub const IPPROTO_RSVP: ::c_int = 46;
+/// General Routing Encap.
+pub const IPPROTO_GRE: ::c_int = 47;
+/// IP6 Encap Sec. Payload
+pub const IPPROTO_ESP: ::c_int = 50;
+/// IP6 Auth Header
+pub const IPPROTO_AH: ::c_int = 51;
+// IPPROTO_ICMPV6 defined in src/unix/mod.rs
+/// IP6 no next header
+pub const IPPROTO_NONE: ::c_int = 59;
+/// IP6 destination option
+pub const IPPROTO_DSTOPTS: ::c_int = 60;
+pub const IPPROTO_MTP: ::c_int = 92;
+pub const IPPROTO_BEETPH: ::c_int = 94;
+/// encapsulation header
+pub const IPPROTO_ENCAP: ::c_int = 98;
+/// Protocol indep. multicast
+pub const IPPROTO_PIM: ::c_int = 103;
+/// IP Payload Comp. Protocol
+pub const IPPROTO_COMP: ::c_int = 108;
+/// SCTP
+pub const IPPROTO_SCTP: ::c_int = 132;
+pub const IPPROTO_MH: ::c_int = 135;
+pub const IPPROTO_UDPLITE: ::c_int = 136;
+pub const IPPROTO_MPLS: ::c_int = 137;
+/// raw IP packet
+pub const IPPROTO_RAW: ::c_int = 255;
+pub const IPPROTO_MAX: ::c_int = 256;
+
 pub const AF_IB: ::c_int = 27;
 pub const AF_MPLS: ::c_int = 28;
 pub const AF_NFC: ::c_int = 39;

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -405,8 +405,6 @@ pub const EWOULDBLOCK: ::c_int = EAGAIN;
 pub const SCM_RIGHTS: ::c_int = 0x01;
 pub const SCM_CREDENTIALS: ::c_int = 0x02;
 
-pub const IPPROTO_RAW: ::c_int = 255;
-
 pub const PROT_GROWSDOWN: ::c_int = 0x1000000;
 pub const PROT_GROWSUP: ::c_int = 0x2000000;
 

--- a/src/unix/uclibc/mod.rs
+++ b/src/unix/uclibc/mod.rs
@@ -578,7 +578,63 @@ pub const EWOULDBLOCK: ::c_int = EAGAIN;
 pub const SCM_RIGHTS: ::c_int = 0x01;
 pub const SCM_CREDENTIALS: ::c_int = 0x02;
 
+// netinet/in.h
+// NOTE: These are in addition to the constants defined in src/unix/mod.rs
+
+// IPPROTO_IP defined in src/unix/mod.rs
+/// Hop-by-hop option header
+pub const IPPROTO_HOPOPTS: ::c_int = 0;
+// IPPROTO_ICMP defined in src/unix/mod.rs
+/// group mgmt protocol
+pub const IPPROTO_IGMP: ::c_int = 2;
+/// for compatibility
+pub const IPPROTO_IPIP: ::c_int = 4;
+// IPPROTO_TCP defined in src/unix/mod.rs
+/// exterior gateway protocol
+pub const IPPROTO_EGP: ::c_int = 8;
+/// pup
+pub const IPPROTO_PUP: ::c_int = 12;
+// IPPROTO_UDP defined in src/unix/mod.rs
+/// xns idp
+pub const IPPROTO_IDP: ::c_int = 22;
+/// tp-4 w/ class negotiation
+pub const IPPROTO_TP: ::c_int = 29;
+/// DCCP
+pub const IPPROTO_DCCP: ::c_int = 33;
+// IPPROTO_IPV6 defined in src/unix/mod.rs
+/// IP6 routing header
+pub const IPPROTO_ROUTING: ::c_int = 43;
+/// IP6 fragmentation header
+pub const IPPROTO_FRAGMENT: ::c_int = 44;
+/// resource reservation
+pub const IPPROTO_RSVP: ::c_int = 46;
+/// General Routing Encap.
+pub const IPPROTO_GRE: ::c_int = 47;
+/// IP6 Encap Sec. Payload
+pub const IPPROTO_ESP: ::c_int = 50;
+/// IP6 Auth Header
+pub const IPPROTO_AH: ::c_int = 51;
+// IPPROTO_ICMPV6 defined in src/unix/mod.rs
+/// IP6 no next header
+pub const IPPROTO_NONE: ::c_int = 59;
+/// IP6 destination option
+pub const IPPROTO_DSTOPTS: ::c_int = 60;
+pub const IPPROTO_MTP: ::c_int = 92;
+pub const IPPROTO_BEETPH: ::c_int = 94;
+/// encapsulation header
+pub const IPPROTO_ENCAP: ::c_int = 98;
+/// Protocol indep. multicast
+pub const IPPROTO_PIM: ::c_int = 103;
+/// IP Payload Comp. Protocol
+pub const IPPROTO_COMP: ::c_int = 108;
+/// SCTP
+pub const IPPROTO_SCTP: ::c_int = 132;
+pub const IPPROTO_MH: ::c_int = 135;
+pub const IPPROTO_UDPLITE: ::c_int = 136;
+pub const IPPROTO_MPLS: ::c_int = 137;
+/// raw IP packet
 pub const IPPROTO_RAW: ::c_int = 255;
+pub const IPPROTO_MAX: ::c_int = 256;
 
 pub const PROT_GROWSDOWN: ::c_int = 0x1000000;
 pub const PROT_GROWSUP: ::c_int = 0x2000000;


### PR DESCRIPTION
Define additional IPPROTO_* constants, e.g. for DCCP and SCTP. These constants are standard across all system types -- the values are those assigned to the protocol by the IANA:
https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml