### PR TITLE
Enable CI for aarch64-unknown-linux-musl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ matrix:
     - env: TARGET=i686-unknown-linux-musl
     - env: TARGET=arm-unknown-linux-gnueabihf
     - env: TARGET=aarch64-unknown-linux-gnu
+    - env: TARGET=aarch64-unknown-linux-musl
     - os: osx
       osx_image: xcode8.2
       env: TARGET=i386-apple-ios

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,11 @@
 #![cfg_attr(all(target_os = "linux", target_arch = "mips"), doc(
     html_root_url = "https://doc.rust-lang.org/libc/mips-unknown-linux-gnu"
 ))]
-#![cfg_attr(all(target_os = "linux", target_arch = "aarch64"), doc(
+#![cfg_attr(all(target_os = "linux", target_arch = "aarch64", target_env = "gnu"), doc(
     html_root_url = "https://doc.rust-lang.org/libc/aarch64-unknown-linux-gnu"
+))]
+#![cfg_attr(all(target_os = "linux", target_arch = "aarch64", target_env = "musl"), doc(
+    html_root_url = "https://doc.rust-lang.org/libc/aarch64-unknown-linux-musl"
 ))]
 #![cfg_attr(all(target_os = "linux", target_env = "musl"), doc(
     html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-linux-musl"


### PR DESCRIPTION
This contains the changes originally in rust-lang/libc#782 that enable CI for aarch64-unknown-linux-musl; they shouldn't be merged until rust-lang/rust#44779 is landed so the triple is available for CI tests.