### PR TITLE
fix size_of function in dox.rs

### DIFF
--- a/src/dox.rs
+++ b/src/dox.rs
@@ -160,6 +160,6 @@ mod imp {
 
     pub mod mem {
         pub fn size_of_val<T>(_: &T) -> usize { 4 }
-        pub fn size_of<T>(_: &T) -> usize { 4 }
+        pub fn size_of<T>() -> usize { 4 }
     }
 }


### PR DESCRIPTION
I'm assuming this is meant to have the same signature as the one in core/std