### PR TITLE
Fix test suite on FreeBSD 11

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -509,6 +509,7 @@ fn main() {
             "CTL_MAXID" |
             "KERN_MAXID" |
             "HW_MAXID" |
+            "NET_MAXID" |
             "USER_MAXID" if freebsd => true,
 
             // These constants were added in FreeBSD 11

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -3,7 +3,7 @@ pub type clock_t = i32;
 pub type ino_t = u32;
 pub type lwpid_t = i32;
 pub type nlink_t = u16;
-pub type blksize_t = u32;
+pub type blksize_t = i32;
 pub type clockid_t = ::c_int;
 pub type sem_t = _sem;
 
@@ -182,7 +182,9 @@ pub const EOWNERDEAD: ::c_int = 96;
 pub const ELAST: ::c_int = 96;
 pub const RLIMIT_NPTS: ::c_int = 11;
 pub const RLIMIT_SWAP: ::c_int = 12;
-pub const RLIM_NLIMITS: ::rlim_t = 13;
+pub const RLIMIT_KQUEUES: ::c_int = 13;
+pub const RLIMIT_UMTXP: ::c_int = 14;
+pub const RLIM_NLIMITS: ::rlim_t = 15;
 
 pub const Q_GETQUOTA: ::c_int = 0x700;
 pub const Q_SETQUOTA: ::c_int = 0x800;
@@ -801,10 +803,10 @@ pub const SHUTDOWN_TIME: ::c_short = 8;
 
 pub const LC_COLLATE_MASK: ::c_int = (1 << 0);
 pub const LC_CTYPE_MASK: ::c_int = (1 << 1);
-pub const LC_MESSAGES_MASK: ::c_int = (1 << 2);
-pub const LC_MONETARY_MASK: ::c_int = (1 << 3);
-pub const LC_NUMERIC_MASK: ::c_int = (1 << 4);
-pub const LC_TIME_MASK: ::c_int = (1 << 5);
+pub const LC_MONETARY_MASK: ::c_int =(1 << 2);
+pub const LC_NUMERIC_MASK: ::c_int = (1 << 3);
+pub const LC_TIME_MASK: ::c_int = (1 << 4);
+pub const LC_MESSAGES_MASK: ::c_int = (1 << 5);
 pub const LC_ALL_MASK: ::c_int = LC_COLLATE_MASK
                                | LC_CTYPE_MASK
                                | LC_MESSAGES_MASK


### PR DESCRIPTION
This PR addresses failures in the test suite on FreeBSD amd64 11.1-RELEASE-p6:

* Exclude `NET_MAXID` from tests as it was [removed from FreeBSD](https://svnweb.freebsd.org/base?view=revision&revision=262489).
* Update the definition of `blksize_t` to match [its FreeBSD definition](https://github.com/freebsd/freebsd/blob/095a5e9be73cf121b1f54cf7c2099d549843732c/sys/sys/_types.h#L38).
* Update various rlimit constants to match [their FreeBSD definition](https://github.com/freebsd/freebsd/blob/095a5e9be73cf121b1f54cf7c2099d549843732c/sys/sys/resource.h#L119).
* Update various locale constants to match [their FreeBSD definitions](https://github.com/freebsd/freebsd/blob/e086fcfb8c1cbcf7df952c4932d2a991447c6bd9/include/xlocale/_locale.h#L37).

With these changes all test pass.