### PR TITLE
Fix CMSG_DATA(3) and friends on BSD

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
@@ -1,3 +1,5 @@
+use dox::mem;
+
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type time_t = i64;
@@ -29,4 +31,7 @@ s! {
     }
 }
 
+// should be pub(crate), but that requires Rust 1.18.0
+#[doc(hidden)]
+pub const _ALIGNBYTES: usize = mem::size_of::<::c_longlong>() - 1;
 pub const MAP_32BIT: ::c_int = 0x00080000;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1,3 +1,5 @@
+use dox::mem;
+
 pub type fflags_t = u32;
 pub type clock_t = i32;
 pub type ino_t = u32;
@@ -962,7 +964,43 @@ pub const UF_READONLY:  ::c_ulong = 0x00001000;
 pub const UF_HIDDEN:    ::c_ulong = 0x00008000;
 pub const SF_SNAPSHOT:  ::c_ulong = 0x00200000;
 
+fn _ALIGN(p: usize) -> usize {
+    (p + _ALIGNBYTES) & !_ALIGNBYTES
+}
+
 f! {
+    pub fn CMSG_DATA(cmsg: *const ::cmsghdr) -> *mut ::c_uchar {
+        (cmsg as *mut ::c_uchar)
+            .offset(_ALIGN(mem::size_of::<::cmsghdr>()) as isize)
+    }
+
+    pub fn CMSG_LEN(length: ::c_uint) -> ::c_uint {
+        _ALIGN(mem::size_of::<::cmsghdr>()) as ::c_uint + length
+    }
+
+    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr, cmsg: *const ::cmsghdr)
+        -> *mut ::cmsghdr
+    {
+        if cmsg.is_null() {
+            return ::CMSG_FIRSTHDR(mhdr);
+        };
+        let next = cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize)
+            + _ALIGN(mem::size_of::<::cmsghdr>());
+        let max = (*mhdr).msg_control as usize
+            + (*mhdr).msg_controllen as usize;
+        if next > max {
+            0 as *mut ::cmsghdr
+        } else {
+            (cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize))
+                as *mut ::cmsghdr
+        }
+    }
+
+    pub fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
+        (_ALIGN(mem::size_of::<::cmsghdr>()) + _ALIGN(length as usize))
+            as ::c_uint
+    }
+
     pub fn uname(buf: *mut ::utsname) -> ::c_int {
         __xuname(256, buf as *mut ::c_void)
     }

--- a/src/unix/bsd/freebsdlike/freebsd/x86.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86.rs
@@ -1,3 +1,5 @@
+use dox::mem;
+
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type time_t = i32;
@@ -29,3 +31,7 @@ s! {
         __unused: [u8; 8],
     }
 }
+
+// should be pub(crate), but that requires Rust 1.18.0
+#[doc(hidden)]
+pub const _ALIGNBYTES: usize = mem::size_of::<::c_long>() - 1;

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64.rs
@@ -1,3 +1,5 @@
+use dox::mem;
+
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type time_t = i64;
@@ -29,4 +31,7 @@ s! {
     }
 }
 
