### PR TITLE
Cleanup dox mess - correction

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/openbsd/mod.rs
@@ -305,6 +305,7 @@ cfg_if! {
             }
         }
     }
+}
 
 //https://github.com/openbsd/src/blob/master/sys/sys/mount.h
 pub const ISOFSMNT_NORRIP: ::c_int = 0x1; // disable Rock Ridge Ext


### PR DESCRIPTION
unbreak openbsd after 7ac0fe53e a `}` was missing