### PR TITLE
Add MAP_STACK constant to OpenBSD

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -526,8 +526,11 @@ fn main() {
             "KERN_USERMOUNT" |
             "KERN_ARND" if openbsd => true,
 
-            // These constats were added in OpenBSD 6.2
+            // These constants were added in OpenBSD 6.2
             "EV_RECEIPT" | "EV_DISPATCH" if openbsd => true,
+
+            // These constants were added in OpenBSD 6.3
+            "MAP_STACK" if openbsd => true,
 
             // These are either unimplemented or optionally built into uClibc
             "LC_CTYPE_MASK" | "LC_NUMERIC_MASK" | "LC_TIME_MASK" | "LC_COLLATE_MASK" | "LC_MONETARY_MASK" | "LC_MESSAGES_MASK" |

--- a/src/unix/bsd/netbsdlike/openbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/openbsd/mod.rs
@@ -27,6 +27,8 @@ s! {
     }
 }
 
+pub const MAP_STACK : ::c_int = 0x4000;
+
 // https://github.com/openbsd/src/blob/master/sys/net/if.h#L187
 pub const IFF_UP: ::c_int = 0x1; // interface is up
 pub const IFF_BROADCAST: ::c_int = 0x2; // broadcast address valid


### PR DESCRIPTION
The mmap(2) flag indicate that the mapping is used as a stack.

https://man.openbsd.org/mmap.2#MAP_STACK
https://marc.info/?l=openbsd-tech&m=152035796722258&w=2