### PR TITLE
mincore has been removed from upcoming OpenBSD 6.5

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -857,6 +857,10 @@ fn main() {
             // to be removed now
             "system" | "ptrace" if ios => true,
 
+            // Removed in OpenBSD 6.5
+            // https://marc.info/?l=openbsd-cvs&m=154723400730318
+            "mincore" if openbsd => true,
+
             _ => false,
         }
     });


### PR DESCRIPTION
remove test from CI on OpenBSD for "mincore" function.

it has been removed from upcoming 6.5:
- https://marc.info/?l=openbsd-cvs&m=154723400730318
- https://github.com/openbsd/src/commit/54e4f6b9a1dc183e1dc7c4a722c2646aa309246a

I am only removing the test from CI, not touching exported function from Rust libc to avoid a breaking change.