### PR TITLE
define more TCP_ sockopts on bsd

### DIFF
--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -640,8 +640,11 @@ pub const IP_DROP_MEMBERSHIP: ::c_int = 13;
 pub const IPV6_JOIN_GROUP: ::c_int = 12;
 pub const IPV6_LEAVE_GROUP: ::c_int = 13;
 
-pub const TCP_NODELAY: ::c_int = 1;
-pub const TCP_KEEPIDLE: ::c_int = 256;
+pub const TCP_NODELAY:   ::c_int = 1;
+pub const TCP_KEEPIDLE:  ::c_int = 256;
+pub const TCP_KEEPINTVL: ::c_int = 512;
+pub const TCP_KEEPCNT:   ::c_int = 1024;
+
 pub const SOL_SOCKET: ::c_int = 0xffff;
 pub const SO_DEBUG: ::c_int = 0x01;
 pub const SO_ACCEPTCONN: ::c_int = 0x0002;

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -413,7 +413,12 @@ pub const IP_HDRINCL: ::c_int = 2;
 pub const IP_ADD_MEMBERSHIP: ::c_int = 12;
 pub const IP_DROP_MEMBERSHIP: ::c_int = 13;
 
-pub const TCP_NODELAY: ::c_int = 0x01;
+pub const TCP_NODELAY:    ::c_int = 0x01;
+pub const TCP_KEEPIDLE:   ::c_int = 3;
+pub const TCP_KEEPINTVL:  ::c_int = 5;
+pub const TCP_KEEPCNT:    ::c_int = 6;
+pub const TCP_KEEPINIT:   ::c_int = 7;
+
 pub const SOL_SOCKET: ::c_int = 0xffff;
 pub const SO_DEBUG: ::c_int = 0x01;
 pub const SO_ACCEPTCONN: ::c_int = 0x0002;


### PR DESCRIPTION
seee #978 

sources for sockopt numbers:
- openbsd: i can't find them, so maybe they dont exist.
- dragonfly: https://github.com/DragonFlyBSD/DragonFlyBSD/search?utf8=%E2%9C%93&q=TCP_KEEPINTVL&type=
- netbsd: https://github.com/IIJ-NetBSD/netbsd-src/search?utf8=%E2%9C%93&q=TCP_KEEPINTVL&type=