### PR TITLE
Remove termios2 from musl targets

### DIFF
--- a/src/unix/notbsd/linux/musl/b32/arm.rs
+++ b/src/unix/notbsd/linux/musl/b32/arm.rs
@@ -138,17 +138,6 @@ s! {
         pub f_namemax: ::c_ulong,
         __f_spare: [::c_int; 6],
     }
-
-    pub struct termios2 {
-        pub c_iflag: ::tcflag_t,
-        pub c_oflag: ::tcflag_t,
-        pub c_cflag: ::tcflag_t,
-        pub c_lflag: ::tcflag_t,
-        pub c_line: ::cc_t,
-        pub c_cc: [::cc_t; 19],
-        pub c_ispeed: ::speed_t,
-        pub c_ospeed: ::speed_t,
-    }
 }
 
 pub const O_DIRECT: ::c_int = 0x10000;

--- a/src/unix/notbsd/linux/musl/b32/mips.rs
+++ b/src/unix/notbsd/linux/musl/b32/mips.rs
@@ -149,17 +149,6 @@ s! {
         pub f_namemax: ::c_ulong,
         __f_spare: [::c_int; 6],
     }
-
-    pub struct termios2 {
-        pub c_iflag: ::tcflag_t,
-        pub c_oflag: ::tcflag_t,
-        pub c_cflag: ::tcflag_t,
-        pub c_lflag: ::tcflag_t,
-        pub c_line: ::cc_t,
-        pub c_cc: [::cc_t; 23],
-        pub c_ispeed: ::speed_t,
-        pub c_ospeed: ::speed_t,
-    }
 }
 
 pub const O_DIRECT: ::c_int = 0o100000;

--- a/src/unix/notbsd/linux/musl/b32/x86.rs
+++ b/src/unix/notbsd/linux/musl/b32/x86.rs
@@ -151,17 +151,6 @@ s! {
         pub f_namemax: ::c_ulong,
         __f_spare: [::c_int; 6],
     }
-
-    pub struct termios2 {
-        pub c_iflag: ::tcflag_t,
-        pub c_oflag: ::tcflag_t,
-        pub c_cflag: ::tcflag_t,
-        pub c_lflag: ::tcflag_t,
-        pub c_line: ::cc_t,
-        pub c_cc: [::cc_t; 19],
-        pub c_ispeed: ::speed_t,
-        pub c_ospeed: ::speed_t,
-    }
 }
 
 pub const O_DIRECT: ::c_int = 0x4000;

--- a/src/unix/notbsd/linux/musl/b64/mod.rs
+++ b/src/unix/notbsd/linux/musl/b64/mod.rs
@@ -118,17 +118,6 @@ s! {
         pub _pad: [::c_int; 29],
         _align: [usize; 0],
     }
-
-    pub struct termios2 {
-        pub c_iflag: ::tcflag_t,
-        pub c_oflag: ::tcflag_t,
-        pub c_cflag: ::tcflag_t,
-        pub c_lflag: ::tcflag_t,
-        pub c_line: ::cc_t,
-        pub c_cc: [::cc_t; 19],
-        pub c_ispeed: ::speed_t,
-        pub c_ospeed: ::speed_t,
-    }
 }
 
 pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 56;


### PR DESCRIPTION
This wasn't caught because the tests disable checking for `termios2` on all targets, so I enabled it on `musl` targets to prevent this from recurring.

Closes #1006