### PR TITLE
Add constants used by getrandom linux syscall

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -250,6 +250,10 @@ fn main() {
         }
     }
 
+    if linux {
+        cfg.header("linux/random.h");
+    }
+
     if freebsd {
         cfg.header("pthread_np.h");
         cfg.header("sched.h");
@@ -474,6 +478,10 @@ fn main() {
             "FALLOC_FL_COLLAPSE_RANGE" | "FALLOC_FL_ZERO_RANGE" |
             "FALLOC_FL_INSERT_RANGE" | "FALLOC_FL_UNSHARE_RANGE" |
             "RENAME_NOREPLACE" | "RENAME_EXCHANGE" | "RENAME_WHITEOUT" if musl => true,
+
+            // Both android and musl use old kernel headers
+            // These are constants used in getrandom syscall
+            "GRND_NONBLOCK" | "GRND_RANDOM" if musl || android => true,
 
             // Defined by libattr not libc on linux (hard to test).
             // See constant definition for more details.

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -848,6 +848,9 @@ pub const NETLINK_NO_ENOBUFS: ::c_int = 5;
 pub const NETLINK_RX_RING: ::c_int = 6;
 pub const NETLINK_TX_RING: ::c_int = 7;
 
+pub const GRND_NONBLOCK: ::c_uint = 0x0001;
+pub const GRND_RANDOM: ::c_uint = 0x0002;
+
 pub const NLA_F_NESTED: ::c_int = 1 << 15;
 pub const NLA_F_NET_BYTEORDER: ::c_int = 1 << 14;
 pub const NLA_TYPE_MASK: ::c_int = !(NLA_F_NESTED | NLA_F_NET_BYTEORDER);

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -996,6 +996,9 @@ pub const PR_CAP_AMBIENT_RAISE: ::c_int = 2;
 pub const PR_CAP_AMBIENT_LOWER: ::c_int = 3;
 pub const PR_CAP_AMBIENT_CLEAR_ALL: ::c_int = 4;
 
+pub const GRND_NONBLOCK: ::c_uint = 0x0001;
+pub const GRND_RANDOM: ::c_uint = 0x0002;
+
 pub const ITIMER_REAL: ::c_int = 0;
 pub const ITIMER_VIRTUAL: ::c_int = 1;
 pub const ITIMER_PROF: ::c_int = 2;


### PR DESCRIPTION
getrandom syscall was added in kernel 3.17. Musl and android seems to use old kernel headers, but considering that they define SYS_getrandom, the constants GRND_NONBLOCK and GRND_RANDOM should also be defined.