### PR TITLE
Retract ucred type alias for sockpeercred from OpenBSD and Bitrig

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
@@ -14,7 +14,6 @@ pub type pthread_cond_t = *mut ::c_void;
 pub type pthread_condattr_t = *mut ::c_void;
 pub type pthread_rwlock_t = *mut ::c_void;
 pub type pthread_rwlockattr_t = *mut ::c_void;
-pub type ucred = ::sockpeercred;
 
 s! {
     pub struct dirent {


### PR DESCRIPTION
Introduced in [this](https://github.com/rust-lang/libc/pull/941) PR.