### PR TITLE
Remove PORT_SOURCE_SIGNAL from Solaris

### DIFF
--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -1171,7 +1171,6 @@ pub const PORT_SOURCE_ALERT: ::c_int = 5;
 pub const PORT_SOURCE_MQ: ::c_int = 6;
 pub const PORT_SOURCE_FILE: ::c_int = 7;
 pub const PORT_SOURCE_POSTWAIT: ::c_int = 8;
-pub const PORT_SOURCE_SIGNAL: ::c_int = 9;
 
 f! {
     pub fn FD_CLR(fd: ::c_int, set: *mut fd_set) -> () {


### PR DESCRIPTION
There is no PORT_SOURCE_SIGNAL for any Solaris or illumos version.