### PR TITLE
Remove sys/ioctl_compat.h from DragonFlyBSD tests.

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -341,7 +341,6 @@ fn main() {
         cfg.header("mqueue.h");
         cfg.header("ufs/ufs/quota.h");
         cfg.header("pthread_np.h");
-        cfg.header("sys/ioctl_compat.h");
         cfg.header("sys/rtprio.h");
     }
 


### PR DESCRIPTION
Per the mailing list[1], sys/ioctl_compat.h has been removed.  This should fix #1198.

1: http://lists.dragonflybsd.org/pipermail/commits/2018-April/672079.html