### PR TITLE
Added ptrace constants for apple

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -747,7 +747,7 @@ pub const PROT_READ: ::c_int = 1;
 pub const PROT_WRITE: ::c_int = 2;
 pub const PROT_EXEC: ::c_int = 4;
 
-pub const PT_TRACEME: ::c_int = 0;
+pub const PT_TRACE_ME: ::c_int = 0;
 pub const PT_READ_I: ::c_int = 1;
 pub const PT_READ_D: ::c_int = 2;
 pub const PT_READ_U: ::c_int = 3;

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -747,6 +747,26 @@ pub const PROT_READ: ::c_int = 1;
 pub const PROT_WRITE: ::c_int = 2;
 pub const PROT_EXEC: ::c_int = 4;
 
+pub const PT_TRACEME: ::c_int = 0;
+pub const PT_READ_I: ::c_int = 1;
+pub const PT_READ_D: ::c_int = 2;
+pub const PT_READ_U: ::c_int = 3;
+pub const PT_WRITE_I: ::c_int = 4;
+pub const PT_WRITE_D: ::c_int = 5;
+pub const PT_WRITE_U: ::c_int = 6;
+pub const PT_CONTINUE: ::c_int = 7;
+pub const PT_KILL: ::c_int = 8;
+pub const PT_STEP: ::c_int = 9;
+pub const PT_ATTACH: ::c_int = 10;
+pub const PT_DETACH: ::c_int = 11;
+pub const PT_SIGEXC: ::c_int = 12;
+pub const PT_THUPDATE: ::c_int = 13;
+pub const PT_ATTACHEXC: ::c_int = 14;
+
+pub const PT_FORCEQUOTA: ::c_int = 30;
+pub const PT_DENY_ATTACH: ::c_int = 31;
+pub const PT_FIRSTMACH: ::c_int = 32;
+
 pub const MAP_FILE: ::c_int = 0x0000;
 pub const MAP_SHARED: ::c_int = 0x0001;
 pub const MAP_PRIVATE: ::c_int = 0x0002;


### PR DESCRIPTION
I noticed the ptrace constants were missing for apple so I've added them referencing this [header](https://opensource.apple.com/source/xnu/xnu-792.13.8/bsd/sys/ptrace.h). This doesn't add any new functions just constants so I haven't added any tests which seems to be correct.