### PR TITLE
Compile an empty library on wasm32 non-Emscripten

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,176 +100,183 @@ extern crate std as core;
 #[macro_use] mod macros;
 mod dox;
 
-// Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help enable
-// more optimization opportunities around it recognizing things like
-// malloc/free.
-#[repr(u8)]
-pub enum c_void {
-    // Two dummy variants so the #[repr] attribute can be used.
-    #[doc(hidden)]
-    __variant1,
-    #[doc(hidden)]
-    __variant2,
-}
+cfg_if! {
+    if #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))] {
+        // empty ...
+    } else {
 
-pub type int8_t = i8;
-pub type int16_t = i16;
-pub type int32_t = i32;
-pub type int64_t = i64;
-pub type uint8_t = u8;
-pub type uint16_t = u16;
-pub type uint32_t = u32;
-pub type uint64_t = u64;
+        // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help enable
+        // more optimization opportunities around it recognizing things like
+        // malloc/free.
+        #[repr(u8)]
+        pub enum c_void {
+            // Two dummy variants so the #[repr] attribute can be used.
+            #[doc(hidden)]
+            __variant1,
+            #[doc(hidden)]
+            __variant2,
+        }
 
-pub type c_schar = i8;
-pub type c_uchar = u8;
-pub type c_short = i16;
-pub type c_ushort = u16;
-pub type c_int = i32;
-pub type c_uint = u32;
-pub type c_float = f32;
-pub type c_double = f64;
-pub type c_longlong = i64;
-pub type c_ulonglong = u64;
-pub type intmax_t = i64;
-pub type uintmax_t = u64;
+        pub type int8_t = i8;
+        pub type int16_t = i16;
+        pub type int32_t = i32;
+        pub type int64_t = i64;
+        pub type uint8_t = u8;
+        pub type uint16_t = u16;
+        pub type uint32_t = u32;
+        pub type uint64_t = u64;
 
-pub type size_t = usize;
-pub type ptrdiff_t = isize;
-pub type intptr_t = isize;
-pub type uintptr_t = usize;
-pub type ssize_t = isize;
+        pub type c_schar = i8;
+        pub type c_uchar = u8;
+        pub type c_short = i16;
+        pub type c_ushort = u16;
+        pub type c_int = i32;
+        pub type c_uint = u32;
+        pub type c_float = f32;
+        pub type c_double = f64;
+        pub type c_longlong = i64;
+        pub type c_ulonglong = u64;
+        pub type intmax_t = i64;
+        pub type uintmax_t = u64;
 
-pub enum FILE {}
-pub enum fpos_t {} // TODO: fill this out with a struct
+        pub type size_t = usize;
+        pub type ptrdiff_t = isize;
+        pub type intptr_t = isize;
+        pub type uintptr_t = usize;
+        pub type ssize_t = isize;
 
-extern {
-    pub fn isalnum(c: c_int) -> c_int;
-    pub fn isalpha(c: c_int) -> c_int;
-    pub fn iscntrl(c: c_int) -> c_int;
-    pub fn isdigit(c: c_int) -> c_int;
-    pub fn isgraph(c: c_int) -> c_int;
-    pub fn islower(c: c_int) -> c_int;
-    pub fn isprint(c: c_int) -> c_int;
-    pub fn ispunct(c: c_int) -> c_int;
-    pub fn isspace(c: c_int) -> c_int;
-    pub fn isupper(c: c_int) -> c_int;
-    pub fn isxdigit(c: c_int) -> c_int;
-    pub fn tolower(c: c_int) -> c_int;
-    pub fn toupper(c: c_int) -> c_int;
+        pub enum FILE {}
+        pub enum fpos_t {} // TODO: fill this out with a struct
 
-    #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
-               link_name = "fopen$UNIX2003")]
-    pub fn fopen(filename: *const c_char,
-                 mode: *const c_char) -> *mut FILE;
-    #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
-               link_name = "freopen$UNIX2003")]
-    pub fn freopen(filename: *const c_char, mode: *const c_char,
-                   file: *mut FILE) -> *mut FILE;
-    pub fn fflush(file: *mut FILE) -> c_int;
-    pub fn fclose(file: *mut FILE) -> c_int;
-    pub fn remove(filename: *const c_char) -> c_int;
-    pub fn rename(oldname: *const c_char, newname: *const c_char) -> c_int;
-    pub fn tmpfile() -> *mut FILE;
-    pub fn setvbuf(stream: *mut FILE,
-                   buffer: *mut c_char,
-                   mode: c_int,
-                   size: size_t) -> c_int;
-    pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
-    pub fn getchar() -> c_int;
-    pub fn putchar(c: c_int) -> c_int;
-    pub fn fgetc(stream: *mut FILE) -> c_int;
-    pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
-    pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;
-    #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
-               link_name = "fputs$UNIX2003")]
-    pub fn fputs(s: *const c_char, stream: *mut FILE)-> c_int;
-    pub fn puts(s: *const c_char) -> c_int;
-    pub fn ungetc(c: c_int, stream: *mut FILE) -> c_int;
-    pub fn fread(ptr: *mut c_void,
-                 size: size_t,
-                 nobj: size_t,
-                 stream: *mut FILE)
-                 -> size_t;
-    #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
-               link_name = "fwrite$UNIX2003")]
-    pub fn fwrite(ptr: *const c_void,
-                  size: size_t,
-                  nobj: size_t,
-                  stream: *mut FILE)
-                  -> size_t;
-    pub fn fseek(stream: *mut FILE, offset: c_long, whence: c_int) -> c_int;
-    pub fn ftell(stream: *mut FILE) -> c_long;
-    pub fn rewind(stream: *mut FILE);
-    #[cfg_attr(target_os = "netbsd", link_name = "__fgetpos50")]
-    pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> c_int;
-    #[cfg_attr(target_os = "netbsd", link_name = "__fsetpos50")]
-    pub fn fsetpos(stream: *mut FILE, ptr: *const fpos_t) -> c_int;
-    pub fn feof(stream: *mut FILE) -> c_int;
-    pub fn ferror(stream: *mut FILE) -> c_int;
-    pub fn perror(s: *const c_char);
-    pub fn atoi(s: *const c_char) -> c_int;
-    #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
-               link_name = "strtod$UNIX2003")]
-    pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
-    pub fn strtol(s: *const c_char,
-                  endp: *mut *mut c_char, base: c_int) -> c_long;
-    pub fn strtoul(s: *const c_char, endp: *mut *mut c_char,
-                   base: c_int) -> c_ulong;
-    pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;
-    pub fn malloc(size: size_t) -> *mut c_void;
-    pub fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
-    pub fn free(p: *mut c_void);
-    pub fn abort() -> !;
-    pub fn exit(status: c_int) -> !;
-    pub fn _exit(status: c_int) -> !;
-    pub fn atexit(cb: extern fn()) -> c_int;
-    #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
-               link_name = "system$UNIX2003")]
-    pub fn system(s: *const c_char) -> c_int;
-    pub fn getenv(s: *const c_char) -> *mut c_char;
+        extern {
+            pub fn isalnum(c: c_int) -> c_int;
+            pub fn isalpha(c: c_int) -> c_int;
+            pub fn iscntrl(c: c_int) -> c_int;
+            pub fn isdigit(c: c_int) -> c_int;
+            pub fn isgraph(c: c_int) -> c_int;
+            pub fn islower(c: c_int) -> c_int;
+            pub fn isprint(c: c_int) -> c_int;
+            pub fn ispunct(c: c_int) -> c_int;
+            pub fn isspace(c: c_int) -> c_int;
+            pub fn isupper(c: c_int) -> c_int;
+            pub fn isxdigit(c: c_int) -> c_int;
+            pub fn tolower(c: c_int) -> c_int;
+            pub fn toupper(c: c_int) -> c_int;
 
-    pub fn strcpy(dst: *mut c_char, src: *const c_char) -> *mut c_char;
-    pub fn strncpy(dst: *mut c_char, src: *const c_char, n: size_t)
-                   -> *mut c_char;
-    pub fn strcat(s: *mut c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strncat(s: *mut c_char, ct: *const c_char, n: size_t) -> *mut c_char;
-    pub fn strcmp(cs: *const c_char, ct: *const c_char) -> c_int;
-    pub fn strncmp(cs: *const c_char, ct: *const c_char, n: size_t) -> c_int;
-    pub fn strcoll(cs: *const c_char, ct: *const c_char) -> c_int;
-    pub fn strchr(cs: *const c_char, c: c_int) -> *mut c_char;
-    pub fn strrchr(cs: *const c_char, c: c_int) -> *mut c_char;
-    pub fn strspn(cs: *const c_char, ct: *const c_char) -> size_t;
-    pub fn strcspn(cs: *const c_char, ct: *const c_char) -> size_t;
-    pub fn strdup(cs: *const c_char) -> *mut c_char;
-    pub fn strpbrk(cs: *const c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strstr(cs: *const c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strlen(cs: *const c_char) -> size_t;
-    pub fn strnlen(cs: *const c_char, maxlen: size_t) -> size_t;
-    #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
-               link_name = "strerror$UNIX2003")]
-    pub fn strerror(n: c_int) -> *mut c_char;
-    pub fn strtok(s: *mut c_char, t: *const c_char) -> *mut c_char;
-    pub fn strxfrm(s: *mut c_char, ct: *const c_char, n: size_t) -> size_t;
-    pub fn wcslen(buf: *const wchar_t) -> size_t;
-    pub fn wcstombs(dest: *mut c_char, src: *const wchar_t, n: size_t) -> ::size_t;
+            #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
+                       link_name = "fopen$UNIX2003")]
+            pub fn fopen(filename: *const c_char,
+                         mode: *const c_char) -> *mut FILE;
+            #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
+                       link_name = "freopen$UNIX2003")]
+            pub fn freopen(filename: *const c_char, mode: *const c_char,
+                           file: *mut FILE) -> *mut FILE;
+            pub fn fflush(file: *mut FILE) -> c_int;
+            pub fn fclose(file: *mut FILE) -> c_int;
+            pub fn remove(filename: *const c_char) -> c_int;
+            pub fn rename(oldname: *const c_char, newname: *const c_char) -> c_int;
+            pub fn tmpfile() -> *mut FILE;
+            pub fn setvbuf(stream: *mut FILE,
+                           buffer: *mut c_char,
+                           mode: c_int,
+                           size: size_t) -> c_int;
+            pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
+            pub fn getchar() -> c_int;
+            pub fn putchar(c: c_int) -> c_int;
+            pub fn fgetc(stream: *mut FILE) -> c_int;
+            pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
+            pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;
+            #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
+                       link_name = "fputs$UNIX2003")]
+            pub fn fputs(s: *const c_char, stream: *mut FILE)-> c_int;
+            pub fn puts(s: *const c_char) -> c_int;
+            pub fn ungetc(c: c_int, stream: *mut FILE) -> c_int;
+            pub fn fread(ptr: *mut c_void,
+                         size: size_t,
+                         nobj: size_t,
+                         stream: *mut FILE)
+                         -> size_t;
+            #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
+                       link_name = "fwrite$UNIX2003")]
+            pub fn fwrite(ptr: *const c_void,
+                          size: size_t,
+                          nobj: size_t,
+                          stream: *mut FILE)
+                          -> size_t;
+            pub fn fseek(stream: *mut FILE, offset: c_long, whence: c_int) -> c_int;
+            pub fn ftell(stream: *mut FILE) -> c_long;
+            pub fn rewind(stream: *mut FILE);
+            #[cfg_attr(target_os = "netbsd", link_name = "__fgetpos50")]
+            pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> c_int;
+            #[cfg_attr(target_os = "netbsd", link_name = "__fsetpos50")]
+            pub fn fsetpos(stream: *mut FILE, ptr: *const fpos_t) -> c_int;
+            pub fn feof(stream: *mut FILE) -> c_int;
+            pub fn ferror(stream: *mut FILE) -> c_int;
+            pub fn perror(s: *const c_char);
+            pub fn atoi(s: *const c_char) -> c_int;
+            #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
+                       link_name = "strtod$UNIX2003")]
+            pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
+            pub fn strtol(s: *const c_char,
+                          endp: *mut *mut c_char, base: c_int) -> c_long;
+            pub fn strtoul(s: *const c_char, endp: *mut *mut c_char,
+                           base: c_int) -> c_ulong;
+            pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;
+            pub fn malloc(size: size_t) -> *mut c_void;
+            pub fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
+            pub fn free(p: *mut c_void);
+            pub fn abort() -> !;
+            pub fn exit(status: c_int) -> !;
+            pub fn _exit(status: c_int) -> !;
+            pub fn atexit(cb: extern fn()) -> c_int;
+            #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
+                       link_name = "system$UNIX2003")]
+            pub fn system(s: *const c_char) -> c_int;
+            pub fn getenv(s: *const c_char) -> *mut c_char;
 
