### PR TITLE
Re-export core::ffi::c_void if it exists

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ description = """
 A library for types and bindings to native C functions often found in libc or
 other common platform libraries.
 """
+build = "build.rs"
 
 [badges]
 travis-ci = { repository = "rust-lang/libc" }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,35 @@
+use std::env;
+use std::process::Command;
+use std::str;
+
+fn main() {
+    /*
+     * If `core::ffi::c_void` exists, libc can just re-export it. Otherwise, it
+     * must define an incompatible type to retain backwards-compatibility.
+     */
+    if rustc_minor_version().expect("Failed to get rustc version") >= 31 {
+        println!("cargo:rustc-cfg=core_cvoid");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    macro_rules! otry {
+        ($e:expr) => {
+            match $e {
+                Some(e) => e,
+                None => return None,
+            }
+        };
+    }
+
+    let rustc = otry!(env::var_os("RUSTC"));
+    let output = otry!(Command::new(rustc).arg("--version").output().ok());
+    let version = otry!(str::from_utf8(&output.stdout).ok());
+    let mut pieces = version.split('.');
+
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+
+    otry!(pieces.next()).parse().ok()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,17 +108,22 @@ cfg_if! {
         // On the Switch, we only define some useful universal types for
         // convenience. Those can be found in the switch.rs file.
     } else {
-
-        // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help enable
-        // more optimization opportunities around it recognizing things like
-        // malloc/free.
-        #[repr(u8)]
-        pub enum c_void {
-            // Two dummy variants so the #[repr] attribute can be used.
-            #[doc(hidden)]
-            __variant1,
-            #[doc(hidden)]
-            __variant2,
+        cfg_if! {
+            if #[cfg(core_cvoid)] {
+                pub use core::ffi::c_void;
+            } else {
+                // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help enable
+                // more optimization opportunities around it recognizing things like
+                // malloc/free.
+                #[repr(u8)]
+                pub enum c_void {
+                    // Two dummy variants so the #[repr] attribute can be used.
+                    #[doc(hidden)]
+                    __variant1,
+                    #[doc(hidden)]
+                    __variant2,
+                }
+            }
         }
 
         pub type int8_t = i8;

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -1,17 +1,5 @@
 //! Switch C type definitions
 
-// Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help enable
-// more optimization opportunities around it recognizing things like
-// malloc/free.
-#[repr(u8)]
-pub enum c_void {
-    // Two dummy variants so the #[repr] attribute can be used.
-    #[doc(hidden)]
-    __variant1,
-    #[doc(hidden)]
-    __variant2,
-}
-
 pub type int8_t = i8;
 pub type int16_t = i16;
 pub type int32_t = i32;
@@ -46,3 +34,21 @@ pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type wchar_t = u32;
+
+cfg_if! {
+    if #[cfg(core_cvoid)] {
+        pub use core::ffi::c_void;
+    } else {
+        // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help
+        // enable more optimization opportunities around it recognizing things
+        // like malloc/free.
+        #[repr(u8)]
+        pub enum c_void {
+            // Two dummy variants so the #[repr] attribute can be used.
+            #[doc(hidden)]
+            __variant1,
+            #[doc(hidden)]
+            __variant2,
+        }
+    }
+}


### PR DESCRIPTION
This is the second part of the implementation of [RFC 2521](https://github.com/rust-lang/rfcs/pull/2521), replacing the definition of `c_void` in libc with a re-export of the type from `core::ffi::c_void` on builds it exists for.

This uses the re-export for rustc version `1.31.0` or greater, as `1.30.x` was the current nightly when [the PR for the changes to libcore and libstd](https://github.com/rust-lang/rust/pull/53910) was merged, so I'm assuming the first nightly they will appear in will be `1.31.0`; is this acceptable?

cc rust-lang/rust#53856