### PR TITLE
Add `net/if_utun.h` and `linux/if_tun.h` constants for macos and linux platform

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -169,6 +169,7 @@ fn main() {
         cfg.header("xlocale.h");
         cfg.header("sys/xattr.h");
         cfg.header("sys/sys_domain.h");
+        cfg.header("net/if_utun.h");
         if target.starts_with("x86") {
             cfg.header("crt_externs.h");
         }
@@ -264,6 +265,7 @@ fn main() {
         cfg.header("linux/random.h");
         cfg.header("elf.h");
         cfg.header("link.h");
+        cfg.header("linux/if_tun.h");
     }
 
     if freebsd {

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -2071,7 +2071,6 @@ pub const MH_MAGIC: u32 = 0xfeedface;
 pub const MH_MAGIC_64: u32 = 0xfeedfacf;
 
 // net/if_utun.h
-pub const UTUN_CONTROL_NAME: &'static str = "com.apple.net.utun_control";
 pub const UTUN_OPT_FLAGS: ::c_int = 1;
 pub const UTUN_OPT_IFNAME: ::c_int = 2;
 

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1523,7 +1523,7 @@ pub const MSG_RCVMORE: ::c_int = 0x4000;
 pub const SCM_TIMESTAMP: ::c_int = 0x02;
 pub const SCM_CREDS: ::c_int = 0x03;
 
-/// https://github.com/aosm/xnu/blob/master/bsd/net/if.h#L140-L156
+// https://github.com/aosm/xnu/blob/master/bsd/net/if.h#L140-L156
 pub const IFF_UP: ::c_int          = 0x1;  // interface is up
 pub const IFF_BROADCAST: ::c_int   = 0x2;  // broadcast address valid
 pub const IFF_DEBUG: ::c_int       = 0x4;  // turn on debugging
@@ -2069,6 +2069,11 @@ pub const LC_SEGMENT_64: u32 = 0x19;
 
 pub const MH_MAGIC: u32 = 0xfeedface;
 pub const MH_MAGIC_64: u32 = 0xfeedfacf;
+
+// net/if_utun.h
+pub const UTUN_CONTROL_NAME: &'static str = "com.apple.net.utun_control";
+pub const UTUN_OPT_FLAGS: ::c_int = 1;
+pub const UTUN_OPT_IFNAME: ::c_int = 2;
 
 f! {
     pub fn WSTOPSIG(status: ::c_int) -> ::c_int {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -210,6 +210,7 @@ pub const S_ISGID: ::c_int = 0x400;
 pub const S_ISVTX: ::c_int = 0x200;
 
 pub const IF_NAMESIZE: ::size_t = 16;
+pub const IFNAMSIZ: ::size_t = IF_NAMESIZE;
 
 pub const LOG_EMERG: ::c_int = 0;
 pub const LOG_ALERT: ::c_int = 1;

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -726,6 +726,28 @@ pub const IFF_LOWER_UP: ::c_int = 0x10000;
 pub const IFF_DORMANT: ::c_int = 0x20000;
 pub const IFF_ECHO: ::c_int = 0x40000;
 
+// linux/if_tun.h
+// Read queue size
+pub const TUN_READQ_SIZE: ::c_short = 500;
+// TUN device type flags: deprecated. Use IFF_TUN/IFF_TAP instead.
+pub const TUN_TUN_DEV: ::c_short   = IFF_TUN;
+pub const TUN_TAP_DEV: ::c_short   = IFF_TAP;
+pub const TUN_TYPE_MASK: ::c_short = 0x000f;
+// TUNSETIFF ifr flags
+pub const IFF_TUN: ::c_short        = 0x0001;
+pub const IFF_TAP: ::c_short        = 0x0002;
+pub const IFF_NO_PI: ::c_short      = 0x1000;
+// This flag has no real effect
+pub const IFF_ONE_QUEUE: ::c_short    = 0x2000;
+pub const IFF_VNET_HDR: ::c_short     = 0x4000;
+pub const IFF_TUN_EXCL: ::c_short     = 0x8000;
+pub const IFF_MULTI_QUEUE: ::c_short  = 0x0100;
+pub const IFF_ATTACH_QUEUE: ::c_short = 0x0200;
+pub const IFF_DETACH_QUEUE: ::c_short = 0x0400;
+// read-only flag
+pub const IFF_PERSIST: ::c_short  = 0x0800;
+pub const IFF_NOFILTER: ::c_short = 0x1000;
+
 pub const ST_RDONLY: ::c_ulong = 1;
 pub const ST_NOSUID: ::c_ulong = 2;
 pub const ST_NODEV: ::c_ulong = 4;


### PR DESCRIPTION
Add `net/if_utun.h` constants for macos platform.

Add `linux/if_tun.h` constants for linux platform.