### PR TITLE
added renamex_np, renameatx_np

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1859,6 +1859,9 @@ pub const NI_MAXHOST: ::socklen_t = 1025;
 pub const Q_GETQUOTA: ::c_int = 0x300;
 pub const Q_SETQUOTA: ::c_int = 0x400;
 
+pub const RENAME_SWAP: ::c_uint = 0x00000002;
+pub const RENAME_EXCL: ::c_uint = 0x00000004;
+
 pub const RTLD_LOCAL: ::c_int = 0x4;
 pub const RTLD_FIRST: ::c_int = 0x100;
 pub const RTLD_NODELETE: ::c_int = 0x80;
@@ -2451,6 +2454,11 @@ extern {
                       size: ::size_t, flags: ::c_int) -> ::ssize_t;
     pub fn removexattr(path: *const ::c_char, name: *const ::c_char,
                        flags: ::c_int) -> ::c_int;
+    pub fn renamex_np(from: *const ::c_char, to: *const ::c_char,
+                      flags: ::c_uint) -> ::c_int;
+    pub fn renameatx_np(fromfd: ::c_int, from: *const ::c_char,
+                        tofd: ::c_int, to: *const ::c_char,
+                        flags: ::c_uint) -> ::c_int;
     pub fn fremovexattr(filedes: ::c_int, name: *const ::c_char,
                         flags: ::c_int) -> ::c_int;
 

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -1616,9 +1616,6 @@ extern {
                            len: ::off_t) -> ::c_int;
     pub fn readahead(fd: ::c_int, offset: ::off64_t,
                      count: ::size_t) -> ::ssize_t;
-    pub fn renameat2(olddirfd: ::c_int, oldpath: *const ::c_char,
-                     newdirfd: ::c_int, newpath: *const ::c_char,
-                     flags: ::c_int) -> ::c_int;
     pub fn getxattr(path: *const c_char, name: *const c_char,
                     value: *mut ::c_void, size: ::size_t) -> ::ssize_t;
     pub fn lgetxattr(path: *const c_char, name: *const c_char,

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -1616,6 +1616,9 @@ extern {
                            len: ::off_t) -> ::c_int;
     pub fn readahead(fd: ::c_int, offset: ::off64_t,
                      count: ::size_t) -> ::ssize_t;
+    pub fn renameat2(olddirfd: ::c_int, oldpath: *const ::c_char,
+                     newdirfd: ::c_int, newpath: *const ::c_char,
+                     flags: ::c_int) -> ::c_int;
     pub fn getxattr(path: *const c_char, name: *const c_char,
                     value: *mut ::c_void, size: ::size_t) -> ::ssize_t;
     pub fn lgetxattr(path: *const c_char, name: *const c_char,


### PR DESCRIPTION
these function can be used to atomically swap files

- added 2 macos specific functions - `renamex_np` and `renameatx_np` and two constants `RENAME_SWAP` and `RENAME_EXCL`
  - [macos stdio.h](https://github.com/apple/darwin-xnu/blob/0ddccd8/bsd/sys/stdio.h#L45-L48)
  - [docs](http://www.manpagez.com/man/2/renameatx_np/osx-10.12.3.php)
- ~added linux specific `renameat2`. according to the [docs](http://man7.org/linux/man-pages/man2/rename.2.html#VERSIONS) it was added to Linux in kernel 3.15.~