### PR TITLE
Fix ALG_OP_* types

### DIFF
--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -1787,8 +1787,8 @@ pub const ALG_SET_OP: ::c_int = 3;
 pub const ALG_SET_AEAD_ASSOCLEN: ::c_int = 4;
 pub const ALG_SET_AEAD_AUTHSIZE: ::c_int = 5;
 
-pub const ALG_OP_DECRYPT: ::c_int = 0;
-pub const ALG_OP_ENCRYPT: ::c_int = 1;
+pub const ALG_OP_DECRYPT: u32 = 0;
+pub const ALG_OP_ENCRYPT: u32 = 1;
 
 f! {
     pub fn CMSG_NXTHDR(mhdr: *const msghdr,

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -1797,8 +1797,8 @@ pub const ALG_SET_OP: ::c_int = 3;
 pub const ALG_SET_AEAD_ASSOCLEN: ::c_int = 4;
 pub const ALG_SET_AEAD_AUTHSIZE: ::c_int = 5;
 
-pub const ALG_OP_DECRYPT: ::c_int = 0;
-pub const ALG_OP_ENCRYPT: ::c_int = 1;
+pub const ALG_OP_DECRYPT: u32 = 0;
+pub const ALG_OP_ENCRYPT: u32 = 1;
 
 f! {
     pub fn CMSG_NXTHDR(mhdr: *const msghdr,


### PR DESCRIPTION
According to https://elixir.bootlin.com/linux/v4.9/source/crypto/af_alg.c#L462 ALG_OP_* constants should be `u32`