### PR TITLE
Add _SC_NPROCESSORS_ONLN for CloudABI.

### DIFF
--- a/src/cloudabi/mod.rs
+++ b/src/cloudabi/mod.rs
@@ -55,6 +55,7 @@ s! {
     }
 }
 
+pub const _SC_NPROCESSORS_ONLN: ::c_int = 52;
 pub const _SC_PAGESIZE: ::c_int = 54;
 
 pub const AF_INET: ::c_int = 1;


### PR DESCRIPTION
This constant is not used by the C library, which is why I didn't add it
initially. It is, however, used by libtest to determine the parallelism
for the execution of tests.