### PR TITLE
Add libc definitions for Megaton-Hammer, a Switch Homebrew toolchain

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,9 @@ mod dox;
 cfg_if! {
     if #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))] {
         // empty ...
+    } else if #[cfg(target_os = "switch")] {
+        // On the Switch, we only define some useful universal types for
+        // convenience. Those can be found in the switch.rs file.
     } else {
 
         // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help enable
@@ -296,6 +299,9 @@ cfg_if! {
     } else if #[cfg(target_os = "fuchsia")] {
         mod fuchsia;
         pub use fuchsia::*;
+    } else if #[cfg(target_os = "switch")] {
+        mod switch;
+        pub use switch::*;
     } else if #[cfg(unix)] {
         mod unix;
         pub use unix::*;

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -1,0 +1,48 @@
+//! Switch C type definitions
+
+// Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help enable
+// more optimization opportunities around it recognizing things like
+// malloc/free.
+#[repr(u8)]
+pub enum c_void {
+    // Two dummy variants so the #[repr] attribute can be used.
+    #[doc(hidden)]
+    __variant1,
+    #[doc(hidden)]
+    __variant2,
+}
+
+pub type int8_t = i8;
+pub type int16_t = i16;
+pub type int32_t = i32;
+pub type int64_t = i64;
+pub type uint8_t = u8;
+pub type uint16_t = u16;
+pub type uint32_t = u32;
+pub type uint64_t = u64;
+
+pub type c_schar = i8;
+pub type c_uchar = u8;
+pub type c_short = i16;
+pub type c_ushort = u16;
+pub type c_int = i32;
+pub type c_uint = u32;
+pub type c_float = f32;
+pub type c_double = f64;
+pub type c_longlong = i64;
+pub type c_ulonglong = u64;
+pub type intmax_t = i64;
+pub type uintmax_t = u64;
+
+pub type size_t = usize;
+pub type ptrdiff_t = isize;
+pub type intptr_t = isize;
+pub type uintptr_t = usize;
+pub type ssize_t = isize;
+
+// Arch specific
+pub type off_t = i64;
+pub type c_char = u8;
+pub type c_long = i64;
+pub type c_ulong = u64;
+pub type wchar_t = u32;


### PR DESCRIPTION
I'm working on a pure-rust toolchain to write homebrew for the Nintendo Switch called [Megaton-Hammer](http://github.com/megatonhammer/megaton-hammer). I'm hoping to get those definitions upstreamed to simplify my life :).

This toolchain does not depend on a C compiler or a libc (it reimplements everything in rust) - but given many crates in the Rust ecosystem rely on the libc crate for the definition of various common types, this is what I came up with.

I was wondering what a good target triple would be ? I currently gate the implementation behind `target_os = "switch"`, but if this goes upstream I figure that might cause trouble for people using the Nintendo SDK (they might already be using `target_os = "switch"` for some things). Would it be better to go with `target_env = "megatonhammer"`?