### PR TITLE
Add F_RDLCK/F_WRLCK/F_UNLCK to several platforms

### DIFF
--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -351,6 +351,10 @@ pub const F_SETLK: ::c_int = 0x0080;
 pub const F_SETLKW: ::c_int = 0x0100;
 pub const F_DUPFD_CLOEXEC: ::c_int = 0x0200;
 
+pub const F_RDLCK: ::c_int = 0x0040;
+pub const F_UNLCK: ::c_int = 0x0200;
+pub const F_WRLCK: ::c_int = 0x0400;
+
 pub const AT_FDCWD: ::c_int = -1;
 pub const AT_SYMLINK_NOFOLLOW: ::c_int = 0x01;
 pub const AT_SYMLINK_FOLLOW: ::c_int = 0x02;

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -744,6 +744,10 @@ pub const F_SETOWN: ::c_int = 8;
 pub const F_SETLK: ::c_int = 6;
 pub const F_SETLKW: ::c_int = 7;
 
+pub const F_RDLCK: ::c_int = 0;
+pub const F_WRLCK: ::c_int = 1;
+pub const F_UNLCK: ::c_int = 2;
+
 pub const TCGETS: ::c_int = 0x5401;
 pub const TCSETS: ::c_int = 0x5402;
 pub const TCSETSW: ::c_int = 0x5403;

--- a/src/unix/notbsd/linux/musl/mod.rs
+++ b/src/unix/notbsd/linux/musl/mod.rs
@@ -121,6 +121,10 @@ pub const ECOMM: ::c_int = 70;
 pub const EPROTO: ::c_int = 71;
 pub const EDOTDOT: ::c_int = 73;
 
+pub const F_RDLCK: ::c_int = 0;
+pub const F_WRLCK: ::c_int = 1;
+pub const F_UNLCK: ::c_int = 2;
+
 pub const SA_NODEFER: ::c_int = 0x40000000;
 pub const SA_RESETHAND: ::c_int = 0x80000000;
 pub const SA_RESTART: ::c_int = 0x10000000;

--- a/src/unix/notbsd/linux/other/b32/mod.rs
+++ b/src/unix/notbsd/linux/other/b32/mod.rs
@@ -251,6 +251,10 @@ pub const F_SETOWN: ::c_int = 8;
 pub const F_SETLK: ::c_int = 6;
 pub const F_SETLKW: ::c_int = 7;
 
+pub const F_RDLCK: ::c_int = 0;
+pub const F_WRLCK: ::c_int = 1;
+pub const F_UNLCK: ::c_int = 2;
+
 pub const SFD_NONBLOCK: ::c_int = 0x0800;
 
 pub const TIOCEXCL: ::c_ulong = 0x540C;

--- a/src/unix/notbsd/linux/other/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/other/b64/aarch64.rs
@@ -340,6 +340,10 @@ pub const F_SETOWN: ::c_int = 8;
 pub const F_SETLK: ::c_int = 6;
 pub const F_SETLKW: ::c_int = 7;
 
+pub const F_RDLCK: ::c_int = 0;
+pub const F_WRLCK: ::c_int = 1;
+pub const F_UNLCK: ::c_int = 2;
+
 pub const SFD_NONBLOCK: ::c_int = 0x0800;
 
 pub const TIOCEXCL: ::c_ulong = 0x540C;

--- a/src/unix/notbsd/linux/other/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/other/b64/powerpc64.rs
@@ -327,6 +327,10 @@ pub const F_SETOWN: ::c_int = 8;
 pub const F_SETLK: ::c_int = 6;
 pub const F_SETLKW: ::c_int = 7;
 
+pub const F_RDLCK: ::c_int = 0;
+pub const F_WRLCK: ::c_int = 1;
+pub const F_UNLCK: ::c_int = 2;
+
 pub const SFD_NONBLOCK: ::c_int = 0x0800;
 
 pub const TIOCEXCL: ::c_ulong = 0x540C;

--- a/src/unix/notbsd/linux/other/b64/sparc64.rs
+++ b/src/unix/notbsd/linux/other/b64/sparc64.rs
@@ -305,6 +305,10 @@ pub const F_SETOWN: ::c_int = 6;
 pub const F_SETLK: ::c_int = 8;
 pub const F_SETLKW: ::c_int = 9;
 
+pub const F_RDLCK: ::c_int = 1;
+pub const F_WRLCK: ::c_int = 2;
+pub const F_UNLCK: ::c_int = 3;
+
 pub const SFD_NONBLOCK: ::c_int = 0x4000;
 
 pub const TIOCEXCL: ::c_ulong = 0x2000740d;


### PR DESCRIPTION
These are used by the flock wrapper in rustc_data_structures. The constants were already present in x86_64-linux-gnu and BSD (since 4928bd986907).

Currently the `flock` wrapper in `rustc_data_structures` does not work on several 32-bit musl targets, because they expect the `LARGEFILE64` version of the `F_SETLK`/`F_SETLKW` constants. This PR is a prerequisite to converting that code to use the `libc` types and constants, instead of (inaccurately) duplicating them, since `libc` already provides architecture-specific definitions of the relevant constants.