### PR TITLE
Fix kqueue filter consts type on NetBSD [WAS: Provide EV_SET]

### DIFF
--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -649,13 +649,13 @@ pub const PTHREAD_MUTEX_ERRORCHECK: ::c_int = 1;
 pub const PTHREAD_MUTEX_RECURSIVE: ::c_int = 2;
 pub const PTHREAD_MUTEX_DEFAULT: ::c_int = PTHREAD_MUTEX_NORMAL;
 
-pub const EVFILT_AIO: ::int32_t = 2;
-pub const EVFILT_PROC: ::int32_t = 4;
-pub const EVFILT_READ: ::int32_t = 0;
-pub const EVFILT_SIGNAL: ::int32_t = 5;
-pub const EVFILT_TIMER: ::int32_t = 6;
-pub const EVFILT_VNODE: ::int32_t = 3;
-pub const EVFILT_WRITE: ::int32_t = 1;
+pub const EVFILT_AIO: ::uint32_t = 2;
+pub const EVFILT_PROC: ::uint32_t = 4;
+pub const EVFILT_READ: ::uint32_t = 0;
+pub const EVFILT_SIGNAL: ::uint32_t = 5;
+pub const EVFILT_TIMER: ::uint32_t = 6;
+pub const EVFILT_VNODE: ::uint32_t = 3;
+pub const EVFILT_WRITE: ::uint32_t = 1;
 
 pub const EV_ADD: ::uint32_t = 0x1;
 pub const EV_DELETE: ::uint32_t = 0x2;


### PR DESCRIPTION
Using BSD kqueue's `kevent` structure is tedious, because some BSD variants define the structure slightly differently. This forces user's code to differentiate between BSD variants and initialize `kevent` accordingly, which is annoying and error-prone.

For an example, refer to [MIO](https://github.com/carllerche/mio/blob/master/src/sys/unix/kqueue.rs#L38).

This is an attempt to fix it - provide a ctor function with the same signature across BSD variants.

Is an `impl` piece for a C structure allowed in libc?

**edit:** I noticed the `kevent` function has a similar problem, maybe I should include a fix for that too... 
**edit:** ^ Done