### PR TITLE
Recycle IFF_NOTRAILERS into IFF_STATICARP in OpenBSD but not in Bitrig.

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsdlike/bitrig/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/bitrig/mod.rs
@@ -65,6 +65,24 @@ pub const ALTMON_12: ::nl_item = 69;
 
 pub const KERN_RND: ::c_int = 31;
 
+// https://github.com/bitrig/bitrig/blob/master/sys/net/if.h#L187
+pub const IFF_UP: ::c_int = 0x1; // interface is up
+pub const IFF_BROADCAST: ::c_int = 0x2; // broadcast address valid
+pub const IFF_DEBUG: ::c_int = 0x4; // turn on debugging
+pub const IFF_LOOPBACK: ::c_int = 0x8; // is a loopback net
+pub const IFF_POINTOPOINT: ::c_int = 0x10; // interface is point-to-point link
+pub const IFF_NOTRAILERS: ::c_int = 0x20; // avoid use of trailers
+pub const IFF_RUNNING: ::c_int = 0x40; // resources allocated
+pub const IFF_NOARP: ::c_int = 0x80; // no address resolution protocol
+pub const IFF_PROMISC: ::c_int = 0x100; // receive all packets
+pub const IFF_ALLMULTI: ::c_int = 0x200; // receive all multicast packets
+pub const IFF_OACTIVE: ::c_int = 0x400; // transmission in progress
+pub const IFF_SIMPLEX: ::c_int = 0x800; // can't hear own transmissions
+pub const IFF_LINK0: ::c_int = 0x1000; // per link layer defined bit
+pub const IFF_LINK1: ::c_int = 0x2000; // per link layer defined bit
+pub const IFF_LINK2: ::c_int = 0x4000; // per link layer defined bit
+pub const IFF_MULTICAST: ::c_int = 0x8000; // supports multicast
+
 extern {
     pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t) -> *mut ::c_char;
     pub fn duplocale(base: ::locale_t) -> ::locale_t;

--- a/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
@@ -243,24 +243,6 @@ pub const SO_RTABLE: ::c_int = 0x1021;
 pub const SO_PEERCRED: ::c_int = 0x1022;
 pub const SO_SPLICE: ::c_int = 0x1023;
 
-// https://github.com/openbsd/src/blob/master/sys/net/if.h#L187
-pub const IFF_UP: ::c_int = 0x1; // interface is up
-pub const IFF_BROADCAST: ::c_int = 0x2; // broadcast address valid
-pub const IFF_DEBUG: ::c_int = 0x4; // turn on debugging
-pub const IFF_LOOPBACK: ::c_int = 0x8; // is a loopback net
-pub const IFF_POINTOPOINT: ::c_int = 0x10; // interface is point-to-point link
-pub const IFF_NOTRAILERS: ::c_int = 0x20; // avoid use of trailers
-pub const IFF_RUNNING: ::c_int = 0x40; // resources allocated
-pub const IFF_NOARP: ::c_int = 0x80; // no address resolution protocol
-pub const IFF_PROMISC: ::c_int = 0x100; // receive all packets
-pub const IFF_ALLMULTI: ::c_int = 0x200; // receive all multicast packets
-pub const IFF_OACTIVE: ::c_int = 0x400; // transmission in progress
-pub const IFF_SIMPLEX: ::c_int = 0x800; // can't hear own transmissions
-pub const IFF_LINK0: ::c_int = 0x1000; // per link layer defined bit
-pub const IFF_LINK1: ::c_int = 0x2000; // per link layer defined bit
-pub const IFF_LINK2: ::c_int = 0x4000; // per link layer defined bit
-pub const IFF_MULTICAST: ::c_int = 0x8000; // supports multicast
-
 // sys/netinet/in.h
 // Protocols (RFC 1700)
 // NOTE: These are in addition to the constants defined in src/unix/mod.rs

--- a/src/unix/bsd/netbsdlike/openbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/openbsd/mod.rs
@@ -27,6 +27,24 @@ s! {
     }
 }
 
+// https://github.com/openbsd/src/blob/master/sys/net/if.h#L187
+pub const IFF_UP: ::c_int = 0x1; // interface is up
+pub const IFF_BROADCAST: ::c_int = 0x2; // broadcast address valid
+pub const IFF_DEBUG: ::c_int = 0x4; // turn on debugging
+pub const IFF_LOOPBACK: ::c_int = 0x8; // is a loopback net
+pub const IFF_POINTOPOINT: ::c_int = 0x10; // interface is point-to-point link
+pub const IFF_STATICARP: ::c_int = 0x20; // only static ARP
+pub const IFF_RUNNING: ::c_int = 0x40; // resources allocated
+pub const IFF_NOARP: ::c_int = 0x80; // no address resolution protocol
+pub const IFF_PROMISC: ::c_int = 0x100; // receive all packets
+pub const IFF_ALLMULTI: ::c_int = 0x200; // receive all multicast packets
+pub const IFF_OACTIVE: ::c_int = 0x400; // transmission in progress
+pub const IFF_SIMPLEX: ::c_int = 0x800; // can't hear own transmissions
+pub const IFF_LINK0: ::c_int = 0x1000; // per link layer defined bit
+pub const IFF_LINK1: ::c_int = 0x2000; // per link layer defined bit
+pub const IFF_LINK2: ::c_int = 0x4000; // per link layer defined bit
+pub const IFF_MULTICAST: ::c_int = 0x8000; // supports multicast
+
 extern {
     pub fn accept4(s: ::c_int, addr: *mut ::sockaddr,
                    addrlen: *mut ::socklen_t, flags: ::c_int) -> ::c_int;


### PR DESCRIPTION
https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/sys/net/if.h?rev=1.190&content-type=text/x-cvsweb-markup