### PR TITLE
Move SOL_BLUETOOTH to notbsd module

### DIFF
--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -269,7 +269,6 @@ pub const SOCK_NONBLOCK: ::c_int = O_NONBLOCK;
 
 pub const SOL_RXRPC: ::c_int = 272;
 pub const SOL_PPPOL2TP: ::c_int = 273;
-pub const SOL_BLUETOOTH: ::c_int = 274;
 pub const SOL_PNPIPE: ::c_int = 275;
 pub const SOL_RDS: ::c_int = 276;
 pub const SOL_IUCV: ::c_int = 277;

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -513,6 +513,7 @@ pub const SOL_LLC: ::c_int = 268;
 pub const SOL_DCCP: ::c_int = 269;
 pub const SOL_NETLINK: ::c_int = 270;
 pub const SOL_TIPC: ::c_int = 271;
+pub const SOL_BLUETOOTH: ::c_int = 274;
 
 pub const AF_UNSPEC: ::c_int = 0;
 pub const AF_UNIX: ::c_int = 1;


### PR DESCRIPTION
https://github.com/torvalds/linux/blob/master/include/linux/socket.h#L334
https://android.googlesource.com/platform/bionic/+/master/libc/include/sys/socket.h#283
https://git.musl-libc.org/cgit/musl/tree/include/sys/socket.h#n259

Seems like it should be okay for a broader exposure than `linux::other`. Maybe I am missing something.