### PR TITLE
Add `project_name` attribute to appveyor badge.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ other common platform libraries.
 
 [badges]
 travis-ci = { repository = "rust-lang/libc" }
-appveyor = { repository = "rust-lang-libs/libc" }
+appveyor = { repository = "rust-lang/libc", project_name = "rust-lang-libs/libc" }
 
 [features]
 default = ["use_std"]


### PR DESCRIPTION
There was a recent [issue](https://github.com/rust-lang/crates.io/issues/587) in crates.io where appveyor is looking for a dash separated URL for the link to appveyors site:
```
https://ci.appveyor.com/project/rust-lang-libs/libc
```
 and the actual repo name for the image badge url:
```
https://ci.appveyor.com/api/projects/status/github/rust-lang/libc?svg=true
```
We recently added the ability to specify a `project_name` that fixes this issue.  You'll notice that currently on https://crates.io/crates/libc the appveyor badge on the right sidebar show `build unknown`, this PR will address that issue.

Please let me know if you have any questions.