### PR TITLE
Fix undefined-behavior on MacOSX structs in stdbuilds 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ env:
     secure: "e2/3QjgRN9atOuSHp22TrYG7QVKcYUWY48Hi9b60w+r1+BhPkTseIJLte7WefRhdXtqpjjUJTooKDhnurFOeHaCT+nmBgiv+FPU893sBl4bhesY4m0vgUJVbNZcs6lTImYekWVb+aqjGdgV/XAgCw7c3kPmrZV0MzGDWL64Xaps="
 matrix:
   include:
-    # 1.0.0 compat
+    # 1.13.0 compat
     - env: TARGET=x86_64-unknown-linux-gnu NO_ADD=1
-      rust: 1.0.0
+      rust: 1.13.0
       script: rm -f Cargo.lock && cargo build
       install:
 

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -416,9 +416,6 @@ fn main() {
             // which is absent in glibc, has to be defined.
             "__timeval" if linux => true,
 
-            // The alignment of this is 4 on 64-bit OSX...
-            "kevent" | "shmid_ds" if apple && x86_64 => true,
-
             // This is actually a union, not a struct
             "sigval" => true,
 

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -416,6 +416,11 @@ fn main() {
             // which is absent in glibc, has to be defined.
             "__timeval" if linux => true,
 
+            // Fixed on stdbuild with repr(packed(4))
+            // Once repr_packed stabilizes we can fix this unconditionally
+            // and remove this check.
+            "kevent" | "shmid_ds" if apple && x86_64 => true,
+
             // This is actually a union, not a struct
             "sigval" => true,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@
 
 // Attributes needed when building as part of the standard library
 #![cfg_attr(feature = "stdbuild", feature(no_std, staged_api, custom_attribute, cfg_target_vendor))]
-#![cfg_attr(feature = "stdbuild", feature(link_cfg))]
+#![cfg_attr(feature = "stdbuild", feature(link_cfg, repr_packed))]
 #![cfg_attr(feature = "stdbuild", no_std)]
 #![cfg_attr(feature = "stdbuild", staged_api)]
 #![cfg_attr(feature = "stdbuild", allow(warnings))]

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -245,7 +245,7 @@ s! {
         pub f_reserved: [::uint32_t; 8],
     }
 
-    // FIXME: this should have align 4 but it's got align 8 on 64-bit
+    #[repr(packed(4))]
     pub struct kevent {
         pub ident: ::uintptr_t,
         pub filter: ::int16_t,
@@ -524,7 +524,7 @@ s! {
         pub _key: ::key_t,
     }
 
-    // FIXME: this should have align 4 but it's got align 8 on 64-bit
+    #[repr(packed(4))]
     pub struct shmid_ds {
         pub shm_perm: ipc_perm,
         pub shm_segsz: ::size_t,

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -245,7 +245,7 @@ s! {
         pub f_reserved: [::uint32_t; 8],
     }
 
-    #[repr(packed(4))]
+    #[cfg_attr(feature = "stdbuild", repr(packed(4)))]
     pub struct kevent {
         pub ident: ::uintptr_t,
         pub filter: ::int16_t,
@@ -524,7 +524,7 @@ s! {
         pub _key: ::key_t,
     }
 
-    #[repr(packed(4))]
+    #[cfg_attr(feature = "stdbuild", repr(packed(4)))]
     pub struct shmid_ds {
         pub shm_perm: ipc_perm,
         pub shm_segsz: ::size_t,


### PR DESCRIPTION
Some MacOSX structs have an incorrect layout that results in undefined behavior. This is because on `x86_64` the MacOSX kernel headers define these using `#pragma pack 4`. 

This PR fixes their layout using `repr(packed(4))` . Since it is only available on nightly, it is only enabled for stdbuilds .