### PR TITLE
fix stack_t on FreeBSD

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -210,6 +210,12 @@ s! {
         pub sdl_rcf: ::c_ushort,
         pub sdl_route: [::c_ushort; 16],
     }
+
+    pub struct stack_t {
+        pub ss_sp: *mut ::c_char,
+        pub ss_size: ::size_t,
+        pub ss_flags: ::c_int,
+    }
 }
 
 pub const RAND_MAX: ::c_int = 0x7fff_ffff;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -184,6 +184,12 @@ s! {
         pub sdl_slen: ::c_uchar,
         pub sdl_data: [::c_char; 46],
     }
+
+    pub struct stack_t {
+        pub ss_sp: *mut ::c_void,
+        pub ss_size: ::size_t,
+        pub ss_flags: ::c_int,
+    }
 }
 
 pub const SIGEV_THREAD_ID: ::c_int = 4;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -82,13 +82,6 @@ s! {
         pub sa_mask: sigset_t,
     }
 
-    pub struct stack_t {
-        // In FreeBSD 11 and later, ss_sp is actually a void*
-        pub ss_sp: *mut ::c_char,
-        pub ss_size: ::size_t,
-        pub ss_flags: ::c_int,
-    }
-
     pub struct sched_param {
         pub sched_priority: ::c_int,
     }


### PR DESCRIPTION
FreeBSD 10.x is EOL, in FreeBSD 11 and later, ss_sp is actually a void* [1]
dragonflybsd still uses c_char [2]

[1] https://svnweb.freebsd.org/base/releng/11.2/sys/sys/signal.h?revision=334459&view=markup#l438
[2] https://github.com/DragonFlyBSD/DragonFlyBSD/blob/master/sys/sys/signal.h#L339

should be committed with https://github.com/rust-lang/rust/pull/57810