### PR TITLE
Expose MFD_ constants on all Linux targets.

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -510,6 +510,7 @@ fn main() {
             "QFMT_VFS_OLD" | "QFMT_VFS_V0" | "QFMT_VFS_V1" if mips && linux => true, // Only on MIPS
             "BOTHER" => true,
 
+            "MFD_CLOEXEC" | "MFD_ALLOW_SEALING" if !mips && musl => true,
             _ => false,
         }
     });

--- a/src/unix/notbsd/linux/mips/mod.rs
+++ b/src/unix/notbsd/linux/mips/mod.rs
@@ -667,9 +667,6 @@ pub const AF_MAX: ::c_int = 42;
 #[doc(hidden)]
 pub const PF_MAX: ::c_int = AF_MAX;
 
-pub const MFD_CLOEXEC: ::c_uint = 0x0001;
-pub const MFD_ALLOW_SEALING: ::c_uint = 0x0002;
-
 #[link(name = "util")]
 extern {
     pub fn sysctl(name: *mut ::c_int,

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -1028,6 +1028,9 @@ pub const SO_ORIGINAL_DST: ::c_int = 80;
 pub const IUTF8: ::tcflag_t = 0x00004000;
 pub const CMSPAR: ::tcflag_t = 0o10000000000;
 
+pub const MFD_CLOEXEC: ::c_uint = 0x0001;
+pub const MFD_ALLOW_SEALING: ::c_uint = 0x0002;
+
 f! {
     pub fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {
         for slot in cpuset.bits.iter_mut() {

--- a/src/unix/notbsd/linux/musl/b32/mips.rs
+++ b/src/unix/notbsd/linux/musl/b32/mips.rs
@@ -771,6 +771,3 @@ pub const SYS_pwritev2: ::c_long = 4000 + 362;
 pub const AF_MAX: ::c_int = 42;
 #[doc(hidden)]
 pub const PF_MAX: ::c_int = AF_MAX;
-
-pub const MFD_CLOEXEC: ::c_uint = 0x0001;
-pub const MFD_ALLOW_SEALING: ::c_uint = 0x0002;

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -548,9 +548,6 @@ pub const AF_MAX: ::c_int = 42;
 #[doc(hidden)]
 pub const PF_MAX: ::c_int = AF_MAX;
 
-pub const MFD_CLOEXEC: ::c_uint = 0x0001;
-pub const MFD_ALLOW_SEALING: ::c_uint = 0x0002;
-
 cfg_if! {
     if #[cfg(any(target_arch = "arm", target_arch = "x86",
                  target_arch = "x86_64"))] {

--- a/src/unix/notbsd/linux/s390x.rs
+++ b/src/unix/notbsd/linux/s390x.rs
@@ -1243,9 +1243,6 @@ pub const SYS_setfsuid: ::c_long = 215;
 pub const SYS_setfsgid: ::c_long = 216;
 pub const SYS_newfstatat: ::c_long = 293;
 
-pub const MFD_CLOEXEC: ::c_uint = 0x0001;
-pub const MFD_ALLOW_SEALING: ::c_uint = 0x0002;
-
 #[link(name = "util")]
 extern {
     pub fn sysctl(name: *mut ::c_int,


### PR DESCRIPTION
These aren't exposed on non-MIPS musl targets, but since they're
part of a kernel API, they're still applicable, so we just don't
test them there but expose them anyways.