### PR TITLE
Add TIOCGWINSZ accessor to solaris module

### DIFF
--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -1195,6 +1195,9 @@ pub const PORT_SOURCE_FILE: ::c_int = 7;
 pub const PORT_SOURCE_POSTWAIT: ::c_int = 8;
 pub const PORT_SOURCE_SIGNAL: ::c_int = 9;
 
+pub const TIOCGWINSZ: ::c_int = 0x5468;
+pub const TIOCSWINSZ: ::c_int = 0x5467;
+
 pub const EPOLLIN: ::c_int = 0x1;
 pub const EPOLLPRI: ::c_int = 0x2;
 pub const EPOLLOUT: ::c_int = 0x4;


### PR DESCRIPTION
Signed-off-by: Ian Henry <ihenry@chef.io>

I recently noticed downstream that these request values were unavailable and needed for things like [the pb crate](https://github.com/a8m/pb). To get access to the request value I ran the following simple C code:
```
#include <sys/ioctl.h>
#include <stdio.h>
#include <sys/termios.h>

int main(int argc, char **argv) {
    printf("Code: 0x%04lx\n", TIOCGWINSZ);
    printf("Code: 0x%04lx\n", TIOCSWINSZ);
    return 0;
}
```
To then validate the change I ran the following simple rust:
```
extern crate libc;

use libc::{ioctl, winsize, STDOUT_FILENO, TIOCGWINSZ};

fn main() {
    let mut wsize = winsize {
        ws_row: 0,
        ws_col: 0,
        ws_xpixel: 0,
        ws_ypixel: 0,
    };
    unsafe {
        ioctl(STDOUT_FILENO, TIOCGWINSZ, &mut wsize);
    }
    println!("Sizes: {{ rows: {}, cols: {}, xpixel: {}, ypixel: {} }}",
             wsize.ws_row,
             wsize.ws_col,
             wsize.ws_xpixel,
             wsize.ws_ypixel);
}
```