### PR TITLE
Bump to 0.2.50

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.49"
+version = "0.2.50"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
I'm using libnx-rs too, and it'd be nice to have #1278 in a release.