### PR TITLE
Add `pthread_sigqueue` to linux/other

### DIFF
--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -864,6 +864,9 @@ extern {
                                          val: *mut ::c_int) -> ::c_int;
     pub fn pthread_rwlockattr_setkind_np(attr: *mut ::pthread_rwlockattr_t,
                                          val: ::c_int) -> ::c_int;
+    pub fn pthread_sigqueue(thread: ::pthread_t,
+                            sig: ::c_int,
+                            value: ::sigval) -> ::c_int;
     pub fn sched_getcpu() -> ::c_int;
     pub fn mallinfo() -> ::mallinfo;
     pub fn malloc_usable_size(ptr: *mut ::c_void) -> ::size_t;


### PR DESCRIPTION
I'm not too sure about where to put this, as it seems to be a GNU extension, but other pthread functions that were also GNU extensions, like `pthread_rwlockattr_setkind_np` was in the same file, so I just put it directly above.