### PR TITLE
Add mq_getfd_np() on FreeBSD and fix mqd_t on DragonFlyBSD

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -16,6 +16,7 @@ pub type uuid_t = ::uuid;
 pub type fsblkcnt_t = u64;
 pub type fsfilcnt_t = u64;
 
+pub type mqd_t = ::c_int;
 pub type sem_t = *mut sem;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -15,6 +15,7 @@ pub type key_t = ::c_long;
 pub type msglen_t = ::c_ulong;
 pub type msgqnum_t = ::c_ulong;
 
+pub type mqd_t = *mut ::c_void;
 pub type posix_spawnattr_t = *mut ::c_void;
 pub type posix_spawn_file_actions_t = *mut ::c_void;
 

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1332,6 +1332,7 @@ extern {
 
     pub fn aio_waitcomplete(iocbp: *mut *mut aiocb,
                             timeout: *mut ::timespec) -> ::ssize_t;
+    pub fn mq_getfd_np(mqd: ::mqd_t) -> ::c_int;
 
     pub fn freelocale(loc: ::locale_t) -> ::c_int;
     pub fn waitid(idtype: idtype_t, id: ::id_t, infop: *mut ::siginfo_t,

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -2,7 +2,6 @@ pub type dev_t = u32;
 pub type mode_t = u16;
 pub type pthread_attr_t = *mut ::c_void;
 pub type rlim_t = i64;
-pub type mqd_t = *mut ::c_void;
 pub type pthread_mutex_t = *mut ::c_void;
 pub type pthread_mutexattr_t = *mut ::c_void;
 pub type pthread_cond_t = *mut ::c_void;


### PR DESCRIPTION
[`mq_getfd_np()` was added in FreeBSD 11](https://svnweb.freebsd.org/base/stable/11/include/mqueue.h?revision=306905&view=markup). I'm already using it in my [posixmq crate](https://github.com/tormol/posixmq) for mio/kqueue integration, and I've tested it both in virtualbox and on Cirrus-CI.

[`mqd_t` in an `int` on DragonFlyBSD](https://github.com/DragonFlyBSD/DragonFlyBSD/blob/e7ab884bd49753f8884eb597d10d6569a08fa0df/sys/sys/types.h#L139) even though it's a pointer on FreeBSD, because [DragonflyBSD's implementation is based on NetBSD](https://github.com/DragonFlyBSD/DragonFlyBSD/commit/f2df0f7ca6de3f944dcbfb9923750d7c88984535). The definitions for `mq_attr` are already separate and correct.
Does fixing this count as a breaking change? I think the current definition will work in most cases, because IIRC the calling convention means that `mqd_t` is always passed via registers, the upper 32 bits might just contain garbage.
I've *not* tested this change on DragonFlyBSD.

I want to add mq symbols for solarish, but is the CDDL license compatible with Apache-2.0 and MIT?