### PR TITLE
Define DCCP constants

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -239,6 +239,13 @@ fn main() {
         }
     }
 
+    if linux || android {
+        // DCCP support
+        if !uclibc && !musl && !emscripten {
+            cfg.header("linux/dccp.h");
+        }
+    }
+
     if freebsd {
         cfg.header("pthread_np.h");
         cfg.header("sched.h");
@@ -253,6 +260,9 @@ fn main() {
         cfg.header("ufs/ufs/quota.h");
         cfg.header("ufs/ufs/quota1.h");
         cfg.header("sys/ioctl_compat.h");
+
+        // DCCP support
+        cfg.header("netinet/dccp.h");
     }
 
     if openbsd {

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -465,6 +465,65 @@ pub const MAP_NORESERVE : ::c_int = 0x40;
 pub const MAP_HASSEMAPHORE : ::c_int = 0x200;
 pub const MAP_WIRED: ::c_int = 0x800;
 
+pub const DCCP_TYPE_REQUEST: ::c_int = 0;
+pub const DCCP_TYPE_RESPONSE: ::c_int = 1;
+pub const DCCP_TYPE_DATA: ::c_int = 2;
+pub const DCCP_TYPE_ACK: ::c_int = 3;
+pub const DCCP_TYPE_DATAACK: ::c_int =  4;
+pub const DCCP_TYPE_CLOSEREQ: ::c_int = 5;
+pub const DCCP_TYPE_CLOSE: ::c_int = 6;
+pub const DCCP_TYPE_RESET: ::c_int = 7;
+pub const DCCP_TYPE_MOVE: ::c_int = 8;
+
+pub const DCCP_FEATURE_CC: ::c_int = 1;
+pub const DCCP_FEATURE_ECN: ::c_int = 2;
+pub const DCCP_FEATURE_ACKRATIO: ::c_int =  3;
+pub const DCCP_FEATURE_ACKVECTOR: ::c_int = 4;
+pub const DCCP_FEATURE_MOBILITY: ::c_int =  5;
+pub const DCCP_FEATURE_LOSSWINDOW: ::c_int = 6;
+pub const DCCP_FEATURE_CONN_NONCE: ::c_int = 8;
+pub const DCCP_FEATURE_IDENTREG: ::c_int =  7;
+
+pub const DCCP_OPT_PADDING: ::c_int = 0;
+pub const DCCP_OPT_DATA_DISCARD: ::c_int = 1;
+pub const DCCP_OPT_SLOW_RECV: ::c_int = 2;
+pub const DCCP_OPT_BUF_CLOSED: ::c_int = 3;
+pub const DCCP_OPT_CHANGE_L: ::c_int = 32;
+pub const DCCP_OPT_CONFIRM_L: ::c_int = 33;
+pub const DCCP_OPT_CHANGE_R: ::c_int = 34;
+pub const DCCP_OPT_CONFIRM_R: ::c_int = 35;
+pub const DCCP_OPT_INIT_COOKIE: ::c_int = 36;
+pub const DCCP_OPT_NDP_COUNT: ::c_int = 37;
+pub const DCCP_OPT_ACK_VECTOR0: ::c_int = 38;
+pub const DCCP_OPT_ACK_VECTOR1: ::c_int = 39;
+pub const DCCP_OPT_RECV_BUF_DROPS: ::c_int = 40;
+pub const DCCP_OPT_TIMESTAMP: ::c_int = 41;
+pub const DCCP_OPT_TIMESTAMP_ECHO: ::c_int = 42;
+pub const DCCP_OPT_ELAPSEDTIME: ::c_int = 43;
+pub const DCCP_OPT_DATACHECKSUM: ::c_int = 44;
+
+pub const DCCP_REASON_UNSPEC: ::c_int = 0;
+pub const DCCP_REASON_CLOSED: ::c_int = 1;
+pub const DCCP_REASON_INVALID: ::c_int = 2;
+pub const DCCP_REASON_OPTION_ERR: ::c_int = 3;
+pub const DCCP_REASON_FEA_ERR: ::c_int = 4;
+pub const DCCP_REASON_CONN_REF: ::c_int = 5;
+pub const DCCP_REASON_BAD_SNAME: ::c_int = 6;
+pub const DCCP_REASON_BAD_COOKIE: ::c_int = 7;
+pub const DCCP_REASON_INV_MOVE: ::c_int = 8;
+pub const DCCP_REASON_UNANSW_CH: ::c_int = 10;
+pub const DCCP_REASON_FRUITLESS_NEG: ::c_int = 11;
+
+pub const DCCP_CCID: ::c_int = 1;
+pub const DCCP_CSLEN: ::c_int = 2;
+pub const DCCP_MAXSEG: ::c_int = 4;
+pub const DCCP_SERVICE: ::c_int = 8;
+
+pub const DCCP_NDP_LIMIT: ::c_int = 16;
+pub const DCCP_SEQ_NUM_LIMIT: ::c_int = 16777216;
+pub const DCCP_MAX_OPTIONS: ::c_int = 32;
+pub const DCCP_MAX_PKTS: ::c_int = 100;
+
 pub const _PC_LINK_MAX : ::c_int = 1;
 pub const _PC_MAX_CANON : ::c_int = 2;
 pub const _PC_MAX_INPUT : ::c_int = 3;

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -485,6 +485,8 @@ pub const ENOTRECOVERABLE: ::c_int = 131;
 pub const SOCK_STREAM: ::c_int = 1;
 pub const SOCK_DGRAM: ::c_int = 2;
 pub const SOCK_SEQPACKET: ::c_int = 5;
+pub const SOCK_DCCP: ::c_int = 6;
+pub const SOCK_PACKET: ::c_int = 10;
 
 pub const SOL_SOCKET: ::c_int = 1;
 pub const SOL_SCTP: ::c_int = 132;
@@ -498,6 +500,27 @@ pub const SOL_ROSE: ::c_int = 260;
 pub const AF_MAX: ::c_int = 43;
 #[doc(hidden)]
 pub const PF_MAX: ::c_int = AF_MAX;
+
+/* DCCP socket options */
+pub const DCCP_SOCKOPT_PACKET_SIZE: ::c_int = 1;
+pub const DCCP_SOCKOPT_SERVICE: ::c_int = 2;
+pub const DCCP_SOCKOPT_CHANGE_L: ::c_int = 3;
+pub const DCCP_SOCKOPT_CHANGE_R: ::c_int = 4;
+pub const DCCP_SOCKOPT_GET_CUR_MPS: ::c_int = 5;
+pub const DCCP_SOCKOPT_SERVER_TIMEWAIT: ::c_int = 6;
+pub const DCCP_SOCKOPT_SEND_CSCOV: ::c_int = 10;
+pub const DCCP_SOCKOPT_RECV_CSCOV: ::c_int = 11;
+pub const DCCP_SOCKOPT_AVAILABLE_CCIDS: ::c_int = 12;
+pub const DCCP_SOCKOPT_CCID: ::c_int = 13;
+pub const DCCP_SOCKOPT_TX_CCID: ::c_int = 14;
+pub const DCCP_SOCKOPT_RX_CCID: ::c_int = 15;
+pub const DCCP_SOCKOPT_QPOLICY_ID: ::c_int = 16;
+pub const DCCP_SOCKOPT_QPOLICY_TXQLEN: ::c_int = 17;
+pub const DCCP_SOCKOPT_CCID_RX_INFO: ::c_int = 128;
+pub const DCCP_SOCKOPT_CCID_TX_INFO: ::c_int = 192;
+
+/// maximum number of services provided on the same listening port
+pub const DCCP_SERVICE_LIST_MAX_LEN: ::c_int = 32;
 
 pub const SO_REUSEADDR: ::c_int = 2;
 pub const SO_TYPE: ::c_int = 3;

--- a/src/unix/notbsd/linux/mips/mod.rs
+++ b/src/unix/notbsd/linux/mips/mod.rs
@@ -294,6 +294,8 @@ pub const MAP_STACK: ::c_int = 0x40000;
 pub const SOCK_STREAM: ::c_int = 2;
 pub const SOCK_DGRAM: ::c_int = 1;
 pub const SOCK_SEQPACKET: ::c_int = 5;
+pub const SOCK_DCCP: ::c_int = 6;
+pub const SOCK_PACKET: ::c_int = 10;
 
 pub const SOL_SOCKET: ::c_int = 0xffff;
 
@@ -352,6 +354,27 @@ pub const SO_BPF_EXTENSIONS: ::c_int = 48;
 pub const SO_INCOMING_CPU: ::c_int = 49;
 pub const SO_ATTACH_BPF: ::c_int = 50;
 pub const SO_DETACH_BPF: ::c_int = SO_DETACH_FILTER;
+
+/* DCCP socket options */
+pub const DCCP_SOCKOPT_PACKET_SIZE: ::c_int = 1;
+pub const DCCP_SOCKOPT_SERVICE: ::c_int = 2;
+pub const DCCP_SOCKOPT_CHANGE_L: ::c_int = 3;
+pub const DCCP_SOCKOPT_CHANGE_R: ::c_int = 4;
+pub const DCCP_SOCKOPT_GET_CUR_MPS: ::c_int = 5;
+pub const DCCP_SOCKOPT_SERVER_TIMEWAIT: ::c_int = 6;
+pub const DCCP_SOCKOPT_SEND_CSCOV: ::c_int = 10;
+pub const DCCP_SOCKOPT_RECV_CSCOV: ::c_int = 11;
+pub const DCCP_SOCKOPT_AVAILABLE_CCIDS: ::c_int = 12;
+pub const DCCP_SOCKOPT_CCID: ::c_int = 13;
+pub const DCCP_SOCKOPT_TX_CCID: ::c_int = 14;
+pub const DCCP_SOCKOPT_RX_CCID: ::c_int = 15;
+pub const DCCP_SOCKOPT_QPOLICY_ID: ::c_int = 16;
+pub const DCCP_SOCKOPT_QPOLICY_TXQLEN: ::c_int = 17;
+pub const DCCP_SOCKOPT_CCID_RX_INFO: ::c_int = 128;
+pub const DCCP_SOCKOPT_CCID_TX_INFO: ::c_int = 192;
+
+/// maximum number of services provided on the same listening port
+pub const DCCP_SERVICE_LIST_MAX_LEN: ::c_int = 32;
 
 pub const FIOCLEX: ::c_ulong = 0x6601;
 pub const FIONBIO: ::c_ulong = 0x667e;

--- a/src/unix/notbsd/linux/musl/mod.rs
+++ b/src/unix/notbsd/linux/musl/mod.rs
@@ -140,6 +140,9 @@ pub const RLIMIT_NLIMITS: ::c_int = 16;
 
 pub const MAP_ANONYMOUS: ::c_int = MAP_ANON;
 
+pub const SOCK_DCCP: ::c_int = 6;
+pub const SOCK_PACKET: ::c_int = 10;
+
 pub const TCP_COOKIE_TRANSACTIONS: ::c_int = 15;
 pub const TCP_THIN_LINEAR_TIMEOUTS: ::c_int = 16;
 pub const TCP_THIN_DUPACK: ::c_int = 17;

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -247,6 +247,8 @@ pub const EREMOTEIO: ::c_int = 121;
 pub const SOCK_STREAM: ::c_int = 1;
 pub const SOCK_DGRAM: ::c_int = 2;
 pub const SOCK_SEQPACKET: ::c_int = 5;
+pub const SOCK_DCCP: ::c_int = 6;
+pub const SOCK_PACKET: ::c_int = 10;
 
 pub const TCP_COOKIE_TRANSACTIONS: ::c_int = 15;
 pub const TCP_THIN_LINEAR_TIMEOUTS: ::c_int = 16;
@@ -258,6 +260,27 @@ pub const TCP_QUEUE_SEQ: ::c_int = 21;
 pub const TCP_REPAIR_OPTIONS: ::c_int = 22;
 pub const TCP_FASTOPEN: ::c_int = 23;
 pub const TCP_TIMESTAMP: ::c_int = 24;
+
+/* DCCP socket options */
+pub const DCCP_SOCKOPT_PACKET_SIZE: ::c_int = 1;
+pub const DCCP_SOCKOPT_SERVICE: ::c_int = 2;
+pub const DCCP_SOCKOPT_CHANGE_L: ::c_int = 3;
+pub const DCCP_SOCKOPT_CHANGE_R: ::c_int = 4;
+pub const DCCP_SOCKOPT_GET_CUR_MPS: ::c_int = 5;
+pub const DCCP_SOCKOPT_SERVER_TIMEWAIT: ::c_int = 6;
+pub const DCCP_SOCKOPT_SEND_CSCOV: ::c_int = 10;
+pub const DCCP_SOCKOPT_RECV_CSCOV: ::c_int = 11;
+pub const DCCP_SOCKOPT_AVAILABLE_CCIDS: ::c_int = 12;
+pub const DCCP_SOCKOPT_CCID: ::c_int = 13;
+pub const DCCP_SOCKOPT_TX_CCID: ::c_int = 14;
+pub const DCCP_SOCKOPT_RX_CCID: ::c_int = 15;
+pub const DCCP_SOCKOPT_QPOLICY_ID: ::c_int = 16;
+pub const DCCP_SOCKOPT_QPOLICY_TXQLEN: ::c_int = 17;
+pub const DCCP_SOCKOPT_CCID_RX_INFO: ::c_int = 128;
+pub const DCCP_SOCKOPT_CCID_TX_INFO: ::c_int = 192;
+
+/// maximum number of services provided on the same listening port
+pub const DCCP_SERVICE_LIST_MAX_LEN: ::c_int = 32;
 
 pub const SIGTTIN: ::c_int = 21;
 pub const SIGTTOU: ::c_int = 22;


### PR DESCRIPTION
This PR defines constants needed to utilize [DCCP](https://en.wikipedia.org/wiki/Datagram_Congestion_Control_Protocol) in Linux and NetBSD.