### PR TITLE
Add ENOATTR for Android

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -560,7 +560,7 @@ fn main() {
 
             // Defined by libattr not libc on linux (hard to test).
             // See constant definition for more details.
-            "ENOATTR" if linux => true,
+            "ENOATTR" if android || linux => true,
 
             // On mips*-unknown-linux-gnu* CMSPAR cannot be included with the set of headers we
             // want to use here for testing. It's originally defined in asm/termbits.h, which is

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -1458,6 +1458,9 @@ pub const SIOCSRARP: ::c_ulong = 0x00008962;
 pub const SIOCGIFMAP: ::c_ulong = 0x00008970;
 pub const SIOCSIFMAP: ::c_ulong = 0x00008971;
 
+// Similarity to Linux it's not used but defined for compatibility.
+pub const ENOATTR: ::c_int = ::ENODATA;
+
 f! {
     pub fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {
         for slot in cpuset.__bits.iter_mut() {


### PR DESCRIPTION
PR based on https://github.com/rust-lang/libc/pull/594

It's defined in Android sysroot so it should work without test workaround (CI should catch it otherwise?).