### PR TITLE
Add CloudABI pthread_mutex related functions and types

### DIFF
--- a/src/cloudabi/mod.rs
+++ b/src/cloudabi/mod.rs
@@ -34,6 +34,9 @@ pub type sa_family_t = u8;
 pub type socklen_t = usize;
 pub type time_t = i64;
 
+pub type clockid_t = *const __clockid;
+pub type cloudabi_clockid_t = u32;
+
 s! {
     pub struct addrinfo {
         pub ai_flags: ::c_int,
@@ -96,13 +99,17 @@ s! {
     }
 
     pub struct pthread_condattr_t {
-        __clock: usize,
+        __clock: clockid_t,
         __pshared: ::c_int,
     }
 
     pub struct timespec {
         pub tv_sec: ::time_t,
         pub tv_nsec: ::c_long,
+    }
+
+    pub struct __clockid {
+        pub id: cloudabi_clockid_t,
     }
 }
 
@@ -155,6 +162,9 @@ pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
 
 pub const SOCK_DGRAM: ::c_int = 128;
 pub const SOCK_STREAM: ::c_int = 130;
+
+pub const CLOCK_MONOTONIC: clockid_t = &__clockid { id: 1 };
+pub const CLOCK_REALTIME: clockid_t = &__clockid { id: 3 };
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum FILE {}
@@ -274,6 +284,8 @@ extern {
     pub fn rand() -> c_int;
     pub fn srand(seed: c_uint);
 
+    pub fn clock_gettime(clock_id: clockid_t, tp: *mut timespec) -> ::c_int;
+
     pub fn arc4random_buf(buf: *const ::c_void, len: ::size_t);
     pub fn freeaddrinfo(res: *mut addrinfo);
     pub fn gai_strerror(errcode: ::c_int) -> *const ::c_char;
@@ -318,6 +330,10 @@ extern {
     ) -> ::c_int;
     pub fn pthread_condattr_destroy(attr: *mut pthread_condattr_t) -> ::c_int;
     pub fn pthread_condattr_init(attr: *mut pthread_condattr_t) -> ::c_int;
+    pub fn pthread_condattr_setclock(
+        attr: *mut pthread_condattr_t,
+        clock_id: clockid_t
+    ) -> ::c_int;
     pub fn pthread_create(
         native: *mut ::pthread_t,
         attr: *const ::pthread_attr_t,

--- a/src/cloudabi/mod.rs
+++ b/src/cloudabi/mod.rs
@@ -301,6 +301,23 @@ extern {
         attr: *mut ::pthread_attr_t,
         stack_size: ::size_t,
     ) -> ::c_int;
+    pub fn pthread_cond_destroy(cond: *mut pthread_cond_t) -> ::c_int;
+    pub fn pthread_cond_init(
+        cond: *mut pthread_cond_t,
+        attr: *const pthread_condattr_t
+    ) -> ::c_int;
+    pub fn pthread_cond_signal(cond: *mut pthread_cond_t) -> ::c_int;
+    pub fn pthread_cond_timedwait(
+        cond: *mut pthread_cond_t,
+        mutex: *mut pthread_mutex_t,
+        abstime: *const timespec,
+    ) -> ::c_int;
+    pub fn pthread_cond_wait(
+        cond: *mut pthread_cond_t,
+        mutex: *mut pthread_mutex_t
+    ) -> ::c_int;
+    pub fn pthread_condattr_destroy(attr: *mut pthread_condattr_t) -> ::c_int;
+    pub fn pthread_condattr_init(attr: *mut pthread_condattr_t) -> ::c_int;
     pub fn pthread_create(
         native: *mut ::pthread_t,
         attr: *const ::pthread_attr_t,
@@ -322,6 +339,9 @@ extern {
         key: pthread_key_t,
         value: *const ::c_void,
     ) -> ::c_int;
+    pub fn pthread_mutex_destroy(mutex: *mut pthread_mutex_t) -> ::c_int;
+    pub fn pthread_mutex_lock(mutex: *mut pthread_mutex_t) -> ::c_int;
+    pub fn pthread_mutex_unlock(mutex: *mut pthread_mutex_t) -> ::c_int;
     pub fn send(
         socket: ::c_int,
         buf: *const ::c_void,

--- a/src/cloudabi/mod.rs
+++ b/src/cloudabi/mod.rs
@@ -54,11 +54,6 @@ s! {
         pub s6_addr: [u8; 16],
     }
 
-    pub struct pthread_attr_t {
-        __detachstate: ::c_int,
-        __stacksize: usize,
-    }
-
     pub struct sockaddr {
         pub sa_family: sa_family_t,
         pub sa_data: [::c_char; 0],
@@ -81,6 +76,28 @@ s! {
     pub struct sockaddr_storage {
         pub ss_family: ::sa_family_t,
         __ss_data: [u8; 32],
+    }
+
+    pub struct pthread_attr_t {
+        __detachstate: ::c_int,
+        __stacksize: usize,
+    }
+
+    pub struct pthread_mutex_t {
+        __state: u32,
+        __write_recursion: i32,
+        __pshared: u8,
+    }
+
+    pub struct pthread_cond_t {
+        __waiters: u32,
+        __clock: u32,
+        __pshared: u8,
+    }
+
+    pub struct pthread_condattr_t {
+        __clock: usize,
+        __pshared: ::c_int,
     }
 }
 
@@ -116,6 +133,20 @@ pub const EXIT_FAILURE: ::c_int = 1;
 pub const EXIT_SUCCESS: ::c_int = 0;
 
 pub const PTHREAD_STACK_MIN: ::size_t = 1024;
+
+pub const PTHREAD_PROCESS_PRIVATE: u8 = 0x4;
+pub const PTHREAD_PROCESS_SHARED: u8 = 0x8;
+
+pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = pthread_cond_t {
+    __waiters: 0,
+    __clock: 3,
+    __pshared: PTHREAD_PROCESS_PRIVATE,
+};
+pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
+    __state: 0,
+    __write_recursion: -1,
+    __pshared: PTHREAD_PROCESS_PRIVATE,
+};
 
 pub const SOCK_DGRAM: ::c_int = 128;
 pub const SOCK_STREAM: ::c_int = 130;

--- a/src/cloudabi/mod.rs
+++ b/src/cloudabi/mod.rs
@@ -99,6 +99,11 @@ s! {
         __clock: usize,
         __pshared: ::c_int,
     }
+
+    pub struct timespec {
+        pub tv_sec: ::time_t,
+        pub tv_nsec: ::c_long,
+    }
 }
 
 pub const INT_MIN: c_int = -2147483648;


### PR DESCRIPTION
Adding types and functions related to creating and using pthread mutexes and condvars on CloudABI. Taken from [these headers](https://github.com/NuxiNL/cloudlibc/blob/92cb7670f864adc625c24eb214ff1c6d888adf6b/src/include/pthread.h).

This is in preparation for implementing a proper `ThreadParker` for CloudABI in `parking_lot`. There is a [pthread one already](https://github.com/Amanieu/parking_lot/blob/56e313f8b23557da8b3b48fd30d3e9837c231ca7/core/src/thread_parker/unix.rs). So hopefully we can just plug that one in when the platform has these libc bindings.

Ping @EdSchouten, who seem knowledgeable about CloudABI synchronization primitives. Do you think this looks reasonable?