### PR TITLE
Add missing powerpc64 in musl/mod.rs

### DIFF
--- a/src/unix/notbsd/linux/musl/mod.rs
+++ b/src/unix/notbsd/linux/musl/mod.rs
@@ -309,7 +309,9 @@ extern {
 }
 
 cfg_if! {
-    if #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))] {
+    if #[cfg(any(target_arch = "x86_64",
+                 target_arch = "aarch64",
+                 target_arch = "powerpc64"))] {
         mod b64;
         pub use self::b64::*;
     } else if #[cfg(any(target_arch = "x86",


### PR DESCRIPTION
powerpc64 was missing in musl/mod.rs and making build fail
as it was not able to find types, like c_char.