### PR TITLE
Fix uname on FreeBSD

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -2659,6 +2659,7 @@ extern {
         fd: ::c_int,
         newfd: ::c_int,
     ) -> ::c_int;
+    pub fn uname(buf: *mut ::utsname) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -801,4 +801,5 @@ extern {
 
     pub fn statfs(path: *const ::c_char, buf: *mut statfs) -> ::c_int;
     pub fn fstatfs(fd: ::c_int, buf: *mut statfs) -> ::c_int;
+    pub fn uname(buf: *mut ::utsname) -> ::c_int;
 }

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -949,6 +949,12 @@ pub const UF_READONLY:  ::c_ulong = 0x00001000;
 pub const UF_HIDDEN:    ::c_ulong = 0x00008000;
 pub const SF_SNAPSHOT:  ::c_ulong = 0x00200000;
 
+f! {
+    pub fn uname(buf: *mut ::utsname) -> ::c_int {
+        __xuname(256, buf as *mut ::c_void)
+    }
+}
+
 extern {
     pub fn __error() -> *mut ::c_int;
 
@@ -1135,6 +1141,7 @@ extern {
     pub fn fstatfs(fd: ::c_int, buf: *mut statfs) -> ::c_int;
 
     pub fn dup3(src: ::c_int, dst: ::c_int, flags: ::c_int) -> ::c_int;
+    pub fn __xuname(nmln: ::c_int, buf: *mut ::c_void) -> ::c_int;
 }
 
 #[link(name = "util")]

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -676,6 +676,7 @@ extern {
                    -> ::c_int;
     pub fn getdomainname(name: *mut ::c_char, len: ::size_t) -> ::c_int;
     pub fn setdomainname(name: *const ::c_char, len: ::size_t) -> ::c_int;
+    pub fn uname(buf: *mut ::utsname) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -1242,6 +1242,7 @@ extern {
                    termp: *mut termios,
                    winp: *mut ::winsize) -> ::pid_t;
     pub fn sethostname(name: *const ::c_char, len: ::size_t) -> ::c_int;
+    pub fn uname(buf: *mut ::utsname) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/hermit/mod.rs
+++ b/src/unix/hermit/mod.rs
@@ -727,6 +727,7 @@ extern {
         -> ::c_int;
 
     pub fn setgroups(ngroups: ::c_int, grouplist: *const ::gid_t) -> ::c_int;
+    pub fn uname(buf: *mut ::utsname) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -972,7 +972,6 @@ extern {
     #[cfg_attr(target_os = "freebsd", link_name = "mknod@FBSD_1.0")]
     pub fn mknod(pathname: *const ::c_char, mode: ::mode_t,
                  dev: ::dev_t) -> ::c_int;
-    pub fn uname(buf: *mut ::utsname) -> ::c_int;
     pub fn gethostname(name: *mut ::c_char, len: ::size_t) -> ::c_int;
     pub fn getservbyname(name: *const ::c_char,
                          proto: *const ::c_char) -> *mut servent;

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -728,6 +728,7 @@ extern {
                link_name = "popen$UNIX2003")]
     pub fn popen(command: *const c_char,
                  mode: *const c_char) -> *mut ::FILE;
+    pub fn uname(buf: *mut ::utsname) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -1242,6 +1242,7 @@ extern {
                    flags: ::c_int) -> ::ssize_t;
     pub fn recvmsg(fd: ::c_int, msg: *mut ::msghdr, flags: ::c_int)
                    -> ::ssize_t;
+    pub fn uname(buf: *mut ::utsname) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -1466,4 +1466,5 @@ extern {
                  mode: *const c_char) -> *mut ::FILE;
 
     pub fn dup3(src: ::c_int, dst: ::c_int, flags: ::c_int) -> ::c_int;
+    pub fn uname(buf: *mut ::utsname) -> ::c_int;
 }

--- a/src/unix/uclibc/mod.rs
+++ b/src/unix/uclibc/mod.rs
@@ -1953,6 +1953,7 @@ extern {
                link_name = "popen$UNIX2003")]
     pub fn popen(command: *const c_char,
                  mode: *const c_char) -> *mut ::FILE;
+    pub fn uname(buf: *mut ::utsname) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
On FreeBSD, uname is an inline function.  The uname that is present in
libc.so is for FreeBSD 1.0 compatibility.  It expects a buffer of a
different size.

Fixes #1190
Reported-by: Alex Zepeda