### PR TITLE
fuchsia: mxio was renamed to fdio

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -264,7 +264,7 @@ cfg_if! {
         extern {}
     } else if #[cfg(target_os = "fuchsia")] {
         #[link(name = "c")]
-        #[link(name = "mxio")]
+        #[link(name = "fdio")]
         extern {}
     } else if #[cfg(target_env = "newlib")] {
         #[link(name = "c")]


### PR DESCRIPTION
As a side effect of the rename of the Magenta kernel to Zircon, the mxio library was renamed to fdio, and the linker directive needs to be updated.