### PR TITLE
Add build job for Rust 1.30 version compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ matrix:
       script: rm -f Cargo.lock && cargo build
       install: true
 
+    # 1.30.0 compat
+    - env: TARGET=x86_64-unknown-linux-gnu
+      rust: 1.30.0
+      script: rm -f Cargo.lock && cargo build
+      install: true
+
     # build documentation
     - env: TARGET=x86_64-unknown-linux-gnu
       rust: nightly


### PR DESCRIPTION
From that version on we use `core::ffi::c_void` instead of our own `c_void`.