### PR TITLE
[WIP] Integrate the cty crate into libc's CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ travis-ci = { repository = "rust-lang/libc" }
 appveyor = { repository = "rust-lang/libc", project_name = "rust-lang-libs/libc" }
 
 [dependencies]
+cty = { version = "0.2", path = "cty" }
 rustc-std-workspace-core = { version = "1.0.0", optional = true }
 
 [features]
@@ -30,4 +31,9 @@ rustc-dep-of-std = ['align', 'rustc-std-workspace-core']
 extra_traits = []
 
 [workspace]
-members = ["libc-test"]
+members = [
+  "cty",
+  "cty-test",
+  "libc-test",
+  "cty-libc-ty-test"
+]

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -43,6 +43,18 @@ test_target() {
     # Test that libc builds without any default features (no libstd)
     "$CARGO" "+${RUST}" build -vv $opt --no-default-features --target "${TARGET}"
 
+    # Test that cty builds
+    (
+        cd cty
+        "$CARGO" "+${RUST}" build -vv $opt --no-default-features --target "${TARGET}"
+    )
+
+    # Test that libc and cty type aliases match
+    (
+        cd cty-libc-tys-test
+        "$CARGO" "+${RUST}" build -vv $opt --no-default-features --target "${TARGET}"
+    )
+
     # Test that libc builds with default features (e.g. libstd)
     # if the target supports libstd
     if [ "$NO_STD" != "1" ]; then

--- a/cty-libc-ty-test/Cargo.toml
+++ b/cty-libc-ty-test/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "cty-libc-ty-test"
+version = "0.1.0"
+authors = ["gnzlbg <gonzalobg88@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+libc = { path = ".." }
+cty = { path = "../cty" }

--- a/cty-libc-ty-test/src/lib.rs
+++ b/cty-libc-ty-test/src/lib.rs
@@ -1,0 +1,55 @@
+#![allow(unused)]
+
+extern crate libc;
+extern crate cty;
+
+// Requires that `_x` and `_y` have the same type.
+fn same_ty<T>(_x: T, _y: T) {}
+
+macro_rules! test_tys {
+    ($ty:ident) => {
+        same_ty(0 as cty::$ty, 0 as libc::$ty);
+    };
+    ($($ty:ident,)*) => { $(test_tys!($ty);)* };
+}
+
+// This test is only executed for those platforms
+// that libc supports.
+#[cfg(any(
+    windows,
+    target_os = "redox",
+    target_os = "cloudabi",
+    target_os = "fuchsia",
+    target_os = "switch",
+    unix,
+    target_env = "sgx",
+))]
+pub fn test() {
+    test_tys! {
+        int8_t, int16_t, int32_t, int64_t,
+        uint8_t, uint16_t, uint32_t, uint64_t,
+
+        c_schar, c_short, c_longlong,
+        c_uchar, c_ushort, c_ulonglong,
+
+        c_float, c_double,
+
+        intmax_t, uintmax_t,
+
+        size_t, ptrdiff_t,
+        intptr_t, uintptr_t,
+    }
+
+    // FIXME: this type is not available in some targets,
+    // but cty always exposes it:
+    #[cfg(not(windows))]
+    test_tys! {
+        ssize_t,
+    }
+
+    // These are often target_os/target_env/target_arch dependent
+    test_tys!{
+        c_long, c_ulong,
+        c_char, c_int, c_uint,
+    }
+}

--- a/cty-test/Cargo.toml
+++ b/cty-test/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cty-test"
+version = "0.1.0"
+authors = ["Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>"]
+build = "build.rs"
+
+[dependencies]
+cty = { path = "../cty" }
+
+[build-dependencies]
+ctest = "0.2"
+
+[[test]]
+name = "main"
+path = "test/main.rs"
+harness = false

