### PR TITLE
added EPOLL(5)  for Illumos (Solaris fork) 

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -215,7 +215,7 @@ fn main() {
             cfg.header("sys/reg.h");
         }
     }
-
+ 
     if linux || android || emscripten {
         cfg.header("malloc.h");
         cfg.header("net/ethernet.h");
@@ -250,6 +250,9 @@ fn main() {
             }
         }
     }
+    if solaris {
+        cfg.header("sys/epoll.h");
+   }
 
     if linux || android {
         cfg.header("sys/fsuid.h");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,8 +144,10 @@ cfg_if! {
         pub type intptr_t = isize;
         pub type uintptr_t = usize;
         pub type ssize_t = isize;
+
         pub enum FILE {}
         pub enum fpos_t {} // TODO: fill this out with a struct
+
         extern {
             pub fn isalnum(c: c_int) -> c_int;
             pub fn isalpha(c: c_int) -> c_int;
@@ -291,7 +293,7 @@ cfg_if! {
         mod fuchsia;
         pub use fuchsia::*;
     } else if #[cfg(unix)] {
-        pub mod unix;
+        mod unix;
         pub use unix::*;
     } else {
         // Unknown target_family

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,6 @@ cfg_if! {
         pub type ssize_t = isize;
         pub enum FILE {}
         pub enum fpos_t {} // TODO: fill this out with a struct
-        pub const EPOLLRDHUP: c_int = 8192;
         extern {
             pub fn isalnum(c: c_int) -> c_int;
             pub fn isalpha(c: c_int) -> c_int;
@@ -279,7 +278,10 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(windows)] {
+     if#[cfg(target_os = "solaris")] {
+        mod unix;
+        pub use unix::*;
+    } else if #[cfg(windows)] {
         mod windows;
         pub use windows::*;
     } else if #[cfg(target_os = "redox")] {
@@ -296,5 +298,7 @@ cfg_if! {
         pub use unix::*;
     } else {
         // Unknown target_family
+        mod unix;
+        pub use unix::*;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,10 +278,7 @@ cfg_if! {
 }
 
 cfg_if! {
-     if#[cfg(target_os = "solaris")] {
-        mod unix;
-        pub use unix::*;
-    } else if #[cfg(windows)] {
+    if #[cfg(windows)] {
         mod windows;
         pub use windows::*;
     } else if #[cfg(target_os = "redox")] {
@@ -298,7 +295,5 @@ cfg_if! {
         pub use unix::*;
     } else {
         // Unknown target_family
-        mod unix;
-        pub use unix::*;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,10 +144,9 @@ cfg_if! {
         pub type intptr_t = isize;
         pub type uintptr_t = usize;
         pub type ssize_t = isize;
-
         pub enum FILE {}
         pub enum fpos_t {} // TODO: fill this out with a struct
-
+        pub const EPOLLRDHUP: c_int = 8192;
         extern {
             pub fn isalnum(c: c_int) -> c_int;
             pub fn isalpha(c: c_int) -> c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,6 +293,9 @@ cfg_if! {
     } else if #[cfg(unix)] {
         mod unix;
         pub use unix::*;
+    }  else if #[cfg(target_os = "solaris")] {
+        mod unix;
+        pub use unix::solaris;
     } else {
         // Unknown target_family
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,9 +293,6 @@ cfg_if! {
     } else if #[cfg(unix)] {
         mod unix;
         pub use unix::*;
-    }  else if #[cfg(target_os = "solaris")] {
-        mod unix;
-        pub use unix::solaris;
     } else {
         // Unknown target_family
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,7 +291,7 @@ cfg_if! {
         mod fuchsia;
         pub use fuchsia::*;
     } else if #[cfg(unix)] {
-        mod unix;
+        pub mod unix;
         pub use unix::*;
     } else {
         // Unknown target_family

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -1137,6 +1137,11 @@ pub const NCCS: usize = 19;
 
 pub const LOG_CRON: ::c_int = 15 << 3;
 
+pub const SYS_epoll_create: ::c_long = 213;
+pub const SYS_epoll_create1: ::c_long = 291;
+
+
+
 pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
     __pthread_mutex_flag1: 0,
     __pthread_mutex_flag2: 0,

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -353,6 +353,13 @@ s! {
         pub portev_object: ::uintptr_t,
         pub portev_user: *mut ::c_void,
     }
+
+    pub struct epoll_event {
+        pub events: ::uint32_t,
+        pub u64: ::uint64_t,
+    }
+
+
 }
 
 pub const LC_CTYPE: ::c_int = 0;
@@ -1361,6 +1368,26 @@ extern {
                        oss: *mut stack_t) -> ::c_int;
     pub fn sem_close(sem: *mut sem_t) -> ::c_int;
     pub fn getdtablesize() -> ::c_int;
+
+    pub fn epoll_pwait(epfd: ::c_int,
+                       events: *mut ::epoll_event,
+                       maxevents: ::c_int,
+                       timeout: ::c_int,
+                       sigmask: *const ::sigset_t) -> ::c_int;
+ 
+    pub fn epoll_create(size: ::c_int) -> ::c_int;
+    pub fn epoll_create1(flags: ::c_int) -> ::c_int;
+    pub fn epoll_wait(epfd: ::c_int,
+                      events: *mut ::epoll_event,
+                      maxevents: ::c_int,
+                      timeout: ::c_int) -> ::c_int;
+    pub fn epoll_ctl(epfd: ::c_int,
+                     op: ::c_int,
+                     fd: ::c_int,
+                     event: *mut ::epoll_event) -> ::c_int;
+ 
+
+
     #[cfg_attr(target_os = "solaris", link_name = "__posix_getgrnam_r")]
     pub fn getgrnam_r(name: *const ::c_char,
                       grp: *mut ::group,

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -36,9 +36,6 @@ pub type nl_item = ::c_int;
 pub type id_t = ::c_int;
 pub type idtype_t = ::c_uint;
 
-
-
-
 pub enum timezone {}
 
 s! {
@@ -361,8 +358,6 @@ s! {
         pub events: ::uint32_t,
         pub u64: ::uint64_t,
     }
-
-
 }
 
 pub const LC_CTYPE: ::c_int = 0;
@@ -1140,8 +1135,6 @@ pub const LOG_CRON: ::c_int = 15 << 3;
 pub const SYS_epoll_create: ::c_long = 213;
 pub const SYS_epoll_create1: ::c_long = 291;
 
-
-
 pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
     __pthread_mutex_flag1: 0,
     __pthread_mutex_flag2: 0,
@@ -1215,8 +1208,6 @@ pub const EPOLL_CLOEXEC: ::c_int = 0x02000000;
 pub const EPOLL_CTL_ADD: ::c_int = 1;
 pub const EPOLL_CTL_MOD: ::c_int = 3;
 pub const EPOLL_CTL_DEL: ::c_int = 2;
-
-
 
 f! {
     pub fn FD_CLR(fd: ::c_int, set: *mut fd_set) -> () {
@@ -1403,7 +1394,6 @@ extern {
                        maxevents: ::c_int,
                        timeout: ::c_int,
                        sigmask: *const ::sigset_t) -> ::c_int;
- 
     pub fn epoll_create(size: ::c_int) -> ::c_int;
     pub fn epoll_create1(flags: ::c_int) -> ::c_int;
     pub fn epoll_wait(epfd: ::c_int,
@@ -1414,8 +1404,6 @@ extern {
                      op: ::c_int,
                      fd: ::c_int,
                      event: *mut ::epoll_event) -> ::c_int;
- 
-
 
     #[cfg_attr(target_os = "solaris", link_name = "__posix_getgrnam_r")]
     pub fn getgrnam_r(name: *const ::c_char,

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -36,6 +36,25 @@ pub type nl_item = ::c_int;
 pub type id_t = ::c_int;
 pub type idtype_t = ::c_uint;
 
+pub const EPOLLIN: ::c_int = 0x1;
+pub const EPOLLPRI: ::c_int = 0x2;
+pub const EPOLLOUT: ::c_int = 0x4;
+pub const EPOLLRDNORM: ::c_int = 0x40;
+pub const EPOLLRDBAND: ::c_int = 0x80;
+pub const EPOLLWRNORM: ::c_int = 0x100;
+pub const EPOLLWRBAND: ::c_int = 0x200;
+pub const EPOLLMSG: ::c_int = 0x400;
+pub const EPOLLERR: ::c_int = 0x8;
+pub const EPOLLHUP: ::c_int = 0x10;
+pub const EPOLLET: ::c_int = 0x80000000;
+
+pub const EPOLL_CTL_ADD: ::c_int = 1;
+pub const EPOLL_CTL_MOD: ::c_int = 3;
+pub const EPOLL_CTL_DEL: ::c_int = 2;
+
+
+
+
 pub enum timezone {}
 
 s! {

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -36,25 +36,6 @@ pub type nl_item = ::c_int;
 pub type id_t = ::c_int;
 pub type idtype_t = ::c_uint;
 
-pub const EPOLLIN: ::c_int = 0x1;
-pub const EPOLLPRI: ::c_int = 0x2;
-pub const EPOLLOUT: ::c_int = 0x4;
-pub const EPOLLRDNORM: ::c_int = 0x40;
-pub const EPOLLRDBAND: ::c_int = 0x80;
-pub const EPOLLWRNORM: ::c_int = 0x100;
-pub const EPOLLWRBAND: ::c_int = 0x200;
-pub const EPOLLMSG: ::c_int = 0x400;
-pub const EPOLLERR: ::c_int = 0x8;
-pub const EPOLLHUP: ::c_int = 0x10;
-pub const EPOLLET: ::c_int = 0x80000000;
-pub const EPOLLRDHUP: ::c_int = 0x2000;
-pub const EPOLLEXCLUSIVE: ::c_int = 0x10000000;
-pub const EPOLLONESHOT: ::c_int = 0x40000000;
-pub const EPOLL_CLOEXEC: ::c_int = 0x02000000;
-pub const EPOLL_CTL_ADD: ::c_int = 1;
-pub const EPOLL_CTL_MOD: ::c_int = 3;
-pub const EPOLL_CTL_DEL: ::c_int = 2;
-
 
 
 
@@ -1210,6 +1191,27 @@ pub const PORT_SOURCE_MQ: ::c_int = 6;
 pub const PORT_SOURCE_FILE: ::c_int = 7;
 pub const PORT_SOURCE_POSTWAIT: ::c_int = 8;
 pub const PORT_SOURCE_SIGNAL: ::c_int = 9;
+
+pub const EPOLLIN: ::c_int = 0x1;
+pub const EPOLLPRI: ::c_int = 0x2;
+pub const EPOLLOUT: ::c_int = 0x4;
+pub const EPOLLRDNORM: ::c_int = 0x40;
+pub const EPOLLRDBAND: ::c_int = 0x80;
+pub const EPOLLWRNORM: ::c_int = 0x100;
+pub const EPOLLWRBAND: ::c_int = 0x200;
+pub const EPOLLMSG: ::c_int = 0x400;
+pub const EPOLLERR: ::c_int = 0x8;
+pub const EPOLLHUP: ::c_int = 0x10;
+pub const EPOLLET: ::c_int = 0x80000000;
+pub const EPOLLRDHUP: ::c_int = 0x2000;
+pub const EPOLLEXCLUSIVE: ::c_int = 0x10000000;
+pub const EPOLLONESHOT: ::c_int = 0x40000000;
+pub const EPOLL_CLOEXEC: ::c_int = 0x02000000;
+pub const EPOLL_CTL_ADD: ::c_int = 1;
+pub const EPOLL_CTL_MOD: ::c_int = 3;
+pub const EPOLL_CTL_DEL: ::c_int = 2;
+
+
 
 f! {
     pub fn FD_CLR(fd: ::c_int, set: *mut fd_set) -> () {

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -47,6 +47,10 @@ pub const EPOLLMSG: ::c_int = 0x400;
 pub const EPOLLERR: ::c_int = 0x8;
 pub const EPOLLHUP: ::c_int = 0x10;
 pub const EPOLLET: ::c_int = 0x80000000;
+pub const EPOLLRDHUP: ::c_int = 0x2000;
+pub const EPOLLEXCLUSIVE: ::c_int = 0x10000000;
+pub const EPOLLONESHOT: ::c_int = 0x40000000;
+
 
 pub const EPOLL_CTL_ADD: ::c_int = 1;
 pub const EPOLL_CTL_MOD: ::c_int = 3;

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -50,8 +50,7 @@ pub const EPOLLET: ::c_int = 0x80000000;
 pub const EPOLLRDHUP: ::c_int = 0x2000;
 pub const EPOLLEXCLUSIVE: ::c_int = 0x10000000;
 pub const EPOLLONESHOT: ::c_int = 0x40000000;
-
-
+pub const EPOLL_CLOEXEC: ::c_int = 0x02000000;
 pub const EPOLL_CTL_ADD: ::c_int = 1;
 pub const EPOLL_CTL_MOD: ::c_int = 3;
 pub const EPOLL_CTL_DEL: ::c_int = 2;


### PR DESCRIPTION
EPOLL(5)  is being used in crates like mio and iovec , this change allows those crates and other that depends on EPOLL(5)  to be built in illumos systems.