### PR TITLE
Use OR in the license field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "libc"
 version = "0.2.43"
 authors = ["The Rust Project Developers"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-lang/libc"
 homepage = "https://github.com/rust-lang/libc"


### PR DESCRIPTION
According to [The Manifest Format](https://doc.rust-lang.org/cargo/reference/manifest.html):
>Multiple licenses can be separated with a `/`, although that usage is deprecated.  Instead, use a license expression with AND and OR operators to get more explicit semantics.