### PR TITLE
Add aarch64 support to newlib bindings

### DIFF
--- a/src/unix/newlib/aarch64/mod.rs
+++ b/src/unix/newlib/aarch64/mod.rs
@@ -1,0 +1,5 @@
+pub type c_char = u8;
+pub type wchar_t = u32;
+
+pub type c_long = i64;
+pub type c_ulong = u64;

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -679,6 +679,9 @@ cfg_if! {
     if #[cfg(target_arch = "arm")] {
         mod arm;
         pub use self::arm::*;
+    } else if #[cfg(target_arch = "aarch64")] {
+        mod aarch64;
+        pub use self::aarch64::*;
     } else {
         // Only tested on ARM so far. Other platforms might have different
         // definitions for types and constants.


### PR DESCRIPTION
It's all in the title. I grabbed the definition from  a small test in with a gcc toolchain, I hope it's correct.

There's currently no tests around newlib in the CI. Would it be possible to add them ? If so, how ?