### PR TITLE
Revisit work on cvoid

### DIFF
--- a/src/switch.rs
+++ b/src/switch.rs
@@ -34,21 +34,3 @@ pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type wchar_t = u32;
-
-cfg_if! {
-    if #[cfg(core_cvoid)] {
-        pub use core::ffi::c_void;
-    } else {
-        // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help
-        // enable more optimization opportunities around it recognizing things
-        // like malloc/free.
-        #[repr(u8)]
-        pub enum c_void {
-            // Two dummy variants so the #[repr] attribute can be used.
-            #[doc(hidden)]
-            __variant1,
-            #[doc(hidden)]
-            __variant2,
-        }
-    }
-}


### PR DESCRIPTION
At the recommendation of @SimonSapin [here](https://github.com/rust-lang/rust/issues/53856#issuecomment-422932721), I have revisited the build script to check whether `core::ffi::c_void` resolves, instead of relying on a particular `rustc` version. This allows use on `1.30.x` builds with `core::ffi::c_void`.

I also noticed that `c_void` is defined twice in this crate, once in `lib.rs` and again in `switch.rs`. This instead defines `c_void` for every target except `wasm32`. As far as I can tell, this shouldn't actually change functionality on any existing targets.