### PR TITLE
Upgrade bunch of EOL docker images to Ubuntu 18.04 

### DIFF
--- a/ci/docker/aarch64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc make libc6-dev git curl ca-certificates \

--- a/ci/docker/arm-unknown-linux-musleabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-musleabihf/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc make libc6-dev git curl ca-certificates \

--- a/ci/docker/i686-unknown-linux-musl/Dockerfile
+++ b/ci/docker/i686-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 RUN dpkg --add-architecture i386
 RUN apt-get update

--- a/ci/docker/mips-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mips-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates qemu-system-mips curl \

--- a/ci/docker/mipsel-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mipsel-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates qemu-system-mips curl \

--- a/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \
@@ -7,4 +7,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER=powerpc-linux-gnu-gcc \
     CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_RUNNER="qemu-ppc -L /usr/powerpc-linux-gnu" \
+    CC=powerpc-linux-gnu-gcc \
     PATH=$PATH:/rust/bin

--- a/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/ci/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -670,8 +670,7 @@ pub const NFPROTO_NETDEV: ::c_int = 5;
 
 // linux/netfilter/nf_tables.h
 cfg_if!{
-    if #[cfg(any(target_arch = "arm", target_arch = "powerpc",
-                 target_arch = "powerpc64", target_arch = "aarch64"))] {
+    if #[cfg(any(target_arch = "arm", target_arch = "aarch64"))] {
         pub const NFT_TABLE_MAXNAMELEN: ::c_int = 32;
         pub const NFT_CHAIN_MAXNAMELEN: ::c_int = 32;
         pub const NFT_SET_MAXNAMELEN: ::c_int = 32;


### PR DESCRIPTION
When upgrading other Dockerfiles (not modified in this PR) they fail with different errors:
https://travis-ci.com/mati865/libc/jobs/181623075
https://travis-ci.com/mati865/libc/jobs/181623059
https://travis-ci.com/mati865/libc/jobs/181623067

I think it's because of these 2 commits in glibc:
https://sourceware.org/git/?p=glibc.git;a=commit;h=b05cb613e7ae507680c8d914b3e788eea782c0d6
https://sourceware.org/git/?p=glibc.git;a=commit;h=2dba5ce7b8115d6a2789bf279892263621088e74

I have no idea how to fix them so leaving it for somebody who knows what to do.