### PR TITLE
Minor fixes for CloudABI ARM support

### DIFF
--- a/src/cloudabi/aarch64.rs
+++ b/src/cloudabi/aarch64.rs
@@ -1,4 +1,4 @@
-pub type c_char = i8;
+pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type wchar_t = u32;

--- a/src/cloudabi/arm.rs
+++ b/src/cloudabi/arm.rs
@@ -1,0 +1,4 @@
+pub type c_char = u8;
+pub type c_long = i32;
+pub type c_ulong = u32;
+pub type wchar_t = u32;

--- a/src/cloudabi/mod.rs
+++ b/src/cloudabi/mod.rs
@@ -151,6 +151,9 @@ cfg_if! {
     if #[cfg(target_arch = "aarch64")] {
         mod aarch64;
         pub use self::aarch64::*;
+    } else if #[cfg(any(target_arch = "arm"))] {
+        mod arm;
+        pub use self::arm::*;
     } else if #[cfg(any(target_arch = "x86"))] {
         mod x86;
         pub use self::x86::*;


### PR DESCRIPTION
In the initial set of fixes for CloudABI, it looks like support for 32-bit ARM was left out, even though it is supported for C/C++. While there, fix up `c_char` for ARM64, which currently has the wrong sign.