### PR TITLE
Commit for if_addr.h constants for rtnetlink struct flags

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -110,6 +110,7 @@ fn main() {
         cfg.header("sys/socket.h");
         if linux && !musl {
             cfg.header("linux/if.h");
+            cfg.header("linux/if_addr.h");
             cfg.header("sys/auxv.h");
         }
         cfg.header("sys/time.h");

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -621,6 +621,21 @@ pub const NF_NETDEV_NUMHOOKS: ::c_int = 1;
 pub const NFPROTO_INET: ::c_int = 1;
 pub const NFPROTO_NETDEV: ::c_int = 5;
 
+// linux/if_addr.h
+pub const IFA_F_SECONDARY: u32 = 0x01;
+pub const IFA_F_TEMPORARY: u32 = 0x01;
+pub const IFA_F_NODAD: u32 = 0x02;
+pub const IFA_F_OPTIMISTIC: u32 = 0x04;
+pub const IFA_F_DADFAILED: u32 = 0x08;
+pub const IFA_F_HOMEADDRESS: u32 = 0x10;
+pub const IFA_F_DEPRECATED: u32 = 0x20;
+pub const IFA_F_TENTATIVE: u32 = 0x40;
+pub const IFA_F_PERMANENT: u32 = 0x80;
+pub const IFA_F_MANAGETEMPADDR: u32 = 0x100;
+pub const IFA_F_NOPREFIXROUTE: u32 = 0x200;
+pub const IFA_F_MCAUTOJOIN: u32 = 0x400;
+pub const IFA_F_STABLE_PRIVACY: u32 = 0x800;
+
 // linux/netfilter/nf_tables.h
 cfg_if!{
     if #[cfg(any(target_arch = "arm", target_arch = "powerpc",


### PR DESCRIPTION
This PR is meant to add more constants to be used in my netlink library. This is specifically for the rtnetlink subsection of the netlink protocol. It will allow strong typing for [this](https://github.com/jbaublitz/neli/blob/64273782838ad825eb1dc38710b8bbe46fc2b150/src/rtnl.rs#L78) field in the struct I've added which cannot be typed the way other flag fields have been in the library thus far as an enum. See issue #1059 for more information.