### PR TITLE
openbsd: glob_t recently changed to conform posix (use size_t)

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsdlike/bitrig/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/bitrig/mod.rs
@@ -1,6 +1,21 @@
 pub type c_char = i8;
 
 s! {
+    pub struct glob_t {
+        pub gl_pathc:   ::c_int,
+        pub gl_matchc:  ::c_int,
+        pub gl_offs:    ::c_int,
+        pub gl_flags:   ::c_int,
+        pub gl_pathv:   *mut *mut ::c_char,
+        __unused1: *mut ::c_void,
+        __unused2: *mut ::c_void,
+        __unused3: *mut ::c_void,
+        __unused4: *mut ::c_void,
+        __unused5: *mut ::c_void,
+        __unused6: *mut ::c_void,
+        __unused7: *mut ::c_void,
+    }
+
     pub struct lconv {
         pub decimal_point: *mut ::c_char,
         pub thousands_sep: *mut ::c_char,

--- a/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
@@ -34,21 +34,6 @@ s! {
         pub sin_zero: [::int8_t; 8],
     }
 
-    pub struct glob_t {
-        pub gl_pathc:   ::c_int,
-        pub gl_matchc:  ::c_int,
-        pub gl_offs:    ::c_int,
-        pub gl_flags:   ::c_int,
-        pub gl_pathv:   *mut *mut ::c_char,
-        __unused1: *mut ::c_void,
-        __unused2: *mut ::c_void,
-        __unused3: *mut ::c_void,
-        __unused4: *mut ::c_void,
-        __unused5: *mut ::c_void,
-        __unused6: *mut ::c_void,
-        __unused7: *mut ::c_void,
-    }
-
     pub struct kevent {
         pub ident: ::uintptr_t,
         pub filter: ::c_short,

--- a/src/unix/bsd/netbsdlike/openbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/openbsd/mod.rs
@@ -1,4 +1,19 @@
 s! {
+    pub struct glob_t {
+        pub gl_pathc:   ::size_t,
+        pub gl_matchc:  ::size_t,
+        pub gl_offs:    ::size_t,
+        pub gl_flags:   ::c_int,
+        pub gl_pathv:   *mut *mut ::c_char,
+        __unused1: *mut ::c_void,
+        __unused2: *mut ::c_void,
+        __unused3: *mut ::c_void,
+        __unused4: *mut ::c_void,
+        __unused5: *mut ::c_void,
+        __unused6: *mut ::c_void,
+        __unused7: *mut ::c_void,
+    }
+
     pub struct lconv {
         pub decimal_point: *mut ::c_char,
         pub thousands_sep: *mut ::c_char,


### PR DESCRIPTION
on openbsd, upcoming stable version have changed glob_t definition to follow posix definition (using `size_t` instead of `int` on some fields)

the change preserves bitrig definition

r? @gnzlbg 