### PR TITLE
Check style using rustfmt and reformat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,11 @@ matrix:
     - env: TARGET=wasm32-unknown-unknown
       install: rustup target add $TARGET
       script: cargo build --no-default-features --target $TARGET --release
-
+    - name: "Style"
+      install: rustup component add rustfmt-preview
+      script:
+        - rustc ci/style.rs && ./style src
+        - cargo fmt --all -- --check
     - name: "Shellcheck"
       install: true
       script:
@@ -102,7 +106,7 @@ script:
       export CARGO_TARGET_DIR=`pwd`/target;
       sh ci/run.sh $TARGET;
     fi
-  - rustc ci/style.rs && ./style src
+
 env:
   global:
     secure: "e2/3QjgRN9atOuSHp22TrYG7QVKcYUWY48Hi9b60w+r1+BhPkTseIJLte7WefRhdXtqpjjUJTooKDhnurFOeHaCT+nmBgiv+FPU893sBl4bhesY4m0vgUJVbNZcs6lTImYekWVb+aqjGdgV/XAgCw7c3kPmrZV0MzGDWL64Xaps="

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -7,13 +7,10 @@ use std::env;
 
 #[cfg(unix)]
 fn do_cc() {
-    cc::Build::new()
-        .file("src/cmsg.c")
-        .compile("cmsg");
+    cc::Build::new().file("src/cmsg.c").compile("cmsg");
 }
 #[cfg(not(unix))]
