### PR TITLE
Comment FIOSEEK* until they're in a NetBSD release

### DIFF
--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -988,8 +988,9 @@ pub const SOCK_CLOEXEC: ::c_int = 0x10000000;
 pub const SOCK_NONBLOCK: ::c_int = 0x20000000;
 
 pub const FIONCLEX: ::c_ulong = 0x20006602;
-pub const FIOSEEKDATA: ::c_ulong = 0xc0086661;
-pub const FIOSEEKHOLE: ::c_ulong = 0xc0086662;
+// Uncomment on next NetBSD release https://github.com/rust-lang/libc/pull/1200#issuecomment-453712616
+// pub const FIOSEEKDATA: ::c_ulong = 0xc0086661;
+// pub const FIOSEEKHOLE: ::c_ulong = 0xc0086662;
 pub const FIONREAD: ::c_ulong = 0x4004667f;
 pub const FIOASYNC: ::c_ulong = 0x8004667d;
 pub const FIOSETOWN: ::c_ulong = 0x8004667c;

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -988,7 +988,7 @@ pub const SOCK_CLOEXEC: ::c_int = 0x10000000;
 pub const SOCK_NONBLOCK: ::c_int = 0x20000000;
 
 pub const FIONCLEX: ::c_ulong = 0x20006602;
-// Uncomment on next NetBSD release https://github.com/rust-lang/libc/pull/1200#issuecomment-453712616
+// Uncomment on next NetBSD release
 // pub const FIOSEEKDATA: ::c_ulong = 0xc0086661;
 // pub const FIOSEEKHOLE: ::c_ulong = 0xc0086662;
 pub const FIONREAD: ::c_ulong = 0x4004667f;


### PR DESCRIPTION
Accidentally included two constants that aren't in the current release of NetBSD.

While this doesn't impact libc-consumers, failing the testsuite on latest NetBSD isn't ideal.

I've commented them out; they can be reintroduced when the next NetBSD ships with them included.