### PR TITLE
add pktinfo consts and structs for linux and apple

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -33,6 +33,8 @@ fn main() {
         cfg.define("_GNU_SOURCE", None);
     } else if netbsd {
         cfg.define("_NETBSD_SOURCE", Some("1"));
+    } else if apple {
+        cfg.define("__APPLE_USE_RFC_3542", None);
     } else if windows {
         cfg.define("_WIN32_WINNT", Some("0x8000"));
     } else if solaris {
@@ -178,6 +180,7 @@ fn main() {
         }
         cfg.header("net/route.h");
         cfg.header("netinet/if_ether.h");
+        cfg.header("netinet/in.h");
         cfg.header("sys/proc_info.h");
         cfg.header("sys/kern_control.h");
         cfg.header("sys/ipc.h");

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -512,6 +512,17 @@ s! {
         pub sc_reserved: [::uint32_t; 5],
     }
 
+    pub struct in_pktinfo {
+        pub ipi_ifindex: ::c_uint,
+        pub ipi_spec_dst: ::in_addr,
+        pub ipi_addr: ::in_addr,
+    }
+
+    pub struct in6_pktinfo {
+        pub ipi6_addr: ::in6_addr,
+        pub ipi6_ifindex: ::c_uint,
+    }
+
     // sys/ipc.h:
 
     pub struct ipc_perm {
@@ -1503,8 +1514,11 @@ pub const IP_TTL: ::c_int = 4;
 pub const IP_HDRINCL: ::c_int = 2;
 pub const IP_ADD_MEMBERSHIP: ::c_int = 12;
 pub const IP_DROP_MEMBERSHIP: ::c_int = 13;
+pub const IP_PKTINFO: ::c_int = 26;
 pub const IPV6_JOIN_GROUP: ::c_int = 12;
 pub const IPV6_LEAVE_GROUP: ::c_int = 13;
+pub const IPV6_PKTINFO: ::c_int = 46;
+pub const IPV6_RECVPKTINFO: ::c_int = 61;
 
 pub const TCP_NODELAY: ::c_int = 0x01;
 pub const TCP_KEEPALIVE: ::c_int = 0x10;

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -229,6 +229,11 @@ s! {
         pub nla_len: u16,
         pub nla_type: u16,
     }
+
+    pub struct in6_pktinfo {
+        pub ipi6_addr: ::in6_addr,
+        pub ipi6_ifindex: ::c_int,
+    }
 }
 
 pub const O_TRUNC: ::c_int = 512;

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -469,6 +469,11 @@ s! {
         pub version: u8,
         pub reserved: u16,
     }
+
+    pub struct in6_pktinfo {
+        pub ipi6_addr: ::in6_addr,
+        pub ipi6_ifindex: ::c_uint,
+    }
 }
 
 pub const ABDAY_1: ::nl_item = 0x20000;

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -177,6 +177,12 @@ s! {
         #[cfg(target_pointer_width = "32")]
         __unused1: [::c_int; 12]
     }
+
+    pub struct in_pktinfo {
+        pub ipi_ifindex: ::c_int,
+        pub ipi_spec_dst: ::in_addr,
+        pub ipi_addr: ::in_addr,
+    }
 }
 
 // intentionally not public, only used for fd_set
@@ -573,6 +579,7 @@ pub const IP_MULTICAST_TTL: ::c_int = 33;
 pub const IP_MULTICAST_LOOP: ::c_int = 34;
 pub const IP_TTL: ::c_int = 2;
 pub const IP_HDRINCL: ::c_int = 3;
+pub const IP_PKTINFO: ::c_int = 8;
 pub const IP_ADD_MEMBERSHIP: ::c_int = 35;
 pub const IP_DROP_MEMBERSHIP: ::c_int = 36;
 pub const IP_TRANSPARENT: ::c_int = 19;
@@ -583,6 +590,8 @@ pub const IPV6_MULTICAST_LOOP: ::c_int = 19;
 pub const IPV6_ADD_MEMBERSHIP: ::c_int = 20;
 pub const IPV6_DROP_MEMBERSHIP: ::c_int = 21;
 pub const IPV6_V6ONLY: ::c_int = 26;
+pub const IPV6_RECVPKTINFO: ::c_int = 49;
+pub const IPV6_PKTINFO: ::c_int = 50;
 
 pub const TCP_NODELAY: ::c_int = 1;
 pub const TCP_MAXSEG: ::c_int = 2;


### PR DESCRIPTION
The constants and structs are from `/usr/include/linux/in.h`, `/usr/include/linux/in6.h` for Linux (+ Android) and `/usr/include/netinet/in.h`, `/usr/include/netinet6/in6.h` for Apple.

With Apple it's important to mention that I'm choosing the RFC 3542 versions of the constants in alignment with other critical pieces of software like [nginx](http://hg.nginx.org/nginx/rev/9fb994513776), and Linux also defaults to this RFC version.