### PR TITLE
Add AF_XDP, PF_XDP and SOL_XDP consts for linux

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -672,6 +672,9 @@ fn main() {
             // shouldn't be used in code anyway...
             "AF_MAX" | "PF_MAX" => true,
 
+            // These are not in a glibc release yet, only in kernel headers.
+            "AF_XDP" | "PF_XDP" | "SOL_XDP" if linux => true,
+
             // Present on historical versions of iOS, but now removed in more
             // recent SDKs
             "ARPOP_REQUEST"

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -1058,10 +1058,12 @@ pub const AF_IB: ::c_int = 27;
 pub const AF_MPLS: ::c_int = 28;
 pub const AF_NFC: ::c_int = 39;
 pub const AF_VSOCK: ::c_int = 40;
+pub const AF_XDP: ::c_int = 44;
 pub const PF_IB: ::c_int = AF_IB;
 pub const PF_MPLS: ::c_int = AF_MPLS;
 pub const PF_NFC: ::c_int = AF_NFC;
 pub const PF_VSOCK: ::c_int = AF_VSOCK;
+pub const PF_XDP: ::c_int = AF_XDP;
 
 // System V IPC
 pub const IPC_PRIVATE: ::key_t = 0;

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -276,6 +276,7 @@ pub const SOL_IUCV: ::c_int = 277;
 pub const SOL_CAIF: ::c_int = 278;
 pub const SOL_ALG: ::c_int = 279;
 pub const SOL_NFC: ::c_int = 280;
+pub const SOL_XDP: ::c_int = 283;
 
 pub const MSG_TRYHARD: ::c_int = 4;
 


### PR DESCRIPTION
These are needed to work with `AF_XDP` sockets, see https://www.kernel.org/doc/html/v4.19/networking/af_xdp.html