### PR TITLE
musl: 64-bit: Ensure proper (c)msghdr layout on big-endian

### DIFF
--- a/src/unix/notbsd/linux/musl/b64/mod.rs
+++ b/src/unix/notbsd/linux/musl/b64/mod.rs
@@ -92,16 +92,25 @@ s! {
         pub msg_name: *mut ::c_void,
         pub msg_namelen: ::socklen_t,
         pub msg_iov: *mut ::iovec,
+        #[cfg(target_endian = "big")]
+        __pad1: ::c_int,
         pub msg_iovlen: ::c_int,
+        #[cfg(target_endian = "little")]
         __pad1: ::c_int,
         pub msg_control: *mut ::c_void,
+        #[cfg(target_endian = "big")]
+        __pad2: ::c_int,
         pub msg_controllen: ::socklen_t,
-        __pad2: ::socklen_t,
+        #[cfg(target_endian = "little")]
+        __pad2: ::c_int,
         pub msg_flags: ::c_int,
     }
 
     pub struct cmsghdr {
+        #[cfg(target_endian = "big")]
+        pub __pad1: ::c_int,
         pub cmsg_len: ::socklen_t,
+        #[cfg(target_endian = "little")]
         pub __pad1: ::c_int,
         pub cmsg_level: ::c_int,
         pub cmsg_type: ::c_int,


### PR DESCRIPTION
Discovered while debugging: djg/audioipc-2#52