### PR TITLE
Add new FreeBSD socket option SO_REUSEPORT_LB.

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -556,7 +556,8 @@ fn main() {
             "PD_CLOEXEC" | "PD_ALLOWED_AT_FORK" if freebsd => true,
 
             // These constants were added in FreeBSD 12
-            "SF_USER_READAHEAD" if freebsd => true,
+            "SF_USER_READAHEAD" |
+            "SO_REUSEPORT_LB" if freebsd => true,
 
             // These OSX constants are removed in Sierra.
             // https://developer.apple.com/library/content/releasenotes/General/APIDiffsMacOS10_12/Swift/Darwin.html

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -457,6 +457,7 @@ pub const JAIL_SYS_INHERIT: ::c_int = 2;
 pub const SO_BINTIME: ::c_int = 0x2000;
 pub const SO_NO_OFFLOAD: ::c_int = 0x4000;
 pub const SO_NO_DDP: ::c_int = 0x8000;
+pub const SO_REUSEPORT_LB: ::c_int = 0x10000;
 pub const SO_LABEL: ::c_int = 0x1009;
 pub const SO_PEERLABEL: ::c_int = 0x1010;
 pub const SO_LISTENQLIMIT: ::c_int = 0x1011;


### PR DESCRIPTION
FreeBSD 12, which is scheduled to be released soon, has a new socket option SO_REUSEPORT_LB.  
From setsockopt man page:
     SO_REUSEPORT_LB allows completely duplicate bindings by multiple
     processes if they all set SO_REUSEPORT_LB before binding the port.
     Incoming TCP and UDP connections are distributed among the sharing
     processes based on a hash function of local port number, foreign IP
     address and port number. A maximum of 256 processes can share one socket.
