### PR TITLE
Use more convenient and UNIX-agnostic shebang

### DIFF
--- a/ci/emscripten-entry.sh
+++ b/ci/emscripten-entry.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/ci/test-runner-linux
+++ b/ci/test-runner-linux
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
Pure sh scripts should use /bin/sh as it's available on every platform.

When using bash-specific features, use env to find it, as bash can
be installed in different places according the OS.