### PR TITLE
Added setegid function

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -3285,6 +3285,7 @@ extern {
                 -> ::ssize_t;
     pub fn rmdir(path: *const c_char) -> ::c_int;
     pub fn seteuid(uid: uid_t) -> ::c_int;
+    pub fn setegid(gid: gid_t) -> ::c_int;
     pub fn setgid(gid: gid_t) -> ::c_int;
     pub fn setpgid(pid: pid_t, pgid: pid_t) -> ::c_int;
     pub fn setsid() -> pid_t;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -711,6 +711,7 @@ extern {
                 -> ::ssize_t;
     pub fn rmdir(path: *const c_char) -> ::c_int;
     pub fn seteuid(uid: uid_t) -> ::c_int;
+    pub fn setegid(gid: gid_t) -> ::c_int;
     pub fn setgid(gid: gid_t) -> ::c_int;
     pub fn setpgid(pid: pid_t, pgid: pid_t) -> ::c_int;
     pub fn setsid() -> pid_t;


### PR DESCRIPTION
Adding the `setegid` function to libc. I had a look and this is in Apple, Linux and Fuchsia so I'm hoping it works for all the BSDs etc. But if anything fails in CI I'll change it accordingly.