### PR TITLE
Make stdbuild a cargo feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,18 +83,18 @@
 ))]
 
 // Attributes needed when building as part of the standard library
-#![cfg_attr(stdbuild, feature(no_std, staged_api, custom_attribute))]
-#![cfg_attr(stdbuild, feature(link_cfg))]
-#![cfg_attr(stdbuild, no_std)]
-#![cfg_attr(stdbuild, staged_api)]
-#![cfg_attr(stdbuild, allow(warnings))]
-#![cfg_attr(stdbuild, unstable(feature = "libc",
+#![cfg_attr(feature = "stdbuild", feature(no_std, staged_api, custom_attribute))]
+#![cfg_attr(feature = "stdbuild", feature(link_cfg))]
+#![cfg_attr(feature = "stdbuild", no_std)]
+#![cfg_attr(feature = "stdbuild", staged_api)]
+#![cfg_attr(feature = "stdbuild", allow(warnings))]
+#![cfg_attr(feature = "stdbuild", unstable(feature = "libc",
                                reason = "use `libc` from crates.io",
                                issue = "27783"))]
 
 #![cfg_attr(not(feature = "use_std"), no_std)]
 
-#[cfg(all(not(stdbuild), not(dox), feature = "use_std"))]
+#[cfg(all(not(dox), feature = "use_std"))]
 extern crate std as core;
 
 #[macro_use] mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@
 ))]
 
 // Attributes needed when building as part of the standard library
-#![cfg_attr(stdbuild, feature(no_std, core, core_slice_ext, staged_api, custom_attribute, cfg_target_vendor))]
+#![cfg_attr(stdbuild, feature(no_std, staged_api, custom_attribute))]
 #![cfg_attr(stdbuild, feature(link_cfg))]
 #![cfg_attr(stdbuild, no_std)]
 #![cfg_attr(stdbuild, staged_api)]

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -235,7 +235,7 @@ cfg_if! {
     } else if #[cfg(target_os = "l4re")] {
         // required libraries for L4Re are linked externally, ATM
     } else if #[cfg(all(not(stdbuild), feature = "use_std"))] {
-        // cargo build, don't pull in anything extra as the libstd  dep
+        // cargo build, don't pull in anything extra as the libstd dep
         // already pulls in all libs.
     } else if #[cfg(any(all(target_env = "musl", not(target_arch = "mips"))))] {
         #[link(name = "c", kind = "static", cfg(target_feature = "crt-static"))]

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -234,7 +234,7 @@ cfg_if! {
         // on dox builds don't pull in anything
     } else if #[cfg(target_os = "l4re")] {
         // required libraries for L4Re are linked externally, ATM
-    } else if #[cfg(all(not(stdbuild), feature = "use_std"))] {
+    } else if #[cfg(feature = "use_std")] {
         // cargo build, don't pull in anything extra as the libstd dep
         // already pulls in all libs.
     } else if #[cfg(any(all(target_env = "musl", not(target_arch = "mips"))))] {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -158,7 +158,8 @@ pub const ENOTEMPTY: ::c_int = 41;
 pub const EILSEQ: ::c_int = 42;
 pub const STRUNCATE: ::c_int = 80;
 
-#[cfg(all(target_env = "msvc", stdbuild))] // " if " -- appease style checker
+// inline comment below appeases style checker
+#[cfg(all(target_env = "msvc", feature = "stdbuild"))] // " if "
 #[link(name = "msvcrt", cfg(not(target_feature = "crt-static")))]
 #[link(name = "libcmt", cfg(target_feature = "crt-static"))]
 extern {}


### PR DESCRIPTION
Also invert the default feature / no std arrangement. The default
still uses std, but no_std now requires opt-in instead of opt-out.

This is work toward removing the shim in rustc.