### PR TITLE
Fix mips-unknown-linux-uclibc target

### DIFF
--- a/src/unix/uclibc/mips/mod.rs
+++ b/src/unix/uclibc/mips/mod.rs
@@ -226,8 +226,8 @@ pub const SO_BPF_EXTENSIONS: ::c_int = 48;
 pub const FIOCLEX: ::c_ulong = 0x6601;
 pub const FIONBIO: ::c_ulong = 0x667e;
 
-pub const SA_ONSTACK: ::c_int = 0x08000000;
-pub const SA_SIGINFO: ::c_int = 0x00000008;
+pub const SA_ONSTACK: ::c_uint = 0x08000000;
+pub const SA_SIGINFO: ::c_uint = 0x00000008;
 pub const SA_NOCLDWAIT: ::c_int = 0x00010000;
 
 pub const SIGCHLD: ::c_int = 18;

--- a/src/unix/uclibc/mod.rs
+++ b/src/unix/uclibc/mod.rs
@@ -1634,6 +1634,8 @@ extern {
     pub fn uselocale(loc: ::locale_t) -> ::locale_t;
     pub fn creat64(path: *const c_char, mode: mode_t) -> ::c_int;
     pub fn fstat64(fildes: ::c_int, buf: *mut stat64) -> ::c_int;
+    pub fn fstatat64(fildes: ::c_int, path: *const ::c_char,
+                     buf: *mut stat64, flag: ::c_int) -> ::c_int;
     pub fn ftruncate64(fd: ::c_int, length: off64_t) -> ::c_int;
     pub fn getrlimit64(resource: ::c_int, rlim: *mut rlimit64) -> ::c_int;
     pub fn lseek64(fd: ::c_int, offset: off64_t, whence: ::c_int) -> off64_t;
@@ -1852,6 +1854,8 @@ extern {
     pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
 
     pub fn seekdir(dirp: *mut ::DIR, loc: ::c_long);
+
+    pub fn dirfd(dirp: *mut ::DIR) -> ::c_int;
 
     pub fn telldir(dirp: *mut ::DIR) -> ::c_long;
     pub fn madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int)


### PR DESCRIPTION
The mips(el)-unknown-linux-uclibc target has apparently been broken in one way or another for over a year. This PR is the patch it took to successfully build a beta toolchain that could support it.

I am pretty sure these fixes are the right answer, after considerable digging in both the libc crate source (_pub-use pub-use everywhere, and not a hint to link_) and the uClibc source (_it's not POSIX, but they've shipped it since 2007, so close enough_).

For those who don't know, the *-uClibc targets are the only way (AFAIK) to create Rust binaries which run on Linux kernels prior to 2.6. It is a use case that is getting quite rare these days, but is still present in embedded ecosystems where chip vendors never migrated their hardware support to newer kernel versions.

Here's hoping these Rust toolchain targets find a maintainer someday.

cc rust-lang/rust#43503