### PR TITLE
Update Fuchsia open flags

### DIFF
--- a/src/unix/notbsd/linux/musl/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/musl/b64/aarch64.rs
@@ -62,10 +62,15 @@ s! {
     }
 }
 
-pub const O_DIRECT: ::c_int = 0x10000;
-pub const O_DIRECTORY: ::c_int = 0x4000;
-pub const O_LARGEFILE: ::c_int = 0x20000;
-pub const O_NOFOLLOW: ::c_int = 0x8000;
+cfg_if! {
+    if #[cfg(not(target_os = "fuchsia"))] {
+        pub const O_DIRECT: ::c_int = 0x10000;
+        pub const O_DIRECTORY: ::c_int = 0x4000;
+        pub const O_LARGEFILE: ::c_int = 0x20000;
+        pub const O_NOFOLLOW: ::c_int = 0x8000;
+    } else {
+    }
+}
 
 pub const MINSIGSTKSZ: ::size_t = 6144;
 pub const SIGSTKSZ: ::size_t = 12288;

--- a/src/unix/notbsd/linux/musl/b64/mod.rs
+++ b/src/unix/notbsd/linux/musl/b64/mod.rs
@@ -134,8 +134,6 @@ s! {
 pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 56;
 pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
 
-pub const O_ASYNC: ::c_int = 0x2000;
-
 pub const FIOCLEX: ::c_int = 0x5451;
 pub const FIONBIO: ::c_int = 0x5421;
 
@@ -145,14 +143,29 @@ pub const RLIMIT_AS: ::c_int = 9;
 pub const RLIMIT_NPROC: ::c_int = 6;
 pub const RLIMIT_MEMLOCK: ::c_int = 8;
 
-pub const O_APPEND: ::c_int = 1024;
-pub const O_CREAT: ::c_int = 64;
-pub const O_EXCL: ::c_int = 128;
-pub const O_NOCTTY: ::c_int = 256;
-pub const O_NONBLOCK: ::c_int = 2048;
-pub const O_SYNC: ::c_int = 1052672;
-pub const O_RSYNC: ::c_int = 1052672;
-pub const O_DSYNC: ::c_int = 4096;
+cfg_if! {
+    if #[cfg(target_os = "fuchsia")] {
+        pub const O_ASYNC:  ::c_int = 0x00000400;
+        pub const O_APPEND: ::c_int = 0x00100000;
+        pub const O_CREAT:  ::c_int = 0x00010000;
+        pub const O_EXCL:   ::c_int = 0x00020000;
+        pub const O_NOCTTY: ::c_int = 0x00000200;
+        pub const O_NONBLOCK: ::c_int = 0x00000010;
+        pub const O_SYNC:   ::c_int = (0x00000040 | O_DSYNC);
+        pub const O_RSYNC:  ::c_int = O_SYNC;
+        pub const O_DSYNC:  ::c_int = 0x00000020;
+    } else {
+        pub const O_ASYNC: ::c_int = 0x2000;
+        pub const O_APPEND: ::c_int = 1024;
+        pub const O_CREAT: ::c_int = 64;
+        pub const O_EXCL: ::c_int = 128;
+        pub const O_NOCTTY: ::c_int = 256;
+        pub const O_NONBLOCK: ::c_int = 2048;
+        pub const O_SYNC: ::c_int = 1052672;
+        pub const O_RSYNC: ::c_int = 1052672;
+        pub const O_DSYNC: ::c_int = 4096;
+    }
+}
 
 pub const SOCK_NONBLOCK: ::c_int = 2048;
 

--- a/src/unix/notbsd/linux/musl/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/musl/b64/powerpc64.rs
@@ -66,10 +66,16 @@ pub const SYS_perf_event_open: ::c_long = 319;
 pub const SYS_memfd_create: ::c_long = 360;
 
 pub const MAP_32BIT: ::c_int = 0x0040;
-pub const O_DIRECT: ::c_int = 0x4000;
-pub const O_DIRECTORY: ::c_int = 0x10000;
-pub const O_LARGEFILE: ::c_int = 0;
-pub const O_NOFOLLOW: ::c_int = 0x20000;
+
+cfg_if! {
+    if #[cfg(not(target_os = "fuchsia"))] {
+        pub const O_DIRECT: ::c_int = 0x4000;
+        pub const O_DIRECTORY: ::c_int = 0x10000;
+        pub const O_LARGEFILE: ::c_int = 0;
+        pub const O_NOFOLLOW: ::c_int = 0x20000;
+    } else {
+    }
+}
 
 pub const SIGSTKSZ: ::size_t = 8192;
 pub const MINSIGSTKSZ: ::size_t = 2048;

--- a/src/unix/notbsd/linux/musl/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/musl/b64/x86_64.rs
@@ -437,10 +437,16 @@ pub const FS: ::c_int = 25;
 pub const GS: ::c_int = 26;
 
 pub const MAP_32BIT: ::c_int = 0x0040;
