### PR TITLE
Change deprecated constants into hidden constants

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -456,15 +456,15 @@ pub const IFF_LOOPBACK: ::c_int = 0x8; // (i) is a loopback net
 pub const IFF_POINTOPOINT: ::c_int = 0x10; // (i) is a point-to-point link
 // 0x20           was IFF_SMART
 pub const IFF_RUNNING: ::c_int = 0x40; // (d) resources allocated
-#[deprecated(since="0.2.34",
-             note="please use the portable `IFF_RUNNING` constant instead")]
+#[doc(hidden)]
+// IFF_DRV_RUNNING is deprecated.  Use the portable `IFF_RUNNING` instead
 pub const IFF_DRV_RUNNING: ::c_int = 0x40;
 pub const IFF_NOARP: ::c_int = 0x80; // (n) no address resolution protocol
 pub const IFF_PROMISC: ::c_int = 0x100; // (n) receive all packets
 pub const IFF_ALLMULTI: ::c_int = 0x200; // (n) receive all multicast packets
 pub const IFF_OACTIVE: ::c_int = 0x400; // (d) tx hardware queue is full
-#[deprecated(since="0.2.34",
-             note="please use the portable `IFF_OACTIVE` constant instead")]
+#[doc(hidden)]
+// IFF_DRV_OACTIVE is deprecated.  Use the portable `IFF_OACTIVE` instead
 pub const IFF_DRV_OACTIVE: ::c_int = 0x400;
 pub const IFF_SIMPLEX: ::c_int = 0x800; // (i) can't hear own transmissions
 pub const IFF_LINK0: ::c_int = 0x1000; // per link layer defined bit


### PR DESCRIPTION
rustc, an important libc consumer, has a policy that they can't use any
crates with deprecated symbols.  Replace libc's two deprecated symbols
with hidden symbols instead.