### PR TITLE
Make netlink struct fields public

### DIFF
--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -187,47 +187,47 @@ s! {
     }
 
     pub struct genlmsghdr {
-        cmd: u8,
-        version: u8,
-        reserved: u16,
+        pub cmd: u8,
+        pub version: u8,
+        pub reserved: u16,
     }
 
     pub struct nlmsghdr {
-        nlmsg_len: u32,
-        nlmsg_type: u16,
-        nlmsg_flags: u16,
-        nlmsg_seq: u32,
-        nlmsg_pid: u32,
+        pub nlmsg_len: u32,
+        pub nlmsg_type: u16,
+        pub nlmsg_flags: u16,
+        pub nlmsg_seq: u32,
+        pub nlmsg_pid: u32,
     }
 
     pub struct nlmsgerr {
-        error: ::c_int,
-        msg: nlmsghdr,
+        pub error: ::c_int,
+        pub msg: nlmsghdr,
     }
 
     pub struct nl_pktinfo {
-        group: u32,
+        pub group: u32,
     }
 
     pub struct nl_mmap_req {
-        nm_block_size: ::c_uint,
-        nm_block_nr: ::c_uint,
-        nm_frame_size: ::c_uint,
-        nm_frame_nr: ::c_uint,
+        pub nm_block_size: ::c_uint,
+        pub nm_block_nr: ::c_uint,
+        pub nm_frame_size: ::c_uint,
+        pub nm_frame_nr: ::c_uint,
     }
 
     pub struct nl_mmap_hdr {
-        nm_status: ::c_uint,
-        nm_len: ::c_uint,
-        nm_group: u32,
-        nm_pid: u32,
-        nm_uid: u32,
-        nm_gid: u32,
+        pub nm_status: ::c_uint,
+        pub nm_len: ::c_uint,
+        pub nm_group: u32,
+        pub nm_pid: u32,
+        pub nm_uid: u32,
+        pub nm_gid: u32,
     }
 
     pub struct nlattr {
-        nla_len: u16,
-        nla_type: u16,
+        pub nla_len: u16,
+        pub nla_type: u16,
     }
 }
 

--- a/src/unix/notbsd/linux/mips/mod.rs
+++ b/src/unix/notbsd/linux/mips/mod.rs
@@ -41,41 +41,41 @@ s! {
     }
 
     pub struct nlmsghdr {
-        nlmsg_len: u32,
-        nlmsg_type: u16,
-        nlmsg_flags: u16,
-        nlmsg_seq: u32,
-        nlmsg_pid: u32,
+        pub nlmsg_len: u32,
+        pub nlmsg_type: u16,
+        pub nlmsg_flags: u16,
+        pub nlmsg_seq: u32,
+        pub nlmsg_pid: u32,
     }
 
     pub struct nlmsgerr {
-        error: ::c_int,
-        msg: nlmsghdr,
+        pub error: ::c_int,
+        pub msg: nlmsghdr,
     }
 
     pub struct nl_pktinfo {
-        group: u32,
+        pub group: u32,
     }
 
     pub struct nl_mmap_req {
-        nm_block_size: ::c_uint,
-        nm_block_nr: ::c_uint,
-        nm_frame_size: ::c_uint,
-        nm_frame_nr: ::c_uint,
+        pub nm_block_size: ::c_uint,
+        pub nm_block_nr: ::c_uint,
+        pub nm_frame_size: ::c_uint,
+        pub nm_frame_nr: ::c_uint,
     }
 
     pub struct nl_mmap_hdr {
-        nm_status: ::c_uint,
-        nm_len: ::c_uint,
-        nm_group: u32,
-        nm_pid: u32,
-        nm_uid: u32,
-        nm_gid: u32,
+        pub nm_status: ::c_uint,
+        pub nm_len: ::c_uint,
+        pub nm_group: u32,
+        pub nm_pid: u32,
+        pub nm_uid: u32,
+        pub nm_gid: u32,
     }
 
     pub struct nlattr {
-        nla_len: u16,
-        nla_type: u16,
+        pub nla_len: u16,
+        pub nla_type: u16,
     }
 }
 

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -485,9 +485,9 @@ s! {
     }
 
     pub struct genlmsghdr {
-        cmd: u8,
-        version: u8,
-        reserved: u16,
+        pub cmd: u8,
+        pub version: u8,
+        pub reserved: u16,
     }
 }
 

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -180,41 +180,41 @@ s! {
     }
 
     pub struct nlmsghdr {
-        nlmsg_len: u32,
-        nlmsg_type: u16,
-        nlmsg_flags: u16,
-        nlmsg_seq: u32,
-        nlmsg_pid: u32,
+        pub nlmsg_len: u32,
+        pub nlmsg_type: u16,
+        pub nlmsg_flags: u16,
+        pub nlmsg_seq: u32,
+        pub nlmsg_pid: u32,
     }
 
     pub struct nlmsgerr {
-        error: ::c_int,
-        msg: nlmsghdr,
+        pub error: ::c_int,
+        pub msg: nlmsghdr,
     }
 
     pub struct nl_pktinfo {
-        group: u32,
+        pub group: u32,
     }
 
     pub struct nl_mmap_req {
-        nm_block_size: ::c_uint,
-        nm_block_nr: ::c_uint,
-        nm_frame_size: ::c_uint,
-        nm_frame_nr: ::c_uint,
+        pub nm_block_size: ::c_uint,
+        pub nm_block_nr: ::c_uint,
+        pub nm_frame_size: ::c_uint,
+        pub nm_frame_nr: ::c_uint,
     }
 
     pub struct nl_mmap_hdr {
-        nm_status: ::c_uint,
-        nm_len: ::c_uint,
-        nm_group: u32,
-        nm_pid: u32,
-        nm_uid: u32,
-        nm_gid: u32,
+        pub nm_status: ::c_uint,
+        pub nm_len: ::c_uint,
+        pub nm_group: u32,
+        pub nm_pid: u32,
+        pub nm_uid: u32,
+        pub nm_gid: u32,
     }
 
     pub struct nlattr {
-        nla_len: u16,
-        nla_type: u16,
+        pub nla_len: u16,
+        pub nla_type: u16,
     }
 }
 


### PR DESCRIPTION
I realized my netlink structs were a bit unusable if their fields are not public :man_facepalming: 

Follow up and improvement to #922