### PR TITLE
Bring back cfg_target_vendor, which is still used

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@
 ))]
 
 // Attributes needed when building as part of the standard library
-#![cfg_attr(feature = "stdbuild", feature(no_std, staged_api, custom_attribute))]
+#![cfg_attr(feature = "stdbuild", feature(no_std, staged_api, custom_attribute, cfg_target_vendor))]
 #![cfg_attr(feature = "stdbuild", feature(link_cfg))]
 #![cfg_attr(feature = "stdbuild", no_std)]
 #![cfg_attr(feature = "stdbuild", staged_api)]


### PR DESCRIPTION
r? @alexcrichton https://github.com/rust-lang/rust/pull/44515#issuecomment-330036756