-    pub fn memchr(cx: *const c_void, c: c_int, n: size_t) -> *mut c_void;
-    pub fn memcmp(cx: *const c_void, ct: *const c_void, n: size_t) -> c_int;
-    pub fn memcpy(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
-    pub fn memmove(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
-    pub fn memset(dest: *mut c_void, c: c_int, n: size_t) -> *mut c_void;
-}
+            pub fn strcpy(dst: *mut c_char, src: *const c_char) -> *mut c_char;
+            pub fn strncpy(dst: *mut c_char, src: *const c_char, n: size_t)
+                           -> *mut c_char;
+            pub fn strcat(s: *mut c_char, ct: *const c_char) -> *mut c_char;
+            pub fn strncat(s: *mut c_char, ct: *const c_char, n: size_t) -> *mut c_char;
+            pub fn strcmp(cs: *const c_char, ct: *const c_char) -> c_int;
+            pub fn strncmp(cs: *const c_char, ct: *const c_char, n: size_t) -> c_int;
+            pub fn strcoll(cs: *const c_char, ct: *const c_char) -> c_int;
+            pub fn strchr(cs: *const c_char, c: c_int) -> *mut c_char;
+            pub fn strrchr(cs: *const c_char, c: c_int) -> *mut c_char;
+            pub fn strspn(cs: *const c_char, ct: *const c_char) -> size_t;
+            pub fn strcspn(cs: *const c_char, ct: *const c_char) -> size_t;
+            pub fn strdup(cs: *const c_char) -> *mut c_char;
+            pub fn strpbrk(cs: *const c_char, ct: *const c_char) -> *mut c_char;
+            pub fn strstr(cs: *const c_char, ct: *const c_char) -> *mut c_char;
+            pub fn strlen(cs: *const c_char) -> size_t;
+            pub fn strnlen(cs: *const c_char, maxlen: size_t) -> size_t;
+            #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
+                       link_name = "strerror$UNIX2003")]
+            pub fn strerror(n: c_int) -> *mut c_char;
+            pub fn strtok(s: *mut c_char, t: *const c_char) -> *mut c_char;
+            pub fn strxfrm(s: *mut c_char, ct: *const c_char, n: size_t) -> size_t;
+            pub fn wcslen(buf: *const wchar_t) -> size_t;
+            pub fn wcstombs(dest: *mut c_char, src: *const wchar_t, n: size_t) -> ::size_t;
 
