### PR TITLE
Use #[repr(align(32))] instead of private field for in6_addr.

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -166,9 +166,9 @@ s! {
         pub s_addr: in_addr_t,
     }
 
+    #[repr(align(4))]
     pub struct in6_addr {
-        pub s6_addr: [u8; 16],
-        __align: [u32; 0],
+        pub s6_addr: [u8; 16]
     }
 
     pub struct ip_mreq {

--- a/src/redox/net.rs
+++ b/src/redox/net.rs
@@ -9,9 +9,9 @@ s! {
         pub s_addr: in_addr_t,
     }
 
+    #[repr(align(4))]
     pub struct in6_addr {
-        pub s6_addr: [u8; 16],
-        __align: [u32; 0],
+        pub s6_addr: [u8; 16]
     }
 
     pub struct ip_mreq {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -104,9 +104,9 @@ s! {
         pub s_addr: in_addr_t,
     }
 
+    #[repr(align(4))]
     pub struct in6_addr {
-        pub s6_addr: [u8; 16],
-        __align: [u32; 0],
+        pub s6_addr: [u8; 16]
     }
 
     pub struct ip_mreq {


### PR DESCRIPTION
This allows constructiong in6_addr instances as a constant from other
crates.

See https://github.com/rust-lang/rust/issues/44582#issuecomment-378488339