--- a/cty-test/build.rs
+++ b/cty-test/build.rs
@@ -1,0 +1,28 @@
+#![deny(warnings)]
+
+extern crate ctest;
+
+fn main() {
+    let mut cfg = ctest::TestGenerator::new();
+
+    cfg.flag("-Wno-deprecated-declarations");
+
+    cfg.header("stddef.h");
+    cfg.header("stdint.h");
+    cfg.header("ctype.h");
+    // For POSIX: ssize_t
+    cfg.header("sys/types.h");
+
+    /* cfg.type_name(move |ty, is_struct, is_union| {
+        match ty {
+            "ssize_t" => "SSIZE_T".to_string(),
+            t if is_union => format!("union {}", t),
+            t if t.ends_with("_t") => t.to_string(),
+            // put `struct` in front of all structs:.
+            t if is_struct => format!("struct {}", t),
+            t => t.to_string(),
+        }
+    });*/
+
+    cfg.generate("../cty/src/lib.rs", "main.rs");
+}

--- a/cty-test/test/main.rs
+++ b/cty-test/test/main.rs
@@ -1,0 +1,7 @@
+#![allow(bad_style, improper_ctypes, deprecated, unused_macros)]
+extern crate cty;
+
+use cty::*;
+
+include!(concat!(env!("OUT_DIR"), "/main.rs"));
+

