### PR TITLE
Add mallopt

### DIFF
--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -1576,20 +1576,6 @@ pub const ATF_MAGIC: ::c_int = 0x80;
 pub const MODULE_INIT_IGNORE_MODVERSIONS: ::c_uint = 0x0001;
 pub const MODULE_INIT_IGNORE_VERMAGIC: ::c_uint = 0x0002;
 
-// malloc.h
-pub const M_MXFAST: ::c_int = 1;
-pub const M_NLBLKS: ::c_int = 2;
-pub const M_GRAIN: ::c_int = 3;
-pub const M_KEEP: ::c_int = 4;
-pub const M_TRIM_THRESHOLD: ::c_int = -1;
-pub const M_TOP_PAD: ::c_int = -2;
-pub const M_MMAP_THRESHOLD: ::c_int = -3;
-pub const M_MMAP_MAX: ::c_int = -4;
-pub const M_CHECK_ACTION: ::c_int = -5;
-pub const M_PERTURB: ::c_int = -6;
-pub const M_ARENA_TEST: ::c_int = -7;
-pub const M_ARENA_MAX: ::c_int = -8;
-
 f! {
     pub fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {
         for slot in cpuset.bits.iter_mut() {
@@ -2143,7 +2129,6 @@ extern {
         nobj: ::size_t,
         stream: *mut ::FILE
     ) -> ::size_t;
-    pub fn mallopt(param: ::c_int, value: ::c_int) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -1576,6 +1576,20 @@ pub const ATF_MAGIC: ::c_int = 0x80;
 pub const MODULE_INIT_IGNORE_MODVERSIONS: ::c_uint = 0x0001;
 pub const MODULE_INIT_IGNORE_VERMAGIC: ::c_uint = 0x0002;
 
+// malloc.h
+pub const M_MXFAST: ::c_int = 1;
+pub const M_NLBLKS: ::c_int = 2;
+pub const M_GRAIN: ::c_int = 3;
+pub const M_KEEP: ::c_int = 4;
+pub const M_TRIM_THRESHOLD: ::c_int = -1;
+pub const M_TOP_PAD: ::c_int = -2;
+pub const M_MMAP_THRESHOLD: ::c_int = -3;
+pub const M_MMAP_MAX: ::c_int = -4;
+pub const M_CHECK_ACTION: ::c_int = -5;
+pub const M_PERTURB: ::c_int = -6;
+pub const M_ARENA_TEST: ::c_int = -7;
+pub const M_ARENA_MAX: ::c_int = -8;
+
 f! {
     pub fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {
         for slot in cpuset.bits.iter_mut() {
@@ -2129,6 +2143,7 @@ extern {
         nobj: ::size_t,
         stream: *mut ::FILE
     ) -> ::size_t;
+    pub fn mallopt(param: ::c_int, value: ::c_int) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -824,6 +824,19 @@ pub const NFT_TRACETYPE_RULE: ::c_int = 3;
 pub const NFT_NG_INCREMENTAL: ::c_int = 0;
 pub const NFT_NG_RANDOM: ::c_int = 1;
 
+pub const M_MXFAST: ::c_int = 1;
+pub const M_NLBLKS: ::c_int = 2;
+pub const M_GRAIN: ::c_int = 3;
+pub const M_KEEP: ::c_int = 4;
+pub const M_TRIM_THRESHOLD: ::c_int = -1;
+pub const M_TOP_PAD: ::c_int = -2;
+pub const M_MMAP_THRESHOLD: ::c_int = -3;
+pub const M_MMAP_MAX: ::c_int = -4;
+pub const M_CHECK_ACTION: ::c_int = -5;
+pub const M_PERTURB: ::c_int = -6;
+pub const M_ARENA_TEST: ::c_int = -7;
+pub const M_ARENA_MAX: ::c_int = -8;
+
 #[doc(hidden)]
 pub const AF_MAX: ::c_int = 42;
 #[doc(hidden)]
@@ -856,6 +869,7 @@ extern {
     pub fn setutxent();
     pub fn endutxent();
     pub fn getpt() -> ::c_int;
+    pub fn mallopt(param: ::c_int, value: ::c_int) -> ::c_int;
 }
 
 #[link(name = "util")]


### PR DESCRIPTION
First time contributor. Thanks for the excellent contributing guide.
I'm not quite sure I put the method in the right place. [The GNULib docs](https://www.gnu.org/software/gnulib/manual/html_node/mallopt.html) say its not on Android 7.1, but there are [mentions of it in some android headers](https://android.googlesource.com/platform/bionic/+/master/libc/include/malloc.h).