### PR TITLE
OS X version cfg

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,12 @@ fn main() {
     if rustc_minor_version().expect("Failed to get rustc version") >= 30 {
         println!("cargo:rustc-cfg=core_cvoid");
     }
+
+    if cfg!(any(target_os = "macos", target_os = "ios")) {
+        let xcrun = Xcrun::version();
+        println!("cargo:rustc-cfg=osx_major=\"{}\"", xcrun.0);
+        println!("cargo:rustc-cfg=osx_minor=\"{}\"", xcrun.1);
+    }
 }
 
 fn rustc_minor_version() -> Option<u32> {
@@ -32,4 +38,38 @@ fn rustc_minor_version() -> Option<u32> {
     }
 
     otry!(pieces.next()).parse().ok()
+}
+
+// Derived from https://github.com/fitzgen/mach/blob/bc30359e394162201f7806e8600606ed6e4a99de/mach-test/build.rs
+
+#[derive(Eq, Ord, PartialEq, PartialOrd, Copy, Clone, Debug)]
+struct Xcrun(pub u32, pub u32);
+
+impl Xcrun {
+    pub fn version() -> Xcrun {
+        use std::process::Command;
+        let out = Command::new("/usr/bin/xcrun")
+            .arg("--show-sdk-version")
+            .output()
+            .expect("failed to execute xcrun");
+        let stdout = ::std::str::from_utf8(&out.stdout).expect("couldn't parse stdout as UTF8");
+        let stderr = ::std::str::from_utf8(&out.stderr).expect("couldn't parse stderr as UTF8");
+
+        if !out.status.success() {
+            eprintln!("stdout: {}", stdout);
+            eprintln!("stderr: {}", stderr);
+            panic!("xcrun --show-sdk-version failed");
+        }
+
+        let mut iter = stdout
+            .split(|c: char| c.is_whitespace() || c == '.')
+            .map(|c| {
+                c.parse()
+                    .expect("failed to parse Xcrun version into number")
+            });
+        let major: u32 = iter.next().expect("failed to parse Xcrun major version");
+        let minor: u32 = iter.next().expect("failed to parse Xcrun minor version");
+
+        Xcrun(major, minor)
+    }
 }

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1528,8 +1528,13 @@ pub const NET_RT_DUMP: ::c_int = 1;
 pub const NET_RT_FLAGS: ::c_int = 2;
 pub const NET_RT_IFLIST: ::c_int = 3;
 #[doc(hidden)]
-pub const NET_RT_MAXID: ::c_int = 10;
-
+cfg_if! {
+    if #[cfg(any(osx_major = "10", osx_minor = "14"))] {
+        pub const NET_RT_MAXID: ::c_int = 11;
+    } else {
+        pub const NET_RT_MAXID: ::c_int = 10;
+    }
+}
 pub const SOMAXCONN: ::c_int = 128;
 
 pub const SOCK_MAXADDRLEN: ::c_int = 255;


### PR DESCRIPTION
Using `xcrun --show-sdk-version` I think we can get an accurate version of the current in-use OS X SDK. This is often, but not always equal to the OS version.

Using this, I then fix the `NET_RT_MAXID` issue I flagged in #981