### PR TITLE
Add fcntl constants for advisory locking on BSDs

### DIFF
--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -215,6 +215,10 @@ pub const O_NDELAY: ::c_int = O_NONBLOCK;
 pub const F_GETOWN: ::c_int = 5;
 pub const F_SETOWN: ::c_int = 6;
 
+pub const F_RDLCK: ::c_short = 1
+pub const F_UNLCK: ::c_short = 2
+pub const F_WRLCK: ::c_short = 3
+
 pub const MNT_FORCE: ::c_int = 0x80000;
 
 pub const Q_SYNC: ::c_int = 0x600;

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -215,9 +215,9 @@ pub const O_NDELAY: ::c_int = O_NONBLOCK;
 pub const F_GETOWN: ::c_int = 5;
 pub const F_SETOWN: ::c_int = 6;
 
-pub const F_RDLCK: ::c_short = 1
-pub const F_UNLCK: ::c_short = 2
-pub const F_WRLCK: ::c_short = 3
+pub const F_RDLCK: ::c_short = 1;
+pub const F_UNLCK: ::c_short = 2;
+pub const F_WRLCK: ::c_short = 3;
 
 pub const MNT_FORCE: ::c_int = 0x80000;
 


### PR DESCRIPTION
For range-based locking POSIX fcntl locks are needed. This adds the
constants F_RDLCK, F_UNLCK, and F_WRLCK for FreeBSD, NetBSD, OpenBSD,
DragonFlyBSD, and macOS/iOS. Fortunately these values are defined the same across these platforms.