### PR TITLE
remove the iOS simulator targets from CI / update ctest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,20 +55,6 @@ matrix:
     - env: TARGET=aarch64-unknown-linux-musl
       # FIXME(#856)
       rust: 1.22.1
-    - os: osx
-      osx_image: xcode9.4
-      env: TARGET=i386-apple-ios
-           CARGO_TARGET_I386_APPLE_IOS_RUNNER=$HOME/runtest
-           RUSTFLAGS=-Clink-arg=-mios-simulator-version-min=7.0
-      before_install:
-        rustc ./ci/ios/deploy_and_run_on_ios_simulator.rs -o $HOME/runtest
-    - os: osx
-      osx_image: xcode9.4
-      env: TARGET=x86_64-apple-ios
-           CARGO_TARGET_X86_64_APPLE_IOS_RUNNER=$HOME/runtest
-           RUSTFLAGS=-Clink-arg=-mios-simulator-version-min=7.0
-      before_install:
-        rustc ./ci/ios/deploy_and_run_on_ios_simulator.rs -o $HOME/runtest
     - env: TARGET=powerpc-unknown-linux-gnu
     - env: TARGET=powerpc64-unknown-linux-gnu
     - env: TARGET=powerpc64le-unknown-linux-gnu
@@ -105,13 +91,6 @@ matrix:
 
     # QEMU based targets that compile in an emulator
     - env: TARGET=x86_64-unknown-freebsd
-  allow_failures:
-    - env: TARGET=i386-apple-ios
-           CARGO_TARGET_I386_APPLE_IOS_RUNNER=$HOME/runtest
-           RUSTFLAGS=-Clink-arg=-mios-simulator-version-min=7.0
-    - env: TARGET=x86_64-apple-ios
-           CARGO_TARGET_X86_64_APPLE_IOS_RUNNER=$HOME/runtest
-           RUSTFLAGS=-Clink-arg=-mios-simulator-version-min=7.0
 
 notifications:
   email:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ctest"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -85,7 +85,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc-test"
 version = "0.1.0"
 dependencies = [
- "ctest 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctest 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43",
 ]
 
@@ -281,7 +281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 "checksum cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "2119ea4867bd2b8ed3aecab467709720b2d55b1bcfe09f772fd68066eaf15275"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
-"checksum ctest 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8642e4e5ef24727d537ae8961ea295a334d670eb0934b51f2a72592e5c50007f"
+"checksum ctest 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e2aae9108e4e3fdabedb2d854882fb70a09210bfbcad4a2bd7320d34cc17bb07"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum extprim 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "054bc2552b3f66fa8097e29e47255bfff583c08e737a67cbbb54b817ddaa5206"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"


### PR DESCRIPTION
The iOS simulator targets failed to produce proper output with xcode 9.4 versions and started failing, which started warning about system libraries being improperly linked, and now they are failing to link. The i386-apple-ios target is deprecated in xcode10, and will supposedly be removed in xcode11. 

This is a shame, but supporting `x86_64-apple-ios` is going to need some work in rustc till it starts working again.