### PR TITLE
Add TIOCGRS485 and TIOCSRS485 for musl #1094

### DIFF
--- a/src/unix/notbsd/linux/musl/b32/arm.rs
+++ b/src/unix/notbsd/linux/musl/b32/arm.rs
@@ -467,6 +467,9 @@ pub const TIOCMSET: ::c_int = 0x5418;
 pub const FIONREAD: ::c_int = 0x541B;
 pub const TIOCCONS: ::c_int = 0x541D;
 
+pub const TIOCGRS485: ::c_int = 0x542E;
+pub const TIOCSRS485: ::c_int = 0x542F;
+
 pub const POLLWRNORM: ::c_short = 0x100;
 pub const POLLWRBAND: ::c_short = 0x200;
 

--- a/src/unix/notbsd/linux/musl/b32/mips.rs
+++ b/src/unix/notbsd/linux/musl/b32/mips.rs
@@ -478,6 +478,9 @@ pub const TIOCMSET: ::c_int = 0x741A;
 pub const FIONREAD: ::c_int = 0x467F;
 pub const TIOCCONS: ::c_int = 0x80047478;
 
+pub const TIOCGRS485: ::c_int = 0x542E;
+pub const TIOCSRS485: ::c_int = 0x542F;
+
 pub const POLLWRNORM: ::c_short = 0x4;
 pub const POLLWRBAND: ::c_short = 0x100;
 

--- a/src/unix/notbsd/linux/musl/b32/mips.rs
+++ b/src/unix/notbsd/linux/musl/b32/mips.rs
@@ -478,8 +478,8 @@ pub const TIOCMSET: ::c_int = 0x741A;
 pub const FIONREAD: ::c_int = 0x467F;
 pub const TIOCCONS: ::c_int = 0x80047478;
 
-pub const TIOCGRS485: ::c_int = 0x542E;
-pub const TIOCSRS485: ::c_int = 0x542F;
+pub const TIOCGRS485: ::c_int = 0x4020542E;
+pub const TIOCSRS485: ::c_int = 0xC020542F;
 
 pub const POLLWRNORM: ::c_short = 0x4;
 pub const POLLWRBAND: ::c_short = 0x100;

--- a/src/unix/notbsd/linux/musl/b32/powerpc.rs
+++ b/src/unix/notbsd/linux/musl/b32/powerpc.rs
@@ -470,6 +470,9 @@ pub const TIOCMSET: ::c_int = 0x5418;
 pub const FIONREAD: ::c_int = 0x4004667F;
 pub const TIOCCONS: ::c_int = 0x541D;
 
+pub const TIOCGRS485: ::c_int = 0x542e;
+pub const TIOCSRS485: ::c_int = 0x542f;
+
 pub const POLLWRNORM: ::c_short = 0x100;
 pub const POLLWRBAND: ::c_short = 0x200;
 

--- a/src/unix/notbsd/linux/musl/b32/x86.rs
+++ b/src/unix/notbsd/linux/musl/b32/x86.rs
@@ -481,6 +481,9 @@ pub const TIOCMSET: ::c_int = 0x5418;
 pub const FIONREAD: ::c_int = 0x541B;
 pub const TIOCCONS: ::c_int = 0x541D;
 
+pub const TIOCGRS485: ::c_int = 0x542E;
+pub const TIOCSRS485: ::c_int = 0x542F;
+
 pub const POLLWRNORM: ::c_short = 0x100;
 pub const POLLWRBAND: ::c_short = 0x200;
 

--- a/src/unix/notbsd/linux/musl/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/musl/b64/aarch64.rs
@@ -459,6 +459,9 @@ pub const TIOCMSET: ::c_int = 0x5418;
 pub const FIONREAD: ::c_int = 0x541B;
 pub const TIOCCONS: ::c_int = 0x541D;
 
+pub const TIOCGRS485: ::c_int = 0x542E;
+pub const TIOCSRS485: ::c_int = 0x542F;
+
 pub const TIOCM_LE: ::c_int = 0x001;
 pub const TIOCM_DTR: ::c_int = 0x002;
 pub const TIOCM_RTS: ::c_int = 0x004;

--- a/src/unix/notbsd/linux/musl/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/musl/b64/powerpc64.rs
@@ -493,6 +493,9 @@ pub const TIOCM_DSR: ::c_ulong = 0x100;
 pub const TIOCM_CD: ::c_ulong = TIOCM_CAR;
 pub const TIOCM_RI: ::c_ulong = TIOCM_RNG;
 
+pub const TIOCGRS485: ::c_ulong = 0x542E;
+pub const TIOCSRS485: ::c_ulong = 0x542F;
+
 pub const RLIMIT_NLIMITS: ::c_int = 15;
 pub const TIOCINQ: ::c_ulong = ::FIONREAD;
 pub const MCL_CURRENT: ::c_int = 0x2000;
@@ -569,4 +572,4 @@ pub const B4000000: ::speed_t = 0o00036;
 
 extern {
     pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
-}
+#endif}

--- a/src/unix/notbsd/linux/musl/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/musl/b64/powerpc64.rs
@@ -572,4 +572,4 @@ pub const B4000000: ::speed_t = 0o00036;
 
 extern {
     pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
-#endif}
+}


### PR DESCRIPTION
I need help with adding `TIOCSRS485` and `TIOCSRS485` constants to libc.