### PR TITLE
adjust PTHREAD_STACK_MIN to current value on OpenBSD

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1088,7 +1088,7 @@ fn test_openbsd(target: &str) {
         (struct_ == "siginfo_t" && field == "si_addr")
     });
 
-    cfg.generate("../src/lib.rs", "linux_fcntl.rs");
+    cfg.generate("../src/lib.rs", "main.rs");
 }
 
 fn test_windows(target: &str) {

--- a/src/unix/bsd/netbsdlike/openbsdlike/bitrig/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/bitrig/mod.rs
@@ -98,6 +98,7 @@ pub const IFF_LINK1: ::c_int = 0x2000; // per link layer defined bit
 pub const IFF_LINK2: ::c_int = 0x4000; // per link layer defined bit
 pub const IFF_MULTICAST: ::c_int = 0x8000; // supports multicast
 
+pub const PTHREAD_STACK_MIN : ::size_t = 2048;
 pub const SIGSTKSZ : ::size_t = 40960;
 
 pub const PT_FIRSTMACH: ::c_int = 32;

--- a/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
@@ -399,8 +399,6 @@ pub const O_RSYNC: ::c_int = O_SYNC;
 pub const MS_SYNC : ::c_int = 0x0002;
 pub const MS_INVALIDATE : ::c_int = 0x0004;
 
-pub const PTHREAD_STACK_MIN : ::size_t = 2048;
-
 pub const POLLNORM: ::c_short = ::POLLRDNORM;
 
 pub const ENOATTR : ::c_int = 83;

--- a/src/unix/bsd/netbsdlike/openbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/openbsd/mod.rs
@@ -403,6 +403,7 @@ pub const IFF_LINK1: ::c_int = 0x2000; // per link layer defined bit
 pub const IFF_LINK2: ::c_int = 0x4000; // per link layer defined bit
 pub const IFF_MULTICAST: ::c_int = 0x8000; // supports multicast
 
+pub const PTHREAD_STACK_MIN : ::size_t = 4096;
 pub const SIGSTKSZ : ::size_t = 28672;
 
 pub const PT_FIRSTMACH: ::c_int = 32;


### PR DESCRIPTION
adjust `PTHREAD_STACK_MIN` to current value on OpenBSD, and while here, generate the right file in test_openbsd()

I should say that I am a bit disappointed. If I didn't miss anything, the related change for `PTHREAD_STACK_MIN` is near to one year old. And clearly with the name error in `test_openbsd()` something wasn't clean.