### PR TITLE
define SYS_renameat2 + flags on linux

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -226,6 +226,7 @@ fn main() {
         cfg.header("sys/reboot.h");
         if !emscripten {
             cfg.header("linux/netfilter_ipv4.h");
+            cfg.header("linux/fs.h");
         }
         if !musl {
             cfg.header("asm/mman.h");
@@ -464,7 +465,8 @@ fn main() {
 
             // Musl uses old, patched kernel headers
             "FALLOC_FL_COLLAPSE_RANGE" | "FALLOC_FL_ZERO_RANGE" |
-            "FALLOC_FL_INSERT_RANGE" | "FALLOC_FL_UNSHARE_RANGE" if musl => true,
+            "FALLOC_FL_INSERT_RANGE" | "FALLOC_FL_UNSHARE_RANGE" |
+            "RENAME_NOREPLACE" | "RENAME_EXCHANGE" | "RENAME_WHITEOUT" if musl => true,
 
             // Defined by libattr not libc on linux (hard to test).
             // See constant definition for more details.

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -673,6 +673,10 @@ pub const PTHREAD_PROCESS_PRIVATE: ::c_int = 0;
 pub const PTHREAD_PROCESS_SHARED: ::c_int = 1;
 pub const __SIZEOF_PTHREAD_COND_T: usize = 48;
 
+pub const RENAME_NOREPLACE: ::c_int = 1;
+pub const RENAME_EXCHANGE: ::c_int = 2;
+pub const RENAME_WHITEOUT: ::c_int = 4;
+
 pub const SCHED_OTHER: ::c_int = 0;
 pub const SCHED_FIFO: ::c_int = 1;
 pub const SCHED_RR: ::c_int = 2;

--- a/src/unix/notbsd/linux/musl/b32/arm.rs
+++ b/src/unix/notbsd/linux/musl/b32/arm.rs
@@ -390,3 +390,6 @@ pub const TIOCM_RNG: ::c_int = 0x080;
 pub const TIOCM_DSR: ::c_int = 0x100;
 pub const TIOCM_CD: ::c_int = TIOCM_CAR;
 pub const TIOCM_RI: ::c_int = TIOCM_RNG;
+
+// Syscall table
+pub const SYS_renameat2: ::c_long = 382;

--- a/src/unix/notbsd/linux/musl/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/musl/b64/aarch64.rs
@@ -79,3 +79,6 @@ pub const SIGSTKSZ: ::size_t = 12288;
 pub const PF_MAX: ::c_int = 43;
 #[doc(hidden)]
 pub const AF_MAX: ::c_int = PF_MAX;
+
+// Syscall table
+pub const SYS_renameat2: ::c_long = 276;

--- a/src/unix/notbsd/linux/musl/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/musl/b64/powerpc64.rs
@@ -78,3 +78,6 @@ pub const MINSIGSTKSZ: ::size_t = 2048;
 pub const AF_MAX: ::c_int = 42;
 #[doc(hidden)]
 pub const PF_MAX: ::c_int = AF_MAX;
+
+// Syscall table
+pub const SYS_renameat2: ::c_long = 357;

--- a/src/unix/notbsd/linux/other/b32/arm.rs
+++ b/src/unix/notbsd/linux/other/b32/arm.rs
@@ -249,3 +249,6 @@ pub const TIOCOUTQ: ::c_ulong = 0x5411;
 pub const TIOCGWINSZ: ::c_ulong = 0x5413;
 pub const TIOCSWINSZ: ::c_ulong = 0x5414;
 pub const FIONREAD: ::c_ulong = 0x541B;
+
+// Syscall table
+pub const SYS_renameat2: ::c_long = 382;

--- a/src/unix/notbsd/linux/other/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/other/b64/aarch64.rs
@@ -488,3 +488,6 @@ pub const TIOCOUTQ: ::c_ulong = 0x5411;
 pub const TIOCGWINSZ: ::c_ulong = 0x5413;
 pub const TIOCSWINSZ: ::c_ulong = 0x5414;
 pub const FIONREAD: ::c_ulong = 0x541B;
+
+// Syscall table
+pub const SYS_renameat2: ::c_long = 276;

--- a/src/unix/notbsd/linux/other/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/other/b64/powerpc64.rs
@@ -485,3 +485,6 @@ pub const TIOCOUTQ: ::c_ulong = 0x40047473;
 pub const TIOCGWINSZ: ::c_ulong = 0x40087468;
 pub const TIOCSWINSZ: ::c_ulong = 0x80087467;
 pub const FIONREAD: ::c_ulong = 0x4004667f;
+
+// Syscall table
+pub const SYS_renameat2: ::c_long = 357;

--- a/src/unix/notbsd/linux/s390x.rs
+++ b/src/unix/notbsd/linux/s390x.rs
@@ -779,6 +779,9 @@ pub const TIOCMSET: ::c_ulong = 0x5418;
 pub const FIONREAD: ::c_ulong = 0x541B;
 pub const TIOCCONS: ::c_ulong = 0x541D;
 
+// Syscall table
+pub const SYS_renameat2: ::c_long = 347;
+
 pub const RTLD_DEEPBIND: ::c_int = 0x8;
 pub const RTLD_GLOBAL: ::c_int = 0x100;
 pub const RTLD_NOLOAD: ::c_int = 0x4;


### PR DESCRIPTION
Motivation: there is no glibc wrapper for this syscall