### PR TITLE
Use Reqwest backend for Appveyor, not Hyper which is deprecated

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 environment:
   # When this was added there were revocation check failures when using the
   # libcurl backend as libcurl checks by default, but rustup doesn't provide the
-  # switch to turn this off. Switch to Hyper which looks to not check for
+  # switch to turn this off. Switch to Reqwest which looks to not check for
   # revocation by default like libcurl does.
-  RUSTUP_USE_HYPER: 1
+  RUSTUP_USE_REQWEST: 1
   CARGO_HTTP_CHECK_REVOKE: false
   matrix:
   - TARGET: x86_64-pc-windows-gnu


### PR DESCRIPTION
Since https://github.com/rust-lang-nursery/rustup.rs/pull/1222 Appveyor builds have been complaining, so should stop asking for the Hyper backend