### PR TITLE
Fix build of `rustc-dep-of-std` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,17 +20,11 @@
 // Enable extra lints:
 #![cfg_attr(feature = "extra_traits", deny(missing_debug_implementations))]
 #![deny(missing_copy_implementations, safe_packed_borrows)]
-// Enable no_std:
-#![cfg_attr(
-    not(any(
-        feature = "use_std",
-        feature = "rustc-dep-of-std",
-    )),
-    no_std
-)]
+#![no_std]
+#![cfg_attr(feature = "rustc-dep-of-std", no_core)]
 
 #[cfg(feature = "use_std")]
-extern crate std as core;
+extern crate std;
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
Enusre that `no_core` is turned on, and while here update the `no_std`
header to be unconditionally applied.

Closes #1267