### PR TITLE
Add the FIO* consts for *-apple-*

### DIFF
--- a/src/unix/bsd/apple/b64.rs
+++ b/src/unix/bsd/apple/b64.rs
@@ -63,5 +63,3 @@ pub const __PTHREAD_RWLOCKATTR_SIZE__: usize = 16;
 
 pub const TIOCTIMESTAMP: ::c_ulong = 0x40107459;
 pub const TIOCDCDTIMESTAMP: ::c_ulong = 0x40107458;
-
-pub const FIONREAD: ::c_ulong = 0x4004667f;

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1085,10 +1085,8 @@ pub const TIOCPTYGRANT: ::c_uint = 0x20007454;
 pub const TIOCPTYGNAME: ::c_uint = 0x40807453;
 pub const TIOCPTYUNLK: ::c_uint = 0x20007452;
 
-pub const FIOCLEX: ::c_uint = 0x20006601;
 pub const FIONCLEX: ::c_uint = 0x20006602;
 pub const FIONREAD: ::c_ulong = 0x4004667f;
-pub const FIONBIO: ::c_ulong = 0x8004667e;
 pub const FIOASYNC: ::c_ulong = 0x8004667d;
 pub const FIOSETOWN: ::c_ulong = 0x8004667c;
 pub const FIOGETOWN: ::c_ulong = 0x4004667b;

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1085,6 +1085,15 @@ pub const TIOCPTYGRANT: ::c_uint = 0x20007454;
 pub const TIOCPTYGNAME: ::c_uint = 0x40807453;
 pub const TIOCPTYUNLK: ::c_uint = 0x20007452;
 
+pub const FIOCLEX: ::c_uint = 0x20006601;
+pub const FIONCLEX: ::c_uint = 0x20006602;
+pub const FIONREAD: ::c_ulong = 0x4004667f;
+pub const FIONBIO: ::c_ulong = 0x8004667e;
+pub const FIOASYNC: ::c_ulong = 0x8004667d;
+pub const FIOSETOWN: ::c_ulong = 0x8004667c;
+pub const FIOGETOWN: ::c_ulong = 0x4004667b;
+pub const FIODTYPE: ::c_ulong = 0x4004667a;
+
 pub const B0: speed_t = 0;
 pub const B50: speed_t = 50;
 pub const B75: speed_t = 75;


### PR DESCRIPTION
Previously only FIONREAD was implemented for x86_64 apple. The constant is shared between i{3..6}86 and x86_64, so I've moved it into the shared module rather than the 64 bit specific one.

They're defined like this in sys/filio.h:
```
#define FIOCLEX	     _IO('f', 1)        /* set close on exec on fd */
#define FIONCLEX     _IO('f', 2)        /* remove close on exec */
#define FIONREAD    _IOR('f', 127, int) /* get # bytes to read */
#define FIONBIO     _IOW('f', 126, int) /* set/clear non-blocking i/o */
#define FIOASYNC    _IOW('f', 125, int) /* set/clear async i/o */
#define FIOSETOWN   _IOW('f', 124, int) /* set owner */
#define FIOGETOWN   _IOR('f', 123, int) /* get owner */
#define FIODTYPE    _IOR('f', 122, int) /* get d_type */
```

Rather than decipher the C macros I got the values like so:
```
#include <stdio.h>
#include <sys/ioctl.h>

int main() {
	printf("pub const FIOCLEX: ::c_uint = 0x%x;\n", FIOCLEX);
	printf("pub const FIONCLEX: ::c_uint = 0x%x;\n", FIONCLEX);
	printf("pub const FIONREAD: ::c_ulong = 0x%lx;\n", FIONREAD);
	printf("pub const FIONBIO: ::c_ulong = 0x%lx;\n", FIONBIO);
	printf("pub const FIOASYNC: ::c_ulong = 0x%lx;\n", FIOASYNC);
	printf("pub const FIOSETOWN: ::c_ulong = 0x%lx;\n", FIOSETOWN);
	printf("pub const FIOGETOWN: ::c_ulong = 0x%lx;\n", FIOGETOWN);
	printf("pub const FIODTYPE: ::c_ulong = 0x%lx;\n", FIODTYPE);
}

$ gcc --target=i686-apple-darwin -o x x.c && file ./x && ./x
./x: Mach-O executable i386
pub const FIOCLEX: ::c_uint = 0x20006601;
pub const FIONCLEX: ::c_uint = 0x20006602;
pub const FIONREAD: ::c_ulong = 0x4004667f;
pub const FIONBIO: ::c_ulong = 0x8004667e;
pub const FIOASYNC: ::c_ulong = 0x8004667d;
pub const FIOSETOWN: ::c_ulong = 0x8004667c;
pub const FIOGETOWN: ::c_ulong = 0x4004667b;
pub const FIODTYPE: ::c_ulong = 0x4004667a;

﻿﻿$ gcc --target=x86_64-apple-darwin -o x x.c && file ./x && ./x
./x: Mach-O 64-bit executable x86_64
pub const FIOCLEX: ::c_uint = 0x20006601;
pub const FIONCLEX: ::c_uint = 0x20006602;
pub const FIONREAD: ::c_ulong = 0x4004667f;
pub const FIONBIO: ::c_ulong = 0x8004667e;
pub const FIOASYNC: ::c_ulong = 0x8004667d;
pub const FIOSETOWN: ::c_ulong = 0x8004667c;
pub const FIOGETOWN: ::c_ulong = 0x4004667b;
pub const FIODTYPE: ::c_ulong = 0x4004667a;
```

I'm just awaiting an XCode install to check they're the same on arm.