--- a/cty/.gitignore
+++ b/cty/.gitignore
@@ -1,0 +1,3 @@
+target/
+**/*.rs.bk
+Cargo.lock

--- a/cty/.travis.yml
+++ b/cty/.travis.yml
@@ -1,0 +1,32 @@
+language: rust
+
+matrix:
+  include:
+      # MSRV
+    - env: TARGET=x86_64-unknown-linux-gnu
+      rust: 1.30.0
+
+    - env: TARGET=x86_64-unknown-linux-gnu
+      rust: stable
+
+before_install: set -e
+
+install:
+  - sh ci/install.sh
+
+script:
+  - sh ci/script.sh
+
+after_script: set +e
+
+cache: cargo
+
+branches:
+  only:
+    - master
+    - staging
+    - trying
+
+notifications:
+  email:
+    on_success: never

--- a/cty/CHANGELOG.md
+++ b/cty/CHANGELOG.md
@@ -5,6 +5,17 @@ This project adheres to $[Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.2.1] - date
+
+### Changed
+
+- `cty` now lives in the `rust-lang/libc` repository
+
+### Added
+
+- On Rust versions older than Rust 1.30.0 `cty` provides a
+  fallback `cty::c_void` type
+
 ## [v0.2.0] - 2019-02-06
 
 ### Changed

--- a/cty/CHANGELOG.md
+++ b/cty/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+This project adheres to $[Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+## [v0.2.0] - 2019-02-06
+
+### Changed
+
+- [breaking-change] `cty::c_void` is now a type alias of `core::ffi::c_void`.
+
+## [v0.1.5] - 2017-05-29
+
+### Added
+
+- More types like `int32_t`
+
+## [v0.1.4] - 2017-05-29
+
+### Added
+
+- Support for the `msp430` architecture.
+
+### Fixed
+
+- [breaking-change] The type definitions of `c_long` and `c_ulong`.
+
+## [v0.1.3] - 2017-05-29 - YANKED
+
+### Added
+
+- Support for the `nvptx` and `nvptx64` architectures.
+
+## [v0.1.2] - 2017-05-29 - YANKED
+
+### Fixed
+
+- [breaking-change] The type definitions of `c_int` and `c_uint`.
+
+## [v0.1.1] - 2017-05-29 - YANKED
+
+### Fixed
+
+- [breaking-change] The type definitions of `c_long`, `c_ulong` and
+  `c_longlong`.
+
+## v0.1.0 - 2017-05-24 - YANKED
+
+- Initial release
+
+[Unreleased]: https://github.com/japaric/cty/compare/v0.2.0...HEAD
+[v0.2.0]: https://github.com/japaric/cty/compare/v0.1.5...v0.2.0
+[v0.1.5]: https://github.com/japaric/cty/compare/v0.1.4...v0.1.5
+[v0.1.4]: https://github.com/japaric/cty/compare/v0.1.3...v0.1.4
+[v0.1.3]: https://github.com/japaric/cty/compare/v0.1.2...v0.1.3
+[v0.1.2]: https://github.com/japaric/cty/compare/v0.1.1...v0.1.2
+[v0.1.1]: https://github.com/japaric/cty/compare/v0.1.0...v0.1.1

--- a/cty/Cargo.toml
+++ b/cty/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+authors = ["Jorge Aparicio <jorge@japaric.io>"]
+categories = ["embedded", "external-ffi-bindings" ,"no-std"]
+description = "Type aliases to C types like c_int for use with bindgen"
+documentation = "https://docs.rs/cty"
+keywords = ["c", "types", "bindgen", "ffi"]
+license = "MIT OR Apache-2.0"
+name = "cty"
+repository = "https://github.com/japaric/cty"
+version = "0.2.0"

--- a/cty/Cargo.toml
+++ b/cty/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 authors = ["Jorge Aparicio <jorge@japaric.io>"]
 categories = ["embedded", "external-ffi-bindings" ,"no-std"]
-description = "Type aliases to C types like c_int for use with bindgen"
+description = "Type aliases for C FFI"
 documentation = "https://docs.rs/cty"
 keywords = ["c", "types", "bindgen", "ffi"]
 license = "MIT OR Apache-2.0"
 name = "cty"
-repository = "https://github.com/japaric/cty"
-version = "0.2.0"
+repository = "https://github.com/rust-lang/libc"
+version = "0.2.1"
+
+[badges]
+travis-ci = { repository = "rust-lang/libc" }
+appveyor = { repository = "rust-lang/libc", project_name = "rust-lang-libs/libc" }

--- a/cty/LICENSE-APACHE
+++ b/cty/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/cty/LICENSE-MIT
+++ b/cty/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2017 Jorge Aparicio
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/cty/README.md
+++ b/cty/README.md
@@ -1,0 +1,22 @@
+[![crates.io](https://img.shields.io/crates/v/cty.svg)](https://crates.io/crates/cty)
+[![crates.io](https://img.shields.io/crates/d/cty.svg)](https://crates.io/crates/cty)
+
+# `cty`
+
+> Type aliases to C types like c_int for use with bindgen
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.

--- a/cty/README.md
+++ b/cty/README.md
@@ -1,22 +1,53 @@
-[![crates.io](https://img.shields.io/crates/v/cty.svg)](https://crates.io/crates/cty)
-[![crates.io](https://img.shields.io/crates/d/cty.svg)](https://crates.io/crates/cty)
+[![Travis-CI Status]][Travis-CI] [![Appveyor Status]][Appveyor] [![Cirrus-CI Status]][Cirrus-CI] [![Latest Version]][crates.io] [![Documentation]][docs.rs] ![License]
 
-# `cty`
+cty - Type aliases for C FFI
+===
 
-> Type aliases to C types like c_int for use with bindgen
+## Usage
+
+Add the following to your `Cargo.toml`:
+
+```toml
+[dependencies]
+cty = "0.2"
+```
 
 ## License
 
-Licensed under either of
+This project is licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
-  http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+  ([LICENSE-APACHE](LICENSE-APACHE))
+
+* [MIT License](http://opensource.org/licenses/MIT)
+  ([LICENSE-MIT](LICENSE-MIT))
 
 at your option.
 
-### Contribution
+## Contributing
+
+We welcome all people who want to contribute. Please see the [contributing
+instructions] for more information.
+
+[contributing instructions]: CONTRIBUTING.md
+
+Contributions in any form (issues, pull requests, etc.) to this project
+must adhere to Rust's [Code of Conduct].
+
+[Code of Conduct]: https://www.rust-lang.org/en-US/conduct.html
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+for inclusion in `cty` by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
+
+[Travis-CI]: https://travis-ci.com/rust-lang/libc
+[Travis-CI Status]: https://travis-ci.com/rust-lang/libc.svg?branch=master
+[Appveyor]: https://ci.appveyor.com/project/rust-lang-libs/libc
+[Appveyor Status]: https://ci.appveyor.com/api/projects/status/github/rust-lang/libc?svg=true
+[Cirrus-CI]: https://cirrus-ci.com/github/rust-lang/libc
+[Cirrus-CI Status]: https://api.cirrus-ci.com/github/rust-lang/libc.svg
+[crates.io]: https://crates.io/crates/cty
+[Latest Version]: https://img.shields.io/crates/v/cty.svg
+[Documentation]: https://docs.rs/cty/badge.svg
+[docs.rs]: https://docs.rs/cty
+[License]: https://img.shields.io/crates/l/cty.svg

--- a/cty/build.rs
+++ b/cty/build.rs
@@ -1,0 +1,39 @@
+use std::env;
+use std::process::Command;
+use std::str;
+
+fn main() {
+    let rustc_minor_ver =
+        rustc_minor_version().expect("Failed to get rustc version");
+    let rustc_dep_of_std =
+        std::env::var("CARGO_FEATURE_RUSTC_DEP_OF_STD").is_ok();
+
+    // Rust >= 1.30 supports `core::ffi::c_void`, so cty can just re-export it.
+    // Otherwise, it defines an incompatible type to retain
+    // backwards-compatibility.
+    if rustc_minor_ver >= 30 || rustc_dep_of_std {
+        println!("cargo:rustc-cfg=cty_core_cvoid");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    macro_rules! otry {
+        ($e:expr) => {
+            match $e {
+                Some(e) => e,
+                None => return None,
+            }
+        };
+    }
+
+    let rustc = otry!(env::var_os("RUSTC"));
+    let output = otry!(Command::new(rustc).arg("--version").output().ok());
+    let version = otry!(str::from_utf8(&output.stdout).ok());
+    let mut pieces = version.split('.');
+
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+
+    otry!(pieces.next()).parse().ok()
+}

--- a/cty/ci/install.sh
+++ b/cty/ci/install.sh
@@ -1,0 +1,7 @@
+set -ex
+
+main() {
+    return
+}
+
+main

--- a/cty/ci/script.sh
+++ b/cty/ci/script.sh
@@ -1,0 +1,10 @@
+set -ex
+
+main() {
+    for target in $(rustup target list | grep linux-gnu | cut -d' ' -f1); do
+        rustup target add $target || continue
+        cargo check --target $target
+    done
+}
+
+main

--- a/cty/src/lib.rs
+++ b/cty/src/lib.rs
@@ -1,0 +1,123 @@
+//! Type aliases to C types like c_int for use with bindgen
+//!
+//! # MSRV
+//!
+//! This crate is guaranteed to compile on stable Rust 1.30.0 and up. It *might* compile with older
+//! versions but that may change in any new patch release.
+
+#![allow(non_camel_case_types)]
+#![deny(warnings)]
+#![no_std]
+
+// AD = Architecture dependent
+pub use ad::*;
+// OD = OS dependent
+pub use od::*;
+// PWD = Pointer Width Dependent
+pub use pwd::*;
+
+#[cfg(any(target_arch = "aarch64",
+          target_arch = "arm",
+          target_arch = "asmjs",
+          target_arch = "wasm32",
+          target_arch = "wasm64",
+          target_arch = "powerpc",
+          target_arch = "powerpc64",
+          target_arch = "s390x"))]
+mod ad {
+    pub type c_char = ::c_uchar;
+
+    pub type c_int = i32;
+    pub type c_uint = u32;
+}
+
+#[cfg(any(target_arch = "mips",
+          target_arch = "mips64",
+          target_arch = "sparc64",
+          target_arch = "x86",
+          target_arch = "x86_64",
+          target_arch = "nvptx",
+          target_arch = "nvptx64"))]
+mod ad {
+    pub type c_char = ::c_schar;
+
+    pub type c_int = i32;
+    pub type c_uint = u32;
+}
+
+#[cfg(target_arch = "msp430")]
+mod ad {
+    pub type c_char = ::c_uchar;
+
+    pub type c_int = i16;
+    pub type c_uint = u16;
+}
+
+// NOTE c_{,u}long definitions come from libc v0.2.3
+#[cfg(not(any(windows,
+              target_os = "redox",
+              target_os = "solaris")))]
+mod od {
+    #[cfg(any(target_pointer_width = "16",
+              target_pointer_width = "32"))]
+    pub type c_long = i32;
+    #[cfg(any(target_pointer_width = "16",
+              target_pointer_width = "32"))]
+    pub type c_ulong = u32;
+
+    #[cfg(target_pointer_width = "64")]
+    pub type c_long = i64;
+    #[cfg(target_pointer_width = "64")]
+    pub type c_ulong = u64;
+}
+
+#[cfg(windows)]
+mod od {
+    pub type c_long = i32;
+    pub type c_ulong = u32;
+}
+
+#[cfg(any(target_os = "redox",
+          target_os = "solaris"))]
+mod od {
+    pub type c_long = i64;
+    pub type c_ulong = u64;
+}
+
+#[cfg(target_pointer_width = "32")]
+mod pwd {}
+
+#[cfg(target_pointer_width = "64")]
+mod pwd {}
+
+pub type int8_t = i8;
+pub type int16_t = i16;
+pub type int32_t = i32;
+pub type int64_t = i64;
+
+pub type uint8_t = u8;
+pub type uint16_t = u16;
+pub type uint32_t = u32;
+pub type uint64_t = u64;
+
+pub type c_schar = i8;
+pub type c_short = i16;
+pub type c_longlong = i64;
+
+pub type c_uchar = u8;
+pub type c_ushort = u16;
+pub type c_ulonglong = u64;
+
+pub type c_float = f32;
+pub type c_double = f64;
+
+pub type intmax_t = i64;
+pub type uintmax_t = u64;
+
+pub type size_t = usize;
+pub type ptrdiff_t = isize;
+pub type intptr_t = isize;
+pub type uintptr_t = usize;
+pub type ssize_t = isize;
+
+pub type c_void = core::ffi::c_void;

--- a/cty/src/lib.rs
+++ b/cty/src/lib.rs
@@ -120,4 +120,20 @@ pub type intptr_t = isize;
 pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
+#[cfg(cty_core_void)]
 pub type c_void = core::ffi::c_void;
+
+// Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help
+// enable more optimization opportunities around it recognizing things
+// like malloc/free.
+#[cfg(not(cty_core_void))]
+#[repr(u8)]
+#[allow(missing_copy_implementations)]
+#[allow(missing_debug_implementations)]
+pub enum c_void {
+    // Two dummy variants so the #[repr] attribute can be used.
+    #[doc(hidden)]
+    __variant1,
+    #[doc(hidden)]
+    __variant2,
+}


### PR DESCRIPTION
So this the successor to #1285 (cc @japaric @Amanieu @alexcrichton ).

It imports the cty crate into the libc repository preserving its commit history, and integrates it with libc's CI. That basically amounts to running the same tests that libc runs on the cty crates type for those targets that we support at run-time (type size, alignment, sign, etc. ).

This PR also adds a crate that tests at compile-time that all types between the libc and the cty crates match except for `c_void`. As @alexcrichton mentioned, `c_void` matches if both use `core::ffi::c_void`, and differs otherwise because each crate defines its own in old compiler versions.

WIP: while doing #1285 I noticed that the types differed in some targets because of bugs. I will manually disable the tests in the archs in which they fail (adding the appropriate comments and filling issues), so that we can decide later on a 1:1 case basis if we want to fix them, and how (we can probably fix cty bugs by just bumping the semver major version, but for libc bugs that's a different story). This PR should essentially be a non-functional change for both crates, except that `cty` now also supports older Rust targets without `core::ffi::c_void`.  