### PR TITLE
Add WCONTINUED const for OpenBSD

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
@@ -651,6 +651,8 @@ pub const SOCK_CLOEXEC: ::c_int = 0x8000;
 pub const SOCK_NONBLOCK: ::c_int = 0x4000;
 pub const SOCK_DNS: ::c_int = 0x1000;
 
+pub const WCONTINUED: ::c_int = 8;
+
 f! {
     pub fn WIFCONTINUED(status: ::c_int) -> bool {
         status & 0o177777 == 0o177777


### PR DESCRIPTION
Simple addition of `WCONTINUED` for OpenBSD-like systems. Built nix against this modified libc and used it to test.