### PR TITLE
Move crt-static and linking to build script on windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,18 @@ fn main() {
     if rustc_minor_version().expect("Failed to get rustc version") >= 30 {
         println!("cargo:rustc-cfg=core_cvoid");
     }
+
+    if cfg!(target_env = "msvc") {
+        if cfg!(target_feature = "crt-static") {
+            //weirdly enough, this doesn't work
+            // println!("cargo:rustc-link-lib=static=libcmt");
+
+            //but this does. maybe I'm misunderstanding something with static vs dynamic linking.
+            println!("cargo:rustc-link-lib=dylib=libcmt");
+        } else {
+            println!("cargo:rustc-link-lib=dylib=msvcrt");
+        }
+    }
 }
 
 fn rustc_minor_version() -> Option<u32> {

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -196,9 +196,9 @@ pub const NSIG: ::c_int = 23;
 pub const SIG_ERR: ::c_int = -1;
 
 // inline comment below appeases style checker
-#[cfg(all(target_env = "msvc", feature = "rustc-dep-of-std"))] // " if "
-#[link(name = "msvcrt", cfg(not(target_feature = "crt-static")))]
-#[link(name = "libcmt", cfg(target_feature = "crt-static"))]
+//#[cfg(all(target_env = "msvc", feature = "rustc-dep-of-std"))] // " if "
+//#[link(name = "msvcrt", cfg(not(target_feature = "crt-static")))]
+//#[link(name = "libcmt", cfg(target_feature = "crt-static"))]
 extern {}
 
 pub enum FILE {}


### PR DESCRIPTION
Seems to fix #1203.

I've tested with a local `cdylib` depending on libc in both `std `and `no_std` mode. Not quite sure about the `crt-static` case, although `libc` itself did compile when passing `RUSTFLAGS='-C target-feature=+crt-static'`.

I'd appreciate someone else testing this to avoid "works on my machine"-issues.