### PR TITLE
Fix for rust-lang/rust issue #50583

### DIFF
--- a/ci/docker/arm-unknown-linux-musleabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-musleabihf/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN curl --retry 5 https://www.musl-libc.org/releases/musl-1.1.19.tar.gz | tar xzf -
 WORKDIR /musl-1.1.19
 RUN CC=arm-linux-gnueabihf-gcc \
-    CFLAGS="-march=armv6 -marm" \
+    CFLAGS="-march=armv6 -marm -mfpu=vfp" \
     ./configure --prefix=/musl-arm --enable-wrapper=yes
 RUN make install -j4
 


### PR DESCRIPTION
Rationale for this fix is in the issue - see https://github.com/rust-lang/rust/issues/50583.

To test I've created a container with the new Dockerfile and verified that the libc.a doesn't have the illegal instruction reported in that issue.  Not sure how to do a more comprehensive test of the CI that presumably produces a liblibc.rlib with this libc.a in it though.