### PR TITLE
dragonfly: add back missing errnos

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -376,6 +376,14 @@ pub const CTL_P1003_1B_SIGQUEUE_MAX: ::c_int = 24;
 pub const CTL_P1003_1B_TIMER_MAX: ::c_int = 25;
 pub const CTL_P1003_1B_MAXID: ::c_int = 26;
 
+pub const ENOMEDIUM: ::c_int = 93;
+pub const EUNUSED94: ::c_int = 94;
+pub const EUNUSED95: ::c_int = 95;
+pub const EUNUSED96: ::c_int = 96;
+pub const EUNUSED97: ::c_int = 97;
+pub const EUNUSED98: ::c_int = 98;
+pub const EASYNC: ::c_int = 99;
+
 pub const EVFILT_READ: ::int16_t = -1;
 pub const EVFILT_WRITE: ::int16_t = -2;
 pub const EVFILT_AIO: ::int16_t = -3;


### PR DESCRIPTION
A couple of errno's went missing from libc in commit 8293ced
(accidentally, I think). However, these are still in DragonflyBSD's
`sys/sys/errno.h` file and this breakage causes the `nix` crate to not
build.

One can see the `errno.h` file [here](http://gitweb.dragonflybsd.org/dragonfly.git/blob/25fa222:/sys/sys/errno.h#l188).

Signed-off-by: Levente Kurusa <lkurusa@acm.org>