### PR TITLE
Add sparc64-unknown-linux-gnu to CI (with disabled tests)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ matrix:
     - env: TARGET=mips64-unknown-linux-gnuabi64
     - env: TARGET=mips-unknown-linux-gnu
     - env: TARGET=s390x-unknown-linux-gnu
+    - env: TARGET=sparc64-unknown-linux-gnu
     - env: TARGET=asmjs-unknown-emscripten
     - env: TARGET=wasm32-unknown-emscripten
 

--- a/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
@@ -1,0 +1,14 @@
+# link fails on 17.10
+FROM ubuntu:17.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gcc libc6-dev qemu-user ca-certificates \
+        gcc-sparc64-linux-gnu libc6-dev-sparc64-cross
+
+ENV CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_LINKER=sparc64-linux-gnu-gcc \
+    # TODO: in theory we should execute this, but qemu segfaults immediately
+    #       see https://github.com/rust-lang/libc/issues/822
+    # CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_RUNNER="qemu-sparc64 -L /usr/sparc64-linux-gnu" \
+    CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_RUNNER=true \
+    CC_sparc64_unknown_linux_gnu=sparc64-linux-gnu-gcc \
+    PATH=$PATH:/rust/bin


### PR DESCRIPTION
Tests are disabled because qemu segfaults, see https://github.com/rust-lang/libc/issues/822

The builder is still useful to catch some errors.