### PR TITLE
Verify that only non-technical breaking changes are applied to libc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,17 +35,11 @@ matrix:
         #  fi
       stage: tools-and-build-and-tier1
     - name: "Semver Linux"
-      install: |
-        travis_retry cargo +nightly install \
-        --git https://github.com/gnzlbg/rust-semverver \
-        --branch fix_exit_code
+      install: travis_retry cargo +nightly install semverver
       script: sh ci/semver.sh
       stage: tools-and-build-and-tier1
     - name: "Semver MacOSX"
-      install: |
-        travis_retry cargo +nightly install \
-        --git https://github.com/gnzlbg/rust-semverver \
-        --branch fix_exit_code
+      install: travis_retry cargo +nightly install semverver
       script: sh ci/semver.sh
       os: osx
       osx_image: xcode10

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,14 +34,14 @@ matrix:
         #      cargo fmt --all -- --check
         #  fi
       stage: tools-and-build-and-tier1
-    - name: "Semver"
+    - name: "Semver Linux"
       install: |
         travis_retry cargo +nightly install \
         --git https://github.com/gnzlbg/rust-semverver \
         --branch fix_exit_code
       script: sh ci/semver.sh
       stage: tools-and-build-and-tier1
-    - name: "Semver"
+    - name: "Semver MacOSX"
       install: |
         travis_retry cargo +nightly install \
         --git https://github.com/gnzlbg/rust-semverver \
@@ -218,6 +218,8 @@ matrix:
       # FIXME: https://github.com/rust-lang/libc/issues/1226
       - env: TARGET=asmjs-unknown-emscripten
       - env: TARGET=wasm32-unknown-emscripten
+      - name: "Semver Linux"
+      - name: "Semver MacOSX"
 
 install: travis_retry rustup target add $TARGET
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,13 @@ stages:
 matrix:
   include:
     # TOOLS
+    - name: "Semver"
+      env: TARGET=x86_64-unknown-linux-gnu
+      install: |
+        travis_retry cargo +nightly install \
+        --git https://github.com/gnzlbg/rust-semverver \
+        --branch fix_exit_code
+      script: cargo +nightly semver --api-guidelines --target="${TARGET}"
     - name: "Documentation"
       env: TARGET=x86_64-unknown-linux-gnu
       script: sh ci/dox.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,6 @@ stages:
 matrix:
   include:
     # TOOLS
-    - name: "Semver"
-      env: TARGET=x86_64-unknown-linux-gnu
-      install: |
-        travis_retry cargo +nightly install \
-        --git https://github.com/gnzlbg/rust-semverver \
-        --branch fix_exit_code
-      script: cargo +nightly semver --api-guidelines --target="${TARGET}"
     - name: "Documentation"
       env: TARGET=x86_64-unknown-linux-gnu
       script: sh ci/dox.sh
@@ -40,6 +33,22 @@ matrix:
         #  if rustup component add rustfmt-preview ; then
         #      cargo fmt --all -- --check
         #  fi
+      stage: tools-and-build-and-tier1
+    - name: "Semver"
+      install: |
+        travis_retry cargo +nightly install \
+        --git https://github.com/gnzlbg/rust-semverver \
+        --branch fix_exit_code
+      script: sh ci/semver.sh
+      stage: tools-and-build-and-tier1
+    - name: "Semver"
+      install: |
+        travis_retry cargo +nightly install \
+        --git https://github.com/gnzlbg/rust-semverver \
+        --branch fix_exit_code
+      script: sh ci/semver.sh
+      os: osx
+      osx_image: xcode10
       stage: tools-and-build-and-tier1
 
     # BUILD stable, beta, nightly

--- a/ci/semver.sh
+++ b/ci/semver.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env sh
+
+# Checks that libc does not contain breaking changes for the following targets.
+
+set -ex
+
+OS=${TRAVIS_OS_NAME}
+
+echo "Testing Semver on ${OS}"
+
+TARGETS=
+case "${OS}" in
+    *linux*)
+        TARGETS="\
+aarch64-fuchsia \
+aarch64-linux-android \
+aarch64-unknown-linux-gnu \
+aarch64-unknown-linux-musl \
+armv7-linux-androideabi \
+armv7-unknown-linux-gnueabihf \
+i586-unknown-linux-gnu \
+i586-unknown-linux-musl \
+i686-linux-android \
+i686-unknown-freebsd \
+i686-unknown-linux-gnu \
+i686-unknown-linux-musl \
+i686-pc-windows-gnu \
+x86_64-unknown-freebsd \
+x86_64-unknown-linux-gnu \
+x86_64-unknown-linux-musl \
+x86_64-unknown-netbsd \
+x86_64-unknown-cloudabi \
+x86_64-sun-solaris \
+x86_64-fuchsia \
+x86_64-pc-windows-gnu \
+x86_64-unknown-linux-gnux32 \
+x86_64-unknown-redox \
+x86_64-fortanix-unknown-sgx \
+wasm32-unknown-unknown \
+"
+    ;;
+    *osx*)
+        TARGETS="\
+aarch64-apple-ios \
+armv7-apple-ios \
+armv7s-apple-ios \
+i386-apple-ios \
+i686-apple-darwin \
+x86_64-apple-darwin \
+x86_64-apple-ios \
+"
+    ;;
+esac
+
+for TARGET in $TARGETS; do
+    # FIXME: rustup often fails to download some artifacts due to network
+    # issues, so we retry this N times.
+    N=5
+    n=0
+    until [ $n -ge $N ]
+    do
+        if rustup target add "${TARGET}" ; then
+            break
+        fi
+        n=$((n+1))
+        sleep 1
+    done
+
+    cargo +nightly semver --api-guidelines --target="${TARGET}"
+done


### PR DESCRIPTION
Closes #270 .

cc @alexcrichton so this would be a solution to #270 that uses rust-semverver to check that the API of `libc` contains only non-technical breaking changes.

This is a WIP and uses a fork of `rust-semverver` for now, but I've sent PRs upstream already. This is the only idea I have for solving #270 . `rust-semverver` is not perfect, but it can deal with functions, consts, and simple structs just fine, and that's pretty much everything that libc uses.

cc @ibabushkin

Some other notes:

* we have to compile `rust-semverver` for each toolchain version, and it depends on `cargo` so we have to build ~160 dependencies. Using `cache: cargo` breaks everything.