### PR TITLE
Local peer credential support for FreeBSD.

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -127,6 +127,14 @@ s! {
         pub shm_dtime: ::time_t,
         pub shm_ctime: ::time_t,
     }
+
+    pub struct xucred {
+        pub cr_version: ::c_uint,
+        pub cr_uid: ::uid_t,
+        pub cr_ngroups: ::c_short,
+        pub cr_groups: [::gid_t;16],
+        __cr_unused1: *mut ::c_void,
+    }
 }
 
 pub const SIGEV_THREAD_ID: ::c_int = 4;
@@ -401,6 +409,11 @@ pub const SO_USER_COOKIE: ::c_int = 0x1015;
 pub const SO_PROTOCOL: ::c_int = 0x1016;
 pub const SO_PROTOTYPE: ::c_int = SO_PROTOCOL;
 pub const SO_VENDOR: ::c_int = 0x80000000;
+
+pub const LOCAL_PEERCRED: ::c_int = 1;
+pub const LOCAL_CREDS: ::c_int = 2;
+pub const LOCAL_CONNWAIT: ::c_int = 4;
+pub const LOCAL_VENDOR: ::c_int = SO_VENDOR;
 
 pub const AF_SLOW: ::c_int = 33;
 pub const AF_SCLUSTER: ::c_int = 34;
@@ -765,6 +778,9 @@ pub const TAB3: ::tcflag_t = 0x00000004;
 pub const _PC_ACL_NFS4: ::c_int = 64;
 
 pub const _SC_CPUSET_SIZE: ::c_int = 122;
+
+pub const XU_NGROUPS: ::c_int = 16;
+pub const XUCRED_VERSION: ::c_uint = 0;
 
 extern {
     pub fn __error() -> *mut ::c_int;


### PR DESCRIPTION
FreeBSD uses SOL_SOCKET/LOCAL_PEERCRED instead of SOL_SOCKET/SO_PEERCRED parameters to getsocktopt to retrieve the credentials of a socket's peer.

(Documented in man 4 unix)