### PR TITLE
Define missing F_RDLCK, F_WRLCK and F_UNLCK constants on linux-s390x

### DIFF
--- a/src/unix/notbsd/linux/s390x.rs
+++ b/src/unix/notbsd/linux/s390x.rs
@@ -791,6 +791,9 @@ pub const MAP_HUGETLB: ::c_int = 0x040000;
 
 pub const EFD_NONBLOCK: ::c_int = 0x800;
 
+pub const F_RDLCK: ::c_int = 0;
+pub const F_WRLCK: ::c_int = 1;
+pub const F_UNLCK: ::c_int = 2;
 pub const F_GETLK: ::c_int = 5;
 pub const F_GETOWN: ::c_int = 9;
 pub const F_SETOWN: ::c_int = 8;


### PR DESCRIPTION
These are defined in the fcntl.h glibc header on s390x systems
on Linux but missing in the libc crate, so add them as they are
required for the file locking API in rustc.