### PR TITLE
Move universal libc types to the root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ use_std = []
 align = []
 rustc-dep-of-std = ['align', 'rustc-std-workspace-core']
 extra_traits = ["align"]
+generic_ctypes = []
 
 [workspace]
 members = ["libc-test"]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ libc = { version = "0.2", features = ["align"] }
 ```
 
 All structs implemented by the libc crate have the `Copy` and `Clone` traits
-implemented for them. The additional traits of `Debug, `Eq`, `Hash`, and
+implemented for them. The additional traits of `Debug`, `Eq`, `Hash`, and
 `PartialEq` can be enabled with the *extra_traits* feature (requires Rust 1.25
 or newer):
 
@@ -53,6 +53,22 @@ or newer):
 [dependencies]
 libc = { version = "0.2", features = ["extra_traits"] }
 ```
+
+A large number of targets are supported by libc; however, some unsupported or
+custom targets just need libc's basic types (`c_int`, `size_t`, etc...) for 
+linking to C code. These types can be enabled for _any_ target with the
+*generic_ctypes* feature:
+
+```toml
+[dependencies.libc]
+version = "0.2"
+default-features = false
+features = ["generic_ctypes"]
+```
+
+Note that if you target has strange definitions for C types, *generic_ctypes*
+will not necessarily generate the correct types, as the generation process is 
+based only on your CPU architecture and pointer size.
 
 ## What is libc?
 

--- a/src/cloudabi/mod.rs
+++ b/src/cloudabi/mod.rs
@@ -1,5 +1,18 @@
 use dox::Option;
 
+pub type c_short = i16;
+pub type c_ushort = u16;
+pub type c_int = i32;
+pub type c_uint = u32;
+pub type c_longlong = i64;
+pub type c_ulonglong = u64;
+pub type intmax_t = i64;
+pub type uintmax_t = u64;
+
+pub type size_t = usize;
+pub type ptrdiff_t = isize;
+pub type ssize_t = isize;
+
 pub type in_addr_t = u32;
 pub type in_port_t = u16;
 pub type pthread_key_t = usize;
@@ -57,6 +70,9 @@ s! {
         __ss_data: [u8; 32],
     }
 }
+
+pub const INT_MIN: c_int = -2147483648;
+pub const INT_MAX: c_int = 2147483647;
 
 pub const _SC_NPROCESSORS_ONLN: ::c_int = 52;
 pub const _SC_PAGESIZE: ::c_int = 54;

--- a/src/cloudabi/mod.rs
+++ b/src/cloudabi/mod.rs
@@ -1,33 +1,5 @@
 use dox::Option;
 
-pub type int8_t = i8;
-pub type int16_t = i16;
-pub type int32_t = i32;
-pub type int64_t = i64;
-pub type uint8_t = u8;
-pub type uint16_t = u16;
-pub type uint32_t = u32;
-pub type uint64_t = u64;
-
-pub type c_schar = i8;
-pub type c_uchar = u8;
-pub type c_short = i16;
-pub type c_ushort = u16;
-pub type c_int = i32;
-pub type c_uint = u32;
-pub type c_float = f32;
-pub type c_double = f64;
-pub type c_longlong = i64;
-pub type c_ulonglong = u64;
-pub type intmax_t = i64;
-pub type uintmax_t = u64;
-
-pub type size_t = usize;
-pub type ptrdiff_t = isize;
-pub type intptr_t = isize;
-pub type uintptr_t = usize;
-pub type ssize_t = isize;
-
 pub type in_addr_t = u32;
 pub type in_port_t = u16;
 pub type pthread_key_t = usize;
@@ -86,9 +58,6 @@ s! {
     }
 }
 
-pub const INT_MIN: c_int = -2147483648;
-pub const INT_MAX: c_int = 2147483647;
-
 pub const _SC_NPROCESSORS_ONLN: ::c_int = 52;
 pub const _SC_PAGESIZE: ::c_int = 54;
 
@@ -136,116 +105,116 @@ impl ::dox::Clone for fpos_t {
 }
 
 extern {
-    pub fn isalnum(c: c_int) -> c_int;
-    pub fn isalpha(c: c_int) -> c_int;
-    pub fn iscntrl(c: c_int) -> c_int;
-    pub fn isdigit(c: c_int) -> c_int;
-    pub fn isgraph(c: c_int) -> c_int;
-    pub fn islower(c: c_int) -> c_int;
-    pub fn isprint(c: c_int) -> c_int;
-    pub fn ispunct(c: c_int) -> c_int;
-    pub fn isspace(c: c_int) -> c_int;
-    pub fn isupper(c: c_int) -> c_int;
-    pub fn isxdigit(c: c_int) -> c_int;
-    pub fn tolower(c: c_int) -> c_int;
-    pub fn toupper(c: c_int) -> c_int;
-    pub fn fopen(filename: *const c_char, mode: *const c_char) -> *mut FILE;
-    pub fn freopen(filename: *const c_char, mode: *const c_char,
+    pub fn isalnum(c: ::c_int) -> ::c_int;
+    pub fn isalpha(c: ::c_int) -> ::c_int;
+    pub fn iscntrl(c: ::c_int) -> ::c_int;
+    pub fn isdigit(c: ::c_int) -> ::c_int;
+    pub fn isgraph(c: ::c_int) -> ::c_int;
+    pub fn islower(c: ::c_int) -> ::c_int;
+    pub fn isprint(c: ::c_int) -> ::c_int;
+    pub fn ispunct(c: ::c_int) -> ::c_int;
+    pub fn isspace(c: ::c_int) -> ::c_int;
+    pub fn isupper(c: ::c_int) -> ::c_int;
+    pub fn isxdigit(c: ::c_int) -> ::c_int;
+    pub fn tolower(c: ::c_int) -> ::c_int;
+    pub fn toupper(c: ::c_int) -> ::c_int;
+    pub fn fopen(filename: *const ::c_char, mode: *const ::c_char) -> *mut FILE;
+    pub fn freopen(filename: *const ::c_char, mode: *const ::c_char,
                    file: *mut FILE) -> *mut FILE;
-    pub fn fflush(file: *mut FILE) -> c_int;
-    pub fn fclose(file: *mut FILE) -> c_int;
-    pub fn remove(filename: *const c_char) -> c_int;
-    pub fn rename(oldname: *const c_char, newname: *const c_char) -> c_int;
+    pub fn fflush(file: *mut FILE) -> ::c_int;
+    pub fn fclose(file: *mut FILE) -> ::c_int;
+    pub fn remove(filename: *const ::c_char) -> ::c_int;
+    pub fn rename(oldname: *const ::c_char, newname: *const ::c_char) -> ::c_int;
     pub fn tmpfile() -> *mut FILE;
-    pub fn setvbuf(stream: *mut FILE, buffer: *mut c_char, mode: c_int,
-                   size: size_t) -> c_int;
-    pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
-    pub fn getchar() -> c_int;
-    pub fn putchar(c: c_int) -> c_int;
-    pub fn fgetc(stream: *mut FILE) -> c_int;
-    pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
-    pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;
-    pub fn fputs(s: *const c_char, stream: *mut FILE) -> c_int;
-    pub fn puts(s: *const c_char) -> c_int;
-    pub fn ungetc(c: c_int, stream: *mut FILE) -> c_int;
-    pub fn fread(ptr: *mut c_void, size: size_t, nobj: size_t,
-                 stream: *mut FILE) -> size_t;
-    pub fn fwrite(ptr: *const c_void, size: size_t, nobj: size_t,
-                  stream: *mut FILE) -> size_t;
-    pub fn fseek(stream: *mut FILE, offset: c_long, whence: c_int) -> c_int;
-    pub fn ftell(stream: *mut FILE) -> c_long;
+    pub fn setvbuf(stream: *mut FILE, buffer: *mut ::c_char, mode: ::c_int,
+                   size: ::size_t) -> ::c_int;
+    pub fn setbuf(stream: *mut FILE, buf: *mut ::c_char);
+    pub fn getchar() -> ::c_int;
+    pub fn putchar(c: ::c_int) -> ::c_int;
+    pub fn fgetc(stream: *mut FILE) -> ::c_int;
+    pub fn fgets(buf: *mut ::c_char, n: ::c_int, stream: *mut FILE) -> *mut ::c_char;
+    pub fn fputc(c: ::c_int, stream: *mut FILE) -> ::c_int;
+    pub fn fputs(s: *const ::c_char, stream: *mut FILE) -> ::c_int;
+    pub fn puts(s: *const ::c_char) -> ::c_int;
+    pub fn ungetc(c: ::c_int, stream: *mut FILE) -> ::c_int;
+    pub fn fread(ptr: *mut ::c_void, size: ::size_t, nobj: ::size_t,
+                 stream: *mut FILE) -> ::size_t;
+    pub fn fwrite(ptr: *const ::c_void, size: ::size_t, nobj: ::size_t,
+                  stream: *mut FILE) -> ::size_t;
+    pub fn fseek(stream: *mut FILE, offset: ::c_long, whence: ::c_int) -> ::c_int;
+    pub fn ftell(stream: *mut FILE) -> ::c_long;
     pub fn rewind(stream: *mut FILE);
-    pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> c_int;
-    pub fn fsetpos(stream: *mut FILE, ptr: *const fpos_t) -> c_int;
-    pub fn feof(stream: *mut FILE) -> c_int;
-    pub fn ferror(stream: *mut FILE) -> c_int;
-    pub fn perror(s: *const c_char);
-    pub fn atoi(s: *const c_char) -> c_int;
-    pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
-    pub fn strtol(s: *const c_char, endp: *mut *mut c_char,
-                  base: c_int) -> c_long;
-    pub fn strtoul(s: *const c_char, endp: *mut *mut c_char,
-                   base: c_int) -> c_ulong;
-    pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;
-    pub fn malloc(size: size_t) -> *mut c_void;
-    pub fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
-    pub fn free(p: *mut c_void);
+    pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> ::c_int;
+    pub fn fsetpos(stream: *mut FILE, ptr: *const fpos_t) -> ::c_int;
+    pub fn feof(stream: *mut FILE) -> ::c_int;
+    pub fn ferror(stream: *mut FILE) -> ::c_int;
+    pub fn perror(s: *const ::c_char);
+    pub fn atoi(s: *const ::c_char) -> ::c_int;
+    pub fn strtod(s: *const ::c_char, endp: *mut *mut ::c_char) -> ::c_double;
+    pub fn strtol(s: *const ::c_char, endp: *mut *mut ::c_char,
+                  base: ::c_int) -> ::c_long;
+    pub fn strtoul(s: *const ::c_char, endp: *mut *mut ::c_char,
+                   base: ::c_int) -> ::c_ulong;
+    pub fn calloc(nobj: ::size_t, size: ::size_t) -> *mut ::c_void;
+    pub fn malloc(size: ::size_t) -> *mut ::c_void;
+    pub fn realloc(p: *mut ::c_void, size: ::size_t) -> *mut ::c_void;
+    pub fn free(p: *mut ::c_void);
     pub fn abort() -> !;
-    pub fn exit(status: c_int) -> !;
-    pub fn _exit(status: c_int) -> !;
-    pub fn atexit(cb: extern fn()) -> c_int;
-    pub fn system(s: *const c_char) -> c_int;
-    pub fn getenv(s: *const c_char) -> *mut c_char;
-    pub fn getline (lineptr: *mut *mut c_char, n: *mut size_t,
-        stream: *mut FILE) -> ssize_t;
+    pub fn exit(status: ::c_int) -> !;
+    pub fn _exit(status: ::c_int) -> !;
+    pub fn atexit(cb: extern fn()) -> ::c_int;
+    pub fn system(s: *const ::c_char) -> ::c_int;
+    pub fn getenv(s: *const ::c_char) -> *mut ::c_char;
+    pub fn getline (lineptr: *mut *mut ::c_char, n: *mut ::size_t,
+        stream: *mut FILE) -> ::ssize_t;
 
-    pub fn strcpy(dst: *mut c_char, src: *const c_char) -> *mut c_char;
-    pub fn strncpy(dst: *mut c_char, src: *const c_char,
-                   n: size_t) -> *mut c_char;
-    pub fn strcat(s: *mut c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strncat(s: *mut c_char, ct: *const c_char, n: size_t) -> *mut c_char;
-    pub fn strcmp(cs: *const c_char, ct: *const c_char) -> c_int;
-    pub fn strncmp(cs: *const c_char, ct: *const c_char, n: size_t) -> c_int;
-    pub fn strcoll(cs: *const c_char, ct: *const c_char) -> c_int;
-    pub fn strchr(cs: *const c_char, c: c_int) -> *mut c_char;
-    pub fn strrchr(cs: *const c_char, c: c_int) -> *mut c_char;
-    pub fn strspn(cs: *const c_char, ct: *const c_char) -> size_t;
-    pub fn strcspn(cs: *const c_char, ct: *const c_char) -> size_t;
-    pub fn strdup(cs: *const c_char) -> *mut c_char;
-    pub fn strpbrk(cs: *const c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strstr(cs: *const c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strcasecmp(s1: *const c_char, s2: *const c_char) -> c_int;
-    pub fn strncasecmp(s1: *const c_char, s2: *const c_char,
-                       n: size_t) -> c_int;
-    pub fn strlen(cs: *const c_char) -> size_t;
-    pub fn strnlen(cs: *const c_char, maxlen: size_t) -> size_t;
-    pub fn strerror(n: c_int) -> *mut c_char;
-    pub fn strtok(s: *mut c_char, t: *const c_char) -> *mut c_char;
-    pub fn strxfrm(s: *mut c_char, ct: *const c_char, n: size_t) -> size_t;
-    pub fn wcslen(buf: *const wchar_t) -> size_t;
-    pub fn wcstombs(dest: *mut c_char, src: *const wchar_t,
-                    n: size_t) -> ::size_t;
+    pub fn strcpy(dst: *mut ::c_char, src: *const ::c_char) -> *mut ::c_char;
+    pub fn strncpy(dst: *mut ::c_char, src: *const ::c_char,
+                   n: ::size_t) -> *mut ::c_char;
+    pub fn strcat(s: *mut ::c_char, ct: *const ::c_char) -> *mut ::c_char;
+    pub fn strncat(s: *mut ::c_char, ct: *const ::c_char, n: ::size_t) -> *mut ::c_char;
+    pub fn strcmp(cs: *const ::c_char, ct: *const ::c_char) -> ::c_int;
+    pub fn strncmp(cs: *const ::c_char, ct: *const ::c_char, n: ::size_t) -> ::c_int;
+    pub fn strcoll(cs: *const ::c_char, ct: *const ::c_char) -> ::c_int;
+    pub fn strchr(cs: *const ::c_char, c: ::c_int) -> *mut ::c_char;
+    pub fn strrchr(cs: *const ::c_char, c: ::c_int) -> *mut ::c_char;
+    pub fn strspn(cs: *const ::c_char, ct: *const ::c_char) -> ::size_t;
+    pub fn strcspn(cs: *const ::c_char, ct: *const ::c_char) -> ::size_t;
+    pub fn strdup(cs: *const ::c_char) -> *mut ::c_char;
+    pub fn strpbrk(cs: *const ::c_char, ct: *const ::c_char) -> *mut ::c_char;
+    pub fn strstr(cs: *const ::c_char, ct: *const ::c_char) -> *mut ::c_char;
+    pub fn strcasecmp(s1: *const ::c_char, s2: *const ::c_char) -> ::c_int;
+    pub fn strncasecmp(s1: *const ::c_char, s2: *const ::c_char,
+                       n: ::size_t) -> ::c_int;
+    pub fn strlen(cs: *const ::c_char) -> ::size_t;
+    pub fn strnlen(cs: *const ::c_char, maxlen: ::size_t) -> ::size_t;
+    pub fn strerror(n: ::c_int) -> *mut ::c_char;
+    pub fn strtok(s: *mut ::c_char, t: *const ::c_char) -> *mut ::c_char;
+    pub fn strxfrm(s: *mut ::c_char, ct: *const ::c_char, n: ::size_t) -> ::size_t;
+    pub fn wcslen(buf: *const wchar_t) -> ::size_t;
+    pub fn wcstombs(dest: *mut ::c_char, src: *const wchar_t,
+                    n: ::size_t) -> ::size_t;
 
-    pub fn memchr(cx: *const c_void, c: c_int, n: size_t) -> *mut c_void;
-    pub fn memcmp(cx: *const c_void, ct: *const c_void, n: size_t) -> c_int;
-    pub fn memcpy(dest: *mut c_void, src: *const c_void,
-                  n: size_t) -> *mut c_void;
-    pub fn memmove(dest: *mut c_void, src: *const c_void,
-                   n: size_t) -> *mut c_void;
-    pub fn memset(dest: *mut c_void, c: c_int, n: size_t) -> *mut c_void;
+    pub fn memchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
+    pub fn memcmp(cx: *const ::c_void, ct: *const ::c_void, n: ::size_t) -> ::c_int;
+    pub fn memcpy(dest: *mut ::c_void, src: *const ::c_void,
+                  n: ::size_t) -> *mut ::c_void;
+    pub fn memmove(dest: *mut ::c_void, src: *const ::c_void,
+                   n: ::size_t) -> *mut ::c_void;
+    pub fn memset(dest: *mut ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
 
-    pub fn abs(i: c_int) -> c_int;
-    pub fn atof(s: *const c_char) -> c_double;
-    pub fn labs(i: c_long) -> c_long;
-    pub fn rand() -> c_int;
-    pub fn srand(seed: c_uint);
+    pub fn abs(i: ::c_int) -> ::c_int;
+    pub fn atof(s: *const ::c_char) -> ::c_double;
+    pub fn labs(i: ::c_long) -> ::c_long;
+    pub fn rand() -> ::c_int;
+    pub fn srand(seed: ::c_uint);
 
     pub fn arc4random_buf(buf: *const ::c_void, len: ::size_t);
     pub fn freeaddrinfo(res: *mut addrinfo);
     pub fn gai_strerror(errcode: ::c_int) -> *const ::c_char;
     pub fn getaddrinfo(
-        node: *const c_char,
-        service: *const c_char,
+        node: *const ::c_char,
+        service: *const ::c_char,
         hints: *const addrinfo,
         res: *mut *mut addrinfo,
     ) -> ::c_int;
@@ -312,24 +281,5 @@ cfg_if! {
         pub use self::x86_64::*;
     } else {
         // Unknown target_arch
-    }
-}
-
-cfg_if! {
-    if #[cfg(core_cvoid)] {
-        pub use core::ffi::c_void;
-    } else {
-        // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help
-        // enable more optimization opportunities around it recognizing things
-        // like malloc/free.
-        #[repr(u8)]
-        #[allow(missing_copy_implementations)]
-        pub enum c_void {
-            // Two dummy variants so the #[repr] attribute can be used.
-            #[doc(hidden)]
-            __variant1,
-            #[doc(hidden)]
-            __variant2,
-        }
     }
 }

--- a/src/cloudabi/mod.rs
+++ b/src/cloudabi/mod.rs
@@ -134,13 +134,15 @@ extern {
     pub fn isxdigit(c: ::c_int) -> ::c_int;
     pub fn tolower(c: ::c_int) -> ::c_int;
     pub fn toupper(c: ::c_int) -> ::c_int;
-    pub fn fopen(filename: *const ::c_char, mode: *const ::c_char) -> *mut FILE;
+    pub fn fopen(filename: *const ::c_char,
+                 mode: *const ::c_char) -> *mut FILE;
     pub fn freopen(filename: *const ::c_char, mode: *const ::c_char,
                    file: *mut FILE) -> *mut FILE;
     pub fn fflush(file: *mut FILE) -> ::c_int;
     pub fn fclose(file: *mut FILE) -> ::c_int;
     pub fn remove(filename: *const ::c_char) -> ::c_int;
-    pub fn rename(oldname: *const ::c_char, newname: *const ::c_char) -> ::c_int;
+    pub fn rename(oldname: *const ::c_char,
+                  newname: *const ::c_char) -> ::c_int;
     pub fn tmpfile() -> *mut FILE;
     pub fn setvbuf(stream: *mut FILE, buffer: *mut ::c_char, mode: ::c_int,
                    size: ::size_t) -> ::c_int;
@@ -148,7 +150,8 @@ extern {
     pub fn getchar() -> ::c_int;
     pub fn putchar(c: ::c_int) -> ::c_int;
     pub fn fgetc(stream: *mut FILE) -> ::c_int;
-    pub fn fgets(buf: *mut ::c_char, n: ::c_int, stream: *mut FILE) -> *mut ::c_char;
+    pub fn fgets(buf: *mut ::c_char, n: ::c_int,
+                 stream: *mut FILE) -> *mut ::c_char;
     pub fn fputc(c: ::c_int, stream: *mut FILE) -> ::c_int;
     pub fn fputs(s: *const ::c_char, stream: *mut FILE) -> ::c_int;
     pub fn puts(s: *const ::c_char) -> ::c_int;
@@ -157,7 +160,8 @@ extern {
                  stream: *mut FILE) -> ::size_t;
     pub fn fwrite(ptr: *const ::c_void, size: ::size_t, nobj: ::size_t,
                   stream: *mut FILE) -> ::size_t;
-    pub fn fseek(stream: *mut FILE, offset: ::c_long, whence: ::c_int) -> ::c_int;
+    pub fn fseek(stream: *mut FILE, offset: ::c_long,
+                 whence: ::c_int) -> ::c_int;
     pub fn ftell(stream: *mut FILE) -> ::c_long;
     pub fn rewind(stream: *mut FILE);
     pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> ::c_int;
@@ -188,9 +192,11 @@ extern {
     pub fn strncpy(dst: *mut ::c_char, src: *const ::c_char,
                    n: ::size_t) -> *mut ::c_char;
     pub fn strcat(s: *mut ::c_char, ct: *const ::c_char) -> *mut ::c_char;
-    pub fn strncat(s: *mut ::c_char, ct: *const ::c_char, n: ::size_t) -> *mut ::c_char;
+    pub fn strncat(s: *mut ::c_char, ct: *const ::c_char,
+                   n: ::size_t) -> *mut ::c_char;
     pub fn strcmp(cs: *const ::c_char, ct: *const ::c_char) -> ::c_int;
-    pub fn strncmp(cs: *const ::c_char, ct: *const ::c_char, n: ::size_t) -> ::c_int;
+    pub fn strncmp(cs: *const ::c_char, ct: *const ::c_char,
+                   n: ::size_t) -> ::c_int;
     pub fn strcoll(cs: *const ::c_char, ct: *const ::c_char) -> ::c_int;
     pub fn strchr(cs: *const ::c_char, c: ::c_int) -> *mut ::c_char;
     pub fn strrchr(cs: *const ::c_char, c: ::c_int) -> *mut ::c_char;
@@ -206,18 +212,22 @@ extern {
     pub fn strnlen(cs: *const ::c_char, maxlen: ::size_t) -> ::size_t;
     pub fn strerror(n: ::c_int) -> *mut ::c_char;
     pub fn strtok(s: *mut ::c_char, t: *const ::c_char) -> *mut ::c_char;
-    pub fn strxfrm(s: *mut ::c_char, ct: *const ::c_char, n: ::size_t) -> ::size_t;
+    pub fn strxfrm(s: *mut ::c_char, ct: *const ::c_char,
+                   n: ::size_t) -> ::size_t;
     pub fn wcslen(buf: *const wchar_t) -> ::size_t;
     pub fn wcstombs(dest: *mut ::c_char, src: *const wchar_t,
                     n: ::size_t) -> ::size_t;
 
-    pub fn memchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
-    pub fn memcmp(cx: *const ::c_void, ct: *const ::c_void, n: ::size_t) -> ::c_int;
+    pub fn memchr(cx: *const ::c_void, c: ::c_int,
+                  n: ::size_t) -> *mut ::c_void;
+    pub fn memcmp(cx: *const ::c_void, ct: *const ::c_void,
+                  n: ::size_t) -> ::c_int;
     pub fn memcpy(dest: *mut ::c_void, src: *const ::c_void,
                   n: ::size_t) -> *mut ::c_void;
     pub fn memmove(dest: *mut ::c_void, src: *const ::c_void,
                    n: ::size_t) -> *mut ::c_void;
-    pub fn memset(dest: *mut ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
+    pub fn memset(dest: *mut ::c_void, c: ::c_int,
+                  n: ::size_t) -> *mut ::c_void;
 
     pub fn abs(i: ::c_int) -> ::c_int;
     pub fn atof(s: *const ::c_char) -> ::c_double;

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -3080,7 +3080,8 @@ extern {
     pub fn fflush(file: *mut FILE) -> ::c_int;
     pub fn fclose(file: *mut FILE) -> ::c_int;
     pub fn remove(filename: *const ::c_char) -> ::c_int;
-    pub fn rename(oldname: *const ::c_char, newname: *const ::c_char) -> ::c_int;
+    pub fn rename(oldname: *const ::c_char,
+                  newname: *const ::c_char) -> ::c_int;
     pub fn tmpfile() -> *mut FILE;
     pub fn setvbuf(stream: *mut FILE, buffer: *mut ::c_char, mode: ::c_int,
                    size: ::size_t) -> ::c_int;
@@ -3088,7 +3089,8 @@ extern {
     pub fn getchar() -> ::c_int;
     pub fn putchar(c: ::c_int) -> ::c_int;
     pub fn fgetc(stream: *mut FILE) -> ::c_int;
-    pub fn fgets(buf: *mut ::c_char, n: ::c_int, stream: *mut FILE) -> *mut ::c_char;
+    pub fn fgets(buf: *mut ::c_char, n: ::c_int,
+                 stream: *mut FILE) -> *mut ::c_char;
     pub fn fputc(c: ::c_int, stream: *mut FILE) -> ::c_int;
     pub fn fputs(s: *const ::c_char, stream: *mut FILE) -> ::c_int;
     pub fn puts(s: *const ::c_char) -> ::c_int;
@@ -3097,7 +3099,8 @@ extern {
                  stream: *mut FILE) -> ::size_t;
     pub fn fwrite(ptr: *const ::c_void, size: ::size_t, nobj: ::size_t,
                   stream: *mut FILE) -> ::size_t;
-    pub fn fseek(stream: *mut FILE, offset: ::c_long, whence: ::c_int) -> ::c_int;
+    pub fn fseek(stream: *mut FILE, offset: ::c_long,
+                 whence: ::c_int) -> ::c_int;
     pub fn ftell(stream: *mut FILE) -> ::c_long;
     pub fn rewind(stream: *mut FILE);
     pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> ::c_int;
@@ -3129,7 +3132,8 @@ extern {
     pub fn strncat(s: *mut ::c_char, ct: *const ::c_char,
                    n: ::size_t) -> *mut ::c_char;
     pub fn strcmp(cs: *const ::c_char, ct: *const ::c_char) -> ::c_int;
-    pub fn strncmp(cs: *const ::c_char, ct: *const ::c_char, n: ::size_t) -> ::c_int;
+    pub fn strncmp(cs: *const ::c_char, ct: *const ::c_char,
+                   n: ::size_t) -> ::c_int;
     pub fn strcoll(cs: *const ::c_char, ct: *const ::c_char) -> ::c_int;
     pub fn strchr(cs: *const ::c_char, c: ::c_int) -> *mut ::c_char;
     pub fn strrchr(cs: *const ::c_char, c: ::c_int) -> *mut ::c_char;
@@ -3142,18 +3146,22 @@ extern {
     pub fn strnlen(cs: *const ::c_char, maxlen: ::size_t) -> ::size_t;
     pub fn strerror(n: ::c_int) -> *mut ::c_char;
     pub fn strtok(s: *mut ::c_char, t: *const ::c_char) -> *mut ::c_char;
-    pub fn strxfrm(s: *mut ::c_char, ct: *const ::c_char, n: ::size_t) -> ::size_t;
+    pub fn strxfrm(s: *mut ::c_char, ct: *const ::c_char,
+                   n: ::size_t) -> ::size_t;
     pub fn wcslen(buf: *const wchar_t) -> ::size_t;
     pub fn wcstombs(dest: *mut ::c_char, src: *const wchar_t,
                     n: ::size_t) -> ::size_t;
 
-    pub fn memchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
-    pub fn memcmp(cx: *const ::c_void, ct: *const ::c_void, n: ::size_t) -> ::c_int;
+    pub fn memchr(cx: *const ::c_void, c: ::c_int,
+                  n: ::size_t) -> *mut ::c_void;
+    pub fn memcmp(cx: *const ::c_void, ct: *const ::c_void,
+                  n: ::size_t) -> ::c_int;
     pub fn memcpy(dest: *mut ::c_void, src: *const ::c_void,
                   n: ::size_t) -> *mut ::c_void;
     pub fn memmove(dest: *mut ::c_void, src: *const ::c_void,
                    n: ::size_t) -> *mut ::c_void;
-    pub fn memset(dest: *mut ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
+    pub fn memset(dest: *mut ::c_void, c: ::c_int,
+                  n: ::size_t) -> *mut ::c_void;
 
     pub fn abs(i: ::c_int) -> ::c_int;
     pub fn atof(s: *const ::c_char) -> ::c_double;
@@ -3786,7 +3794,8 @@ extern {
     pub fn flistxattr(filedes: ::c_int, list: *mut ::c_char,
                       size: ::size_t) -> ::ssize_t;
     pub fn removexattr(path: *const ::c_char, name: *const ::c_char) -> ::c_int;
-    pub fn lremovexattr(path: *const ::c_char, name: *const ::c_char) -> ::c_int;
+    pub fn lremovexattr(path: *const ::c_char,
+                        name: *const ::c_char) -> ::c_int;
     pub fn fremovexattr(filedes: ::c_int, name: *const ::c_char) -> ::c_int;
     pub fn signalfd(fd: ::c_int,
                     mask: *const ::sigset_t,

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -7,6 +7,19 @@ use dox::{mem, Option};
 
 // PUB_TYPE
 
+pub type c_short = i16;
+pub type c_ushort = u16;
+pub type c_int = i32;
+pub type c_uint = u32;
+pub type c_longlong = i64;
+pub type c_ulonglong = u64;
+pub type intmax_t = i64;
+pub type uintmax_t = u64;
+
+pub type size_t = usize;
+pub type ptrdiff_t = isize;
+pub type ssize_t = isize;
+
 pub type pid_t = i32;
 pub type uid_t = u32;
 pub type gid_t = u32;
@@ -1068,6 +1081,9 @@ s! {
 }
 
 // PUB_CONST
+
+pub const INT_MIN: c_int = -2147483648;
+pub const INT_MAX: c_int = 2147483647;
 
 pub const SIG_DFL: sighandler_t = 0 as sighandler_t;
 pub const SIG_IGN: sighandler_t = 1 as sighandler_t;

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -7,34 +7,6 @@ use dox::{mem, Option};
 
 // PUB_TYPE
 
-pub type int8_t = i8;
-pub type int16_t = i16;
-pub type int32_t = i32;
-pub type int64_t = i64;
-pub type uint8_t = u8;
-pub type uint16_t = u16;
-pub type uint32_t = u32;
-pub type uint64_t = u64;
-
-pub type c_schar = i8;
-pub type c_uchar = u8;
-pub type c_short = i16;
-pub type c_ushort = u16;
-pub type c_int = i32;
-pub type c_uint = u32;
-pub type c_float = f32;
-pub type c_double = f64;
-pub type c_longlong = i64;
-pub type c_ulonglong = u64;
-pub type intmax_t = i64;
-pub type uintmax_t = u64;
-
-pub type size_t = usize;
-pub type ptrdiff_t = isize;
-pub type intptr_t = isize;
-pub type uintptr_t = usize;
-pub type ssize_t = isize;
-
 pub type pid_t = i32;
 pub type uid_t = u32;
 pub type gid_t = u32;
@@ -52,7 +24,7 @@ pub type id_t = ::c_uint;
 pub type useconds_t = u32;
 pub type dev_t = u64;
 pub type socklen_t = u32;
-pub type pthread_t = c_ulong;
+pub type pthread_t = ::c_ulong;
 pub type mode_t = u32;
 pub type ino64_t = u64;
 pub type off64_t = i64;
@@ -81,9 +53,9 @@ pub type Elf64_Off = u64;
 pub type Elf64_Addr = u64;
 pub type Elf64_Xword = u64;
 
-pub type clock_t = c_long;
-pub type time_t = c_long;
-pub type suseconds_t = c_long;
+pub type clock_t = ::c_long;
+pub type time_t = ::c_long;
+pub type suseconds_t = ::c_long;
 pub type ino_t = u64;
 pub type off_t = i64;
 pub type blkcnt_t = i64;
@@ -160,46 +132,46 @@ s! {
     pub struct rusage {
         pub ru_utime: timeval,
         pub ru_stime: timeval,
-        pub ru_maxrss: c_long,
+        pub ru_maxrss: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad1: u32,
-        pub ru_ixrss: c_long,
+        pub ru_ixrss: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad2: u32,
-        pub ru_idrss: c_long,
+        pub ru_idrss: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad3: u32,
-        pub ru_isrss: c_long,
+        pub ru_isrss: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad4: u32,
-        pub ru_minflt: c_long,
+        pub ru_minflt: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad5: u32,
-        pub ru_majflt: c_long,
+        pub ru_majflt: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad6: u32,
-        pub ru_nswap: c_long,
+        pub ru_nswap: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad7: u32,
-        pub ru_inblock: c_long,
+        pub ru_inblock: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad8: u32,
-        pub ru_oublock: c_long,
+        pub ru_oublock: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad9: u32,
-        pub ru_msgsnd: c_long,
+        pub ru_msgsnd: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad10: u32,
-        pub ru_msgrcv: c_long,
+        pub ru_msgrcv: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad11: u32,
-        pub ru_nsignals: c_long,
+        pub ru_nsignals: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad12: u32,
-        pub ru_nvcsw: c_long,
+        pub ru_nvcsw: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad13: u32,
-        pub ru_nivcsw: c_long,
+        pub ru_nivcsw: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad14: u32,
 
@@ -397,7 +369,7 @@ s! {
 
         pub ai_addr: *mut ::sockaddr,
 
-        pub ai_canonname: *mut c_char,
+        pub ai_canonname: *mut ::c_char,
 
         pub ai_next: *mut addrinfo,
     }
@@ -525,7 +497,7 @@ s! {
 
     pub struct glob_t {
         pub gl_pathc: ::size_t,
-        pub gl_pathv: *mut *mut c_char,
+        pub gl_pathv: *mut *mut ::c_char,
         pub gl_offs: ::size_t,
         pub gl_flags: ::c_int,
 
@@ -538,7 +510,7 @@ s! {
 
     pub struct ifaddrs {
         pub ifa_next: *mut ifaddrs,
-        pub ifa_name: *mut c_char,
+        pub ifa_name: *mut ::c_char,
         pub ifa_flags: ::c_uint,
         pub ifa_addr: *mut ::sockaddr,
         pub ifa_netmask: *mut ::sockaddr,
@@ -1096,9 +1068,6 @@ s! {
 }
 
 // PUB_CONST
-
-pub const INT_MIN: c_int = -2147483648;
-pub const INT_MAX: c_int = 2147483647;
 
 pub const SIG_DFL: sighandler_t = 0 as sighandler_t;
 pub const SIG_IGN: sighandler_t = 1 as sighandler_t;
@@ -1786,8 +1755,8 @@ pub const P_ALL: idtype_t = 0;
 pub const P_PID: idtype_t = 1;
 pub const P_PGID: idtype_t = 2;
 
-pub const UTIME_OMIT: c_long = 1073741822;
-pub const UTIME_NOW: c_long = 1073741823;
+pub const UTIME_OMIT: ::c_long = 1073741822;
+pub const UTIME_NOW: ::c_long = 1073741823;
 
 pub const POLLIN: ::c_short = 0x1;
 pub const POLLPRI: ::c_short = 0x2;
@@ -3076,105 +3045,105 @@ impl ::dox::Clone for fpos_t {
 }
 
 extern {
-    pub fn isalnum(c: c_int) -> c_int;
-    pub fn isalpha(c: c_int) -> c_int;
-    pub fn iscntrl(c: c_int) -> c_int;
-    pub fn isdigit(c: c_int) -> c_int;
-    pub fn isgraph(c: c_int) -> c_int;
-    pub fn islower(c: c_int) -> c_int;
-    pub fn isprint(c: c_int) -> c_int;
-    pub fn ispunct(c: c_int) -> c_int;
-    pub fn isspace(c: c_int) -> c_int;
-    pub fn isupper(c: c_int) -> c_int;
-    pub fn isxdigit(c: c_int) -> c_int;
-    pub fn tolower(c: c_int) -> c_int;
-    pub fn toupper(c: c_int) -> c_int;
-    pub fn fopen(filename: *const c_char, mode: *const c_char) -> *mut FILE;
-    pub fn freopen(filename: *const c_char, mode: *const c_char,
+    pub fn isalnum(c: ::c_int) -> ::c_int;
+    pub fn isalpha(c: ::c_int) -> ::c_int;
+    pub fn iscntrl(c: ::c_int) -> ::c_int;
+    pub fn isdigit(c: ::c_int) -> ::c_int;
+    pub fn isgraph(c: ::c_int) -> ::c_int;
+    pub fn islower(c: ::c_int) -> ::c_int;
+    pub fn isprint(c: ::c_int) -> ::c_int;
+    pub fn ispunct(c: ::c_int) -> ::c_int;
+    pub fn isspace(c: ::c_int) -> ::c_int;
+    pub fn isupper(c: ::c_int) -> ::c_int;
+    pub fn isxdigit(c: ::c_int) -> ::c_int;
+    pub fn tolower(c: ::c_int) -> ::c_int;
+    pub fn toupper(c: ::c_int) -> ::c_int;
+    pub fn fopen(filename: *const ::c_char, mode: *const ::c_char) -> *mut FILE;
+    pub fn freopen(filename: *const ::c_char, mode: *const ::c_char,
                    file: *mut FILE) -> *mut FILE;
-    pub fn fflush(file: *mut FILE) -> c_int;
-    pub fn fclose(file: *mut FILE) -> c_int;
-    pub fn remove(filename: *const c_char) -> c_int;
-    pub fn rename(oldname: *const c_char, newname: *const c_char) -> c_int;
+    pub fn fflush(file: *mut FILE) -> ::c_int;
+    pub fn fclose(file: *mut FILE) -> ::c_int;
+    pub fn remove(filename: *const ::c_char) -> ::c_int;
+    pub fn rename(oldname: *const ::c_char, newname: *const ::c_char) -> ::c_int;
     pub fn tmpfile() -> *mut FILE;
-    pub fn setvbuf(stream: *mut FILE, buffer: *mut c_char, mode: c_int,
-                   size: size_t) -> c_int;
-    pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
-    pub fn getchar() -> c_int;
-    pub fn putchar(c: c_int) -> c_int;
-    pub fn fgetc(stream: *mut FILE) -> c_int;
-    pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
-    pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;
-    pub fn fputs(s: *const c_char, stream: *mut FILE) -> c_int;
-    pub fn puts(s: *const c_char) -> c_int;
-    pub fn ungetc(c: c_int, stream: *mut FILE) -> c_int;
-    pub fn fread(ptr: *mut c_void, size: size_t, nobj: size_t,
-                 stream: *mut FILE) -> size_t;
-    pub fn fwrite(ptr: *const c_void, size: size_t, nobj: size_t,
-                  stream: *mut FILE) -> size_t;
-    pub fn fseek(stream: *mut FILE, offset: c_long, whence: c_int) -> c_int;
-    pub fn ftell(stream: *mut FILE) -> c_long;
+    pub fn setvbuf(stream: *mut FILE, buffer: *mut ::c_char, mode: ::c_int,
+                   size: ::size_t) -> ::c_int;
+    pub fn setbuf(stream: *mut FILE, buf: *mut ::c_char);
+    pub fn getchar() -> ::c_int;
+    pub fn putchar(c: ::c_int) -> ::c_int;
+    pub fn fgetc(stream: *mut FILE) -> ::c_int;
+    pub fn fgets(buf: *mut ::c_char, n: ::c_int, stream: *mut FILE) -> *mut ::c_char;
+    pub fn fputc(c: ::c_int, stream: *mut FILE) -> ::c_int;
+    pub fn fputs(s: *const ::c_char, stream: *mut FILE) -> ::c_int;
+    pub fn puts(s: *const ::c_char) -> ::c_int;
+    pub fn ungetc(c: ::c_int, stream: *mut FILE) -> ::c_int;
+    pub fn fread(ptr: *mut ::c_void, size: ::size_t, nobj: ::size_t,
+                 stream: *mut FILE) -> ::size_t;
+    pub fn fwrite(ptr: *const ::c_void, size: ::size_t, nobj: ::size_t,
+                  stream: *mut FILE) -> ::size_t;
+    pub fn fseek(stream: *mut FILE, offset: ::c_long, whence: ::c_int) -> ::c_int;
+    pub fn ftell(stream: *mut FILE) -> ::c_long;
     pub fn rewind(stream: *mut FILE);
-    pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> c_int;
-    pub fn fsetpos(stream: *mut FILE, ptr: *const fpos_t) -> c_int;
-    pub fn feof(stream: *mut FILE) -> c_int;
-    pub fn ferror(stream: *mut FILE) -> c_int;
-    pub fn perror(s: *const c_char);
-    pub fn atoi(s: *const c_char) -> c_int;
-    pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
-    pub fn strtol(s: *const c_char, endp: *mut *mut c_char,
-                  base: c_int) -> c_long;
-    pub fn strtoul(s: *const c_char, endp: *mut *mut c_char,
-                   base: c_int) -> c_ulong;
-    pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;
-    pub fn malloc(size: size_t) -> *mut c_void;
-    pub fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
-    pub fn free(p: *mut c_void);
+    pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> ::c_int;
+    pub fn fsetpos(stream: *mut FILE, ptr: *const fpos_t) -> ::c_int;
+    pub fn feof(stream: *mut FILE) -> ::c_int;
+    pub fn ferror(stream: *mut FILE) -> ::c_int;
+    pub fn perror(s: *const ::c_char);
+    pub fn atoi(s: *const ::c_char) -> ::c_int;
+    pub fn strtod(s: *const ::c_char, endp: *mut *mut ::c_char) -> ::c_double;
+    pub fn strtol(s: *const ::c_char, endp: *mut *mut ::c_char,
+                  base: ::c_int) -> ::c_long;
+    pub fn strtoul(s: *const ::c_char, endp: *mut *mut ::c_char,
+                   base: ::c_int) -> ::c_ulong;
+    pub fn calloc(nobj: ::size_t, size: ::size_t) -> *mut ::c_void;
+    pub fn malloc(size: ::size_t) -> *mut ::c_void;
+    pub fn realloc(p: *mut ::c_void, size: ::size_t) -> *mut ::c_void;
+    pub fn free(p: *mut ::c_void);
     pub fn abort() -> !;
-    pub fn exit(status: c_int) -> !;
-    pub fn _exit(status: c_int) -> !;
-    pub fn atexit(cb: extern fn()) -> c_int;
-    pub fn system(s: *const c_char) -> c_int;
-    pub fn getenv(s: *const c_char) -> *mut c_char;
+    pub fn exit(status: ::c_int) -> !;
+    pub fn _exit(status: ::c_int) -> !;
+    pub fn atexit(cb: extern fn()) -> ::c_int;
+    pub fn system(s: *const ::c_char) -> ::c_int;
+    pub fn getenv(s: *const ::c_char) -> *mut ::c_char;
 
-    pub fn strcpy(dst: *mut c_char, src: *const c_char) -> *mut c_char;
-    pub fn strncpy(dst: *mut c_char, src: *const c_char,
-                   n: size_t) -> *mut c_char;
-    pub fn strcat(s: *mut c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strncat(s: *mut c_char, ct: *const c_char,
-                   n: size_t) -> *mut c_char;
-    pub fn strcmp(cs: *const c_char, ct: *const c_char) -> c_int;
-    pub fn strncmp(cs: *const c_char, ct: *const c_char, n: size_t) -> c_int;
-    pub fn strcoll(cs: *const c_char, ct: *const c_char) -> c_int;
-    pub fn strchr(cs: *const c_char, c: c_int) -> *mut c_char;
-    pub fn strrchr(cs: *const c_char, c: c_int) -> *mut c_char;
-    pub fn strspn(cs: *const c_char, ct: *const c_char) -> size_t;
-    pub fn strcspn(cs: *const c_char, ct: *const c_char) -> size_t;
-    pub fn strdup(cs: *const c_char) -> *mut c_char;
-    pub fn strpbrk(cs: *const c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strstr(cs: *const c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strlen(cs: *const c_char) -> size_t;
-    pub fn strnlen(cs: *const c_char, maxlen: size_t) -> size_t;
-    pub fn strerror(n: c_int) -> *mut c_char;
-    pub fn strtok(s: *mut c_char, t: *const c_char) -> *mut c_char;
-    pub fn strxfrm(s: *mut c_char, ct: *const c_char, n: size_t) -> size_t;
-    pub fn wcslen(buf: *const wchar_t) -> size_t;
-    pub fn wcstombs(dest: *mut c_char, src: *const wchar_t,
-                    n: size_t) -> ::size_t;
+    pub fn strcpy(dst: *mut ::c_char, src: *const ::c_char) -> *mut ::c_char;
+    pub fn strncpy(dst: *mut ::c_char, src: *const ::c_char,
+                   n: ::size_t) -> *mut ::c_char;
+    pub fn strcat(s: *mut ::c_char, ct: *const ::c_char) -> *mut ::c_char;
+    pub fn strncat(s: *mut ::c_char, ct: *const ::c_char,
+                   n: ::size_t) -> *mut ::c_char;
+    pub fn strcmp(cs: *const ::c_char, ct: *const ::c_char) -> ::c_int;
+    pub fn strncmp(cs: *const ::c_char, ct: *const ::c_char, n: ::size_t) -> ::c_int;
+    pub fn strcoll(cs: *const ::c_char, ct: *const ::c_char) -> ::c_int;
+    pub fn strchr(cs: *const ::c_char, c: ::c_int) -> *mut ::c_char;
+    pub fn strrchr(cs: *const ::c_char, c: ::c_int) -> *mut ::c_char;
+    pub fn strspn(cs: *const ::c_char, ct: *const ::c_char) -> ::size_t;
+    pub fn strcspn(cs: *const ::c_char, ct: *const ::c_char) -> ::size_t;
+    pub fn strdup(cs: *const ::c_char) -> *mut ::c_char;
+    pub fn strpbrk(cs: *const ::c_char, ct: *const ::c_char) -> *mut ::c_char;
+    pub fn strstr(cs: *const ::c_char, ct: *const ::c_char) -> *mut ::c_char;
+    pub fn strlen(cs: *const ::c_char) -> ::size_t;
+    pub fn strnlen(cs: *const ::c_char, maxlen: ::size_t) -> ::size_t;
+    pub fn strerror(n: ::c_int) -> *mut ::c_char;
+    pub fn strtok(s: *mut ::c_char, t: *const ::c_char) -> *mut ::c_char;
+    pub fn strxfrm(s: *mut ::c_char, ct: *const ::c_char, n: ::size_t) -> ::size_t;
+    pub fn wcslen(buf: *const wchar_t) -> ::size_t;
+    pub fn wcstombs(dest: *mut ::c_char, src: *const wchar_t,
+                    n: ::size_t) -> ::size_t;
 
-    pub fn memchr(cx: *const c_void, c: c_int, n: size_t) -> *mut c_void;
-    pub fn memcmp(cx: *const c_void, ct: *const c_void, n: size_t) -> c_int;
-    pub fn memcpy(dest: *mut c_void, src: *const c_void,
-                  n: size_t) -> *mut c_void;
-    pub fn memmove(dest: *mut c_void, src: *const c_void,
-                   n: size_t) -> *mut c_void;
-    pub fn memset(dest: *mut c_void, c: c_int, n: size_t) -> *mut c_void;
+    pub fn memchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
+    pub fn memcmp(cx: *const ::c_void, ct: *const ::c_void, n: ::size_t) -> ::c_int;
+    pub fn memcpy(dest: *mut ::c_void, src: *const ::c_void,
+                  n: ::size_t) -> *mut ::c_void;
+    pub fn memmove(dest: *mut ::c_void, src: *const ::c_void,
+                   n: ::size_t) -> *mut ::c_void;
+    pub fn memset(dest: *mut ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
 
-    pub fn abs(i: c_int) -> c_int;
-    pub fn atof(s: *const c_char) -> c_double;
-    pub fn labs(i: c_long) -> c_long;
-    pub fn rand() -> c_int;
-    pub fn srand(seed: c_uint);
+    pub fn abs(i: ::c_int) -> ::c_int;
+    pub fn atof(s: *const ::c_char) -> ::c_double;
+    pub fn labs(i: ::c_long) -> ::c_long;
+    pub fn rand() -> ::c_int;
+    pub fn srand(seed: ::c_uint);
 
     pub fn getpwnam(name: *const ::c_char) -> *mut passwd;
     pub fn getpwuid(uid: ::uid_t) -> *mut passwd;
@@ -3211,24 +3180,24 @@ extern {
                   addrlen: socklen_t) -> ::ssize_t;
     pub fn shutdown(socket: ::c_int, how: ::c_int) -> ::c_int;
 
-    pub fn chmod(path: *const c_char, mode: mode_t) -> ::c_int;
+    pub fn chmod(path: *const ::c_char, mode: mode_t) -> ::c_int;
     pub fn fchmod(fd: ::c_int, mode: mode_t) -> ::c_int;
 
     pub fn fstat(fildes: ::c_int, buf: *mut stat) -> ::c_int;
 
-    pub fn mkdir(path: *const c_char, mode: mode_t) -> ::c_int;
+    pub fn mkdir(path: *const ::c_char, mode: mode_t) -> ::c_int;
 
-    pub fn stat(path: *const c_char, buf: *mut stat) -> ::c_int;
+    pub fn stat(path: *const ::c_char, buf: *mut stat) -> ::c_int;
 
     pub fn pclose(stream: *mut ::FILE) -> ::c_int;
-    pub fn fdopen(fd: ::c_int, mode: *const c_char) -> *mut ::FILE;
+    pub fn fdopen(fd: ::c_int, mode: *const ::c_char) -> *mut ::FILE;
     pub fn fileno(stream: *mut ::FILE) -> ::c_int;
 
-    pub fn open(path: *const c_char, oflag: ::c_int, ...) -> ::c_int;
-    pub fn creat(path: *const c_char, mode: mode_t) -> ::c_int;
+    pub fn open(path: *const ::c_char, oflag: ::c_int, ...) -> ::c_int;
+    pub fn creat(path: *const ::c_char, mode: mode_t) -> ::c_int;
     pub fn fcntl(fd: ::c_int, cmd: ::c_int, ...) -> ::c_int;
 
-    pub fn opendir(dirname: *const c_char) -> *mut ::DIR;
+    pub fn opendir(dirname: *const ::c_char) -> *mut ::DIR;
     pub fn readdir(dirp: *mut ::DIR) -> *mut ::dirent;
     pub fn readdir_r(dirp: *mut ::DIR, entry: *mut ::dirent,
                      result: *mut *mut ::dirent) -> ::c_int;
@@ -3262,50 +3231,50 @@ extern {
     pub fn unlinkat(dirfd: ::c_int, pathname: *const ::c_char,
                     flags: ::c_int) -> ::c_int;
 
-    pub fn access(path: *const c_char, amode: ::c_int) -> ::c_int;
+    pub fn access(path: *const ::c_char, amode: ::c_int) -> ::c_int;
     pub fn alarm(seconds: ::c_uint) -> ::c_uint;
-    pub fn chdir(dir: *const c_char) -> ::c_int;
+    pub fn chdir(dir: *const ::c_char) -> ::c_int;
     pub fn fchdir(dirfd: ::c_int) -> ::c_int;
-    pub fn chown(path: *const c_char, uid: uid_t,
+    pub fn chown(path: *const ::c_char, uid: uid_t,
                  gid: gid_t) -> ::c_int;
-    pub fn lchown(path: *const c_char, uid: uid_t,
+    pub fn lchown(path: *const ::c_char, uid: uid_t,
                   gid: gid_t) -> ::c_int;
     pub fn close(fd: ::c_int) -> ::c_int;
     pub fn dup(fd: ::c_int) -> ::c_int;
     pub fn dup2(src: ::c_int, dst: ::c_int) -> ::c_int;
-    pub fn execl(path: *const c_char,
-                 arg0: *const c_char, ...) -> ::c_int;
+    pub fn execl(path: *const ::c_char,
+                 arg0: *const ::c_char, ...) -> ::c_int;
     pub fn execle(path: *const ::c_char,
                   arg0: *const ::c_char, ...) -> ::c_int;
     pub fn execlp(file: *const ::c_char,
                   arg0: *const ::c_char, ...) -> ::c_int;
-    pub fn execv(prog: *const c_char,
-                 argv: *const *const c_char) -> ::c_int;
-    pub fn execve(prog: *const c_char, argv: *const *const c_char,
-                  envp: *const *const c_char)
+    pub fn execv(prog: *const ::c_char,
+                 argv: *const *const ::c_char) -> ::c_int;
+    pub fn execve(prog: *const ::c_char, argv: *const *const ::c_char,
+                  envp: *const *const ::c_char)
                   -> ::c_int;
-    pub fn execvp(c: *const c_char,
-                  argv: *const *const c_char) -> ::c_int;
+    pub fn execvp(c: *const ::c_char,
+                  argv: *const *const ::c_char) -> ::c_int;
     pub fn fork() -> pid_t;
-    pub fn fpathconf(filedes: ::c_int, name: ::c_int) -> c_long;
-    pub fn getcwd(buf: *mut c_char, size: ::size_t) -> *mut c_char;
+    pub fn fpathconf(filedes: ::c_int, name: ::c_int) -> ::c_long;
+    pub fn getcwd(buf: *mut ::c_char, size: ::size_t) -> *mut ::c_char;
     pub fn getegid() -> gid_t;
     pub fn geteuid() -> uid_t;
     pub fn getgid() -> gid_t;
     pub fn getgroups(ngroups_max: ::c_int, groups: *mut gid_t)
                      -> ::c_int;
-    pub fn getlogin() -> *mut c_char;
-    pub fn getopt(argc: ::c_int, argv: *const *mut c_char,
-                  optstr: *const c_char) -> ::c_int;
+    pub fn getlogin() -> *mut ::c_char;
+    pub fn getopt(argc: ::c_int, argv: *const *mut ::c_char,
+                  optstr: *const ::c_char) -> ::c_int;
     pub fn getpgid(pid: pid_t) -> pid_t;
     pub fn getpgrp() -> pid_t;
     pub fn getpid() -> pid_t;
     pub fn getppid() -> pid_t;
     pub fn getuid() -> uid_t;
     pub fn isatty(fd: ::c_int) -> ::c_int;
-    pub fn link(src: *const c_char, dst: *const c_char) -> ::c_int;
+    pub fn link(src: *const ::c_char, dst: *const ::c_char) -> ::c_int;
     pub fn lseek(fd: ::c_int, offset: off_t, whence: ::c_int) -> off_t;
-    pub fn pathconf(path: *const c_char, name: ::c_int) -> c_long;
+    pub fn pathconf(path: *const ::c_char, name: ::c_int) -> ::c_long;
     pub fn pause() -> ::c_int;
     pub fn pipe(fds: *mut ::c_int) -> ::c_int;
     pub fn posix_memalign(memptr: *mut *mut ::c_void,
@@ -3313,7 +3282,7 @@ extern {
                       size: ::size_t) -> ::c_int;
     pub fn read(fd: ::c_int, buf: *mut ::c_void, count: ::size_t)
                 -> ::ssize_t;
-    pub fn rmdir(path: *const c_char) -> ::c_int;
+    pub fn rmdir(path: *const ::c_char) -> ::c_int;
     pub fn seteuid(uid: uid_t) -> ::c_int;
     pub fn setegid(gid: gid_t) -> ::c_int;
     pub fn setgid(gid: gid_t) -> ::c_int;
@@ -3325,8 +3294,8 @@ extern {
                      rmtp: *mut timespec) -> ::c_int;
     pub fn tcgetpgrp(fd: ::c_int) -> pid_t;
     pub fn tcsetpgrp(fd: ::c_int, pgrp: ::pid_t) -> ::c_int;
-    pub fn ttyname(fd: ::c_int) -> *mut c_char;
-    pub fn unlink(c: *const c_char) -> ::c_int;
+    pub fn ttyname(fd: ::c_int) -> *mut ::c_char;
+    pub fn unlink(c: *const ::c_char) -> ::c_int;
     pub fn wait(status: *mut ::c_int) -> pid_t;
     pub fn waitpid(pid: pid_t, status: *mut ::c_int, options: ::c_int)
                    -> pid_t;
@@ -3338,7 +3307,7 @@ extern {
                   offset: off_t) -> ::ssize_t;
     pub fn umask(mask: mode_t) -> mode_t;
 
-    pub fn utime(file: *const c_char, buf: *const utimbuf) -> ::c_int;
+    pub fn utime(file: *const ::c_char, buf: *const utimbuf) -> ::c_int;
 
     pub fn kill(pid: pid_t, sig: ::c_int) -> ::c_int;
 
@@ -3356,20 +3325,20 @@ extern {
                 -> *mut ::c_void;
     pub fn munmap(addr: *mut ::c_void, len: ::size_t) -> ::c_int;
 
-    pub fn if_nametoindex(ifname: *const c_char) -> ::c_uint;
+    pub fn if_nametoindex(ifname: *const ::c_char) -> ::c_uint;
     pub fn if_indextoname(ifindex: ::c_uint,
                           ifname: *mut ::c_char) -> *mut ::c_char;
 
-    pub fn lstat(path: *const c_char, buf: *mut stat) -> ::c_int;
+    pub fn lstat(path: *const ::c_char, buf: *mut stat) -> ::c_int;
 
     pub fn fsync(fd: ::c_int) -> ::c_int;
 
-    pub fn setenv(name: *const c_char, val: *const c_char,
+    pub fn setenv(name: *const ::c_char, val: *const ::c_char,
                   overwrite: ::c_int) -> ::c_int;
-    pub fn unsetenv(name: *const c_char) -> ::c_int;
+    pub fn unsetenv(name: *const ::c_char) -> ::c_int;
 
-    pub fn symlink(path1: *const c_char,
-                   path2: *const c_char) -> ::c_int;
+    pub fn symlink(path1: *const ::c_char,
+                   path2: *const ::c_char) -> ::c_int;
 
     pub fn ftruncate(fd: ::c_int, length: off_t) -> ::c_int;
 
@@ -3442,7 +3411,7 @@ extern {
     pub fn pthread_rwlockattr_init(attr: *mut pthread_rwlockattr_t) -> ::c_int;
     pub fn pthread_rwlockattr_destroy(attr: *mut pthread_rwlockattr_t)
                                       -> ::c_int;
-    pub fn strerror_r(errnum: ::c_int, buf: *mut c_char,
+    pub fn strerror_r(errnum: ::c_int, buf: *mut ::c_char,
                       buflen: ::size_t) -> ::c_int;
 
     pub fn getsockopt(sockfd: ::c_int,
@@ -3465,8 +3434,8 @@ extern {
     pub fn dlclose(handle: *mut ::c_void) -> ::c_int;
     pub fn dladdr(addr: *const ::c_void, info: *mut Dl_info) -> ::c_int;
 
-    pub fn getaddrinfo(node: *const c_char,
-                       service: *const c_char,
+    pub fn getaddrinfo(node: *const ::c_char,
+                       service: *const ::c_char,
                        hints: *const addrinfo,
                        res: *mut *mut addrinfo) -> ::c_int;
     pub fn freeaddrinfo(res: *mut addrinfo);
@@ -3494,7 +3463,7 @@ extern {
                 flags: ::c_int) -> ::ssize_t;
     pub fn recv(socket: ::c_int, buf: *mut ::c_void, len: ::size_t,
                 flags: ::c_int) -> ::ssize_t;
-    pub fn putenv(string: *mut c_char) -> ::c_int;
+    pub fn putenv(string: *mut ::c_char) -> ::c_int;
     pub fn poll(fds: *mut pollfd, nfds: nfds_t, timeout: ::c_int) -> ::c_int;
     pub fn select(nfds: ::c_int,
                   readfs: *mut fd_set,
@@ -3513,11 +3482,11 @@ extern {
                     pshared: ::c_int,
                     value: ::c_uint)
                     -> ::c_int;
-    pub fn statvfs(path: *const c_char, buf: *mut statvfs) -> ::c_int;
+    pub fn statvfs(path: *const ::c_char, buf: *mut statvfs) -> ::c_int;
     pub fn fstatvfs(fd: ::c_int, buf: *mut statvfs) -> ::c_int;
 
-    pub fn readlink(path: *const c_char,
-                    buf: *mut c_char,
+    pub fn readlink(path: *const ::c_char,
+                    buf: *mut ::c_char,
                     bufsz: ::size_t)
                     -> ::ssize_t;
 
@@ -3539,7 +3508,7 @@ extern {
 
     pub fn sysconf(name: ::c_int) -> ::c_long;
 
-    pub fn mkfifo(path: *const c_char, mode: mode_t) -> ::c_int;
+    pub fn mkfifo(path: *const ::c_char, mode: mode_t) -> ::c_int;
 
     pub fn pselect(nfds: ::c_int,
                    readfs: *mut fd_set,
@@ -3620,14 +3589,14 @@ extern {
                      locale: *const ::c_char,
                      base: ::locale_t) -> ::locale_t;
     pub fn uselocale(loc: ::locale_t) -> ::locale_t;
-    pub fn creat64(path: *const c_char, mode: mode_t) -> ::c_int;
+    pub fn creat64(path: *const ::c_char, mode: mode_t) -> ::c_int;
     pub fn fstat64(fildes: ::c_int, buf: *mut stat64) -> ::c_int;
-    pub fn fstatat64(dirfd: ::c_int, pathname: *const c_char,
+    pub fn fstatat64(dirfd: ::c_int, pathname: *const ::c_char,
                      buf: *mut stat64, flags: ::c_int) -> ::c_int;
     pub fn ftruncate64(fd: ::c_int, length: off64_t) -> ::c_int;
     pub fn getrlimit64(resource: ::c_int, rlim: *mut rlimit64) -> ::c_int;
     pub fn lseek64(fd: ::c_int, offset: off64_t, whence: ::c_int) -> off64_t;
-    pub fn lstat64(path: *const c_char, buf: *mut stat64) -> ::c_int;
+    pub fn lstat64(path: *const ::c_char, buf: *mut stat64) -> ::c_int;
     pub fn mmap64(addr: *mut ::c_void,
                   len: ::size_t,
                   prot: ::c_int,
@@ -3635,9 +3604,9 @@ extern {
                   fd: ::c_int,
                   offset: off64_t)
                   -> *mut ::c_void;
-    pub fn open64(path: *const c_char, oflag: ::c_int, ...) -> ::c_int;
+    pub fn open64(path: *const ::c_char, oflag: ::c_int, ...) -> ::c_int;
     pub fn openat64(fd: ::c_int,
-                    path: *const c_char,
+                    path: *const ::c_char,
                     oflag: ::c_int, ...) -> ::c_int;
     pub fn pread64(fd: ::c_int, buf: *mut ::c_void, count: ::size_t,
                    offset: off64_t) -> ::ssize_t;
@@ -3655,8 +3624,8 @@ extern {
     pub fn readdir64_r(dirp: *mut ::DIR, entry: *mut ::dirent64,
                        result: *mut *mut ::dirent64) -> ::c_int;
     pub fn setrlimit64(resource: ::c_int, rlim: *const rlimit64) -> ::c_int;
-    pub fn stat64(path: *const c_char, buf: *mut stat64) -> ::c_int;
-    pub fn truncate64(path: *const c_char, length: off64_t) -> ::c_int;
+    pub fn stat64(path: *const ::c_char, buf: *mut stat64) -> ::c_int;
+    pub fn truncate64(path: *const ::c_char, length: off64_t) -> ::c_int;
 
     pub fn fdopendir(fd: ::c_int) -> *mut ::DIR;
 
@@ -3733,7 +3702,7 @@ extern {
     pub fn getspent() -> *mut spwd;
     pub fn getspnam(__name: *const ::c_char) -> *mut spwd;
 
-    pub fn shm_open(name: *const c_char, oflag: ::c_int,
+    pub fn shm_open(name: *const ::c_char, oflag: ::c_int,
                     mode: mode_t) -> ::c_int;
 
     // System V IPC
@@ -3762,9 +3731,9 @@ extern {
                     -> ::c_int;
     pub fn __errno_location() -> *mut ::c_int;
 
-    pub fn fopen64(filename: *const c_char,
-                   mode: *const c_char) -> *mut ::FILE;
-    pub fn freopen64(filename: *const c_char, mode: *const c_char,
+    pub fn fopen64(filename: *const ::c_char,
+                   mode: *const ::c_char) -> *mut ::FILE;
+    pub fn freopen64(filename: *const ::c_char, mode: *const ::c_char,
                      file: *mut ::FILE) -> *mut ::FILE;
     pub fn tmpfile64() -> *mut ::FILE;
     pub fn fgetpos64(stream: *mut ::FILE, ptr: *mut fpos64_t) -> ::c_int;
@@ -3779,30 +3748,30 @@ extern {
                            len: ::off_t) -> ::c_int;
     pub fn readahead(fd: ::c_int, offset: ::off64_t,
                      count: ::size_t) -> ::ssize_t;
-    pub fn getxattr(path: *const c_char, name: *const c_char,
+    pub fn getxattr(path: *const ::c_char, name: *const ::c_char,
                     value: *mut ::c_void, size: ::size_t) -> ::ssize_t;
-    pub fn lgetxattr(path: *const c_char, name: *const c_char,
+    pub fn lgetxattr(path: *const ::c_char, name: *const ::c_char,
                      value: *mut ::c_void, size: ::size_t) -> ::ssize_t;
-    pub fn fgetxattr(filedes: ::c_int, name: *const c_char,
+    pub fn fgetxattr(filedes: ::c_int, name: *const ::c_char,
                      value: *mut ::c_void, size: ::size_t) -> ::ssize_t;
-    pub fn setxattr(path: *const c_char, name: *const c_char,
+    pub fn setxattr(path: *const ::c_char, name: *const ::c_char,
                     value: *const ::c_void, size: ::size_t,
                     flags: ::c_int) -> ::c_int;
-    pub fn lsetxattr(path: *const c_char, name: *const c_char,
+    pub fn lsetxattr(path: *const ::c_char, name: *const ::c_char,
                      value: *const ::c_void, size: ::size_t,
                      flags: ::c_int) -> ::c_int;
-    pub fn fsetxattr(filedes: ::c_int, name: *const c_char,
+    pub fn fsetxattr(filedes: ::c_int, name: *const ::c_char,
                      value: *const ::c_void, size: ::size_t,
                      flags: ::c_int) -> ::c_int;
-    pub fn listxattr(path: *const c_char, list: *mut c_char,
+    pub fn listxattr(path: *const ::c_char, list: *mut ::c_char,
                      size: ::size_t) -> ::ssize_t;
-    pub fn llistxattr(path: *const c_char, list: *mut c_char,
+    pub fn llistxattr(path: *const ::c_char, list: *mut ::c_char,
                       size: ::size_t) -> ::ssize_t;
-    pub fn flistxattr(filedes: ::c_int, list: *mut c_char,
+    pub fn flistxattr(filedes: ::c_int, list: *mut ::c_char,
                       size: ::size_t) -> ::ssize_t;
-    pub fn removexattr(path: *const c_char, name: *const c_char) -> ::c_int;
-    pub fn lremovexattr(path: *const c_char, name: *const c_char) -> ::c_int;
-    pub fn fremovexattr(filedes: ::c_int, name: *const c_char) -> ::c_int;
+    pub fn removexattr(path: *const ::c_char, name: *const ::c_char) -> ::c_int;
+    pub fn lremovexattr(path: *const ::c_char, name: *const ::c_char) -> ::c_int;
+    pub fn fremovexattr(filedes: ::c_int, name: *const ::c_char) -> ::c_int;
     pub fn signalfd(fd: ::c_int,
                     mask: *const ::sigset_t,
                     flags: ::c_int) -> ::c_int;
@@ -3904,9 +3873,9 @@ extern {
                   flags: ::c_int,
                   ...) -> *mut ::c_void;
 
-    pub fn glob(pattern: *const c_char,
+    pub fn glob(pattern: *const ::c_char,
                 flags: ::c_int,
-                errfunc: Option<extern fn(epath: *const c_char,
+                errfunc: Option<extern fn(epath: *const ::c_char,
                                           errno: ::c_int) -> ::c_int>,
                 pglob: *mut ::glob_t) -> ::c_int;
     pub fn globfree(pglob: *mut ::glob_t);
@@ -4089,8 +4058,8 @@ extern {
                         ngroups: *mut ::c_int) -> ::c_int;
     pub fn pthread_mutexattr_getpshared(attr: *const pthread_mutexattr_t,
                                         pshared: *mut ::c_int) -> ::c_int;
-    pub fn popen(command: *const c_char,
-                 mode: *const c_char) -> *mut ::FILE;
+    pub fn popen(command: *const ::c_char,
+                 mode: *const ::c_char) -> *mut ::FILE;
     pub fn faccessat(dirfd: ::c_int, pathname: *const ::c_char,
                      mode: ::c_int, flags: ::c_int) -> ::c_int;
     pub fn pthread_create(native: *mut ::pthread_t,
@@ -4116,24 +4085,5 @@ cfg_if! {
         pub use self::x86_64::*;
     } else {
         // Unknown target_arch
-    }
-}
-
-cfg_if! {
-    if #[cfg(core_cvoid)] {
-        pub use core::ffi::c_void;
-    } else {
-        // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help
-        // enable more optimization opportunities around it recognizing things
-        // like malloc/free.
-        #[repr(u8)]
-        #[allow(missing_copy_implementations)]
-        pub enum c_void {
-            // Two dummy variants so the #[repr] attribute can be used.
-            #[doc(hidden)]
-            __variant1,
-            #[doc(hidden)]
-            __variant2,
-        }
     }
 }

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -22,50 +22,29 @@ pub type ssize_t = isize;
 //   - longs can either be 32-bit or 64-bit
 
 // Whether chars default to signed or unsigned is primarily determined by
-// architecture (windows is the main exception here).
+// architecture (Windows is the main exception here).
 cfg_if! {
     if #[cfg(any(target_arch = "aarch64",
                  target_arch = "arm",
-                 target_arch = "armebv7r",
-                 target_arch = "armv5te",
-                 target_arch = "armv7",
-                 target_arch = "armv7r",
-                 target_arch = "armv7s",
                  target_arch = "asmjs",
                  target_arch = "wasm32",
                  target_arch = "wasm64",
                  target_arch = "powerpc",
                  target_arch = "powerpc64",
-                 target_arch = "powerpc64le",
-                 target_arch = "s390x",
-                 target_arch = "thumbv6",
-                 target_arch = "thumbv6m",
-                 target_arch = "thummv7",
-                 target_arch = "thumbv7em",
-                 target_arch = "thumbv7m",
-                 target_arch = "thumbv7neon",
-                 target_arch = "tummbv8",
-                 target_arch = "thumbv8m",
-                 target_arch = "thumbv8m.main"))] {
+                 target_arch = "s390x"))] {
         pub type c_char = u8;
         pub type wchar_t = u32;
-    } else if #[cfg(any(target_arch = "i386",
-                        target_arch = "i586",
-                        target_arch = "i686",
-                        target_arch = "x86",
+    } else if #[cfg(any(target_arch = "x86",
                         target_arch = "x86_64",
                         target_arch = "mips",
                         target_arch = "mips64",
-                        target_arch = "mips64el",
-                        target_arch = "mipsel",
+                        target_arch = "msp430",
                         target_arch = "nvptx",
                         target_arch = "nvptx64",
+                        target_arch = "sparc",
                         target_arch = "sparc64",
-                        target_arch = "sparcv9",
-                        target_arch = "riscv64",
                         target_arch = "riscv32",
-                        target_arch = "riscv32imac",
-                        target_arch = "riscv32imc"))] {
+                        target_arch = "riscv64"))] {
         pub type c_char = i8;
         pub type wchar_t = i32;
     }

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -1,0 +1,100 @@
+//! This module attempts to attempts to give reasonable definitions for most
+//! basic C types. Note that these are essentially educated guesses and are NOT
+//! guaranteed to match the types produced by your C compiler.
+
+// Per the C11 specification, these type definitions are not guaranteed to be
+// correct for all platforms. However, virtually all platforms use these
+// definitions, including all targets supported by rustc.
+pub type c_short = i16;
+pub type c_ushort = u16;
+pub type c_int = i32;
+pub type c_uint = u32;
+pub type c_longlong = i64;
+pub type c_ulonglong = u64;
+pub type intmax_t = i64;
+pub type uintmax_t = u64;
+pub type size_t = usize;
+pub type ptrdiff_t = isize;
+pub type ssize_t = isize;
+
+pub const INT_MIN: c_int = -2147483648;
+pub const INT_MAX: c_int = 2147483647;
+
+// There are two ways that platforms (in practice) differ in their C types:
+//   - chars can either be signed or unsigned
+//   - longs can either be 32-bit or 64-bit
+
+// Whether chars default to signed or unsigned is primarily determined by
+// architecture (windows is the main exception here).
+pub use self::chars::*;
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "arm",
+    target_arch = "armebv7r",
+    target_arch = "armv5te",
+    target_arch = "armv7",
+    target_arch = "armv7r",
+    target_arch = "armv7s",
+    target_arch = "asmjs",
+    target_arch = "wasm32",
+    target_arch = "wasm64",
+    target_arch = "powerpc",
+    target_arch = "powerpc64",
+    target_arch = "powerpc64le",
+    target_arch = "s390x",
+    target_arch = "thumbv6",
+    target_arch = "thumbv6m",
+    target_arch = "thummv7",
+    target_arch = "thumbv7em",
+    target_arch = "thumbv7m",
+    target_arch = "thumbv7neon",
+    target_arch = "tummbv8",
+    target_arch = "thumbv8m",
+    target_arch = "thumbv8m.main"
+))]
+mod chars {
+    pub type c_char = u8;
+    pub type wchar_t = u32;
+}
+
+#[cfg(any(
+    target_arch = "i386",
+    target_arch = "i586",
+    target_arch = "i686",
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "mips",
+    target_arch = "mips64",
+    target_arch = "mips64el",
+    target_arch = "mipsel",
+    target_arch = "nvptx",
+    target_arch = "nvptx64",
+    target_arch = "sparc64",
+    target_arch = "sparcv9",
+    target_arch = "riscv64",
+    target_arch = "riscv32",
+    target_arch = "riscv32imac",
+    target_arch = "riscv32imc"
+))]
+mod chars {
+    pub type c_char = i8;
+    pub type wchar_t = i32;
+}
+
+// On all platforms but Windows, longs are the same size as a pointer.
+pub use self::long::*;
+#[cfg(target_pointer_width = "64")]
+mod long {
+    pub type c_long = i64;
+    pub type c_ulong = u64;
+}
+
+#[cfg(any(target_pointer_width = "16", target_pointer_width = "32"))]
+mod long {
+    pub type c_long = i32;
+    pub type c_ulong = u32;
+}
+
+// POSIX specifications make no guarantees that off_t == long int, but this is
+// what GNU and others always do.
+pub type off_t = ::c_long;

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -47,6 +47,8 @@ cfg_if! {
                         target_arch = "riscv64"))] {
         pub type c_char = i8;
         pub type wchar_t = i32;
+    } else {
+        // Unknown arch, so we don't know if chars are signed or unsigned
     }
 }
 

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -17,84 +17,75 @@ pub type size_t = usize;
 pub type ptrdiff_t = isize;
 pub type ssize_t = isize;
 
-pub const INT_MIN: c_int = -2147483648;
-pub const INT_MAX: c_int = 2147483647;
-
 // There are two ways that platforms (in practice) differ in their C types:
 //   - chars can either be signed or unsigned
 //   - longs can either be 32-bit or 64-bit
 
 // Whether chars default to signed or unsigned is primarily determined by
 // architecture (windows is the main exception here).
-pub use self::chars::*;
-#[cfg(any(
-    target_arch = "aarch64",
-    target_arch = "arm",
-    target_arch = "armebv7r",
-    target_arch = "armv5te",
-    target_arch = "armv7",
-    target_arch = "armv7r",
-    target_arch = "armv7s",
-    target_arch = "asmjs",
-    target_arch = "wasm32",
-    target_arch = "wasm64",
-    target_arch = "powerpc",
-    target_arch = "powerpc64",
-    target_arch = "powerpc64le",
-    target_arch = "s390x",
-    target_arch = "thumbv6",
-    target_arch = "thumbv6m",
-    target_arch = "thummv7",
-    target_arch = "thumbv7em",
-    target_arch = "thumbv7m",
-    target_arch = "thumbv7neon",
-    target_arch = "tummbv8",
-    target_arch = "thumbv8m",
-    target_arch = "thumbv8m.main"
-))]
-mod chars {
-    pub type c_char = u8;
-    pub type wchar_t = u32;
-}
-
-#[cfg(any(
-    target_arch = "i386",
-    target_arch = "i586",
-    target_arch = "i686",
-    target_arch = "x86",
-    target_arch = "x86_64",
-    target_arch = "mips",
-    target_arch = "mips64",
-    target_arch = "mips64el",
-    target_arch = "mipsel",
-    target_arch = "nvptx",
-    target_arch = "nvptx64",
-    target_arch = "sparc64",
-    target_arch = "sparcv9",
-    target_arch = "riscv64",
-    target_arch = "riscv32",
-    target_arch = "riscv32imac",
-    target_arch = "riscv32imc"
-))]
-mod chars {
-    pub type c_char = i8;
-    pub type wchar_t = i32;
+cfg_if! {
+    if #[cfg(any(target_arch = "aarch64",
+                 target_arch = "arm",
+                 target_arch = "armebv7r",
+                 target_arch = "armv5te",
+                 target_arch = "armv7",
+                 target_arch = "armv7r",
+                 target_arch = "armv7s",
+                 target_arch = "asmjs",
+                 target_arch = "wasm32",
+                 target_arch = "wasm64",
+                 target_arch = "powerpc",
+                 target_arch = "powerpc64",
+                 target_arch = "powerpc64le",
+                 target_arch = "s390x",
+                 target_arch = "thumbv6",
+                 target_arch = "thumbv6m",
+                 target_arch = "thummv7",
+                 target_arch = "thumbv7em",
+                 target_arch = "thumbv7m",
+                 target_arch = "thumbv7neon",
+                 target_arch = "tummbv8",
+                 target_arch = "thumbv8m",
+                 target_arch = "thumbv8m.main"))] {
+        pub type c_char = u8;
+        pub type wchar_t = u32;
+    } else if #[cfg(any(target_arch = "i386",
+                        target_arch = "i586",
+                        target_arch = "i686",
+                        target_arch = "x86",
+                        target_arch = "x86_64",
+                        target_arch = "mips",
+                        target_arch = "mips64",
+                        target_arch = "mips64el",
+                        target_arch = "mipsel",
+                        target_arch = "nvptx",
+                        target_arch = "nvptx64",
+                        target_arch = "sparc64",
+                        target_arch = "sparcv9",
+                        target_arch = "riscv64",
+                        target_arch = "riscv32",
+                        target_arch = "riscv32imac",
+                        target_arch = "riscv32imc"))] {
+        pub type c_char = i8;
+        pub type wchar_t = i32;
+    }
 }
 
 // On all platforms but Windows, longs are the same size as a pointer.
-pub use self::long::*;
-#[cfg(target_pointer_width = "64")]
-mod long {
-    pub type c_long = i64;
-    pub type c_ulong = u64;
-}
-
-#[cfg(any(target_pointer_width = "16", target_pointer_width = "32"))]
-mod long {
-    pub type c_long = i32;
-    pub type c_ulong = u32;
+cfg_if! {
+    if #[cfg(target_pointer_width = "64")] {
+        pub type c_long = i64;
+        pub type c_ulong = u64;
+    } else {
+        pub type c_long = i32;
+        pub type c_ulong = u32;
+    }
 }
 
 // POSIX specifications make no guarantees that off_t == long int, but this is
 // what GNU and others always do.
 pub type off_t = ::c_long;
+
+// These follow directly from the definition of c_int
+pub const INT_MIN: c_int = -2147483648;
+pub const INT_MAX: c_int = 2147483647;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,57 @@ mod macros;
 
 mod dox;
 
+// C types that are always the same Rust type
+pub type int8_t = i8;
+pub type int16_t = i16;
+pub type int32_t = i32;
+pub type int64_t = i64;
+pub type uint8_t = u8;
+pub type uint16_t = u16;
+pub type uint32_t = u32;
+pub type uint64_t = u64;
+
+pub type c_schar = i8;
+pub type c_uchar = u8;
+pub type c_short = i16;
+pub type c_ushort = u16;
+pub type c_int = i32;
+pub type c_uint = u32;
+pub type c_float = f32;
+pub type c_double = f64;
+pub type c_longlong = i64;
+pub type c_ulonglong = u64;
+pub type intmax_t = i64;
+pub type uintmax_t = u64;
+
+pub type size_t = usize;
+pub type ptrdiff_t = isize;
+pub type intptr_t = isize;
+pub type uintptr_t = usize;
+pub type ssize_t = isize;
+
+pub const INT_MIN: c_int = -2147483648;
+pub const INT_MAX: c_int = 2147483647;
+
+cfg_if! {
+    if #[cfg(core_cvoid)] {
+        pub use core::ffi::c_void;
+    } else {
+        // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help
+        // enable more optimization opportunities around it recognizing things
+        // like malloc/free.
+        #[repr(u8)]
+        #[allow(missing_copy_implementations)]
+        pub enum c_void {
+            // Two dummy variants so the #[repr] attribute can be used.
+            #[doc(hidden)]
+            __variant1,
+            #[doc(hidden)]
+            __variant2,
+        }
+    }
+}
+
 cfg_if! {
     if #[cfg(windows)] {
         mod windows;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ mod macros;
 
 mod dox;
 
-// C types that are always the same Rust type
+// Per the Rust and C11 specs, these C types will always have these definitions.
 pub type int8_t = i8;
 pub type int16_t = i16;
 pub type int32_t = i32;
@@ -186,28 +186,12 @@ pub type uint8_t = u8;
 pub type uint16_t = u16;
 pub type uint32_t = u32;
 pub type uint64_t = u64;
-
-pub type c_schar = i8;
-pub type c_uchar = u8;
-pub type c_short = i16;
-pub type c_ushort = u16;
-pub type c_int = i32;
-pub type c_uint = u32;
-pub type c_float = f32;
-pub type c_double = f64;
-pub type c_longlong = i64;
-pub type c_ulonglong = u64;
-pub type intmax_t = i64;
-pub type uintmax_t = u64;
-
-pub type size_t = usize;
-pub type ptrdiff_t = isize;
 pub type intptr_t = isize;
 pub type uintptr_t = usize;
-pub type ssize_t = isize;
-
-pub const INT_MIN: c_int = -2147483648;
-pub const INT_MAX: c_int = 2147483647;
+pub type c_schar = i8;
+pub type c_uchar = u8;
+pub type c_float = f32;
+pub type c_double = f64;
 
 cfg_if! {
     if #[cfg(core_cvoid)] {
@@ -241,16 +225,13 @@ cfg_if! {
     } else if #[cfg(target_os = "fuchsia")] {
         mod fuchsia;
         pub use fuchsia::*;
-    } else if #[cfg(target_os = "switch")] {
-        mod switch;
-        pub use switch::*;
     } else if #[cfg(unix)] {
         mod unix;
         pub use unix::*;
-    } else if #[cfg(target_env = "sgx")] {
-        mod sgx;
-        pub use sgx::*;
-    }  else {
-        // non-supported targets: empty...
+    } else {
+        // Some targets only need the generic C types (and don't need functions)
+        #[cfg(any(feature = "generic_ctypes", target_env = "sgx", target_os = "switch"))]
+        mod generic;
+        pub use generic::*;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,10 +228,13 @@ cfg_if! {
     } else if #[cfg(unix)] {
         mod unix;
         pub use unix::*;
-    } else {
+    } else if #[cfg(any(feature = "generic_ctypes",
+                        target_env = "sgx",
+                        target_os = "switch"))] {
         // Some targets only need the generic C types (and don't need functions)
-        #[cfg(any(feature = "generic_ctypes", target_env = "sgx", target_os = "switch"))]
         mod generic;
         pub use generic::*;
+    } else {
+        // If you didn't request generic_ctypes, libc is empty
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -34,6 +34,7 @@ macro_rules! __cfg_if_apply {
     }
 }
 
+#[allow(unused_macros)]
 macro_rules! s {
     ($($(#[$attr:meta])* pub $t:ident $i:ident { $($field:tt)* })*) => ($(
         __item! {
@@ -49,6 +50,7 @@ macro_rules! s {
     )*)
 }
 
+#[allow(unused_macros)]
 macro_rules! s_no_extra_traits {
     ($($(#[$attr:meta])* pub $t:ident $i:ident { $($field:tt)* })*) => ($(
         __item! {
@@ -82,6 +84,7 @@ macro_rules! f {
     )*)
 }
 
+#[allow(unused_macros)]
 macro_rules! __item {
     ($i:item) => {
         $i

--- a/src/redox/mod.rs
+++ b/src/redox/mod.rs
@@ -1,31 +1,3 @@
-pub type int8_t = i8;
-pub type int16_t = i16;
-pub type int32_t = i32;
-pub type int64_t = i64;
-pub type uint8_t = u8;
-pub type uint16_t = u16;
-pub type uint32_t = u32;
-pub type uint64_t = u64;
-
-pub type c_schar = i8;
-pub type c_uchar = u8;
-pub type c_short = i16;
-pub type c_ushort = u16;
-pub type c_int = i32;
-pub type c_uint = u32;
-pub type c_float = f32;
-pub type c_double = f64;
-pub type c_longlong = i64;
-pub type c_ulonglong = u64;
-pub type intmax_t = i64;
-pub type uintmax_t = u64;
-
-pub type size_t = usize;
-pub type ptrdiff_t = isize;
-pub type intptr_t = isize;
-pub type uintptr_t = usize;
-pub type ssize_t = isize;
-
 pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
@@ -34,31 +6,31 @@ pub type wchar_t = i32;
 pub type wint_t = u32;
 pub type wctype_t = i64;
 
-pub type regoff_t = size_t;
-pub type off_t = c_long;
-pub type mode_t = c_int;
-pub type time_t = c_long;
-pub type pid_t = c_int;
-pub type id_t = c_uint;
-pub type gid_t = c_int;
-pub type uid_t = c_int;
-pub type dev_t = c_long;
-pub type ino_t = c_ulong;
-pub type nlink_t = c_ulong;
-pub type blksize_t = c_long;
-pub type blkcnt_t = c_ulong;
+pub type regoff_t = ::size_t;
+pub type off_t = ::c_long;
+pub type mode_t = ::c_int;
+pub type time_t = ::c_long;
+pub type pid_t = ::c_int;
+pub type id_t = ::c_uint;
+pub type gid_t = ::c_int;
+pub type uid_t = ::c_int;
+pub type dev_t = ::c_long;
+pub type ino_t = ::c_ulong;
+pub type nlink_t = ::c_ulong;
+pub type blksize_t = ::c_long;
+pub type blkcnt_t = ::c_ulong;
 
-pub type fsblkcnt_t = c_ulong;
-pub type fsfilcnt_t = c_ulong;
+pub type fsblkcnt_t = ::c_ulong;
+pub type fsfilcnt_t = ::c_ulong;
 
-pub type useconds_t = c_uint;
-pub type suseconds_t = c_int;
+pub type useconds_t = ::c_uint;
+pub type suseconds_t = ::c_int;
 
-pub type clock_t = c_long;
-pub type clockid_t = c_int;
-pub type timer_t = *mut c_void;
+pub type clock_t = ::c_long;
+pub type clockid_t = ::c_int;
+pub type timer_t = *mut ::c_void;
 
-pub type nfds_t = c_ulong;
+pub type nfds_t = ::c_ulong;
 
 s! {
     pub struct fd_set {
@@ -97,12 +69,9 @@ s! {
 
     pub struct timespec {
         pub tv_sec: time_t,
-        pub tv_nsec: c_long,
+        pub tv_nsec: ::c_long,
     }
 }
-
-pub const INT_MIN: c_int = -2147483648;
-pub const INT_MAX: c_int = 2147483647;
 
 pub const STDIN_FILENO: ::c_int = 0;
 pub const STDOUT_FILENO: ::c_int = 1;
@@ -244,112 +213,112 @@ cfg_if! {
 }
 
 extern {
-    pub fn isalnum(c: c_int) -> c_int;
-    pub fn isalpha(c: c_int) -> c_int;
-    pub fn iscntrl(c: c_int) -> c_int;
-    pub fn isdigit(c: c_int) -> c_int;
-    pub fn isgraph(c: c_int) -> c_int;
-    pub fn islower(c: c_int) -> c_int;
-    pub fn isprint(c: c_int) -> c_int;
-    pub fn ispunct(c: c_int) -> c_int;
-    pub fn isspace(c: c_int) -> c_int;
-    pub fn isupper(c: c_int) -> c_int;
-    pub fn isxdigit(c: c_int) -> c_int;
-    pub fn tolower(c: c_int) -> c_int;
-    pub fn toupper(c: c_int) -> c_int;
-    pub fn fopen(filename: *const c_char, mode: *const c_char) -> *mut FILE;
-    pub fn freopen(filename: *const c_char, mode: *const c_char,
+    pub fn isalnum(c: ::c_int) -> ::c_int;
+    pub fn isalpha(c: ::c_int) -> ::c_int;
+    pub fn iscntrl(c: ::c_int) -> ::c_int;
+    pub fn isdigit(c: ::c_int) -> ::c_int;
+    pub fn isgraph(c: ::c_int) -> ::c_int;
+    pub fn islower(c: ::c_int) -> ::c_int;
+    pub fn isprint(c: ::c_int) -> ::c_int;
+    pub fn ispunct(c: ::c_int) -> ::c_int;
+    pub fn isspace(c: ::c_int) -> ::c_int;
+    pub fn isupper(c: ::c_int) -> ::c_int;
+    pub fn isxdigit(c: ::c_int) -> ::c_int;
+    pub fn tolower(c: ::c_int) -> ::c_int;
+    pub fn toupper(c: ::c_int) -> ::c_int;
+    pub fn fopen(filename: *const ::c_char, mode: *const ::c_char) -> *mut FILE;
+    pub fn freopen(filename: *const ::c_char, mode: *const ::c_char,
                    file: *mut FILE) -> *mut FILE;
-    pub fn fflush(file: *mut FILE) -> c_int;
-    pub fn fclose(file: *mut FILE) -> c_int;
-    pub fn remove(filename: *const c_char) -> c_int;
-    pub fn rename(oldname: *const c_char, newname: *const c_char) -> c_int;
+    pub fn fflush(file: *mut FILE) -> ::c_int;
+    pub fn fclose(file: *mut FILE) -> ::c_int;
+    pub fn remove(filename: *const ::c_char) -> ::c_int;
+    pub fn rename(oldname: *const ::c_char, newname: *const ::c_char) -> ::c_int;
     pub fn tmpfile() -> *mut FILE;
-    pub fn setvbuf(stream: *mut FILE, buffer: *mut c_char, mode: c_int,
-                   size: size_t) -> c_int;
-    pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
-    pub fn getchar() -> c_int;
-    pub fn putchar(c: c_int) -> c_int;
-    pub fn fgetc(stream: *mut FILE) -> c_int;
-    pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
-    pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;
-    pub fn fputs(s: *const c_char, stream: *mut FILE) -> c_int;
-    pub fn puts(s: *const c_char) -> c_int;
-    pub fn ungetc(c: c_int, stream: *mut FILE) -> c_int;
-    pub fn fread(ptr: *mut c_void, size: size_t, nobj: size_t,
-                 stream: *mut FILE) -> size_t;
-    pub fn fwrite(ptr: *const c_void, size: size_t, nobj: size_t,
-                  stream: *mut FILE) -> size_t;
-    pub fn fseek(stream: *mut FILE, offset: c_long, whence: c_int) -> c_int;
-    pub fn ftell(stream: *mut FILE) -> c_long;
+    pub fn setvbuf(stream: *mut FILE, buffer: *mut ::c_char, mode: ::c_int,
+                   size: ::size_t) -> ::c_int;
+    pub fn setbuf(stream: *mut FILE, buf: *mut ::c_char);
+    pub fn getchar() -> ::c_int;
+    pub fn putchar(c: ::c_int) -> ::c_int;
+    pub fn fgetc(stream: *mut FILE) -> ::c_int;
+    pub fn fgets(buf: *mut ::c_char, n: ::c_int, stream: *mut FILE) -> *mut ::c_char;
+    pub fn fputc(c: ::c_int, stream: *mut FILE) -> ::c_int;
+    pub fn fputs(s: *const ::c_char, stream: *mut FILE) -> ::c_int;
+    pub fn puts(s: *const ::c_char) -> ::c_int;
+    pub fn ungetc(c: ::c_int, stream: *mut FILE) -> ::c_int;
+    pub fn fread(ptr: *mut ::c_void, size: ::size_t, nobj: ::size_t,
+                 stream: *mut FILE) -> ::size_t;
+    pub fn fwrite(ptr: *const ::c_void, size: ::size_t, nobj: ::size_t,
+                  stream: *mut FILE) -> ::size_t;
+    pub fn fseek(stream: *mut FILE, offset: ::c_long, whence: ::c_int) -> ::c_int;
+    pub fn ftell(stream: *mut FILE) -> ::c_long;
     pub fn rewind(stream: *mut FILE);
-    pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> c_int;
-    pub fn fsetpos(stream: *mut FILE, ptr: *const fpos_t) -> c_int;
-    pub fn feof(stream: *mut FILE) -> c_int;
-    pub fn ferror(stream: *mut FILE) -> c_int;
-    pub fn perror(s: *const c_char);
-    pub fn atoi(s: *const c_char) -> c_int;
-    pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
-    pub fn strtol(s: *const c_char, endp: *mut *mut c_char,
-                  base: c_int) -> c_long;
-    pub fn strtoul(s: *const c_char, endp: *mut *mut c_char,
-                   base: c_int) -> c_ulong;
-    pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;
-    pub fn malloc(size: size_t) -> *mut c_void;
-    pub fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
-    pub fn free(p: *mut c_void);
+    pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> ::c_int;
+    pub fn fsetpos(stream: *mut FILE, ptr: *const fpos_t) -> ::c_int;
+    pub fn feof(stream: *mut FILE) -> ::c_int;
+    pub fn ferror(stream: *mut FILE) -> ::c_int;
+    pub fn perror(s: *const ::c_char);
+    pub fn atoi(s: *const ::c_char) -> ::c_int;
+    pub fn strtod(s: *const ::c_char, endp: *mut *mut ::c_char) -> ::c_double;
+    pub fn strtol(s: *const ::c_char, endp: *mut *mut ::c_char,
+                  base: ::c_int) -> ::c_long;
+    pub fn strtoul(s: *const ::c_char, endp: *mut *mut ::c_char,
+                   base: ::c_int) -> ::c_ulong;
+    pub fn calloc(nobj: ::size_t, size: ::size_t) -> *mut ::c_void;
+    pub fn malloc(size: ::size_t) -> *mut ::c_void;
+    pub fn realloc(p: *mut ::c_void, size: ::size_t) -> *mut ::c_void;
+    pub fn free(p: *mut ::c_void);
     pub fn abort() -> !;
-    pub fn exit(status: c_int) -> !;
-    pub fn _exit(status: c_int) -> !;
-    pub fn atexit(cb: extern fn()) -> c_int;
-    pub fn system(s: *const c_char) -> c_int;
-    pub fn getenv(s: *const c_char) -> *mut c_char;
+    pub fn exit(status: ::c_int) -> !;
+    pub fn _exit(status: ::c_int) -> !;
+    pub fn atexit(cb: extern fn()) -> ::c_int;
+    pub fn system(s: *const ::c_char) -> ::c_int;
+    pub fn getenv(s: *const ::c_char) -> *mut ::c_char;
 
-    pub fn strcpy(dst: *mut c_char, src: *const c_char) -> *mut c_char;
-    pub fn strncpy(dst: *mut c_char, src: *const c_char,
-                   n: size_t) -> *mut c_char;
-    pub fn strcat(s: *mut c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strncat(s: *mut c_char, ct: *const c_char,
-                   n: size_t) -> *mut c_char;
-    pub fn strcmp(cs: *const c_char, ct: *const c_char) -> c_int;
-    pub fn strncmp(cs: *const c_char, ct: *const c_char,
-                   n: size_t) -> c_int;
-    pub fn strcoll(cs: *const c_char, ct: *const c_char) -> c_int;
-    pub fn strchr(cs: *const c_char, c: c_int) -> *mut c_char;
-    pub fn strrchr(cs: *const c_char, c: c_int) -> *mut c_char;
-    pub fn strspn(cs: *const c_char, ct: *const c_char) -> size_t;
-    pub fn strcspn(cs: *const c_char, ct: *const c_char) -> size_t;
-    pub fn strdup(cs: *const c_char) -> *mut c_char;
-    pub fn strpbrk(cs: *const c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strstr(cs: *const c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strcasestr(cs: *const c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strcasecmp(s1: *const c_char, s2: *const c_char) -> c_int;
-    pub fn strncasecmp(s1: *const c_char, s2: *const c_char,
-                       n: size_t) -> c_int;
-    pub fn strlen(cs: *const c_char) -> size_t;
-    pub fn strnlen(cs: *const c_char, maxlen: size_t) -> size_t;
-    pub fn strerror(n: c_int) -> *mut c_char;
-    pub fn strtok(s: *mut c_char, t: *const c_char) -> *mut c_char;
-    pub fn strxfrm(s: *mut c_char, ct: *const c_char, n: size_t) -> size_t;
-    pub fn wcslen(buf: *const wchar_t) -> size_t;
-    pub fn wcstombs(dest: *mut c_char, src: *const wchar_t,
-                    n: size_t) -> ::size_t;
+    pub fn strcpy(dst: *mut ::c_char, src: *const ::c_char) -> *mut ::c_char;
+    pub fn strncpy(dst: *mut ::c_char, src: *const ::c_char,
+                   n: ::size_t) -> *mut ::c_char;
+    pub fn strcat(s: *mut ::c_char, ct: *const ::c_char) -> *mut ::c_char;
+    pub fn strncat(s: *mut ::c_char, ct: *const ::c_char,
+                   n: ::size_t) -> *mut ::c_char;
+    pub fn strcmp(cs: *const ::c_char, ct: *const ::c_char) -> ::c_int;
+    pub fn strncmp(cs: *const ::c_char, ct: *const ::c_char,
+                   n: ::size_t) -> ::c_int;
+    pub fn strcoll(cs: *const ::c_char, ct: *const ::c_char) -> ::c_int;
+    pub fn strchr(cs: *const ::c_char, c: ::c_int) -> *mut ::c_char;
+    pub fn strrchr(cs: *const ::c_char, c: ::c_int) -> *mut ::c_char;
+    pub fn strspn(cs: *const ::c_char, ct: *const ::c_char) -> ::size_t;
+    pub fn strcspn(cs: *const ::c_char, ct: *const ::c_char) -> ::size_t;
+    pub fn strdup(cs: *const ::c_char) -> *mut ::c_char;
+    pub fn strpbrk(cs: *const ::c_char, ct: *const ::c_char) -> *mut ::c_char;
+    pub fn strstr(cs: *const ::c_char, ct: *const ::c_char) -> *mut ::c_char;
+    pub fn strcasestr(cs: *const ::c_char, ct: *const ::c_char) -> *mut ::c_char;
+    pub fn strcasecmp(s1: *const ::c_char, s2: *const ::c_char) -> ::c_int;
+    pub fn strncasecmp(s1: *const ::c_char, s2: *const ::c_char,
+                       n: ::size_t) -> ::c_int;
+    pub fn strlen(cs: *const ::c_char) -> ::size_t;
+    pub fn strnlen(cs: *const ::c_char, maxlen: ::size_t) -> ::size_t;
+    pub fn strerror(n: ::c_int) -> *mut ::c_char;
+    pub fn strtok(s: *mut ::c_char, t: *const ::c_char) -> *mut ::c_char;
+    pub fn strxfrm(s: *mut ::c_char, ct: *const ::c_char, n: ::size_t) -> ::size_t;
+    pub fn wcslen(buf: *const wchar_t) -> ::size_t;
+    pub fn wcstombs(dest: *mut ::c_char, src: *const wchar_t,
+                    n: ::size_t) -> ::size_t;
 
-    pub fn memchr(cx: *const c_void, c: c_int, n: size_t) -> *mut c_void;
-    pub fn memcmp(cx: *const c_void, ct: *const c_void, n: size_t) -> c_int;
-    pub fn memcpy(dest: *mut c_void, src: *const c_void,
-                  n: size_t) -> *mut c_void;
-    pub fn memmove(dest: *mut c_void, src: *const c_void,
-                   n: size_t) -> *mut c_void;
-    pub fn memset(dest: *mut c_void, c: c_int, n: size_t) -> *mut c_void;
+    pub fn memchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
+    pub fn memcmp(cx: *const ::c_void, ct: *const ::c_void, n: ::size_t) -> ::c_int;
+    pub fn memcpy(dest: *mut ::c_void, src: *const ::c_void,
+                  n: ::size_t) -> *mut ::c_void;
+    pub fn memmove(dest: *mut ::c_void, src: *const ::c_void,
+                   n: ::size_t) -> *mut ::c_void;
+    pub fn memset(dest: *mut ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
 
-    pub fn abs(i: c_int) -> c_int;
-    pub fn atof(s: *const c_char) -> c_double;
-    pub fn labs(i: c_long) -> c_long;
-    pub fn rand() -> c_int;
-    pub fn srand(seed: c_uint);
+    pub fn abs(i: ::c_int) -> ::c_int;
+    pub fn atof(s: *const ::c_char) -> ::c_double;
+    pub fn labs(i: ::c_long) -> ::c_long;
+    pub fn rand() -> ::c_int;
+    pub fn srand(seed: ::c_uint);
 
-    pub fn chown(path: *const c_char, uid: uid_t, gid: gid_t) -> ::c_int;
+    pub fn chown(path: *const ::c_char, uid: uid_t, gid: gid_t) -> ::c_int;
     pub fn close(fd: ::c_int) -> ::c_int;
     pub fn fchown(fd: ::c_int, uid: ::uid_t, gid: ::gid_t) -> ::c_int;
     pub fn fcntl(fd: ::c_int, cmd: ::c_int, ...) -> ::c_int;
@@ -370,9 +339,9 @@ extern {
     pub fn munmap(addr: *mut ::c_void, len: ::size_t) -> ::c_int;
     pub fn poll(fds: *mut pollfd, nfds: nfds_t, timeout: ::c_int) -> ::c_int;
     pub fn read(fd: ::c_int, buf: *mut ::c_void, count: ::size_t) -> ::ssize_t;
-    pub fn setenv(name: *const c_char, val: *const c_char, overwrite: ::c_int)
+    pub fn setenv(name: *const ::c_char, val: *const ::c_char, overwrite: ::c_int)
                   -> ::c_int;
-    pub fn unsetenv(name: *const c_char) -> ::c_int;
+    pub fn unsetenv(name: *const ::c_char) -> ::c_int;
     pub fn write(fd: ::c_int, buf: *const ::c_void, count: ::size_t)
                  -> ::ssize_t;
 }
@@ -384,22 +353,3 @@ extern {}
 pub use self::net::*;
 
 mod net;
-
-cfg_if! {
-    if #[cfg(core_cvoid)] {
-        pub use core::ffi::c_void;
-    } else {
-        // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help
-        // enable more optimization opportunities around it recognizing things
-        // like malloc/free.
-        #[repr(u8)]
-        #[allow(missing_copy_implementations)]
-        pub enum c_void {
-            // Two dummy variants so the #[repr] attribute can be used.
-            #[doc(hidden)]
-            __variant1,
-            #[doc(hidden)]
-            __variant2,
-        }
-    }
-}

--- a/src/redox/mod.rs
+++ b/src/redox/mod.rs
@@ -1,3 +1,16 @@
+pub type c_short = i16;
+pub type c_ushort = u16;
+pub type c_int = i32;
+pub type c_uint = u32;
+pub type c_longlong = i64;
+pub type c_ulonglong = u64;
+pub type intmax_t = i64;
+pub type uintmax_t = u64;
+
+pub type size_t = usize;
+pub type ptrdiff_t = isize;
+pub type ssize_t = isize;
+
 pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
@@ -72,6 +85,9 @@ s! {
         pub tv_nsec: ::c_long,
     }
 }
+
+pub const INT_MIN: ::c_int = -2147483648;
+pub const INT_MAX: ::c_int = 2147483647;
 
 pub const STDIN_FILENO: ::c_int = 0;
 pub const STDOUT_FILENO: ::c_int = 1;

--- a/src/redox/mod.rs
+++ b/src/redox/mod.rs
@@ -248,7 +248,8 @@ extern {
     pub fn fflush(file: *mut FILE) -> ::c_int;
     pub fn fclose(file: *mut FILE) -> ::c_int;
     pub fn remove(filename: *const ::c_char) -> ::c_int;
-    pub fn rename(oldname: *const ::c_char, newname: *const ::c_char) -> ::c_int;
+    pub fn rename(oldname: *const ::c_char,
+                  newname: *const ::c_char) -> ::c_int;
     pub fn tmpfile() -> *mut FILE;
     pub fn setvbuf(stream: *mut FILE, buffer: *mut ::c_char, mode: ::c_int,
                    size: ::size_t) -> ::c_int;
@@ -256,7 +257,8 @@ extern {
     pub fn getchar() -> ::c_int;
     pub fn putchar(c: ::c_int) -> ::c_int;
     pub fn fgetc(stream: *mut FILE) -> ::c_int;
-    pub fn fgets(buf: *mut ::c_char, n: ::c_int, stream: *mut FILE) -> *mut ::c_char;
+    pub fn fgets(buf: *mut ::c_char, n: ::c_int,
+                 stream: *mut FILE) -> *mut ::c_char;
     pub fn fputc(c: ::c_int, stream: *mut FILE) -> ::c_int;
     pub fn fputs(s: *const ::c_char, stream: *mut FILE) -> ::c_int;
     pub fn puts(s: *const ::c_char) -> ::c_int;
@@ -265,7 +267,8 @@ extern {
                  stream: *mut FILE) -> ::size_t;
     pub fn fwrite(ptr: *const ::c_void, size: ::size_t, nobj: ::size_t,
                   stream: *mut FILE) -> ::size_t;
-    pub fn fseek(stream: *mut FILE, offset: ::c_long, whence: ::c_int) -> ::c_int;
+    pub fn fseek(stream: *mut FILE, offset: ::c_long,
+                 whence: ::c_int) -> ::c_int;
     pub fn ftell(stream: *mut FILE) -> ::c_long;
     pub fn rewind(stream: *mut FILE);
     pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> ::c_int;
@@ -307,7 +310,8 @@ extern {
     pub fn strdup(cs: *const ::c_char) -> *mut ::c_char;
     pub fn strpbrk(cs: *const ::c_char, ct: *const ::c_char) -> *mut ::c_char;
     pub fn strstr(cs: *const ::c_char, ct: *const ::c_char) -> *mut ::c_char;
-    pub fn strcasestr(cs: *const ::c_char, ct: *const ::c_char) -> *mut ::c_char;
+    pub fn strcasestr(cs: *const ::c_char,
+                      ct: *const ::c_char) -> *mut ::c_char;
     pub fn strcasecmp(s1: *const ::c_char, s2: *const ::c_char) -> ::c_int;
     pub fn strncasecmp(s1: *const ::c_char, s2: *const ::c_char,
                        n: ::size_t) -> ::c_int;
@@ -315,18 +319,22 @@ extern {
     pub fn strnlen(cs: *const ::c_char, maxlen: ::size_t) -> ::size_t;
     pub fn strerror(n: ::c_int) -> *mut ::c_char;
     pub fn strtok(s: *mut ::c_char, t: *const ::c_char) -> *mut ::c_char;
-    pub fn strxfrm(s: *mut ::c_char, ct: *const ::c_char, n: ::size_t) -> ::size_t;
+    pub fn strxfrm(s: *mut ::c_char, ct: *const ::c_char,
+                   n: ::size_t) -> ::size_t;
     pub fn wcslen(buf: *const wchar_t) -> ::size_t;
     pub fn wcstombs(dest: *mut ::c_char, src: *const wchar_t,
                     n: ::size_t) -> ::size_t;
 
-    pub fn memchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
-    pub fn memcmp(cx: *const ::c_void, ct: *const ::c_void, n: ::size_t) -> ::c_int;
+    pub fn memchr(cx: *const ::c_void, c: ::c_int,
+                  n: ::size_t) -> *mut ::c_void;
+    pub fn memcmp(cx: *const ::c_void, ct: *const ::c_void,
+                  n: ::size_t) -> ::c_int;
     pub fn memcpy(dest: *mut ::c_void, src: *const ::c_void,
                   n: ::size_t) -> *mut ::c_void;
     pub fn memmove(dest: *mut ::c_void, src: *const ::c_void,
                    n: ::size_t) -> *mut ::c_void;
-    pub fn memset(dest: *mut ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
+    pub fn memset(dest: *mut ::c_void, c: ::c_int,
+                  n: ::size_t) -> *mut ::c_void;
 
     pub fn abs(i: ::c_int) -> ::c_int;
     pub fn atof(s: *const ::c_char) -> ::c_double;
@@ -355,8 +363,8 @@ extern {
     pub fn munmap(addr: *mut ::c_void, len: ::size_t) -> ::c_int;
     pub fn poll(fds: *mut pollfd, nfds: nfds_t, timeout: ::c_int) -> ::c_int;
     pub fn read(fd: ::c_int, buf: *mut ::c_void, count: ::size_t) -> ::ssize_t;
-    pub fn setenv(name: *const ::c_char, val: *const ::c_char, overwrite: ::c_int)
-                  -> ::c_int;
+    pub fn setenv(name: *const ::c_char, val: *const ::c_char,
+                  overwrite: ::c_int) -> ::c_int;
     pub fn unsetenv(name: *const ::c_char) -> ::c_int;
     pub fn write(fd: ::c_int, buf: *const ::c_void, count: ::size_t)
                  -> ::ssize_t;

--- a/src/sgx.rs
+++ b/src/sgx.rs
@@ -1,5 +1,0 @@
-//! SGX C types definition
-
-pub type c_char = i8;
-pub type c_long = i64;
-pub type c_ulong = u64;

--- a/src/sgx.rs
+++ b/src/sgx.rs
@@ -1,55 +1,5 @@
 //! SGX C types definition
 
-pub type int8_t = i8;
-pub type int16_t = i16;
-pub type int32_t = i32;
-pub type int64_t = i64;
-pub type uint8_t = u8;
-pub type uint16_t = u16;
-pub type uint32_t = u32;
-pub type uint64_t = u64;
-
-pub type c_schar = i8;
-pub type c_uchar = u8;
-pub type c_short = i16;
-pub type c_ushort = u16;
-pub type c_int = i32;
-pub type c_uint = u32;
-pub type c_float = f32;
-pub type c_double = f64;
-pub type c_longlong = i64;
-pub type c_ulonglong = u64;
-pub type intmax_t = i64;
-pub type uintmax_t = u64;
-
-pub type size_t = usize;
-pub type ptrdiff_t = isize;
-pub type intptr_t = isize;
-pub type uintptr_t = usize;
-pub type ssize_t = isize;
-
 pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
-
-pub const INT_MIN: c_int = -2147483648;
-pub const INT_MAX: c_int = 2147483647;
-
-cfg_if! {
-    if #[cfg(core_cvoid)] {
-        pub use core::ffi::c_void;
-    } else {
-        // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help
-        // enable more optimization opportunities around it recognizing things
-        // like malloc/free.
-        #[repr(u8)]
-        #[allow(missing_copy_implementations)]
-        pub enum c_void {
-            // Two dummy variants so the #[repr] attribute can be used.
-            #[doc(hidden)]
-            __variant1,
-            #[doc(hidden)]
-            __variant2,
-        }
-    }
-}

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -1,58 +1,7 @@
 //! Switch C type definitions
 
-pub type int8_t = i8;
-pub type int16_t = i16;
-pub type int32_t = i32;
-pub type int64_t = i64;
-pub type uint8_t = u8;
-pub type uint16_t = u16;
-pub type uint32_t = u32;
-pub type uint64_t = u64;
-
-pub type c_schar = i8;
-pub type c_uchar = u8;
-pub type c_short = i16;
-pub type c_ushort = u16;
-pub type c_int = i32;
-pub type c_uint = u32;
-pub type c_float = f32;
-pub type c_double = f64;
-pub type c_longlong = i64;
-pub type c_ulonglong = u64;
-pub type intmax_t = i64;
-pub type uintmax_t = u64;
-
-pub type size_t = usize;
-pub type ptrdiff_t = isize;
-pub type intptr_t = isize;
-pub type uintptr_t = usize;
-pub type ssize_t = isize;
-
 pub type off_t = i64;
 pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type wchar_t = u32;
-
-pub const INT_MIN: c_int = -2147483648;
-pub const INT_MAX: c_int = 2147483647;
-
-cfg_if! {
-    if #[cfg(core_cvoid)] {
-        pub use core::ffi::c_void;
-    } else {
-        // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help
-        // enable more optimization opportunities around it recognizing things
-        // like malloc/free.
-        #[repr(u8)]
-        #[allow(missing_copy_implementations)]
-        pub enum c_void {
-            // Two dummy variants so the #[repr] attribute can be used.
-            #[doc(hidden)]
-            __variant1,
-            #[doc(hidden)]
-            __variant2,
-        }
-    }
-}
-

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -1,7 +1,0 @@
-//! Switch C type definitions
-
-pub type off_t = i64;
-pub type c_char = u8;
-pub type c_long = i64;
-pub type c_ulong = u64;
-pub type wchar_t = u32;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -409,7 +409,8 @@ extern {
     pub fn getchar() -> ::c_int;
     pub fn putchar(c: ::c_int) -> ::c_int;
     pub fn fgetc(stream: *mut FILE) -> ::c_int;
-    pub fn fgets(buf: *mut c_char, n: ::c_int, stream: *mut FILE) -> *mut c_char;
+    pub fn fgets(buf: *mut c_char, n: ::c_int,
+                 stream: *mut FILE) -> *mut c_char;
     pub fn fputc(c: ::c_int, stream: *mut FILE) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
@@ -426,7 +427,8 @@ extern {
     )]
     pub fn fwrite(ptr: *const ::c_void, size: ::size_t, nobj: ::size_t,
                   stream: *mut FILE) -> ::size_t;
-    pub fn fseek(stream: *mut FILE, offset: ::c_long, whence: ::c_int) -> ::c_int;
+    pub fn fseek(stream: *mut FILE, offset: ::c_long,
+                 whence: ::c_int) -> ::c_int;
     pub fn ftell(stream: *mut FILE) -> ::c_long;
     pub fn rewind(stream: *mut FILE);
     #[cfg_attr(target_os = "netbsd", link_name = "__fgetpos50")]
@@ -468,7 +470,8 @@ extern {
     pub fn strncat(s: *mut c_char, ct: *const c_char,
                    n: ::size_t) -> *mut c_char;
     pub fn strcmp(cs: *const c_char, ct: *const c_char) -> ::c_int;
-    pub fn strncmp(cs: *const c_char, ct: *const c_char, n: ::size_t) -> ::c_int;
+    pub fn strncmp(cs: *const c_char, ct: *const c_char,
+                   n: ::size_t) -> ::c_int;
     pub fn strcoll(cs: *const c_char, ct: *const c_char) -> ::c_int;
     pub fn strchr(cs: *const c_char, c: ::c_int) -> *mut c_char;
     pub fn strrchr(cs: *const c_char, c: ::c_int) -> *mut c_char;
@@ -493,13 +496,16 @@ extern {
     pub fn wcstombs(dest: *mut c_char, src: *const wchar_t,
                     n: ::size_t) -> ::size_t;
 
-    pub fn memchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
-    pub fn memcmp(cx: *const ::c_void, ct: *const ::c_void, n: ::size_t) -> ::c_int;
+    pub fn memchr(cx: *const ::c_void, c: ::c_int,
+                  n: ::size_t) -> *mut ::c_void;
+    pub fn memcmp(cx: *const ::c_void, ct: *const ::c_void,
+                  n: ::size_t) -> ::c_int;
     pub fn memcpy(dest: *mut ::c_void, src: *const ::c_void,
                   n: ::size_t) -> *mut ::c_void;
     pub fn memmove(dest: *mut ::c_void, src: *const ::c_void,
                    n: ::size_t) -> *mut ::c_void;
-    pub fn memset(dest: *mut ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
+    pub fn memset(dest: *mut ::c_void, c: ::c_int,
+                  n: ::size_t) -> *mut ::c_void;
 }
 
 extern {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -5,6 +5,19 @@
 
 use dox::Option;
 
+pub type c_short = i16;
+pub type c_ushort = u16;
+pub type c_int = i32;
+pub type c_uint = u32;
+pub type c_longlong = i64;
+pub type c_ulonglong = u64;
+pub type intmax_t = i64;
+pub type uintmax_t = u64;
+
+pub type size_t = usize;
+pub type ptrdiff_t = isize;
+pub type ssize_t = isize;
+
 pub type pid_t = i32;
 pub type uid_t = u32;
 pub type gid_t = u32;
@@ -197,6 +210,9 @@ s! {
         pub p_proto: ::c_int,
     }
 }
+
+pub const INT_MIN: ::c_int = -2147483648;
+pub const INT_MAX: ::c_int = 2147483647;
 
 pub const SIG_DFL: sighandler_t = 0 as sighandler_t;
 pub const SIG_IGN: sighandler_t = 1 as sighandler_t;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -5,34 +5,6 @@
 
 use dox::Option;
 
-pub type int8_t = i8;
-pub type int16_t = i16;
-pub type int32_t = i32;
-pub type int64_t = i64;
-pub type uint8_t = u8;
-pub type uint16_t = u16;
-pub type uint32_t = u32;
-pub type uint64_t = u64;
-
-pub type c_schar = i8;
-pub type c_uchar = u8;
-pub type c_short = i16;
-pub type c_ushort = u16;
-pub type c_int = i32;
-pub type c_uint = u32;
-pub type c_float = f32;
-pub type c_double = f64;
-pub type c_longlong = i64;
-pub type c_ulonglong = u64;
-pub type intmax_t = i64;
-pub type uintmax_t = u64;
-
-pub type size_t = usize;
-pub type ptrdiff_t = isize;
-pub type intptr_t = isize;
-pub type uintptr_t = usize;
-pub type ssize_t = isize;
-
 pub type pid_t = i32;
 pub type uid_t = u32;
 pub type gid_t = u32;
@@ -90,46 +62,46 @@ s! {
     pub struct rusage {
         pub ru_utime: timeval,
         pub ru_stime: timeval,
-        pub ru_maxrss: c_long,
+        pub ru_maxrss: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad1: u32,
-        pub ru_ixrss: c_long,
+        pub ru_ixrss: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad2: u32,
-        pub ru_idrss: c_long,
+        pub ru_idrss: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad3: u32,
-        pub ru_isrss: c_long,
+        pub ru_isrss: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad4: u32,
-        pub ru_minflt: c_long,
+        pub ru_minflt: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad5: u32,
-        pub ru_majflt: c_long,
+        pub ru_majflt: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad6: u32,
-        pub ru_nswap: c_long,
+        pub ru_nswap: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad7: u32,
-        pub ru_inblock: c_long,
+        pub ru_inblock: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad8: u32,
-        pub ru_oublock: c_long,
+        pub ru_oublock: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad9: u32,
-        pub ru_msgsnd: c_long,
+        pub ru_msgsnd: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad10: u32,
-        pub ru_msgrcv: c_long,
+        pub ru_msgrcv: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad11: u32,
-        pub ru_nsignals: c_long,
+        pub ru_nsignals: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad12: u32,
-        pub ru_nvcsw: c_long,
+        pub ru_nvcsw: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad13: u32,
-        pub ru_nivcsw: c_long,
+        pub ru_nivcsw: ::c_long,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad14: u32,
 
@@ -225,9 +197,6 @@ s! {
         pub p_proto: ::c_int,
     }
 }
-
-pub const INT_MIN: c_int = -2147483648;
-pub const INT_MAX: c_int = 2147483647;
 
 pub const SIG_DFL: sighandler_t = 0 as sighandler_t;
 pub const SIG_IGN: sighandler_t = 1 as sighandler_t;
@@ -389,19 +358,19 @@ impl ::dox::Clone for fpos_t {
 }
 
 extern {
-    pub fn isalnum(c: c_int) -> c_int;
-    pub fn isalpha(c: c_int) -> c_int;
-    pub fn iscntrl(c: c_int) -> c_int;
-    pub fn isdigit(c: c_int) -> c_int;
-    pub fn isgraph(c: c_int) -> c_int;
-    pub fn islower(c: c_int) -> c_int;
-    pub fn isprint(c: c_int) -> c_int;
-    pub fn ispunct(c: c_int) -> c_int;
-    pub fn isspace(c: c_int) -> c_int;
-    pub fn isupper(c: c_int) -> c_int;
-    pub fn isxdigit(c: c_int) -> c_int;
-    pub fn tolower(c: c_int) -> c_int;
-    pub fn toupper(c: c_int) -> c_int;
+    pub fn isalnum(c: ::c_int) -> ::c_int;
+    pub fn isalpha(c: ::c_int) -> ::c_int;
+    pub fn iscntrl(c: ::c_int) -> ::c_int;
+    pub fn isdigit(c: ::c_int) -> ::c_int;
+    pub fn isgraph(c: ::c_int) -> ::c_int;
+    pub fn islower(c: ::c_int) -> ::c_int;
+    pub fn isprint(c: ::c_int) -> ::c_int;
+    pub fn ispunct(c: ::c_int) -> ::c_int;
+    pub fn isspace(c: ::c_int) -> ::c_int;
+    pub fn isupper(c: ::c_int) -> ::c_int;
+    pub fn isxdigit(c: ::c_int) -> ::c_int;
+    pub fn tolower(c: ::c_int) -> ::c_int;
+    pub fn toupper(c: ::c_int) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "fopen$UNIX2003"
@@ -413,108 +382,108 @@ extern {
     )]
     pub fn freopen(filename: *const c_char, mode: *const c_char,
                    file: *mut FILE) -> *mut FILE;
-    pub fn fflush(file: *mut FILE) -> c_int;
-    pub fn fclose(file: *mut FILE) -> c_int;
-    pub fn remove(filename: *const c_char) -> c_int;
-    pub fn rename(oldname: *const c_char, newname: *const c_char) -> c_int;
+    pub fn fflush(file: *mut FILE) -> ::c_int;
+    pub fn fclose(file: *mut FILE) -> ::c_int;
+    pub fn remove(filename: *const c_char) -> ::c_int;
+    pub fn rename(oldname: *const c_char, newname: *const c_char) -> ::c_int;
     pub fn tmpfile() -> *mut FILE;
-    pub fn setvbuf(stream: *mut FILE, buffer: *mut c_char, mode: c_int,
-                   size: size_t) -> c_int;
+    pub fn setvbuf(stream: *mut FILE, buffer: *mut c_char, mode: ::c_int,
+                   size: ::size_t) -> ::c_int;
     pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
-    pub fn getchar() -> c_int;
-    pub fn putchar(c: c_int) -> c_int;
-    pub fn fgetc(stream: *mut FILE) -> c_int;
-    pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
-    pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;
+    pub fn getchar() -> ::c_int;
+    pub fn putchar(c: ::c_int) -> ::c_int;
+    pub fn fgetc(stream: *mut FILE) -> ::c_int;
+    pub fn fgets(buf: *mut c_char, n: ::c_int, stream: *mut FILE) -> *mut c_char;
+    pub fn fputc(c: ::c_int, stream: *mut FILE) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "fputs$UNIX2003"
     )]
-    pub fn fputs(s: *const c_char, stream: *mut FILE) -> c_int;
-    pub fn puts(s: *const c_char) -> c_int;
-    pub fn ungetc(c: c_int, stream: *mut FILE) -> c_int;
-    pub fn fread(ptr: *mut c_void, size: size_t, nobj: size_t,
-                 stream: *mut FILE) -> size_t;
+    pub fn fputs(s: *const c_char, stream: *mut FILE) -> ::c_int;
+    pub fn puts(s: *const c_char) -> ::c_int;
+    pub fn ungetc(c: ::c_int, stream: *mut FILE) -> ::c_int;
+    pub fn fread(ptr: *mut ::c_void, size: ::size_t, nobj: ::size_t,
+                 stream: *mut FILE) -> ::size_t;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "fwrite$UNIX2003"
     )]
-    pub fn fwrite(ptr: *const c_void, size: size_t, nobj: size_t,
-                  stream: *mut FILE) -> size_t;
-    pub fn fseek(stream: *mut FILE, offset: c_long, whence: c_int) -> c_int;
-    pub fn ftell(stream: *mut FILE) -> c_long;
+    pub fn fwrite(ptr: *const ::c_void, size: ::size_t, nobj: ::size_t,
+                  stream: *mut FILE) -> ::size_t;
+    pub fn fseek(stream: *mut FILE, offset: ::c_long, whence: ::c_int) -> ::c_int;
+    pub fn ftell(stream: *mut FILE) -> ::c_long;
     pub fn rewind(stream: *mut FILE);
     #[cfg_attr(target_os = "netbsd", link_name = "__fgetpos50")]
-    pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> c_int;
+    pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__fsetpos50")]
-    pub fn fsetpos(stream: *mut FILE, ptr: *const fpos_t) -> c_int;
-    pub fn feof(stream: *mut FILE) -> c_int;
-    pub fn ferror(stream: *mut FILE) -> c_int;
+    pub fn fsetpos(stream: *mut FILE, ptr: *const fpos_t) -> ::c_int;
+    pub fn feof(stream: *mut FILE) -> ::c_int;
+    pub fn ferror(stream: *mut FILE) -> ::c_int;
     pub fn perror(s: *const c_char);
-    pub fn atoi(s: *const c_char) -> c_int;
+    pub fn atoi(s: *const c_char) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "strtod$UNIX2003"
     )]
-    pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
+    pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> ::c_double;
     pub fn strtol(s: *const c_char, endp: *mut *mut c_char,
-                  base: c_int) -> c_long;
+                  base: ::c_int) -> ::c_long;
     pub fn strtoul(s: *const c_char, endp: *mut *mut c_char,
-                   base: c_int) -> c_ulong;
-    pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;
-    pub fn malloc(size: size_t) -> *mut c_void;
-    pub fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
-    pub fn free(p: *mut c_void);
+                   base: ::c_int) -> ::c_ulong;
+    pub fn calloc(nobj: ::size_t, size: ::size_t) -> *mut ::c_void;
+    pub fn malloc(size: ::size_t) -> *mut ::c_void;
+    pub fn realloc(p: *mut ::c_void, size: ::size_t) -> *mut ::c_void;
+    pub fn free(p: *mut ::c_void);
     pub fn abort() -> !;
-    pub fn exit(status: c_int) -> !;
-    pub fn _exit(status: c_int) -> !;
-    pub fn atexit(cb: extern fn()) -> c_int;
+    pub fn exit(status: ::c_int) -> !;
+    pub fn _exit(status: ::c_int) -> !;
+    pub fn atexit(cb: extern fn()) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "system$UNIX2003"
     )]
-    pub fn system(s: *const c_char) -> c_int;
+    pub fn system(s: *const c_char) -> ::c_int;
     pub fn getenv(s: *const c_char) -> *mut c_char;
 
     pub fn strcpy(dst: *mut c_char, src: *const c_char) -> *mut c_char;
     pub fn strncpy(dst: *mut c_char, src: *const c_char,
-                   n: size_t) -> *mut c_char;
+                   n: ::size_t) -> *mut c_char;
     pub fn strcat(s: *mut c_char, ct: *const c_char) -> *mut c_char;
     pub fn strncat(s: *mut c_char, ct: *const c_char,
-                   n: size_t) -> *mut c_char;
-    pub fn strcmp(cs: *const c_char, ct: *const c_char) -> c_int;
-    pub fn strncmp(cs: *const c_char, ct: *const c_char, n: size_t) -> c_int;
-    pub fn strcoll(cs: *const c_char, ct: *const c_char) -> c_int;
-    pub fn strchr(cs: *const c_char, c: c_int) -> *mut c_char;
-    pub fn strrchr(cs: *const c_char, c: c_int) -> *mut c_char;
-    pub fn strspn(cs: *const c_char, ct: *const c_char) -> size_t;
-    pub fn strcspn(cs: *const c_char, ct: *const c_char) -> size_t;
+                   n: ::size_t) -> *mut c_char;
+    pub fn strcmp(cs: *const c_char, ct: *const c_char) -> ::c_int;
+    pub fn strncmp(cs: *const c_char, ct: *const c_char, n: ::size_t) -> ::c_int;
+    pub fn strcoll(cs: *const c_char, ct: *const c_char) -> ::c_int;
+    pub fn strchr(cs: *const c_char, c: ::c_int) -> *mut c_char;
+    pub fn strrchr(cs: *const c_char, c: ::c_int) -> *mut c_char;
+    pub fn strspn(cs: *const c_char, ct: *const c_char) -> ::size_t;
+    pub fn strcspn(cs: *const c_char, ct: *const c_char) -> ::size_t;
     pub fn strdup(cs: *const c_char) -> *mut c_char;
     pub fn strpbrk(cs: *const c_char, ct: *const c_char) -> *mut c_char;
     pub fn strstr(cs: *const c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strcasecmp(s1: *const c_char, s2: *const c_char) -> c_int;
+    pub fn strcasecmp(s1: *const c_char, s2: *const c_char) -> ::c_int;
     pub fn strncasecmp(s1: *const c_char, s2: *const c_char,
-                       n: size_t) -> c_int;
-    pub fn strlen(cs: *const c_char) -> size_t;
-    pub fn strnlen(cs: *const c_char, maxlen: size_t) -> size_t;
+                       n: ::size_t) -> ::c_int;
+    pub fn strlen(cs: *const c_char) -> ::size_t;
+    pub fn strnlen(cs: *const c_char, maxlen: ::size_t) -> ::size_t;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "strerror$UNIX2003"
     )]
-    pub fn strerror(n: c_int) -> *mut c_char;
+    pub fn strerror(n: ::c_int) -> *mut c_char;
     pub fn strtok(s: *mut c_char, t: *const c_char) -> *mut c_char;
-    pub fn strxfrm(s: *mut c_char, ct: *const c_char, n: size_t) -> size_t;
-    pub fn wcslen(buf: *const wchar_t) -> size_t;
+    pub fn strxfrm(s: *mut c_char, ct: *const c_char, n: ::size_t) -> ::size_t;
+    pub fn wcslen(buf: *const wchar_t) -> ::size_t;
     pub fn wcstombs(dest: *mut c_char, src: *const wchar_t,
-                    n: size_t) -> ::size_t;
+                    n: ::size_t) -> ::size_t;
 
-    pub fn memchr(cx: *const c_void, c: c_int, n: size_t) -> *mut c_void;
-    pub fn memcmp(cx: *const c_void, ct: *const c_void, n: size_t) -> c_int;
-    pub fn memcpy(dest: *mut c_void, src: *const c_void,
-                  n: size_t) -> *mut c_void;
-    pub fn memmove(dest: *mut c_void, src: *const c_void,
-                   n: size_t) -> *mut c_void;
-    pub fn memset(dest: *mut c_void, c: c_int, n: size_t) -> *mut c_void;
+    pub fn memchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
+    pub fn memcmp(cx: *const ::c_void, ct: *const ::c_void, n: ::size_t) -> ::c_int;
+    pub fn memcpy(dest: *mut ::c_void, src: *const ::c_void,
+                  n: ::size_t) -> *mut ::c_void;
+    pub fn memmove(dest: *mut ::c_void, src: *const ::c_void,
+                   n: ::size_t) -> *mut ::c_void;
+    pub fn memset(dest: *mut ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
 }
 
 extern {
@@ -697,7 +666,7 @@ extern {
     pub fn execvp(c: *const c_char,
                   argv: *const *const c_char) -> ::c_int;
     pub fn fork() -> pid_t;
-    pub fn fpathconf(filedes: ::c_int, name: ::c_int) -> c_long;
+    pub fn fpathconf(filedes: ::c_int, name: ::c_int) -> ::c_long;
     pub fn getcwd(buf: *mut c_char, size: ::size_t) -> *mut c_char;
     pub fn getegid() -> gid_t;
     pub fn geteuid() -> uid_t;
@@ -717,7 +686,7 @@ extern {
     pub fn isatty(fd: ::c_int) -> ::c_int;
     pub fn link(src: *const c_char, dst: *const c_char) -> ::c_int;
     pub fn lseek(fd: ::c_int, offset: off_t, whence: ::c_int) -> off_t;
-    pub fn pathconf(path: *const c_char, name: ::c_int) -> c_long;
+    pub fn pathconf(path: *const c_char, name: ::c_int) -> ::c_long;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "pause$UNIX2003")]
     pub fn pause() -> ::c_int;
@@ -1129,8 +1098,8 @@ extern {
     pub fn unlockpt(fd: ::c_int) -> ::c_int;
 
     pub fn strcasestr(cs: *const c_char, ct: *const c_char) -> *mut c_char;
-    pub fn getline (lineptr: *mut *mut c_char, n: *mut size_t,
-        stream: *mut FILE) -> ssize_t;
+    pub fn getline (lineptr: *mut *mut c_char, n: *mut ::size_t,
+        stream: *mut FILE) -> ::ssize_t;
 }
 
 cfg_if! {
@@ -1165,24 +1134,5 @@ cfg_if! {
         pub use self::hermit::*;
     } else {
         // Unknown target_os
-    }
-}
-
-cfg_if! {
-    if #[cfg(core_cvoid)] {
-        pub use core::ffi::c_void;
-    } else {
-        // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help
-        // enable more optimization opportunities around it recognizing things
-        // like malloc/free.
-        #[repr(u8)]
-        #[allow(missing_copy_implementations)]
-        pub enum c_void {
-            // Two dummy variants so the #[repr] attribute can be used.
-            #[doc(hidden)]
-            __variant1,
-            #[doc(hidden)]
-            __variant2,
-        }
     }
 }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -218,13 +218,15 @@ extern {
     pub fn isxdigit(c: ::c_int) -> ::c_int;
     pub fn tolower(c: ::c_int) -> ::c_int;
     pub fn toupper(c: ::c_int) -> ::c_int;
-    pub fn fopen(filename: *const ::c_char, mode: *const ::c_char) -> *mut FILE;
+    pub fn fopen(filename: *const ::c_char,
+                 mode: *const ::c_char) -> *mut FILE;
     pub fn freopen(filename: *const ::c_char, mode: *const ::c_char,
                    file: *mut FILE) -> *mut FILE;
     pub fn fflush(file: *mut FILE) -> ::c_int;
     pub fn fclose(file: *mut FILE) -> ::c_int;
     pub fn remove(filename: *const ::c_char) -> ::c_int;
-    pub fn rename(oldname: *const ::c_char, newname: *const ::c_char) -> ::c_int;
+    pub fn rename(oldname: *const ::c_char,
+                  newname: *const ::c_char) -> ::c_int;
     pub fn tmpfile() -> *mut FILE;
     pub fn setvbuf(stream: *mut FILE, buffer: *mut ::c_char, mode: ::c_int,
                    size: ::size_t) -> ::c_int;
@@ -232,7 +234,8 @@ extern {
     pub fn getchar() -> ::c_int;
     pub fn putchar(c: ::c_int) -> ::c_int;
     pub fn fgetc(stream: *mut FILE) -> ::c_int;
-    pub fn fgets(buf: *mut ::c_char, n: ::c_int, stream: *mut FILE) -> *mut ::c_char;
+    pub fn fgets(buf: *mut ::c_char, n: ::c_int,
+                 stream: *mut FILE) -> *mut ::c_char;
     pub fn fputc(c: ::c_int, stream: *mut FILE) -> ::c_int;
     pub fn fputs(s: *const ::c_char, stream: *mut FILE) -> ::c_int;
     pub fn puts(s: *const ::c_char) -> ::c_int;
@@ -241,7 +244,8 @@ extern {
                  stream: *mut FILE) -> ::size_t;
     pub fn fwrite(ptr: *const ::c_void, size: ::size_t, nobj: ::size_t,
                   stream: *mut FILE) -> ::size_t;
-    pub fn fseek(stream: *mut FILE, offset: ::c_long, whence: ::c_int) -> ::c_int;
+    pub fn fseek(stream: *mut FILE, offset: ::c_long,
+                 whence: ::c_int) -> ::c_int;
     pub fn ftell(stream: *mut FILE) -> ::c_long;
     pub fn rewind(stream: *mut FILE);
     pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> ::c_int;
@@ -273,7 +277,8 @@ extern {
     pub fn strncat(s: *mut ::c_char, ct: *const ::c_char,
                    n: ::size_t) -> *mut ::c_char;
     pub fn strcmp(cs: *const ::c_char, ct: *const ::c_char) -> ::c_int;
-    pub fn strncmp(cs: *const ::c_char, ct: *const ::c_char, n: ::size_t) -> ::c_int;
+    pub fn strncmp(cs: *const ::c_char, ct: *const ::c_char,
+                   n: ::size_t) -> ::c_int;
     pub fn strcoll(cs: *const ::c_char, ct: *const ::c_char) -> ::c_int;
     pub fn strchr(cs: *const ::c_char, c: ::c_int) -> *mut ::c_char;
     pub fn strrchr(cs: *const ::c_char, c: ::c_int) -> *mut ::c_char;
@@ -286,18 +291,22 @@ extern {
     pub fn strnlen(cs: *const ::c_char, maxlen: ::size_t) -> ::size_t;
     pub fn strerror(n: ::c_int) -> *mut ::c_char;
     pub fn strtok(s: *mut ::c_char, t: *const ::c_char) -> *mut ::c_char;
-    pub fn strxfrm(s: *mut ::c_char, ct: *const ::c_char, n: ::size_t) -> ::size_t;
+    pub fn strxfrm(s: *mut ::c_char, ct: *const ::c_char,
+                   n: ::size_t) -> ::size_t;
     pub fn wcslen(buf: *const wchar_t) -> ::size_t;
     pub fn wcstombs(dest: *mut ::c_char, src: *const wchar_t,
                     n: ::size_t) -> ::size_t;
 
-    pub fn memchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
-    pub fn memcmp(cx: *const ::c_void, ct: *const ::c_void, n: ::size_t) -> ::c_int;
+    pub fn memchr(cx: *const ::c_void, c: ::c_int,
+                  n: ::size_t) -> *mut ::c_void;
+    pub fn memcmp(cx: *const ::c_void, ct: *const ::c_void,
+                  n: ::size_t) -> ::c_int;
     pub fn memcpy(dest: *mut ::c_void, src: *const ::c_void,
                   n: ::size_t) -> *mut ::c_void;
     pub fn memmove(dest: *mut ::c_void, src: *const ::c_void,
                    n: ::size_t) -> *mut ::c_void;
-    pub fn memset(dest: *mut ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
+    pub fn memset(dest: *mut ::c_void, c: ::c_int,
+                  n: ::size_t) -> *mut ::c_void;
 
     pub fn abs(i: ::c_int) -> ::c_int;
     pub fn atof(s: *const ::c_char) -> ::c_double;
@@ -325,7 +334,8 @@ extern {
     #[link_name = "_wutime64"]
     pub fn wutime(file: *const wchar_t, buf: *mut utimbuf) -> ::c_int;
     #[link_name = "_popen"]
-    pub fn popen(command: *const ::c_char, mode: *const ::c_char) -> *mut ::FILE;
+    pub fn popen(command: *const ::c_char,
+                 mode: *const ::c_char) -> *mut ::FILE;
     #[link_name = "_pclose"]
     pub fn pclose(stream: *mut ::FILE) -> ::c_int;
     #[link_name = "_fdopen"]
@@ -349,7 +359,8 @@ extern {
     #[link_name = "_dup2"]
     pub fn dup2(src: ::c_int, dst: ::c_int) -> ::c_int;
     #[link_name = "_execv"]
-    pub fn execv(prog: *const ::c_char, argv: *const *const ::c_char) -> ::intptr_t;
+    pub fn execv(prog: *const ::c_char,
+                 argv: *const *const ::c_char) -> ::intptr_t;
     #[link_name = "_execve"]
     pub fn execve(prog: *const ::c_char, argv: *const *const ::c_char,
                   envp: *const *const ::c_char) -> ::c_int;
@@ -384,7 +395,8 @@ extern {
     pub fn get_osfhandle(fd: ::c_int) -> ::intptr_t;
     #[link_name = "_open_osfhandle"]
     pub fn open_osfhandle(osfhandle: ::intptr_t, flags: ::c_int) -> ::c_int;
-    pub fn setlocale(category: ::c_int, locale: *const ::c_char) -> *mut ::c_char;
+    pub fn setlocale(category: ::c_int,
+                     locale: *const ::c_char) -> *mut ::c_char;
     #[link_name = "_wsetlocale"]
     pub fn wsetlocale(category: ::c_int,
                       locale: *const wchar_t) -> *mut wchar_t;

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1,5 +1,17 @@
 //! Windows CRT definitions
 
+pub type c_short = i16;
+pub type c_ushort = u16;
+pub type c_int = i32;
+pub type c_uint = u32;
+pub type c_longlong = i64;
+pub type c_ulonglong = u64;
+pub type intmax_t = i64;
+pub type uintmax_t = u64;
+
+pub type size_t = usize;
+pub type ptrdiff_t = isize;
+pub type ssize_t = isize;
 pub type sighandler_t = usize;
 
 pub type c_char = i8;
@@ -79,6 +91,9 @@ s! {
         pub sa_data: [::c_char; 14],
     }
 }
+
+pub const INT_MIN: ::c_int = -2147483648;
+pub const INT_MAX: ::c_int = 2147483647;
 
 pub const EXIT_FAILURE: ::c_int = 1;
 pub const EXIT_SUCCESS: ::c_int = 0;

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1,32 +1,5 @@
 //! Windows CRT definitions
 
-pub type int8_t = i8;
-pub type int16_t = i16;
-pub type int32_t = i32;
-pub type int64_t = i64;
-pub type uint8_t = u8;
-pub type uint16_t = u16;
-pub type uint32_t = u32;
-pub type uint64_t = u64;
-
-pub type c_schar = i8;
-pub type c_uchar = u8;
-pub type c_short = i16;
-pub type c_ushort = u16;
-pub type c_int = i32;
-pub type c_uint = u32;
-pub type c_float = f32;
-pub type c_double = f64;
-pub type c_longlong = i64;
-pub type c_ulonglong = u64;
-pub type intmax_t = i64;
-pub type uintmax_t = u64;
-
-pub type size_t = usize;
-pub type ptrdiff_t = isize;
-pub type intptr_t = isize;
-pub type uintptr_t = usize;
-pub type ssize_t = isize;
 pub type sighandler_t = usize;
 
 pub type c_char = i8;
@@ -92,23 +65,20 @@ s! {
     }
 
     pub struct timeval {
-        pub tv_sec: c_long,
-        pub tv_usec: c_long,
+        pub tv_sec: ::c_long,
+        pub tv_usec: ::c_long,
     }
 
     pub struct timespec {
         pub tv_sec: time_t,
-        pub tv_nsec: c_long,
+        pub tv_nsec: ::c_long,
     }
 
     pub struct sockaddr {
-        pub sa_family: c_ushort,
-        pub sa_data: [c_char; 14],
+        pub sa_family: ::c_ushort,
+        pub sa_data: [::c_char; 14],
     }
 }
-
-pub const INT_MIN: c_int = -2147483648;
-pub const INT_MAX: c_int = 2147483647;
 
 pub const EXIT_FAILURE: ::c_int = 1;
 pub const EXIT_SUCCESS: ::c_int = 0;
@@ -220,143 +190,143 @@ impl ::dox::Clone for fpos_t {
 }
 
 extern {
-    pub fn isalnum(c: c_int) -> c_int;
-    pub fn isalpha(c: c_int) -> c_int;
-    pub fn iscntrl(c: c_int) -> c_int;
-    pub fn isdigit(c: c_int) -> c_int;
-    pub fn isgraph(c: c_int) -> c_int;
-    pub fn islower(c: c_int) -> c_int;
-    pub fn isprint(c: c_int) -> c_int;
-    pub fn ispunct(c: c_int) -> c_int;
-    pub fn isspace(c: c_int) -> c_int;
-    pub fn isupper(c: c_int) -> c_int;
-    pub fn isxdigit(c: c_int) -> c_int;
-    pub fn tolower(c: c_int) -> c_int;
-    pub fn toupper(c: c_int) -> c_int;
-    pub fn fopen(filename: *const c_char, mode: *const c_char) -> *mut FILE;
-    pub fn freopen(filename: *const c_char, mode: *const c_char,
+    pub fn isalnum(c: ::c_int) -> ::c_int;
+    pub fn isalpha(c: ::c_int) -> ::c_int;
+    pub fn iscntrl(c: ::c_int) -> ::c_int;
+    pub fn isdigit(c: ::c_int) -> ::c_int;
+    pub fn isgraph(c: ::c_int) -> ::c_int;
+    pub fn islower(c: ::c_int) -> ::c_int;
+    pub fn isprint(c: ::c_int) -> ::c_int;
+    pub fn ispunct(c: ::c_int) -> ::c_int;
+    pub fn isspace(c: ::c_int) -> ::c_int;
+    pub fn isupper(c: ::c_int) -> ::c_int;
+    pub fn isxdigit(c: ::c_int) -> ::c_int;
+    pub fn tolower(c: ::c_int) -> ::c_int;
+    pub fn toupper(c: ::c_int) -> ::c_int;
+    pub fn fopen(filename: *const ::c_char, mode: *const ::c_char) -> *mut FILE;
+    pub fn freopen(filename: *const ::c_char, mode: *const ::c_char,
                    file: *mut FILE) -> *mut FILE;
-    pub fn fflush(file: *mut FILE) -> c_int;
-    pub fn fclose(file: *mut FILE) -> c_int;
-    pub fn remove(filename: *const c_char) -> c_int;
-    pub fn rename(oldname: *const c_char, newname: *const c_char) -> c_int;
+    pub fn fflush(file: *mut FILE) -> ::c_int;
+    pub fn fclose(file: *mut FILE) -> ::c_int;
+    pub fn remove(filename: *const ::c_char) -> ::c_int;
+    pub fn rename(oldname: *const ::c_char, newname: *const ::c_char) -> ::c_int;
     pub fn tmpfile() -> *mut FILE;
-    pub fn setvbuf(stream: *mut FILE, buffer: *mut c_char, mode: c_int,
-                   size: size_t) -> c_int;
-    pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
-    pub fn getchar() -> c_int;
-    pub fn putchar(c: c_int) -> c_int;
-    pub fn fgetc(stream: *mut FILE) -> c_int;
-    pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
-    pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;
-    pub fn fputs(s: *const c_char, stream: *mut FILE) -> c_int;
-    pub fn puts(s: *const c_char) -> c_int;
-    pub fn ungetc(c: c_int, stream: *mut FILE) -> c_int;
-    pub fn fread(ptr: *mut c_void, size: size_t, nobj: size_t,
-                 stream: *mut FILE) -> size_t;
-    pub fn fwrite(ptr: *const c_void, size: size_t, nobj: size_t,
-                  stream: *mut FILE) -> size_t;
-    pub fn fseek(stream: *mut FILE, offset: c_long, whence: c_int) -> c_int;
-    pub fn ftell(stream: *mut FILE) -> c_long;
+    pub fn setvbuf(stream: *mut FILE, buffer: *mut ::c_char, mode: ::c_int,
+                   size: ::size_t) -> ::c_int;
+    pub fn setbuf(stream: *mut FILE, buf: *mut ::c_char);
+    pub fn getchar() -> ::c_int;
+    pub fn putchar(c: ::c_int) -> ::c_int;
+    pub fn fgetc(stream: *mut FILE) -> ::c_int;
+    pub fn fgets(buf: *mut ::c_char, n: ::c_int, stream: *mut FILE) -> *mut ::c_char;
+    pub fn fputc(c: ::c_int, stream: *mut FILE) -> ::c_int;
+    pub fn fputs(s: *const ::c_char, stream: *mut FILE) -> ::c_int;
+    pub fn puts(s: *const ::c_char) -> ::c_int;
+    pub fn ungetc(c: ::c_int, stream: *mut FILE) -> ::c_int;
+    pub fn fread(ptr: *mut ::c_void, size: ::size_t, nobj: ::size_t,
+                 stream: *mut FILE) -> ::size_t;
+    pub fn fwrite(ptr: *const ::c_void, size: ::size_t, nobj: ::size_t,
+                  stream: *mut FILE) -> ::size_t;
+    pub fn fseek(stream: *mut FILE, offset: ::c_long, whence: ::c_int) -> ::c_int;
+    pub fn ftell(stream: *mut FILE) -> ::c_long;
     pub fn rewind(stream: *mut FILE);
-    pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> c_int;
-    pub fn fsetpos(stream: *mut FILE, ptr: *const fpos_t) -> c_int;
-    pub fn feof(stream: *mut FILE) -> c_int;
-    pub fn ferror(stream: *mut FILE) -> c_int;
-    pub fn perror(s: *const c_char);
-    pub fn atoi(s: *const c_char) -> c_int;
-    pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
-    pub fn strtol(s: *const c_char, endp: *mut *mut c_char,
-                  base: c_int) -> c_long;
-    pub fn strtoul(s: *const c_char, endp: *mut *mut c_char,
-                   base: c_int) -> c_ulong;
-    pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;
-    pub fn malloc(size: size_t) -> *mut c_void;
-    pub fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
-    pub fn free(p: *mut c_void);
+    pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> ::c_int;
+    pub fn fsetpos(stream: *mut FILE, ptr: *const fpos_t) -> ::c_int;
+    pub fn feof(stream: *mut FILE) -> ::c_int;
+    pub fn ferror(stream: *mut FILE) -> ::c_int;
+    pub fn perror(s: *const ::c_char);
+    pub fn atoi(s: *const ::c_char) -> ::c_int;
+    pub fn strtod(s: *const ::c_char, endp: *mut *mut ::c_char) -> ::c_double;
+    pub fn strtol(s: *const ::c_char, endp: *mut *mut ::c_char,
+                  base: ::c_int) -> ::c_long;
+    pub fn strtoul(s: *const ::c_char, dp: *mut *mut ::c_char,
+                   base: ::c_int) -> c_ulong;
+    pub fn calloc(nobj: ::size_t, size: ::size_t) -> *mut ::c_void;
+    pub fn malloc(size: ::size_t) -> *mut ::c_void;
+    pub fn realloc(p: *mut ::c_void, size: ::size_t) -> *mut ::c_void;
+    pub fn free(p: *mut ::c_void);
     pub fn abort() -> !;
-    pub fn exit(status: c_int) -> !;
-    pub fn _exit(status: c_int) -> !;
-    pub fn atexit(cb: extern fn()) -> c_int;
-    pub fn system(s: *const c_char) -> c_int;
-    pub fn getenv(s: *const c_char) -> *mut c_char;
+    pub fn exit(status: ::c_int) -> !;
+    pub fn _exit(status: ::c_int) -> !;
+    pub fn atexit(cb: extern fn()) -> ::c_int;
+    pub fn system(s: *const ::c_char) -> ::c_int;
+    pub fn getenv(s: *const ::c_char) -> *mut ::c_char;
 
-    pub fn strcpy(dst: *mut c_char, src: *const c_char) -> *mut c_char;
-    pub fn strncpy(dst: *mut c_char, src: *const c_char,
-                   n: size_t) -> *mut c_char;
-    pub fn strcat(s: *mut c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strncat(s: *mut c_char, ct: *const c_char,
-                   n: size_t) -> *mut c_char;
-    pub fn strcmp(cs: *const c_char, ct: *const c_char) -> c_int;
-    pub fn strncmp(cs: *const c_char, ct: *const c_char, n: size_t) -> c_int;
-    pub fn strcoll(cs: *const c_char, ct: *const c_char) -> c_int;
-    pub fn strchr(cs: *const c_char, c: c_int) -> *mut c_char;
-    pub fn strrchr(cs: *const c_char, c: c_int) -> *mut c_char;
-    pub fn strspn(cs: *const c_char, ct: *const c_char) -> size_t;
-    pub fn strcspn(cs: *const c_char, ct: *const c_char) -> size_t;
-    pub fn strdup(cs: *const c_char) -> *mut c_char;
-    pub fn strpbrk(cs: *const c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strstr(cs: *const c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strlen(cs: *const c_char) -> size_t;
-    pub fn strnlen(cs: *const c_char, maxlen: size_t) -> size_t;
-    pub fn strerror(n: c_int) -> *mut c_char;
-    pub fn strtok(s: *mut c_char, t: *const c_char) -> *mut c_char;
-    pub fn strxfrm(s: *mut c_char, ct: *const c_char, n: size_t) -> size_t;
-    pub fn wcslen(buf: *const wchar_t) -> size_t;
-    pub fn wcstombs(dest: *mut c_char, src: *const wchar_t,
-                    n: size_t) -> ::size_t;
+    pub fn strcpy(dst: *mut ::c_char, src: *const ::c_char) -> *mut ::c_char;
+    pub fn strncpy(dst: *mut ::c_char, src: *const ::c_char,
+                   n: ::size_t) -> *mut ::c_char;
+    pub fn strcat(s: *mut ::c_char, ct: *const ::c_char) -> *mut ::c_char;
+    pub fn strncat(s: *mut ::c_char, ct: *const ::c_char,
+                   n: ::size_t) -> *mut ::c_char;
+    pub fn strcmp(cs: *const ::c_char, ct: *const ::c_char) -> ::c_int;
+    pub fn strncmp(cs: *const ::c_char, ct: *const ::c_char, n: ::size_t) -> ::c_int;
+    pub fn strcoll(cs: *const ::c_char, ct: *const ::c_char) -> ::c_int;
+    pub fn strchr(cs: *const ::c_char, c: ::c_int) -> *mut ::c_char;
+    pub fn strrchr(cs: *const ::c_char, c: ::c_int) -> *mut ::c_char;
+    pub fn strspn(cs: *const ::c_char, ct: *const ::c_char) -> ::size_t;
+    pub fn strcspn(cs: *const ::c_char, ct: *const ::c_char) -> ::size_t;
+    pub fn strdup(cs: *const ::c_char) -> *mut ::c_char;
+    pub fn strpbrk(cs: *const ::c_char, ct: *const ::c_char) -> *mut ::c_char;
+    pub fn strstr(cs: *const ::c_char, ct: *const ::c_char) -> *mut ::c_char;
+    pub fn strlen(cs: *const ::c_char) -> ::size_t;
+    pub fn strnlen(cs: *const ::c_char, maxlen: ::size_t) -> ::size_t;
+    pub fn strerror(n: ::c_int) -> *mut ::c_char;
+    pub fn strtok(s: *mut ::c_char, t: *const ::c_char) -> *mut ::c_char;
+    pub fn strxfrm(s: *mut ::c_char, ct: *const ::c_char, n: ::size_t) -> ::size_t;
+    pub fn wcslen(buf: *const wchar_t) -> ::size_t;
+    pub fn wcstombs(dest: *mut ::c_char, src: *const wchar_t,
+                    n: ::size_t) -> ::size_t;
 
-    pub fn memchr(cx: *const c_void, c: c_int, n: size_t) -> *mut c_void;
-    pub fn memcmp(cx: *const c_void, ct: *const c_void, n: size_t) -> c_int;
-    pub fn memcpy(dest: *mut c_void, src: *const c_void,
-                  n: size_t) -> *mut c_void;
-    pub fn memmove(dest: *mut c_void, src: *const c_void,
-                   n: size_t) -> *mut c_void;
-    pub fn memset(dest: *mut c_void, c: c_int, n: size_t) -> *mut c_void;
+    pub fn memchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
+    pub fn memcmp(cx: *const ::c_void, ct: *const ::c_void, n: ::size_t) -> ::c_int;
+    pub fn memcpy(dest: *mut ::c_void, src: *const ::c_void,
+                  n: ::size_t) -> *mut ::c_void;
+    pub fn memmove(dest: *mut ::c_void, src: *const ::c_void,
+                   n: ::size_t) -> *mut ::c_void;
+    pub fn memset(dest: *mut ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
 
-    pub fn abs(i: c_int) -> c_int;
-    pub fn atof(s: *const c_char) -> c_double;
-    pub fn labs(i: c_long) -> c_long;
-    pub fn rand() -> c_int;
-    pub fn srand(seed: c_uint);
+    pub fn abs(i: ::c_int) -> ::c_int;
+    pub fn atof(s: *const ::c_char) -> ::c_double;
+    pub fn labs(i: ::c_long) -> ::c_long;
+    pub fn rand() -> ::c_int;
+    pub fn srand(seed: ::c_uint);
 
-    pub fn signal(signum: c_int, handler: sighandler_t) -> sighandler_t;
-    pub fn raise(signum: c_int) -> c_int;
+    pub fn signal(signum: ::c_int, handler: sighandler_t) -> sighandler_t;
+    pub fn raise(signum: ::c_int) -> ::c_int;
 
     #[link_name = "_chmod"]
-    pub fn chmod(path: *const c_char, mode: ::c_int) -> ::c_int;
+    pub fn chmod(path: *const ::c_char, mode: ::c_int) -> ::c_int;
     #[link_name = "_wchmod"]
     pub fn wchmod(path: *const wchar_t, mode: ::c_int) -> ::c_int;
     #[link_name = "_mkdir"]
-    pub fn mkdir(path: *const c_char) -> ::c_int;
+    pub fn mkdir(path: *const ::c_char) -> ::c_int;
     #[link_name = "_wrmdir"]
     pub fn wrmdir(path: *const wchar_t) -> ::c_int;
     #[link_name = "_fstat64"]
     pub fn fstat(fildes: ::c_int, buf: *mut stat) -> ::c_int;
     #[link_name = "_stat64"]
-    pub fn stat(path: *const c_char, buf: *mut stat) -> ::c_int;
+    pub fn stat(path: *const ::c_char, buf: *mut stat) -> ::c_int;
     #[link_name = "_wstat64"]
     pub fn wstat(path: *const wchar_t, buf: *mut stat) -> ::c_int;
     #[link_name = "_wutime64"]
     pub fn wutime(file: *const wchar_t, buf: *mut utimbuf) -> ::c_int;
     #[link_name = "_popen"]
-    pub fn popen(command: *const c_char, mode: *const c_char) -> *mut ::FILE;
+    pub fn popen(command: *const ::c_char, mode: *const ::c_char) -> *mut ::FILE;
     #[link_name = "_pclose"]
     pub fn pclose(stream: *mut ::FILE) -> ::c_int;
     #[link_name = "_fdopen"]
-    pub fn fdopen(fd: ::c_int, mode: *const c_char) -> *mut ::FILE;
+    pub fn fdopen(fd: ::c_int, mode: *const ::c_char) -> *mut ::FILE;
     #[link_name = "_fileno"]
     pub fn fileno(stream: *mut ::FILE) -> ::c_int;
     #[link_name = "_open"]
-    pub fn open(path: *const c_char, oflag: ::c_int, ...) -> ::c_int;
+    pub fn open(path: *const ::c_char, oflag: ::c_int, ...) -> ::c_int;
     #[link_name = "_wopen"]
     pub fn wopen(path: *const wchar_t, oflag: ::c_int, ...) -> ::c_int;
     #[link_name = "_creat"]
-    pub fn creat(path: *const c_char, mode: ::c_int) -> ::c_int;
+    pub fn creat(path: *const ::c_char, mode: ::c_int) -> ::c_int;
     #[link_name = "_access"]
-    pub fn access(path: *const c_char, amode: ::c_int) -> ::c_int;
+    pub fn access(path: *const ::c_char, amode: ::c_int) -> ::c_int;
     #[link_name = "_chdir"]
-    pub fn chdir(dir: *const c_char) -> ::c_int;
+    pub fn chdir(dir: *const ::c_char) -> ::c_int;
     #[link_name = "_close"]
     pub fn close(fd: ::c_int) -> ::c_int;
     #[link_name = "_dup"]
@@ -364,23 +334,23 @@ extern {
     #[link_name = "_dup2"]
     pub fn dup2(src: ::c_int, dst: ::c_int) -> ::c_int;
     #[link_name = "_execv"]
-    pub fn execv(prog: *const c_char, argv: *const *const c_char) -> ::intptr_t;
+    pub fn execv(prog: *const ::c_char, argv: *const *const ::c_char) -> ::intptr_t;
     #[link_name = "_execve"]
-    pub fn execve(prog: *const c_char, argv: *const *const c_char,
-                  envp: *const *const c_char) -> ::c_int;
+    pub fn execve(prog: *const ::c_char, argv: *const *const ::c_char,
+                  envp: *const *const ::c_char) -> ::c_int;
     #[link_name = "_execvp"]
-    pub fn execvp(c: *const c_char, argv: *const *const c_char) -> ::c_int;
+    pub fn execvp(c: *const ::c_char, argv: *const *const ::c_char) -> ::c_int;
     #[link_name = "_execvpe"]
-    pub fn execvpe(c: *const c_char, argv: *const *const c_char,
-                   envp: *const *const c_char) -> ::c_int;
+    pub fn execvpe(c: *const ::c_char, argv: *const *const ::c_char,
+                   envp: *const *const ::c_char) -> ::c_int;
     #[link_name = "_getcwd"]
-    pub fn getcwd(buf: *mut c_char, size: ::c_int) -> *mut c_char;
+    pub fn getcwd(buf: *mut ::c_char, size: ::c_int) -> *mut ::c_char;
     #[link_name = "_getpid"]
     pub fn getpid() -> ::c_int;
     #[link_name = "_isatty"]
     pub fn isatty(fd: ::c_int) -> ::c_int;
     #[link_name = "_lseek"]
-    pub fn lseek(fd: ::c_int, offset: c_long, origin: ::c_int) -> c_long;
+    pub fn lseek(fd: ::c_int, offset: ::c_long, origin: ::c_int) -> ::c_long;
     #[link_name = "_pipe"]
     pub fn pipe(fds: *mut ::c_int,
                 psize: ::c_uint,
@@ -388,9 +358,9 @@ extern {
     #[link_name = "_read"]
     pub fn read(fd: ::c_int, buf: *mut ::c_void, count: ::c_uint) -> ::c_int;
     #[link_name = "_rmdir"]
-    pub fn rmdir(path: *const c_char) -> ::c_int;
+    pub fn rmdir(path: *const ::c_char) -> ::c_int;
     #[link_name = "_unlink"]
-    pub fn unlink(c: *const c_char) -> ::c_int;
+    pub fn unlink(c: *const ::c_char) -> ::c_int;
     #[link_name = "_write"]
     pub fn write(fd: ::c_int, buf: *const ::c_void, count: ::c_uint) -> ::c_int;
     #[link_name = "_commit"]
@@ -399,7 +369,7 @@ extern {
     pub fn get_osfhandle(fd: ::c_int) -> ::intptr_t;
     #[link_name = "_open_osfhandle"]
     pub fn open_osfhandle(osfhandle: ::intptr_t, flags: ::c_int) -> ::c_int;
-    pub fn setlocale(category: ::c_int, locale: *const c_char) -> *mut c_char;
+    pub fn setlocale(category: ::c_int, locale: *const ::c_char) -> *mut ::c_char;
     #[link_name = "_wsetlocale"]
     pub fn wsetlocale(category: ::c_int,
                       locale: *const wchar_t) -> *mut wchar_t;
@@ -431,25 +401,6 @@ extern "system" {
                       optlen: ::c_int) -> ::c_int;
     pub fn socket(af: ::c_int, socket_type: ::c_int,
                   protocol: ::c_int) -> SOCKET;
-}
-
-cfg_if! {
-    if #[cfg(core_cvoid)] {
-        pub use core::ffi::c_void;
-    } else {
-        // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help
-        // enable more optimization opportunities around it recognizing things
-        // like malloc/free.
-        #[repr(u8)]
-        #[allow(missing_copy_implementations)]
-        pub enum c_void {
-            // Two dummy variants so the #[repr] attribute can be used.
-            #[doc(hidden)]
-            __variant1,
-            #[doc(hidden)]
-            __variant2,
-        }
-    }
 }
 
 cfg_if! {


### PR DESCRIPTION
Per @alexcrichton's comment [here](https://github.com/rust-lang/libc/pull/1129#issuecomment-440821828), we should move the _truely_ universal types back into the crate root. Let me know if you think some of these types are _not_ universal (I've never seen a C-compiler use any definitions except the ones below).

This allows for crates like [ring](https://github.com/briansmith/ring) to [use the libc crate](https://github.com/briansmith/ring/blob/dd5f7fec815daf28e67bb5738166eb92dfe17ce0/Cargo.toml#L302) while still supporting custom/unsupported targets (like `x86_64-unknown-uefi`). 

Specifically the following code was moved from `::{unix, windows, cloudabi, redox, fuchsia, sgx, switch}` to `::`.
```rust
pub type int8_t = i8;	
pub type int16_t = i16;	
pub type int32_t = i32;	
pub type int64_t = i64;	
pub type uint8_t = u8;	
pub type uint16_t = u16;	
pub type uint32_t = u32;	
pub type uint64_t = u64;	

pub type c_schar = i8;	
pub type c_uchar = u8;	
pub type c_short = i16;	
pub type c_ushort = u16;	
pub type c_int = i32;	
pub type c_uint = u32;	
pub type c_float = f32;	
pub type c_double = f64;	
pub type c_longlong = i64;	
pub type c_ulonglong = u64;	
pub type intmax_t = i64;	
pub type uintmax_t = u64;	

pub type size_t = usize;	
pub type ptrdiff_t = isize;	
pub type intptr_t = isize;	
pub type uintptr_t = usize;	
pub type ssize_t = isize;

pub const INT_MIN: c_int = -2147483648;	
pub const INT_MAX: c_int = 2147483647;
```

This change also makes sure that all basic C types are referred to like `::c_int`, this will make moving this code around in the future much easier.