### PR TITLE
Update the FreeBSD CI image

### DIFF
--- a/ci/docker/x86_64-unknown-freebsd/Dockerfile
+++ b/ci/docker/x86_64-unknown-freebsd/Dockerfile
@@ -1,13 +1,13 @@
-FROM alexcrichton/port-prebuilt-freebsd:2017-09-16
+FROM wezm/port-prebuilt-freebsd11@sha256:43553e2265ec702ec72a63a765df333f50b1858b896e69385749e96d8624e9b0
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
-  qemu genext2fs
+  qemu genext2fs xz-utils
 RUN apt-get install -y curl ca-certificates gcc
 
 ENTRYPOINT ["sh"]
 
 ENV PATH=$PATH:/rust/bin \
-    QEMU=2016-11-06/freebsd.qcow2.gz \
+    QEMU=2018-03-15/FreeBSD-11.1-RELEASE-amd64.qcow2.xz \
     CAN_CROSS=1 \
-    CARGO_TARGET_X86_64_UNKNOWN_FREEBSD_LINKER=x86_64-unknown-freebsd10-gcc
+    CARGO_TARGET_X86_64_UNKNOWN_FREEBSD_LINKER=x86_64-unknown-freebsd11-gcc

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -24,6 +24,13 @@ if [ "$QEMU" != "" ]; then
       curl https://s3-us-west-1.amazonaws.com/rust-lang-ci2/libc/$QEMU | \
         gunzip -d > $tmpdir/$qemufile
     fi
+  elif [ -z "${QEMU#*.xz}" ]; then
+    # image is .xz : download and uncompress it
+    qemufile=$(echo ${QEMU%.xz} | sed 's/\//__/g')
+    if [ ! -f $tmpdir/$qemufile ]; then
+      curl https://s3-us-west-1.amazonaws.com/rust-lang-ci2/libc/$QEMU | \
+        unxz > $tmpdir/$qemufile
+    fi
   else
     # plain qcow2 image: just download it
     qemufile=$(echo ${QEMU} | sed 's/\//__/g')

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -509,6 +509,7 @@ fn main() {
             "CTL_MAXID" |
             "KERN_MAXID" |
             "HW_MAXID" |
+            "NET_MAXID" |
             "USER_MAXID" if freebsd => true,
 
             // These constants were added in FreeBSD 11

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -3,7 +3,7 @@ pub type clock_t = i32;
 pub type ino_t = u32;
 pub type lwpid_t = i32;
 pub type nlink_t = u16;
-pub type blksize_t = u32;
+pub type blksize_t = i32;
 pub type clockid_t = ::c_int;
 pub type sem_t = _sem;
 
@@ -182,7 +182,9 @@ pub const EOWNERDEAD: ::c_int = 96;
 pub const ELAST: ::c_int = 96;
 pub const RLIMIT_NPTS: ::c_int = 11;
 pub const RLIMIT_SWAP: ::c_int = 12;
-pub const RLIM_NLIMITS: ::rlim_t = 13;
+pub const RLIMIT_KQUEUES: ::c_int = 13;
+pub const RLIMIT_UMTXP: ::c_int = 14;
+pub const RLIM_NLIMITS: ::rlim_t = 15;
 
 pub const Q_GETQUOTA: ::c_int = 0x700;
 pub const Q_SETQUOTA: ::c_int = 0x800;
@@ -801,10 +803,10 @@ pub const SHUTDOWN_TIME: ::c_short = 8;
 
 pub const LC_COLLATE_MASK: ::c_int = (1 << 0);
 pub const LC_CTYPE_MASK: ::c_int = (1 << 1);
-pub const LC_MESSAGES_MASK: ::c_int = (1 << 2);
-pub const LC_MONETARY_MASK: ::c_int = (1 << 3);
-pub const LC_NUMERIC_MASK: ::c_int = (1 << 4);
-pub const LC_TIME_MASK: ::c_int = (1 << 5);
+pub const LC_MONETARY_MASK: ::c_int =(1 << 2);
+pub const LC_NUMERIC_MASK: ::c_int = (1 << 3);
+pub const LC_TIME_MASK: ::c_int = (1 << 4);
+pub const LC_MESSAGES_MASK: ::c_int = (1 << 5);
 pub const LC_ALL_MASK: ::c_int = LC_COLLATE_MASK
                                | LC_CTYPE_MASK
                                | LC_MESSAGES_MASK


### PR DESCRIPTION
As per #948 and #799 the FreeBSD CI qemu image needs to be updated to FreeBSD 11. I have done this and updated the README with the detailed steps taken. The new image is available for download at: http://bsd-ci.com/FreeBSD-11.1-RELEASE-amd64.qcow2.xz 