### PR TITLE
add signal and raise bindings for windows

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -76,6 +76,7 @@ fn main() {
         cfg.header("windows.h");
         cfg.header("process.h");
         cfg.header("ws2ipdef.h");
+        cfg.header("signal.h");
 
         if target.contains("gnu") {
             cfg.header("ws2tcpip.h");

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -508,6 +508,7 @@ fn main() {
             n if n.starts_with("P") => true,
             n if n.starts_with("H") => true,
             n if n.starts_with("LP") => true,
+            "__p_sig_fn_t" if mingw => true,
             _ => false,
         }
     });

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -373,6 +373,7 @@ fn main() {
             // Fixup a few types on windows that don't actually exist.
             "time64_t" if windows => "__time64_t".to_string(),
             "ssize_t" if windows => "SSIZE_T".to_string(),
+            "_crt_signal_t" if windows => "__p_sig_fn_t".to_string(),
 
             // OSX calls this something else
             "sighandler_t" if bsdlike => "sig_t".to_string(),

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -373,8 +373,9 @@ fn main() {
             // Fixup a few types on windows that don't actually exist.
             "time64_t" if windows => "__time64_t".to_string(),
             "ssize_t" if windows => "SSIZE_T".to_string(),
-            "_crt_signal_t" if windows => "__p_sig_fn_t".to_string(),
-
+            // windows 
+            "sighandler_t" if windows && !mingw => "_crt_signal_t".to_string(),
+            "sighandler_t" if windows && mingw => "__p_sig_fn_t".to_string(),
             // OSX calls this something else
             "sighandler_t" if bsdlike => "sig_t".to_string(),
 

--- a/src/windows/gnu.rs
+++ b/src/windows/gnu.rs
@@ -1,19 +1,7 @@
-pub type __p_sig_fn_t = ::size_t;
-
 pub const L_tmpnam: ::c_uint = 14;
 pub const TMP_MAX: ::c_uint = 0x7fff;
-pub const SIGINT: ::c_int = 2;
-pub const SIGILL: ::c_int = 4;
-pub const SIGFPE: ::c_int = 8;
-pub const SIGSEGV: ::c_int = 11;
-pub const SIGTERM: ::c_int = 15;
-pub const SIGABRT: ::c_int = 22;
-pub const NSIG: ::c_int = 23;
-pub const SIG_ERR: ::c_int = -1;
 
 extern {
-    pub fn signal(signum: ::c_int, handler: __p_sig_fn_t) -> __p_sig_fn_t;
-    pub fn raise(signum: ::c_int) -> ::c_int;
     pub fn strcasecmp(s1: *const ::c_char, s2: *const ::c_char) -> ::c_int;
     pub fn strncasecmp(s1: *const ::c_char, s2: *const ::c_char,
                        n: ::size_t) -> ::c_int;

--- a/src/windows/gnu.rs
+++ b/src/windows/gnu.rs
@@ -1,8 +1,20 @@
+pub type __p_sig_fn_t = ::size_t;
+
 pub const L_tmpnam: ::c_uint = 14;
 pub const TMP_MAX: ::c_uint = 0x7fff;
+pub const SIGINT: ::c_int = 2;
+pub const SIGILL: ::c_int = 4;
+pub const SIGFPE: ::c_int = 8;
+pub const SIGSEGV: ::c_int = 11;
+pub const SIGTERM: ::c_int = 15;
+pub const SIGABRT: ::c_int = 22;
+pub const NSIG: ::c_int = 23;
+pub const SIG_ERR: ::c_int = -1;
 
 extern {
+    pub fn signal(signum: ::c_int, handler: __p_sig_fn_t) -> __p_sig_fn_t;
+    pub fn raise(signum: ::c_int) -> ::c_int;
     pub fn strcasecmp(s1: *const ::c_char, s2: *const ::c_char) -> ::c_int;
     pub fn strncasecmp(s1: *const ::c_char, s2: *const ::c_char,
-                    n: ::size_t) -> ::c_int;
+                       n: ::size_t) -> ::c_int;
 }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -27,7 +27,7 @@ pub type ptrdiff_t = isize;
 pub type intptr_t = isize;
 pub type uintptr_t = usize;
 pub type ssize_t = isize;
-pub type __p_sig_fn_t = usize;
+pub type sighandler_t = usize;
 
 pub type c_char = i8;
 pub type c_long = i32;
@@ -298,7 +298,7 @@ extern {
     pub fn rand() -> c_int;
     pub fn srand(seed: c_uint);
 
-    pub fn signal(signum: c_int, handler: __p_sig_fn_t) -> __p_sig_fn_t;
+    pub fn signal(signum: c_int, handler: sighandler_t) -> sighandler_t;
     pub fn raise(signum: c_int) -> c_int;
 
     #[link_name = "_chmod"]

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -27,6 +27,7 @@ pub type ptrdiff_t = isize;
 pub type intptr_t = isize;
 pub type uintptr_t = usize;
 pub type ssize_t = isize;
+pub type __p_sig_fn_t = usize;
 
 pub type c_char = i8;
 pub type c_long = i32;
@@ -177,6 +178,16 @@ pub const ENOTEMPTY: ::c_int = 41;
 pub const EILSEQ: ::c_int = 42;
 pub const STRUNCATE: ::c_int = 80;
 
+// signal codes
+pub const SIGINT: ::c_int = 2;
+pub const SIGILL: ::c_int = 4;
+pub const SIGFPE: ::c_int = 8;
+pub const SIGSEGV: ::c_int = 11;
+pub const SIGTERM: ::c_int = 15;
+pub const SIGABRT: ::c_int = 22;
+pub const NSIG: ::c_int = 23;
+pub const SIG_ERR: ::c_int = -1;
+
 // inline comment below appeases style checker
 #[cfg(all(target_env = "msvc", feature = "rustc-dep-of-std"))] // " if "
 #[link(name = "msvcrt", cfg(not(target_feature = "crt-static")))]
@@ -286,6 +297,9 @@ extern {
     pub fn labs(i: c_long) -> c_long;
     pub fn rand() -> c_int;
     pub fn srand(seed: c_uint);
+
+    pub fn signal(signum: c_int, handler: __p_sig_fn_t) -> __p_sig_fn_t;
+    pub fn raise(signum: c_int) -> c_int;
 
     #[link_name = "_chmod"]
     pub fn chmod(path: *const c_char, mode: ::c_int) -> ::c_int;

--- a/src/windows/msvc.rs
+++ b/src/windows/msvc.rs
@@ -1,18 +1,7 @@
-pub type _crt_signal_t = ::size_t;
-
 pub const L_tmpnam: ::c_uint = 260;
 pub const TMP_MAX: ::c_uint = 0x7fff_ffff;
-pub const SIGINT: ::c_int = 2;
-pub const SIGILL: ::c_int = 4;
-pub const SIGABRT: ::c_int = 22;
-pub const SIGFPE: ::c_int = 8;
-pub const SIGSEGV: ::c_int = 11;
-pub const SIGTERM: ::c_int = 15;
-pub const SIG_ERR: ::c_int = -1;
 
 extern {
-    pub fn signal(signum: ::c_int, handler: _crt_signal_t) -> _crt_signal_t;
-    pub fn raise(signum: ::c_int) -> ::c_int;
     #[link_name = "_stricmp"]
     pub fn stricmp(s1: *const ::c_char, s2: *const ::c_char) -> ::c_int;
     #[link_name = "_strnicmp"]

--- a/src/windows/msvc.rs
+++ b/src/windows/msvc.rs
@@ -1,7 +1,18 @@
+pub type _crt_signal_t = ::size_t;
+
 pub const L_tmpnam: ::c_uint = 260;
 pub const TMP_MAX: ::c_uint = 0x7fff_ffff;
+pub const SIGINT: ::c_int = 2;
+pub const SIGILL: ::c_int = 4;
+pub const SIGABRT: ::c_int = 22;
+pub const SIGFPE: ::c_int = 8;
+pub const SIGSEGV: ::c_int = 11;
+pub const SIGTERM: ::c_int = 15;
+pub const SIG_ERR: ::c_int = -1;
 
 extern {
+    pub fn signal(signum: ::c_int, handler: _crt_signal_t) -> _crt_signal_t;
+    pub fn raise(signum: ::c_int) -> ::c_int;
     #[link_name = "_stricmp"]
     pub fn stricmp(s1: *const ::c_char, s2: *const ::c_char) -> ::c_int;
     #[link_name = "_strnicmp"]


### PR DESCRIPTION
This PR adds `signal` and `raise` bindings for windows.

I don't know these functions or linux very well, so I leaned on other overrides of signal in the linux bindings, and the [cppreference page](https://en.cppreference.com/w/cpp/header/csignal) for adding the bindings.

I added some constants that were shown on the [microsoft signal page](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/signal?view=vs-2017) and used the default values I found spelunking through my own copy of `signal.h` that came along with visual studio.

The automated tests pass and my toy apps use the `signal` and `raise` as expected. Let me know if there is anything else I need to do, or any extra tests to write. 

EDIT:
currently working on getting a nice isolated msys2 environment I can use to dev against. 
- [x] msys2 env setup and building