+// should be pub(crate), but that requires Rust 1.18.0
+#[doc(hidden)]
+pub const _ALIGNBYTES: usize = mem::size_of::<::c_long>() - 1;
 pub const MAP_32BIT: ::c_int = 0x00080000;

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -340,41 +340,12 @@ pub const POLLRDBAND: ::c_short = 0x080;
 pub const POLLWRBAND: ::c_short = 0x100;
 
 f! {
-    pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= mem::size_of::<cmsghdr>() {
-            (*mhdr).msg_control as *mut cmsghdr
+    pub fn CMSG_FIRSTHDR(mhdr: *const ::msghdr) -> *mut ::cmsghdr {
+        if (*mhdr).msg_controllen as usize >= mem::size_of::<::cmsghdr>() {
+            (*mhdr).msg_control as *mut ::cmsghdr
         } else {
-            0 as *mut cmsghdr
+            0 as *mut ::cmsghdr
         }
-    }
-
-    pub fn CMSG_NXTHDR(mhdr: *const msghdr,
-                       cmsg: *const cmsghdr) -> *mut cmsghdr {
-        if cmsg.is_null() {
-            return CMSG_FIRSTHDR(mhdr);
-        };
-        let pad = mem::align_of::<cmsghdr>() - 1;
-        let next = cmsg as usize + (*cmsg).cmsg_len as usize + pad & !pad;
-        let max = (*mhdr).msg_control as usize
-            + (*mhdr).msg_controllen as usize;
-        if next < max {
-            next as *mut cmsghdr
-        } else {
-            0 as *mut cmsghdr
-        }
-    }
-
-    pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut ::c_uchar {
-        cmsg.offset(1) as *mut ::c_uchar
-    }
-
-    pub fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
-        let pad = mem::align_of::<cmsghdr>() as ::c_uint - 1;
-        mem::size_of::<cmsghdr>() as ::c_uint + ((length + pad) & !pad)
-    }
-
-    pub fn CMSG_LEN(length: ::c_uint) -> ::c_uint {
-        mem::size_of::<cmsghdr>() as ::c_uint + length
     }
 
     pub fn FD_CLR(fd: ::c_int, set: *mut fd_set) -> () {

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -1,3 +1,5 @@
+use dox::mem;
+
 pub type time_t = i64;
 pub type mode_t = u32;
 pub type nlink_t = ::uint32_t;
@@ -593,7 +595,43 @@ pub const SF_APPEND:        ::c_ulong = 0x00040000;
 
 pub const TIMER_ABSTIME: ::c_int = 1;
 
+fn _ALIGN(p: usize) -> usize {
+    (p + _ALIGNBYTES) & !_ALIGNBYTES
+}
+
 f! {
+    pub fn CMSG_DATA(cmsg: *const ::cmsghdr) -> *mut ::c_uchar {
+        (cmsg as *mut ::c_uchar)
+            .offset(_ALIGN(mem::size_of::<::cmsghdr>()) as isize)
+    }
+
+    pub fn CMSG_LEN(length: ::c_uint) -> ::c_uint {
+        _ALIGN(mem::size_of::<::cmsghdr>()) as ::c_uint + length
+    }
+
+    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr, cmsg: *const ::cmsghdr)
+        -> *mut ::cmsghdr
+    {
+        if cmsg.is_null() {
+            return ::CMSG_FIRSTHDR(mhdr);
+        };
+        let next = cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize)
+            + _ALIGN(mem::size_of::<::cmsghdr>());
+        let max = (*mhdr).msg_control as usize
+            + (*mhdr).msg_controllen as usize;
+        if next > max {
+            0 as *mut ::cmsghdr
+        } else {
+            (cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize))
+                as *mut ::cmsghdr
+        }
+    }
+
+    pub fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
+        (_ALIGN(mem::size_of::<::cmsghdr>()) + _ALIGN(length as usize))
+            as ::c_uint
+    }
+
     pub fn WSTOPSIG(status: ::c_int) -> ::c_int {
         status >> 8
     }

--- a/src/unix/bsd/netbsdlike/netbsd/aarch64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/aarch64.rs
@@ -1,9 +1,15 @@
+use dox::mem;
+
 use PT_FIRSTMACH;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type c_char = u8;
 pub type __cpu_simple_lock_nv_t = ::c_uchar;
+
+// should be pub(crate), but that requires Rust 1.18.0
+#[doc(hidden)]
+pub const _ALIGNBYTES: usize = mem::size_of::<::c_int>() - 1;
 
 pub const PT_GETREGS: ::c_int = PT_FIRSTMACH + 0;
 pub const PT_SETREGS: ::c_int = PT_FIRSTMACH + 1;

--- a/src/unix/bsd/netbsdlike/netbsd/arm.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/arm.rs
@@ -1,9 +1,15 @@
+use dox::mem;
+
 use PT_FIRSTMACH;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type c_char = u8;
 pub type __cpu_simple_lock_nv_t = ::c_int;
+
+// should be pub(crate), but that requires Rust 1.18.0
+#[doc(hidden)]
+pub const _ALIGNBYTES: usize = mem::size_of::<::c_longlong>() - 1;
 
 pub const PT_GETREGS: ::c_int = PT_FIRSTMACH + 1;
 pub const PT_SETREGS: ::c_int = PT_FIRSTMACH + 2;

