### PR TITLE
Add `IFF_*` constants  to linux, android and fuchsia

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -265,7 +265,7 @@ fn main() {
         cfg.header("sys/fsuid.h");
         cfg.header("linux/seccomp.h");
         cfg.header("linux/if_ether.h");
-
+        cfg.header("linux/if_tun.h");
         // DCCP support
         if !uclibc && !musl && !emscripten {
             cfg.header("linux/dccp.h");
@@ -280,7 +280,6 @@ fn main() {
         cfg.header("linux/random.h");
         cfg.header("elf.h");
         cfg.header("link.h");
-        cfg.header("linux/if_tun.h");
         cfg.header("spawn.h");
     }
 

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -1351,6 +1351,9 @@ pub const IFF_MULTICAST: ::c_int = 0x1000;
 pub const IFF_PORTSEL: ::c_int = 0x2000;
 pub const IFF_AUTOMEDIA: ::c_int = 0x4000;
 pub const IFF_DYNAMIC: ::c_int = 0x8000;
+pub const IFF_TUN: ::c_int = 0x0001;
+pub const IFF_TAP: ::c_int = 0x0002;
+pub const IFF_NO_PI: ::c_int = 0x1000;
 
 pub const SOL_IP: ::c_int = 0;
 pub const SOL_TCP: ::c_int = 6;

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -978,6 +978,10 @@ pub const NFT_MSG_DELOBJ: ::c_int = 20;
 pub const NFT_MSG_GETOBJ_RESET: ::c_int = 21;
 pub const NFT_MSG_MAX: ::c_int = 22;
 
+pub const IFF_TUN: ::c_int = 0x0001;
+pub const IFF_TAP: ::c_int = 0x0002;
+pub const IFF_NO_PI: ::c_int = 0x1000;
+
 f! {
     pub fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {
         for slot in cpuset.__bits.iter_mut() {

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -756,16 +756,15 @@ pub const IFF_DORMANT: ::c_int = 0x20000;
 pub const IFF_ECHO: ::c_int = 0x40000;
 
 // linux/if_tun.h
+pub const IFF_TUN: ::c_short = 0x0001;
+pub const IFF_TAP: ::c_short = 0x0002;
+pub const IFF_NO_PI: ::c_short = 0x1000;
 // Read queue size
 pub const TUN_READQ_SIZE: ::c_short = 500;
 // TUN device type flags: deprecated. Use IFF_TUN/IFF_TAP instead.
-pub const TUN_TUN_DEV: ::c_short   = IFF_TUN;
-pub const TUN_TAP_DEV: ::c_short   = IFF_TAP;
+pub const TUN_TUN_DEV: ::c_short   = ::IFF_TUN;
+pub const TUN_TAP_DEV: ::c_short   = ::IFF_TAP;
 pub const TUN_TYPE_MASK: ::c_short = 0x000f;
-// TUNSETIFF ifr flags
-pub const IFF_TUN: ::c_short        = 0x0001;
-pub const IFF_TAP: ::c_short        = 0x0002;
-pub const IFF_NO_PI: ::c_short      = 0x1000;
 // This flag has no real effect
 pub const IFF_ONE_QUEUE: ::c_short    = 0x2000;
 pub const IFF_VNET_HDR: ::c_short     = 0x4000;


### PR DESCRIPTION
Add constants to android and fuchsia:

*    IFF_TUN
*    IFF_TAP
*    IFF_NO_PI

Type problem: https://github.com/rust-lang/libc/issues/915

so change constants type `libc::c_short` to `libc::c_int` :

*    IFF_*
