### PR TITLE
Remove fexecve from netbsdlike as it's not implemented

### DIFF
--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -671,9 +671,6 @@ extern {
                         groups: *mut ::gid_t,
                         ngroups: *mut ::c_int) -> ::c_int;
     pub fn initgroups(name: *const ::c_char, basegid: ::gid_t) -> ::c_int;
-    pub fn fexecve(fd: ::c_int, argv: *const *const ::c_char,
-                   envp: *const *const ::c_char)
-                   -> ::c_int;
     pub fn getdomainname(name: *mut ::c_char, len: ::size_t) -> ::c_int;
     pub fn setdomainname(name: *const ::c_char, len: ::size_t) -> ::c_int;
     pub fn uname(buf: *mut ::utsname) -> ::c_int;


### PR DESCRIPTION
Sometimes it causes confusion in downstream users of libc, for example it caused nix-rust/nix to fail to compile on OpenBSD 6.4 (see https://github.com/nix-rust/nix/pull/1000).

OpenBSD doesn't implement fexecve. The only reference of it that I can
find in the OpenBSD source is in the man pages of signal(3) and
sigaction(2) (where it's mentioned that it is not implemented).

OpenBSD official source code link:
https://cvsweb.openbsd.org/src/lib/libc/sys/sigaction.2?rev=1.75&content-type=text/x-cvsweb-markup

OpenBSD Github mirror:
https://github.com/openbsd/src/blob/master/lib/libc/sys/sigaction.2#L619

On NetBSD's unistd.h I see that it is under an ifdef. Calling it returns
78 / ENOSYS / Function not implemented.

NetBSD office source code link:
http://cvsweb.netbsd.org/bsdweb.cgi/src/include/unistd.h?rev=1.151&content-type=text/x-cvsweb-markup&only_with_tag=MAIN

NetBSD Github mirror:
https://github.com/NetBSD/src/blob/trunk/include/unistd.h#L319

Tests on OpenBSD 6.4 after the change:
```bash
user@openbsd64 ~/RUST/libc $ cargo build
   Compiling libc v0.2.46 (/home/user/RUST/libc)
    Finished dev [unoptimized + debuginfo] target(s) in 3.88s

user@openbsd64 ~/RUST/libc $ cargo build --release
   Compiling libc v0.2.46 (/home/user/RUST/libc)
    Finished release [optimized] target(s) in 2.21s

user@openbsd64 ~/RUST/libc/libc-test $ cargo test
   Compiling proc-macro2 v0.4.24
   Compiling unicode-xid v0.1.0
   Compiling semver-parser v0.7.0
   Compiling serde v1.0.84
   Compiling libc v0.2.45
   Compiling num-traits v0.2.6
   Compiling ryu v0.2.7
   Compiling cfg-if v0.1.6
   Compiling itoa v0.4.3
   Compiling term v0.4.6
   Compiling bitflags v0.9.1
   Compiling cc v1.0.28
   Compiling libc v0.2.46 (/home/user/RUST/libc)
   Compiling log v0.4.6
   Compiling semver v0.9.0
   Compiling log v0.3.9
   Compiling rustc_version v0.2.3
   Compiling rand v0.4.3
   Compiling extprim v1.6.0
   Compiling quote v0.6.10
   Compiling syn v0.15.23
   Compiling serde_derive v1.0.84
   Compiling syntex_pos v0.59.1
   Compiling serde_json v1.0.34
   Compiling syntex_errors v0.59.1
   Compiling syntex_syntax v0.59.1
   Compiling ctest v0.2.8
   Compiling libc-test v0.1.0 (/home/user/RUST/libc/libc-test)
    Finished dev [unoptimized + debuginfo] target(s) in 2m 16s
     Running /home/user/RUST/libc/target/debug/deps/linux_fcntl-08861a7cd96d1b94
RUNNING ALL TESTS
PASSED 0 tests
     Running /home/user/RUST/libc/target/debug/deps/main-57e266d38aa58cce
RUNNING ALL TESTS
PASSED 7187 tests
```
I've tried running the tests on a NetBSD 8.0 box unfortunately there `libc-test` fails to compile even before this change. 