### PR TITLE
Default RHS to Self for Div and Shl

### DIFF
--- a/src/dox.rs
+++ b/src/dox.rs
@@ -68,13 +68,13 @@ mod imp {
     }
 
     #[lang = "div"]
-    pub trait Div<RHS> {
+    pub trait Div<RHS=Self> {
         type Output;
         fn div(self, rhs: RHS) -> Self::Output;
     }
 
     #[lang = "shl"]
-    pub trait Shl<RHS> {
+    pub trait Shl<RHS=Self> {
         type Output;
         fn shl(self, rhs: RHS) -> Self::Output;
     }


### PR DESCRIPTION
This fixes a consistency issue with the other operator traits.