### PR TITLE
Temporarily allow Android build jobs to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -189,6 +189,9 @@ matrix:
       stage: tier2
 
   allow_failures:
+      # FIXME: android build bots time out irregularly
+      - env: TARGET=aarch64-linux-android
+      - env: TARGET=arm-linux-androideabi
       # FIXME: https://github.com/rust-lang/libc/issues/1226
       - env: TARGET=asmjs-unknown-emscripten
       - env: TARGET=wasm32-unknown-emscripten


### PR DESCRIPTION
These are still too brittle for some reason.