### PR TITLE
make tm struct members public

### DIFF
--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -73,15 +73,15 @@ s! {
     }
 
     pub struct tm {
-        tm_sec: ::c_int,
-        tm_min: ::c_int,
-        tm_hour: ::c_int,
-        tm_mday: ::c_int,
-        tm_mon: ::c_int,
-        tm_year: ::c_int,
-        tm_wday: ::c_int,
-        tm_yday: ::c_int,
-        tm_isdst: ::c_int,
+        pub tm_sec: ::c_int,
+        pub tm_min: ::c_int,
+        pub tm_hour: ::c_int,
+        pub tm_mday: ::c_int,
+        pub tm_mon: ::c_int,
+        pub tm_year: ::c_int,
+        pub tm_wday: ::c_int,
+        pub tm_yday: ::c_int,
+        pub tm_isdst: ::c_int,
     }
 
     pub struct timeval {


### PR DESCRIPTION
This PR makes the members of `struct tm` public.

I see no reason why these fields should not be public fields. They are public in the other targets. I did a blame and it seems that they have been private since added a couple years ago. 

https://github.com/rust-lang/libc/commit/53e0d387f8765e9faa1ea921450167bb7f0b31ff