### PR TITLE
Add missing condition for musl mips64

### DIFF
--- a/src/unix/uclibc/mod.rs
+++ b/src/unix/uclibc/mod.rs
@@ -1950,7 +1950,7 @@ extern {
 }
 
 cfg_if! {
-    if #[cfg(target_arch = "mips")] {
+    if #[cfg(any(target_arch = "mips", target_arch = "mips64"))] {
         mod mips;
         pub use self::mips::*;
     } else if #[cfg(target_arch = "x86_64")] {


### PR DESCRIPTION
unix::uclibc::mips has both support for mips and mips64, but it's
currently only imported for mips.