### PR TITLE
add missing netlink constants for linux

### DIFF
--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -903,6 +903,10 @@ pub const NLM_F_EXCL: ::c_int = 0x200;
 pub const NLM_F_CREATE: ::c_int = 0x400;
 pub const NLM_F_APPEND: ::c_int = 0x800;
 
+pub const NLM_F_NONREC: ::c_int = 0x100;
+pub const NLM_F_CAPPED: ::c_int = 0x100;
+pub const NLM_F_ACK_TLVS: ::c_int = 0x200;
+
 pub const NLMSG_NOOP: ::c_int = 0x1;
 pub const NLMSG_ERROR: ::c_int = 0x2;
 pub const NLMSG_DONE: ::c_int = 0x3;

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -903,10 +903,6 @@ pub const NLM_F_EXCL: ::c_int = 0x200;
 pub const NLM_F_CREATE: ::c_int = 0x400;
 pub const NLM_F_APPEND: ::c_int = 0x800;
 
-pub const NLM_F_NONREC: ::c_int = 0x100;
-pub const NLM_F_CAPPED: ::c_int = 0x100;
-pub const NLM_F_ACK_TLVS: ::c_int = 0x200;
-
 pub const NLMSG_NOOP: ::c_int = 0x1;
 pub const NLMSG_ERROR: ::c_int = 0x2;
 pub const NLMSG_DONE: ::c_int = 0x3;

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -555,6 +555,10 @@ pub const NLM_F_EXCL: ::c_int = 0x200;
 pub const NLM_F_CREATE: ::c_int = 0x400;
 pub const NLM_F_APPEND: ::c_int = 0x800;
 
+pub const NLM_F_NONREC: ::c_int = 0x100;
+pub const NLM_F_CAPPED: ::c_int = 0x100;
+pub const NLM_F_ACK_TLVS: ::c_int = 0x200;
+
 pub const NETLINK_ADD_MEMBERSHIP: ::c_int = 1;
 pub const NETLINK_DROP_MEMBERSHIP: ::c_int = 2;
 pub const NETLINK_PKTINFO: ::c_int = 3;


### PR DESCRIPTION
NLM_F_NONREC was added to the linux kernel on the 3 septembre 2017 in
commit 2335ba704f32b855651d0cd15dd9b271ec565fb6

NLM_F_CAPPED and NLM_F_ACK_TLVS were added on 12 april 2017 in commit
2d4bc93368f5a0ddb57c8c885cdad9c9b7a10ed5

Here are the definitions copy/pasted from the v4.16.8 kernel:

  ```
  /* Modifiers to DELETE request */
  #define NLM_F_NONREC    0x100  /* Do not delete recursively  */

  /* Flags for ACK message */
  #define NLM_F_CAPPED    0x100  /* request was capped */
  #define NLM_F_ACK_TLVS  0x200  /* extended ACK TVLs were included */
  ```