### PR TITLE
Arguments of pledge(2) changed.

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsdlike/bitrig/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/bitrig/mod.rs
@@ -73,6 +73,8 @@ extern {
                      locale: *const ::c_char,
                      base: ::locale_t) -> ::locale_t;
     pub fn uselocale(loc: ::locale_t) -> ::locale_t;
+    pub fn pledge(promises: *const ::c_char,
+                  paths: *mut *const ::c_char) -> ::c_int;
     pub fn querylocale(mask: ::c_int, loc: ::locale_t) -> *const ::c_char;
 }
 

--- a/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
@@ -738,8 +738,6 @@ extern {
                   newlen: ::size_t)
                   -> ::c_int;
     pub fn getentropy(buf: *mut ::c_void, buflen: ::size_t) -> ::c_int;
-    pub fn pledge(promises: *const ::c_char,
-                  paths: *mut *const ::c_char) -> ::c_int;
     pub fn setresgid(rgid: ::gid_t, egid: ::gid_t, sgid: ::gid_t) -> ::c_int;
     pub fn setresuid(ruid: ::uid_t, euid: ::uid_t, suid: ::uid_t) -> ::c_int;
 }

--- a/src/unix/bsd/netbsdlike/openbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/openbsd/mod.rs
@@ -32,6 +32,8 @@ extern {
                    addrlen: *mut ::socklen_t, flags: ::c_int) -> ::c_int;
     pub fn execvpe(file: *const ::c_char, argv: *const *const ::c_char,
                    envp: *const *const ::c_char) -> ::c_int;
+    pub fn pledge(promises: *const ::c_char,
+                  execpromises: *const ::c_char) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
The arguments of pledge(2) have changed. However, the changes have to yet been propagated to Bitrig.

https://marc.info/?l=openbsd-tech&m=151268831628549&w=2
