### PR TITLE
Add support for cfg(target_family = "none")

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,6 +295,11 @@ cfg_if! {
     } else if #[cfg(unix)] {
         mod unix;
         pub use unix::*;
+    } else if #[cfg(target_family = "none")] {
+        pub type c_char = c_uchar;
+        pub type c_long = c_int;
+        pub type c_ulong = c_uint;
+        pub type wchar_t = c_int;
     } else {
         // Unknown target_family
     }


### PR DESCRIPTION
When working on bare-metal platforms, it is often useful to have
Rust code interoperate with existing C code. In such cases,
the target will typically have a minimal, non-standards-compliant
in terms of completeness libc, exporting at least the most basic
library functions like memcpy (this libc could even be provided
via the rlibc crate).

To interoperate with the C code on such platforms, it is useful
to have libc types defined, especially so when using existing
crates that provide bindings to libraries (the motivating
example for this change is the libunwind crate, which binds
to libunwind, which has recently gained[1] first-class support
for bare-metal platforms). However, right now, the libc crate
cannot be built for #[cfg(target_family = "none")] because
of missing definitions for basic types such as c_char.

This commit provides a set of reasonable default aliases.
These will likely not be correct for every platform, and should
be refined in the future.

[1]: https://github.com/llvm-mirror/libunwind/commit/0b964a1ed14cfc93e1c9487f7cf14af8c7bc26ec

Discuss? I intend this to be a first step.