### PR TITLE
Prepare for being included via crates.io into std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
-
 name = "libc"
-version = "0.2.43"
+version = "0.2.44"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -19,10 +18,14 @@ exclude = ["/ci/*", "/.travis.yml", "/appveyor.yml"]
 travis-ci = { repository = "rust-lang/libc" }
 appveyor = { repository = "rust-lang/libc", project_name = "rust-lang-libs/libc" }
 
+[dependencies]
+rustc-std-workspace-core = { version = "1.0.0", optional = true }
+
 [features]
 default = ["use_std"]
 use_std = []
 align = []
+rustc-dep-of-std = ['align', 'rustc-std-workspace-core']
 
 [workspace]
 members = ["libc-test"]

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -441,7 +441,7 @@ fn main() {
             // which is absent in glibc, has to be defined.
             "__timeval" if linux => true,
 
-            // Fixed on stdbuild with repr(packed(4))
+            // Fixed on feature=align with repr(packed(4))
             // Once repr_packed stabilizes we can fix this unconditionally
             // and remove this check.
             "kevent" | "shmid_ds" if apple && x86_64 => true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,21 +150,32 @@
     )
 )]
 // Attributes needed when building as part of the standard library
-#![cfg_attr(feature = "stdbuild", feature(staged_api, cfg_target_vendor))]
-#![cfg_attr(feature = "stdbuild", feature(link_cfg, repr_packed))]
-#![cfg_attr(feature = "stdbuild", allow(warnings))]
+#![cfg_attr(feature = "rustc-dep-of-std", feature(staged_api, cfg_target_vendor))]
+#![cfg_attr(feature = "rustc-dep-of-std", feature(link_cfg, repr_packed))]
+#![cfg_attr(feature = "rustc-dep-of-std", feature(no_core))]
+#![cfg_attr(feature = "rustc-dep-of-std", no_core)]
+#![cfg_attr(feature = "rustc-dep-of-std", allow(warnings))]
 #![cfg_attr(
-    feature = "stdbuild",
+    feature = "rustc-dep-of-std",
     unstable(
         feature = "libc",
         reason = "use `libc` from crates.io",
         issue = "27783"
     )
 )]
-#![cfg_attr(not(feature = "use_std"), no_std)]
+#![cfg_attr(not(any(feature = "use_std", feature = "rustc-dep-of-std")), no_std)]
 
 #[cfg(all(not(cross_platform_docs), feature = "use_std"))]
 extern crate std as core;
+
+#[cfg(feature = "rustc-dep-of-std")]
+extern crate rustc_std_workspace_core as core;
+#[cfg(feature = "rustc-dep-of-std")]
+#[allow(unused_imports)]
+use core::iter;
+#[cfg(feature = "rustc-dep-of-std")]
+#[allow(unused_imports)]
+use core::option;
 
 #[macro_use]
 mod macros;

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -245,7 +245,7 @@ s! {
         pub f_reserved: [::uint32_t; 8],
     }
 
-    #[cfg_attr(feature = "stdbuild", repr(packed(4)))]
+    #[cfg_attr(feature = "rustc-dep-of-std", repr(packed(4)))]
     pub struct kevent {
         pub ident: ::uintptr_t,
         pub filter: ::int16_t,
@@ -535,7 +535,7 @@ s! {
         pub _key: ::key_t,
     }
 
-    #[cfg_attr(feature = "stdbuild", repr(packed(4)))]
+    #[cfg_attr(feature = "rustc-dep-of-std", repr(packed(4)))]
     pub struct shmid_ds {
         pub shm_perm: ipc_perm,
         pub shm_segsz: ::size_t,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -318,17 +318,18 @@ cfg_if! {
         // cargo build, don't pull in anything extra as the libstd dep
         // already pulls in all libs.
     } else if #[cfg(target_env = "musl")] {
-        #[cfg_attr(feature = "stdbuild",
+        #[cfg_attr(feature = "rustc-dep-of-std",
                    link(name = "c", kind = "static",
                         cfg(target_feature = "crt-static")))]
-        #[cfg_attr(feature = "stdbuild",
+        #[cfg_attr(feature = "rustc-dep-of-std",
                    link(name = "c", cfg(not(target_feature = "crt-static"))))]
         extern {}
     } else if #[cfg(target_os = "emscripten")] {
         #[link(name = "c")]
         extern {}
     } else if #[cfg(all(target_os = "netbsd",
-                        feature = "stdbuild", target_vendor = "rumprun"))] {
+                        feature = "rustc-dep-of-std",
+                        target_vendor = "rumprun"))] {
         // Since we don't use -nodefaultlibs on Rumprun, libc is always pulled
         // in automatically by the linker. We avoid passing it explicitly, as it
         // causes some versions of binutils to crash with an assertion failure.

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -190,7 +190,7 @@ pub const EILSEQ: ::c_int = 42;
 pub const STRUNCATE: ::c_int = 80;
 
 // inline comment below appeases style checker
-#[cfg(all(target_env = "msvc", feature = "stdbuild"))] // " if "
+#[cfg(all(target_env = "msvc", feature = "rustc-dep-of-std"))] // " if "
 #[link(name = "msvcrt", cfg(not(target_feature = "crt-static")))]
 #[link(name = "libcmt", cfg(target_feature = "crt-static"))]
 extern {}


### PR DESCRIPTION
This commit prepares the `libc` crate to be included directly into the
standard library via crates.io. More details about this can be found on
rust-lang/rust#56092, but the main idea is that this crate now depends
on core/compiler-builtins explicitly (but off-by-default).

The main caveat here is that this activates `no_core` when building as
part of libstd, which means that it needs to explicitly have an `iter`
and `option` module for the expansion of `for` loops to work.