### PR TITLE
[TEST] use arr branch of ctest

### DIFF
--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -10,7 +10,7 @@ default-features = false
 
 [build-dependencies]
 cc = "1.0"
-ctest = "0.2"
+ctest = { git = "https://github.com/gnzlbg/ctest", branch = "arr" }
 
 [features]
 default = [ "use_std" ]


### PR DESCRIPTION
This PR test whether the arr branch of ctest breaks anything. It requires being a bit more explicit about how arrays are passed in C FFI. 