### PR TITLE
Add Redox definitions for net functions

### DIFF
--- a/src/redox/net.rs
+++ b/src/redox/net.rs
@@ -107,4 +107,16 @@ extern {
     pub fn setsockopt(socket: ::c_int, level: ::c_int, name: ::c_int,
                       value: *const ::c_void,
                       option_len: socklen_t) -> ::c_int;
+    pub fn getpeername(socket: ::c_int, address: *mut sockaddr,
+                       address_len: *mut socklen_t) -> ::c_int;
+    pub fn sendto(socket: ::c_int, buf: *const ::c_void, len: ::size_t,
+                  flags: ::c_int, addr: *const sockaddr,
+                  addrlen: socklen_t) -> ::ssize_t;
+    pub fn send(socket: ::c_int, buf: *const ::c_void, len: ::size_t,
+                flags: ::c_int) -> ::ssize_t;
+    pub fn recvfrom(socket: ::c_int, buf: *mut ::c_void, len: ::size_t,
+                    flags: ::c_int, addr: *mut ::sockaddr,
+                    addrlen: *mut ::socklen_t) -> ::ssize_t;
+    pub fn recv(socket: ::c_int, buf: *mut ::c_void, len: ::size_t,
+                flags: ::c_int) -> ::ssize_t;
 }


### PR DESCRIPTION
Adds the following function definitions for Redox:

- getpeername
- sendto
- send
- recvfrom
- recv

If it is possible to do a release after merging this, that would be great! These function definitions are required for porting mio and tokio to Redox