### PR TITLE
Add time_t for CloudABI.

### DIFF
--- a/src/cloudabi/mod.rs
+++ b/src/cloudabi/mod.rs
@@ -4,6 +4,7 @@ pub type pthread_key_t = usize;
 pub type pthread_t = usize;
 pub type sa_family_t = u8;
 pub type socklen_t = usize;
+pub type time_t = i64;
 
 s! {
     pub struct addrinfo {


### PR DESCRIPTION
Even though this data type is not used by libstd in any platform
independent code, one of the unit tests in src/libstd/time/mod.rs refers
to it. Instead of making that unit test more complicated, simply add
time_t, matching the type used by the C library.