### PR TITLE
Add missing group entry functions for Solaris/Illumos

### DIFF
--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1781,6 +1781,9 @@ extern {
                           parent: ::Option<unsafe extern fn()>,
                           child: ::Option<unsafe extern fn()>) -> ::c_int;
     pub fn getgrgid(gid: ::gid_t) -> *mut ::group;
+    pub fn setgrent();
+    pub fn endgrent();
+    pub fn getgrent() -> *mut ::group;
     pub fn popen(command: *const c_char,
                  mode: *const c_char) -> *mut ::FILE;
 


### PR DESCRIPTION
This commit adds definitions for `setgrent`, `endgrent`, and `getgrent` which were missing (but available for FreeBSD and other *nix systems).