### PR TITLE
Clean libc-test for apple targets

### DIFF
--- a/libc-test/test/linux_fcntl.rs
+++ b/libc-test/test/linux_fcntl.rs
@@ -1,7 +1,10 @@
-#![allow(bad_style, improper_ctypes, unused)]
+#![allow(bad_style, improper_ctypes, unused, deprecated)]
 
 extern crate libc;
-
 use libc::*;
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 include!(concat!(env!("OUT_DIR"), "/linux_fcntl.rs"));
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn main() {}

--- a/libc-test/test/main.rs
+++ b/libc-test/test/main.rs
@@ -1,4 +1,4 @@
-#![allow(bad_style, improper_ctypes)]
+#![allow(bad_style, improper_ctypes, deprecated)]
 extern crate libc;
 
 use libc::*;

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -139,6 +139,7 @@ s! {
     }
 
     pub struct sigaction {
+        // FIXME: this field is actually a union
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: sigset_t,
         pub sa_flags: ::c_int,
@@ -2255,12 +2256,14 @@ pub const NOTE_NONE: ::uint32_t = 0x00000080;
 pub const NOTE_EXIT: ::uint32_t = 0x80000000;
 pub const NOTE_FORK: ::uint32_t = 0x40000000;
 pub const NOTE_EXEC: ::uint32_t = 0x20000000;
+#[deprecated(since="0.2.49", note="Deprecated since MacOSX 10.9")]
 pub const NOTE_REAP: ::uint32_t = 0x10000000;
 pub const NOTE_SIGNAL: ::uint32_t = 0x08000000;
 pub const NOTE_EXITSTATUS: ::uint32_t = 0x04000000;
 pub const NOTE_EXIT_DETAIL: ::uint32_t = 0x02000000;
 pub const NOTE_PDATAMASK: ::uint32_t = 0x000fffff;
 pub const NOTE_PCTRLMASK: ::uint32_t = 0xfff00000;
+#[deprecated(since="0.2.49", note="Deprecated since MacOSX 10.9")]
 pub const NOTE_EXIT_REPARENTED: ::uint32_t = 0x00080000;
 pub const NOTE_EXIT_DETAIL_MASK: ::uint32_t = 0x00070000;
 pub const NOTE_EXIT_DECRYPTFAIL: ::uint32_t = 0x00010000;
@@ -2466,7 +2469,9 @@ pub const KERN_KDSETRTCDEC: ::c_int = 15;
 pub const KERN_KDGETENTROPY: ::c_int = 16;
 pub const KERN_KDWRITETR: ::c_int = 17;
 pub const KERN_KDWRITEMAP: ::c_int = 18;
+#[deprecated(since = "0.2.49", note ="Removed in MacOSX 10.12")]
 pub const KERN_KDENABLE_BG_TRACE: ::c_int = 19;
+#[deprecated(since = "0.2.49", note ="Removed in MacOSX 10.12")]
 pub const KERN_KDDISABLE_BG_TRACE: ::c_int = 20;
 pub const KERN_KDREADCURTHRMAP: ::c_int = 21;
 pub const KERN_KDSET_TYPEFILTER: ::c_int = 22;
@@ -2846,6 +2851,16 @@ f! {
 }
 
 extern {
+    #[deprecated(since="0.2.49", note="Deprecated in MacOSX 10.5")]
+    #[link_name = "daemon$1050"]
+    pub fn daemon(nochdir: ::c_int, noclose: ::c_int) -> ::c_int;
+    #[deprecated(since="0.2.49", note="Deprecated in MacOSX 10.10")]
+    pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
+    #[deprecated(since="0.2.49", note="Deprecated in MacOSX 10.10")]
+    pub fn sem_init(sem: *mut sem_t,
+                    pshared: ::c_int,
+                    value: ::c_uint)
+                    -> ::c_int;
     pub fn aio_read(aiocbp: *mut aiocb) -> ::c_int;
     pub fn aio_write(aiocbp: *mut aiocb) -> ::c_int;
     pub fn aio_fsync(op: ::c_int, aiocbp: *mut aiocb) -> ::c_int;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1050,6 +1050,14 @@ f! {
 }
 
 extern {
+    pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t,
+                    pshared: ::c_int,
+                    value: ::c_uint)
+                    -> ::c_int;
+
+    pub fn daemon(nochdir: ::c_int, noclose: ::c_int) -> ::c_int;
+
     pub fn accept4(s: ::c_int, addr: *mut ::sockaddr,
                    addrlen: *mut ::socklen_t, flags: ::c_int) -> ::c_int;
     pub fn aio_read(aiocbp: *mut aiocb) -> ::c_int;

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -623,7 +623,6 @@ extern {
     pub fn pthread_cancel(thread: ::pthread_t) -> ::c_int;
     pub fn pthread_kill(thread: ::pthread_t, sig: ::c_int) -> ::c_int;
     pub fn sem_unlink(name: *const ::c_char) -> ::c_int;
-    pub fn daemon(nochdir: ::c_int, noclose: ::c_int) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__getpwnam_r50")]
     #[cfg_attr(target_os = "solaris", link_name = "__posix_getpwnam_r")]
     pub fn getpwnam_r(name: *const ::c_char,

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -597,6 +597,13 @@ pub const TIMER_ABSTIME: ::c_int = 1;
 
 #[link(name = "util")]
 extern {
+    pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t,
+                    pshared: ::c_int,
+                    value: ::c_uint)
+                    -> ::c_int;
+
+    pub fn daemon(nochdir: ::c_int, noclose: ::c_int) -> ::c_int;
     pub fn mincore(addr: *mut ::c_void, len: ::size_t,
                    vec: *mut ::c_char) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__clock_getres50")]

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -1111,6 +1111,12 @@ extern {
 
 #[link(name = "bsd")]
 extern {
+    pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t,
+                    pshared: ::c_int,
+                    value: ::c_uint)
+                    -> ::c_int;
+
     pub fn clock_gettime(clk_id: ::c_int, tp: *mut ::timespec) -> ::c_int;
     pub fn clock_settime(clk_id: ::c_int, tp: *const ::timespec) -> ::c_int;
     pub fn pthread_create(thread: *mut ::pthread_t,

--- a/src/unix/hermit/mod.rs
+++ b/src/unix/hermit/mod.rs
@@ -705,6 +705,12 @@ f! {
 }
 
 extern {
+    pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t,
+                    pshared: ::c_int,
+                    value: ::c_uint)
+                    -> ::c_int;
+
     pub fn abs(i: ::c_int) -> ::c_int;
     pub fn atof(s: *const ::c_char) -> ::c_double;
     pub fn labs(i: ::c_long) -> ::c_long;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1021,16 +1021,11 @@ extern {
                      locale: *const ::c_char) -> *mut ::c_char;
     pub fn localeconv() -> *mut lconv;
 
-    pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "sem_wait$UNIX2003")]
     pub fn sem_wait(sem: *mut sem_t) -> ::c_int;
     pub fn sem_trywait(sem: *mut sem_t) -> ::c_int;
     pub fn sem_post(sem: *mut sem_t) -> ::c_int;
-    pub fn sem_init(sem: *mut sem_t,
-                    pshared: ::c_int,
-                    value: ::c_uint)
-                    -> ::c_int;
     pub fn statvfs(path: *const c_char, buf: *mut statvfs) -> ::c_int;
     pub fn fstatvfs(fd: ::c_int, buf: *mut statvfs) -> ::c_int;
 

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -568,6 +568,12 @@ f! {
 }
 
 extern {
+    pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t,
+                    pshared: ::c_int,
+                    value: ::c_uint)
+                    -> ::c_int;
+
     pub fn abs(i: ::c_int) -> ::c_int;
     pub fn atof(s: *const ::c_char) -> ::c_double;
     pub fn labs(i: ::c_long) -> ::c_long;

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -1290,6 +1290,12 @@ f! {
 }
 
 extern {
+    pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t,
+                    pshared: ::c_int,
+                    value: ::c_uint)
+                    -> ::c_int;
+
     pub fn fdatasync(fd: ::c_int) -> ::c_int;
     pub fn mincore(addr: *mut ::c_void, len: ::size_t,
                    vec: *mut ::c_uchar) -> ::c_int;

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1557,6 +1557,12 @@ f! {
 }
 
 extern {
+    pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t,
+                    pshared: ::c_int,
+                    value: ::c_uint)
+                    -> ::c_int;
+
     pub fn abs(i: ::c_int) -> ::c_int;
     pub fn acct(filename: *const ::c_char) -> ::c_int;
     pub fn atof(s: *const ::c_char) -> ::c_double;

--- a/src/unix/uclibc/mod.rs
+++ b/src/unix/uclibc/mod.rs
@@ -1481,6 +1481,12 @@ f! {
 }
 
 extern {
+    pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t,
+                    pshared: ::c_int,
+                    value: ::c_uint)
+                    -> ::c_int;
+
     pub fn abs(i: ::c_int) -> ::c_int;
     pub fn atof(s: *const ::c_char) -> ::c_double;
     pub fn labs(i: ::c_long) -> ::c_long;


### PR DESCRIPTION
This cleans up the build.rs of `libc-test` for apple targets. 

I wanted to update the docker containers of some targets so that we can start testing newer currently-skipped APIs properly, but it is impossible to figure out which headers and APIs are skipped for each target, which has to change if we update the glibc version in one Linux container but not the other (updating them all at once is just madness).

This PR separates the testing of apple targets into its own self-contained function. This allows seeing exactly which headers are included, and which items are skipped. A lot of work will be required to separate the testing of all major platforms and make the script reasonable. 

During the clean up, I discovered that, at least for apple targets, deprecated but not removed APIs are not tested. I re-enabled testing for those, and fixed `daemon`, which was not properly linking its symbol. I also added the `#[deprecated]` attribute to the `#[deprecated]` APIs of the apple targets. The attribute is available since Rust 1.9.0 and the min. Rust version we support is Rust 1.13.0.

Many other APIs are also currently not tested "because they are weird" which I interpret as "the test failed for an unknown reason", as a consequence:

* the signatures of execv, execve, and execvp are incorrect (see https://github.com/rust-lang/libc/issues/1272)

* the `sig_t` type is called `sighandler_t` in libc for some reason: https://github.com/rust-lang/libc/issues/1273

This probably explains why some other things, like the `sa_handler`/`sa_sigaction` fields of `sigaction` were skipped. The field is actually a union, which can be either a `sig_t` for the `sa_handler` field, or some other type for the `sa_sigaction` field, but because the distinction was not made, the field was not checked. 

The latest ctest version can check volatile pointers, so a couple of skipped tests are now tested using this feature.