-// These are all inline functions on android, so they end up just being entirely
-// missing on that platform.
-#[cfg(not(target_os = "android"))]
-extern {
-    pub fn abs(i: c_int) -> c_int;
-    pub fn atof(s: *const c_char) -> c_double;
-    pub fn labs(i: c_long) -> c_long;
-    pub fn rand() -> c_int;
-    pub fn srand(seed: c_uint);
+            pub fn memchr(cx: *const c_void, c: c_int, n: size_t) -> *mut c_void;
+            pub fn memcmp(cx: *const c_void, ct: *const c_void, n: size_t) -> c_int;
+            pub fn memcpy(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
+            pub fn memmove(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
+            pub fn memset(dest: *mut c_void, c: c_int, n: size_t) -> *mut c_void;
+        }
+
+        // These are all inline functions on android, so they end up just being entirely
+        // missing on that platform.
+        #[cfg(not(target_os = "android"))]
+        extern {
+            pub fn abs(i: c_int) -> c_int;
+            pub fn atof(s: *const c_char) -> c_double;
+            pub fn labs(i: c_long) -> c_long;
+            pub fn rand() -> c_int;
+            pub fn srand(seed: c_uint);
+        }
+    }
 }
 
 cfg_if! {


### PR DESCRIPTION
In preparation for eventually having a non-Emscripten based wasm32 target, this
commit makes `libc` the crate an empty library on wasm32 targets that are not
with `target_os = "emscripten"`. This may eventually get filled out over time,
but for now it's all empty!