-pub const O_DIRECT: ::c_int = 0x4000;
-pub const O_DIRECTORY: ::c_int = 0x10000;
-pub const O_LARGEFILE: ::c_int = 0;
-pub const O_NOFOLLOW: ::c_int = 0x20000;
+
+cfg_if! {
+    if #[cfg(not(target_os = "fuchsia"))] {
+        pub const O_DIRECT: ::c_int = 0x4000;
+        pub const O_DIRECTORY: ::c_int = 0x10000;
+        pub const O_LARGEFILE: ::c_int = 0;
+        pub const O_NOFOLLOW: ::c_int = 0x20000;
+    } else {
+    }
+}
 
 pub const SIGSTKSZ: ::size_t = 8192;
 pub const MINSIGSTKSZ: ::size_t = 2048;

--- a/src/unix/notbsd/linux/musl/mod.rs
+++ b/src/unix/notbsd/linux/musl/mod.rs
@@ -87,10 +87,42 @@ pub const SFD_CLOEXEC: ::c_int = 0x080000;
 
 pub const NCCS: usize = 32;
 
-pub const O_TRUNC: ::c_int = 512;
-pub const O_NOATIME: ::c_int = 0o1000000;
-pub const O_CLOEXEC: ::c_int = 0x80000;
-pub const O_TMPFILE: ::c_int = 0o20000000 | O_DIRECTORY;
+cfg_if! {
+    if #[cfg(target_os = "fuchsia")] {
+        pub const O_TRUNC: ::c_int = 0x00040000;
+        pub const O_NOATIME: ::c_int = 0x00002000;
+        pub const O_CLOEXEC: ::c_int = 0x00000100;
+        pub const O_TMPFILE: ::c_int = 0x00004000;
+        pub const O_PATH: ::c_int = 0x00400000;
+        pub const O_EXEC: ::c_int = O_PATH;
+        pub const O_SEARCH: ::c_int = O_PATH;
+        pub const O_ACCMODE: ::c_int = (03 | O_SEARCH);
+        pub const O_NDELAY: ::c_int = O_NONBLOCK;
+
+        // These constants are typically defined per-architecture, but they're
+        // the same across all fuchsia architectures.
+        pub const O_DIRECTORY: ::c_int = 0x00080000;
+        pub const O_DIRECT:    ::c_int = 0x00000800;
+        pub const O_LARGEFILE: ::c_int = 0x00001000;
+        pub const O_NOFOLLOW:  ::c_int = 0x00000080;
+
+        // These constants are fuchsia-specific.
+        // They don't appear in libc on other platforms.
+        pub const O_NOREMOTE: ::c_int = 0x00200000;
+        pub const O_ADMIN:    ::c_int = 0x00000004;
+        pub const O_PIPELINE: ::c_int = 0x80000000;
+    } else {
+        pub const O_TRUNC: ::c_int = 512;
+        pub const O_NOATIME: ::c_int = 0o1000000;
+        pub const O_CLOEXEC: ::c_int = 0x80000;
+        pub const O_TMPFILE: ::c_int = 0o20000000 | O_DIRECTORY;
+        pub const O_PATH: ::c_int = 0o10000000;
+        pub const O_EXEC: ::c_int = 0o10000000;
+        pub const O_SEARCH: ::c_int = 0o10000000;
+        pub const O_ACCMODE: ::c_int = 0o10000003;
+        pub const O_NDELAY: ::c_int = O_NONBLOCK;
+    }
+}
 
 pub const EBFONT: ::c_int = 59;
 pub const ENOSTR: ::c_int = 60;
@@ -119,11 +151,6 @@ pub const EFD_CLOEXEC: ::c_int = 0x80000;
 pub const BUFSIZ: ::c_uint = 1024;
 pub const TMP_MAX: ::c_uint = 10000;
 pub const FOPEN_MAX: ::c_uint = 1000;
-pub const O_PATH: ::c_int = 0o10000000;
-pub const O_EXEC: ::c_int = 0o10000000;
-pub const O_SEARCH: ::c_int = 0o10000000;
-pub const O_ACCMODE: ::c_int = 0o10000003;
-pub const O_NDELAY: ::c_int = O_NONBLOCK;
 pub const NI_MAXHOST: ::socklen_t = 255;
 pub const PTHREAD_STACK_MIN: ::size_t = 2048;
 pub const POSIX_FADV_DONTNEED: ::c_int = 4;


### PR DESCRIPTION
These are being changed internally-- see [here](https://fuchsia-review.googlesource.com/c/zircon/+/83959/15/third_party/ulib/musl/include/fcntl.h#57).

I wasn't sure about the best way to cfg the entries that were architecture specific, so I just blocked them out and inserted them at a higher level. Let me know if there's a better way to organize the cfgs.

cc @smklein