### PR TITLE
Added ucred (sockpeercred) for OpenBSD and Bitrig

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
@@ -14,6 +14,7 @@ pub type pthread_cond_t = *mut ::c_void;
 pub type pthread_condattr_t = *mut ::c_void;
 pub type pthread_rwlock_t = *mut ::c_void;
 pub type pthread_rwlockattr_t = *mut ::c_void;
+pub type ucred = ::sockpeercred;
 
 s! {
     pub struct dirent {
@@ -186,6 +187,12 @@ s! {
         pub sdl_alen: ::c_uchar,
         pub sdl_slen: ::c_uchar,
         pub sdl_data: [::c_char; 24],
+    }
+
+    pub struct sockpeercred {
+        pub uid: ::uid_t,
+        pub gid: ::gid_t,
+        pub pid: ::pid_t,
     }
 }
 


### PR DESCRIPTION
OpenBSD and Bitrig has `struct ucred`implemented in the way it is used in `getsockopt(2)` with `SOL_SOCKET` and `SO_PEERCRED`. However, it is called `struct sockpeercred`.

Source: https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/sys/sys/socket.h?rev=1.65&content-type=text/x-cvsweb-markup

I added a type alias for `ucred` to enable Linux compatibility, but I'm not sure this is the correct way to do it.