### PR TITLE
add FIO* for FreeBSD and NetBSD

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -447,6 +447,19 @@ pub const TIOCSIG: ::c_uint = 0x2004745f;
 pub const TIOCM_DCD: ::c_int = 0x40;
 pub const H4DISC: ::c_int = 0x7;
 
+pub const FIONCLEX: ::c_ulong = 0x20006602;
+pub const FIONREAD: ::c_ulong = 0x4004667f;
+pub const FIOASYNC: ::c_ulong = 0x8004667d;
+pub const FIOSETOWN: ::c_ulong = 0x8004667c;
+pub const FIOGETOWN: ::c_ulong = 0x4004667b;
+pub const FIODTYPE: ::c_ulong = 0x4004667a;
+pub const FIOGETLBA: ::c_ulong = 0x40046679;
+pub const FIODGNAME: ::c_ulong = 0x80106678;
+pub const FIONWRITE: ::c_ulong = 0x40046677;
+pub const FIONSPACE: ::c_ulong = 0x40046676;
+pub const FIOSEEKDATA: ::c_ulong = 0xc0086661;
+pub const FIOSEEKHOLE: ::c_ulong = 0xc0086662;
+
 pub const JAIL_API_VERSION: u32 = 2;
 pub const JAIL_CREATE: ::c_int = 0x01;
 pub const JAIL_UPDATE: ::c_int = 0x02;

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -987,6 +987,19 @@ pub const CHWFLOW: ::tcflag_t = ::MDMBUF | ::CRTSCTS | ::CDTRCTS;
 pub const SOCK_CLOEXEC: ::c_int = 0x10000000;
 pub const SOCK_NONBLOCK: ::c_int = 0x20000000;
 
+pub const FIONCLEX: ::c_ulong = 0x20006602;
+pub const FIOSEEKDATA: ::c_ulong = 0xc0086661;
+pub const FIOSEEKHOLE: ::c_ulong = 0xc0086662;
+pub const FIONREAD: ::c_ulong = 0x4004667f;
+pub const FIOASYNC: ::c_ulong = 0x8004667d;
+pub const FIOSETOWN: ::c_ulong = 0x8004667c;
+pub const FIOGETOWN: ::c_ulong = 0x4004667b;
+pub const OFIOGETBMAP: ::c_ulong = 0xc004667a;
+pub const FIOGETBMAP: ::c_ulong = 0xc008667a;
+pub const FIONWRITE: ::c_ulong = 0x40046679;
+pub const FIONSPACE: ::c_ulong = 0x40046678;
+pub const FIBMAP: ::c_ulong = 0xc008667a;
+
 pub const SIGSTKSZ : ::size_t = 40960;
 
 pub const PT_DUMPCORE: ::c_int = 12;


### PR DESCRIPTION
Calculated [here](https://repl.it/repls/PaltryTroubledMonitors) from FreeBSD [source](https://github.com/freebsd/freebsd/blob/9867e6d8fe1cac34121e5f2df9357363f5659617/sys/sys/filio.h).

Calculated [here](https://repl.it/repls/ProfitableImpracticalComputeranimation) from NetBSD [source](https://github.com/NetBSD/src/blob/64b8a48e1288eb3902ed73113d157af50b2ec596/sys/sys/filio.h).

Some of these are likely identical across all BSDs – if this can be confirmed they could be elevated to `unix/bsd/mod.rs` alongside `FIOCLEX` and `FIONBIO`.