### PR TITLE
Undo division of in6_addr on Fuchsia

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -164,13 +164,7 @@ s! {
     }
 
     pub struct in6_addr {
-        pub __in6_union: in6_union,
-    }
-
-    pub union in6_union {
-        pub __s6_addr: [u8; 16],
-        pub __s6_addr16: [u16; 8],
-        pub __s6_addr32: [u32; 4],
+        pub s6_addr: [u8; 16],
     }
 
     pub struct ip_mreq {


### PR DESCRIPTION
This was broken out into a separate type to match the native representation on Fuchsia in https://github.com/rust-lang/libc/pull/1067/files, but it caused [a breakage in libstd/net/addr.rs](https://github.com/rust-lang/rust/pull/53623#issuecomment-415730133) because some platform-independent code was expecting to be able to access the fields of this struct directly. In order to avoid introducing new `cfg`s into the codebase, this change is being rolled back (especially since the two forms should be equivalent in how the wrapping struct is passed via the C ABI).

r? @alexcrichton 