### PR TITLE
Expose futimens and utimensat on FreeBSD and DragonFly

### DIFF
--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1136,6 +1136,9 @@ extern {
                         timeout: *const ::timespec) -> ::c_int;
     pub fn sigwaitinfo(set: *const sigset_t,
                        info: *mut siginfo_t) -> ::c_int;
+    pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
+    pub fn utimensat(dirfd: ::c_int, path: *const ::c_char,
+                     times: *const ::timespec, flag: ::c_int) -> ::c_int;
     pub fn openpty(amaster: *mut ::c_int,
                    aslave: *mut ::c_int,
                    name: *mut ::c_char,


### PR DESCRIPTION
Should have sent this out with #1084 but I didn't notice then that these were missing (see https://github.com/nix-rust/nix/pull/944).

Haven't been able to test these locally as I do not have access to these platforms. Will rely on CI to verify these for me.