### PR TITLE
glibc x86: add the register offset constants for mcontext_t.gregs

### DIFF
--- a/src/unix/notbsd/linux/other/b32/x86.rs
+++ b/src/unix/notbsd/linux/other/b32/x86.rs
@@ -758,6 +758,27 @@ pub const EFL: ::c_int = 14;
 pub const UESP: ::c_int = 15;
 pub const SS: ::c_int = 16;
 
+// offsets in mcontext_t.gregs from sys/ucontext.h
+pub const REG_GS: ::c_int = 0;
+pub const REG_FS: ::c_int = 1;
+pub const REG_ES: ::c_int = 2;
+pub const REG_DS: ::c_int = 3;
+pub const REG_EDI: ::c_int = 4;
+pub const REG_ESI: ::c_int = 5;
+pub const REG_EBP: ::c_int = 6;
+pub const REG_ESP: ::c_int = 7;
+pub const REG_EBX: ::c_int = 8;
+pub const REG_EDX: ::c_int = 9;
+pub const REG_ECX: ::c_int = 10;
+pub const REG_EAX: ::c_int = 11;
+pub const REG_TRAPNO: ::c_int = 12;
+pub const REG_ERR: ::c_int = 13;
+pub const REG_EIP: ::c_int = 14;
+pub const REG_CS: ::c_int = 15;
+pub const REG_EFL: ::c_int = 16;
+pub const REG_UESP: ::c_int = 17;
+pub const REG_S: ::c_int = 18;
+
 extern {
     pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;
     pub fn setcontext(ucp: *const ucontext_t) -> ::c_int;

--- a/src/unix/notbsd/linux/other/b32/x86.rs
+++ b/src/unix/notbsd/linux/other/b32/x86.rs
@@ -777,7 +777,7 @@ pub const REG_EIP: ::c_int = 14;
 pub const REG_CS: ::c_int = 15;
 pub const REG_EFL: ::c_int = 16;
 pub const REG_UESP: ::c_int = 17;
-pub const REG_S: ::c_int = 18;
+pub const REG_SS: ::c_int = 18;
 
 extern {
     pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;

--- a/src/unix/notbsd/linux/other/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/other/b64/x86_64.rs
@@ -644,6 +644,31 @@ pub const ES: ::c_int = 24;
 pub const FS: ::c_int = 25;
 pub const GS: ::c_int = 26;
 
+// offsets in mcontext_t.gregs from sys/ucontext.h
+pub const REG_R8: ::c_int = 0;
+pub const REG_R9: ::c_int = 1;
+pub const REG_R10: ::c_int = 2;
+pub const REG_R11: ::c_int = 3;
+pub const REG_R12: ::c_int = 4;
+pub const REG_R13: ::c_int = 5;
+pub const REG_R14: ::c_int = 6;
+pub const REG_R15: ::c_int = 7;
+pub const REG_RDI: ::c_int = 8;
+pub const REG_RSI: ::c_int = 9;
+pub const REG_RBP: ::c_int = 10;
+pub const REG_RBX: ::c_int = 11;
+pub const REG_RDX: ::c_int = 12;
+pub const REG_RAX: ::c_int = 13;
+pub const REG_RCX: ::c_int = 14;
+pub const REG_RSP: ::c_int = 15;
+pub const REG_RIP: ::c_int = 16;
+pub const REG_EFL: ::c_int = 17;
+pub const REG_CSGSFS: ::c_int = 18;
+pub const REG_ERR: ::c_int = 19;
+pub const REG_TRAPNO: ::c_int = 20;
+pub const REG_OLDMASK: ::c_int = 21;
+pub const REG_CR2: ::c_int = 22;
+
 extern {
     pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;
     pub fn setcontext(ucp: *const ucontext_t) -> ::c_int;


### PR DESCRIPTION
Constants calculated from the [glibc source](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/x86/sys/ucontext.h;h=3d883c2bf1220ef50cedc6b1491d699c0727c508;hb=HEAD). These are needed when using `mcontext_t`. Thanks!