--- a/src/unix/bsd/netbsdlike/netbsd/powerpc.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/powerpc.rs
@@ -1,9 +1,15 @@
+use dox::mem;
+
 use PT_FIRSTMACH;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type c_char = u8;
 pub type __cpu_simple_lock_nv_t = ::c_int;
+
+// should be pub(crate), but that requires Rust 1.18.0
+#[doc(hidden)]
+pub const _ALIGNBYTES: usize = mem::size_of::<::c_double>() - 1;
 
 pub const PT_STEP: ::c_int = PT_FIRSTMACH + 0;
 pub const PT_GETREGS: ::c_int = PT_FIRSTMACH + 1;

--- a/src/unix/bsd/netbsdlike/netbsd/sparc64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/sparc64.rs
@@ -2,3 +2,7 @@ pub type c_long = i64;
 pub type c_ulong = u64;
 pub type c_char = i8;
 pub type __cpu_simple_lock_nv_t = ::c_uchar;
+
+// should be pub(crate), but that requires Rust 1.18.0
+#[doc(hidden)]
+pub const _ALIGNBYTES: usize = 0xf;

--- a/src/unix/bsd/netbsdlike/netbsd/x86.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/x86.rs
@@ -1,4 +1,10 @@
+use dox::mem;
+
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type c_char = i8;
 pub type __cpu_simple_lock_nv_t = ::c_uchar;
+
+// should be pub(crate), but that requires Rust 1.18.0
+#[doc(hidden)]
+pub const _ALIGNBYTES: usize = mem::size_of::<::c_int>() - 1;

--- a/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
@@ -1,9 +1,15 @@
+use dox::mem;
+
 use PT_FIRSTMACH;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type c_char = i8;
 pub type __cpu_simple_lock_nv_t = ::c_uchar;
+
+// should be pub(crate), but that requires Rust 1.18.0
+#[doc(hidden)]
+pub const _ALIGNBYTES: usize = mem::size_of::<::c_long>() - 1;
 
 pub const PT_STEP: ::c_int = PT_FIRSTMACH + 0;
 pub const PT_GETREGS: ::c_int = PT_FIRSTMACH + 1;

--- a/src/unix/bsd/netbsdlike/openbsdlike/openbsd/aarch64.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/openbsd/aarch64.rs
@@ -1,3 +1,9 @@
+use dox::mem;
+
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type c_char = u8;
+
+// should be pub(crate), but that requires Rust 1.18.0
+#[doc(hidden)]
+pub const _ALIGNBYTES: usize = mem::size_of::<::c_long>() - 1;

--- a/src/unix/bsd/netbsdlike/openbsdlike/openbsd/x86.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/openbsd/x86.rs
@@ -1,3 +1,9 @@
+use dox::mem;
+
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type c_char = i8;
+
+// should be pub(crate), but that requires Rust 1.18.0
+#[doc(hidden)]
+pub const _ALIGNBYTES: usize = mem::size_of::<::c_int>() - 1;

--- a/src/unix/bsd/netbsdlike/openbsdlike/openbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/openbsd/x86_64.rs
@@ -1,8 +1,14 @@
+use dox::mem;
+
 use PT_FIRSTMACH;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type c_char = i8;
+
+// should be pub(crate), but that requires Rust 1.18.0
+#[doc(hidden)]
+pub const _ALIGNBYTES: usize = mem::size_of::<::c_long>() - 1;
 
 pub const PT_STEP: ::c_int = PT_FIRSTMACH + 0;
 pub const PT_GETREGS: ::c_int = PT_FIRSTMACH + 1;


### PR DESCRIPTION
PR #1098 added the CMSG_DATA(3) family of functions into libc.  Because
they're defined as macros in C, they had to be rewritten as Rust
functions for libc.  Also, they can't be tested in CI for the same
reason.  But that PR erroneously used the same definitions in BSD as in
Linux.

This commit corrects the definitions for OSX, FreeBSD, DragonflyBSD,
OpenBSD, and NetBSD.  I renamed a few variables and collapsed a few
macros in order to combine the definitions where possible.

Fixes #1210