### PR TITLE
Add essential target_vendor check for sgx

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ cfg_if! {
     } else if #[cfg(target_os = "hermit")] {
         mod hermit;
         pub use hermit::*;
-    } else if #[cfg(target_env = "sgx")] {
+    } else if #[cfg(all(target_env = "sgx", target_vendor = "fortanix"))] {
         mod sgx;
         pub use sgx::*;
     }  else {


### PR DESCRIPTION
As discussed in issue [57231](https://github.com/rust-lang/rust/issues/57231), the current `sgx` branch only works for Fortanix's sgx platform. So the `target_vendor` should be checked here.

Signed-off-by: Yu Ding <dingelish@gmail.com>