### PR TITLE
Add alias for MAP_ANONYMOUS to Apple targets.

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -772,6 +772,7 @@ pub const MAP_SHARED: ::c_int = 0x0001;
 pub const MAP_PRIVATE: ::c_int = 0x0002;
 pub const MAP_FIXED: ::c_int = 0x0010;
 pub const MAP_ANON: ::c_int = 0x1000;
+pub const MAP_ANONYMOUS: ::c_int = MAP_ANON;
 
 pub const VM_FLAGS_FIXED: ::c_int = 0x0000;
 pub const VM_FLAGS_ANYWHERE: ::c_int = 0x0001;


### PR DESCRIPTION
Closes #1060 .