### PR TITLE
Add acct(2) to BSD module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,6 @@ matrix:
            RUSTFLAGS=-Clink-arg=-mios-simulator-version-min=7.0
       before_install:
         rustc ./ci/ios/deploy_and_run_on_ios_simulator.rs -o $HOME/runtest
-    - env: TARGET=x86_64-rumprun-netbsd
     - env: TARGET=powerpc-unknown-linux-gnu
     - env: TARGET=powerpc64-unknown-linux-gnu
     - env: TARGET=powerpc64le-unknown-linux-gnu

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -543,7 +543,6 @@ extern {
                           attr: *const ::pthread_attr_t,
                           f: extern fn(*mut ::c_void) -> *mut ::c_void,
                           value: *mut ::c_void) -> ::c_int;
-    #[cfg(not(target_vendor = "rumprun"))]
     pub fn acct(filename: *const ::c_char) -> ::c_int;
 }
 

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -543,6 +543,8 @@ extern {
                           attr: *const ::pthread_attr_t,
                           f: extern fn(*mut ::c_void) -> *mut ::c_void,
                           value: *mut ::c_void) -> ::c_int;
+    #[cfg(not(target_vendor = "rumprun"))]
+    pub fn acct(filename: *const ::c_char) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
The `acct` syscall is supported on BSD platforms, the PR aims to add it to the BSD module.