-fn do_cc() {
-}
+fn do_cc() {}
 
 fn do_ctest() {
     let target = env::var("TARGET").unwrap();
@@ -385,7 +382,7 @@ fn do_ctest() {
             // Fixup a few types on windows that don't actually exist.
             "time64_t" if windows => "__time64_t".to_string(),
             "ssize_t" if windows => "SSIZE_T".to_string(),
-            // windows 
+            // windows
             "sighandler_t" if windows && !mingw => "_crt_signal_t".to_string(),
             "sighandler_t" if windows && mingw => "__p_sig_fn_t".to_string(),
             // OSX calls this something else
@@ -671,7 +668,11 @@ fn do_ctest() {
             // MFD_HUGETLB is not available in some older libc versions on the CI builders. On the
             // x86_64 and i686 builders it seems to be available for all targets, so at least test
             // it there.
-            "MFD_HUGETLB" if !(x86_64 || i686) || musl || (x86_64 && android)=> true,
+            "MFD_HUGETLB"
+                if !(x86_64 || i686) || musl || (x86_64 && android) =>
+            {
+                true
+            }
 
             "DT_FIFO" | "DT_CHR" | "DT_DIR" | "DT_BLK" | "DT_REG"
             | "DT_LNK" | "DT_SOCK"

--- a/libc-test/test/cmsg.rs
+++ b/libc-test/test/cmsg.rs
@@ -6,94 +6,96 @@ extern crate libc;
 #[cfg(unix)]
 mod t {
 
-use libc::{self, c_uchar, c_uint, c_void, cmsghdr, msghdr};
-use std::mem;
+    use libc::{self, c_uchar, c_uint, c_void, cmsghdr, msghdr};
+    use std::mem;
 
-extern {
-    pub fn cmsg_firsthdr(msgh: *const msghdr) -> *mut cmsghdr;
-    pub fn cmsg_nxthdr(mhdr: *const msghdr,
-                       cmsg: *const cmsghdr) -> *mut cmsghdr;
-    pub fn cmsg_space(length: c_uint) -> usize;
-    pub fn cmsg_len(length: c_uint) -> usize;
-    pub fn cmsg_data(cmsg: *const cmsghdr) -> *mut c_uchar;
-}
+    extern "C" {
+        pub fn cmsg_firsthdr(msgh: *const msghdr) -> *mut cmsghdr;
+        pub fn cmsg_nxthdr(
+            mhdr: *const msghdr,
+            cmsg: *const cmsghdr,
+        ) -> *mut cmsghdr;
+        pub fn cmsg_space(length: c_uint) -> usize;
+        pub fn cmsg_len(length: c_uint) -> usize;
+        pub fn cmsg_data(cmsg: *const cmsghdr) -> *mut c_uchar;
+    }
 
-#[test]
-fn test_cmsg_data() {
-    for l in 0..128 {
-        let pcmsghdr = l as *const cmsghdr;
-        unsafe {
-            assert_eq!(libc::CMSG_DATA(pcmsghdr), cmsg_data(pcmsghdr));
+    #[test]
+    fn test_cmsg_data() {
+        for l in 0..128 {
+            let pcmsghdr = l as *const cmsghdr;
+            unsafe {
+                assert_eq!(libc::CMSG_DATA(pcmsghdr), cmsg_data(pcmsghdr));
+            }
         }
     }
-}
 
-#[test]
-fn test_cmsg_firsthdr() {
-    let mut mhdr: msghdr = unsafe{mem::zeroed()};
-    mhdr.msg_control = 0xdeadbeef as *mut c_void;
-    let pmhdr = &mhdr as *const msghdr;
-    for l in 0..128 {
-        mhdr.msg_controllen = l;
-        unsafe {
-            assert_eq!(libc::CMSG_FIRSTHDR(pmhdr), cmsg_firsthdr(pmhdr));
+    #[test]
+    fn test_cmsg_firsthdr() {
+        let mut mhdr: msghdr = unsafe { mem::zeroed() };
+        mhdr.msg_control = 0xdeadbeef as *mut c_void;
+        let pmhdr = &mhdr as *const msghdr;
+        for l in 0..128 {
+            mhdr.msg_controllen = l;
+            unsafe {
+                assert_eq!(libc::CMSG_FIRSTHDR(pmhdr), cmsg_firsthdr(pmhdr));
+            }
         }
     }
-}
 
-#[test]
-fn test_cmsg_len() {
-    for l in 0..128 {
-        unsafe {
-            assert_eq!(libc::CMSG_LEN(l) as usize, cmsg_len(l));
+    #[test]
+    fn test_cmsg_len() {
+        for l in 0..128 {
+            unsafe {
+                assert_eq!(libc::CMSG_LEN(l) as usize, cmsg_len(l));
+            }
         }
     }
-}
 
-// Skip on sparc64
-// https://github.com/rust-lang/libc/issues/1239
-#[cfg(not(target_arch = "sparc64"))]
-#[test]
-fn test_cmsg_nxthdr() {
-    use std::ptr;
+    // Skip on sparc64
+    // https://github.com/rust-lang/libc/issues/1239
+    #[cfg(not(target_arch = "sparc64"))]
+    #[test]
+    fn test_cmsg_nxthdr() {
+        use std::ptr;
 
-    let mut buffer = [0u8; 256];
-    let mut mhdr: msghdr = unsafe{mem::zeroed()};
-    let pmhdr = &mhdr as *const msghdr;
-    for start_ofs in 0..64 {
-        let pcmsghdr = &mut buffer[start_ofs] as *mut u8 as *mut cmsghdr;
-        mhdr.msg_control = pcmsghdr as *mut c_void;
-        mhdr.msg_controllen = (160 - start_ofs) as _;
-        for cmsg_len in 0..64 {
-            for next_cmsg_len in 0..32 {
-                for i in buffer[start_ofs..].iter_mut() {
-                    *i = 0;
-                }
-                unsafe {
-                    (*pcmsghdr).cmsg_len = cmsg_len;
-                    let libc_next = libc::CMSG_NXTHDR(pmhdr, pcmsghdr);
-                    let next = cmsg_nxthdr(pmhdr, pcmsghdr);
-                    assert_eq!(libc_next, next);
-
-                    if libc_next != ptr::null_mut() {
-                        (*libc_next).cmsg_len = next_cmsg_len;
+        let mut buffer = [0u8; 256];
+        let mut mhdr: msghdr = unsafe { mem::zeroed() };
+        let pmhdr = &mhdr as *const msghdr;
+        for start_ofs in 0..64 {
+            let pcmsghdr = &mut buffer[start_ofs] as *mut u8 as *mut cmsghdr;
+            mhdr.msg_control = pcmsghdr as *mut c_void;
+            mhdr.msg_controllen = (160 - start_ofs) as _;
+            for cmsg_len in 0..64 {
+                for next_cmsg_len in 0..32 {
+                    for i in buffer[start_ofs..].iter_mut() {
+                        *i = 0;
+                    }
+                    unsafe {
+                        (*pcmsghdr).cmsg_len = cmsg_len;
                         let libc_next = libc::CMSG_NXTHDR(pmhdr, pcmsghdr);
                         let next = cmsg_nxthdr(pmhdr, pcmsghdr);
                         assert_eq!(libc_next, next);
+
+                        if libc_next != ptr::null_mut() {
+                            (*libc_next).cmsg_len = next_cmsg_len;
+                            let libc_next = libc::CMSG_NXTHDR(pmhdr, pcmsghdr);
+                            let next = cmsg_nxthdr(pmhdr, pcmsghdr);
+                            assert_eq!(libc_next, next);
+                        }
                     }
                 }
             }
         }
     }
-}
 
-#[test]
-fn test_cmsg_space() {
-    unsafe {
-        for l in 0..128 {
-            assert_eq!(libc::CMSG_SPACE(l) as usize, cmsg_space(l));
+    #[test]
+    fn test_cmsg_space() {
+        unsafe {
+            for l in 0..128 {
+                assert_eq!(libc::CMSG_SPACE(l) as usize, cmsg_space(l));
+            }
         }
     }
-}
 
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+max_width = 79
+comment_width = 79
+error_on_line_overflow = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,10 @@
 #![cfg_attr(feature = "rustc-dep-of-std", feature(no_core))]
 #![cfg_attr(feature = "rustc-dep-of-std", no_core)]
 #![cfg_attr(feature = "rustc-dep-of-std", allow(warnings))]
-#![cfg_attr(not(any(feature = "use_std", feature = "rustc-dep-of-std")), no_std)]
+#![cfg_attr(
+    not(any(feature = "use_std", feature = "rustc-dep-of-std")),
+    no_std
+)]
 // Enable lints
 #![cfg_attr(feature = "extra_traits", deny(missing_debug_implementations))]
 #![deny(missing_copy_implementations)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -90,7 +90,9 @@ macro_rules! __item {
 
 #[allow(unused_macros)]
 macro_rules! align_const {
-    ($($(#[$attr:meta])* pub const $name:ident : $t1:ty = $t2:ident { $($field:tt)* };)*) => ($(
+    ($($(#[$attr:meta])*
+       pub const $name:ident : $t1:ty
+       = $t2:ident { $($field:tt)* };)*) => ($(
         #[cfg(feature = "align")]
         $(#[$attr])*
         pub const $name : $t1 = $t2 {


### PR DESCRIPTION
A couple of recent PRs attempt to reformat the library using rustfmt and run into issues against libc's style checker because rustfmt default settings differ.

This PR uses the rustfmt-preview from nightly to check that the library is appropriately formatted, adding a style as similar to libc's style as possible, so that both style checkers work properly simultaneously. 