### PR TITLE
Re-enable android build jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ matrix:
         - shellcheck --version
         - shellcheck ci/*.sh
 
-    allow_failures:
+  allow_failures:
       # FIXME: https://github.com/rust-lang/libc/issues/1226
       - env: TARGET=asmjs-unknown-emscripten
       - env: TARGET=wasm32-unknown-emscripten

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,10 +88,6 @@ matrix:
         - shellcheck --version
         - shellcheck ci/*.sh
 
-  allow_failures:
-    - env: TARGET=aarch64-linux-android
-    - env: TARGET=x86_64-linux-android
-
 install: rustup target add $TARGET
 script:
   - cargo generate-lockfile --manifest-path libc-test/Cargo.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,11 @@ matrix:
         - shellcheck --version
         - shellcheck ci/*.sh
 
+    allow_failures:
+      # FIXME: https://github.com/rust-lang/libc/issues/1226
+      - env: TARGET=asmjs-unknown-emscripten
+      - env: TARGET=wasm32-unknown-emscripten
+
 install: rustup target add $TARGET
 script:
   - cargo generate-lockfile --manifest-path libc-test/Cargo.toml

--- a/ci/android-install-sdk.sh
+++ b/ci/android-install-sdk.sh
@@ -46,9 +46,9 @@ case "$1" in
 esac;
 
 # --no_https avoids
-# javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: No trusted certificate found
-echo "yes" | \
-    ./sdk/tools/bin/sdkmanager --no_https \
+     # javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: No trusted certificate found
+yes | ./sdk/tools/bin/sdkmanager --licenses --no_https
+yes | ./sdk/tools/bin/sdkmanager --no_https \
         "emulator" \
         "platform-tools" \
         "platforms;android-24" \

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -658,7 +658,7 @@ fn main() {
             // MFD_HUGETLB is not available in some older libc versions on the CI builders. On the
             // x86_64 and i686 builders it seems to be available for all targets, so at least test
             // it there.
-            "MFD_HUGETLB" if !(x86_64 || i686) || musl => true,
+            "MFD_HUGETLB" if !(x86_64 || i686) || musl || (x86_64 && android)=> true,
 
             "DT_FIFO" | "DT_CHR" | "DT_DIR" | "DT_BLK" | "DT_REG"
             | "DT_LNK" | "DT_SOCK"


### PR DESCRIPTION
This performs a `yes | ./sdk/tools/bin/sdkmanager --licenses` - the sole purpose of the `--licenses` flag is to allow the user to accept all licenses a priori, so that all other commands don't show any licenses. 

For some reason, after all licenses have been accepted, the install step says that some licenses are still not accepted... so we need to accept those too... Why? I have no idea, and accepting licenses while installing still appears to make things hang a little, but it only does so for one non-accepted license, instead of for 5-6 like before, so now things do work. 