### PR TITLE
redox: support crt-static

### DIFF
--- a/src/redox/mod.rs
+++ b/src/redox/mod.rs
@@ -377,8 +377,12 @@ extern {
                  -> ::ssize_t;
 }
 
-#[link(name = "c")]
-#[link(name = "m")]
+
+#[cfg_attr(feature = "rustc-dep-of-std",
+           link(name = "c", kind = "static",
+                cfg(target_feature = "crt-static")))]
+#[cfg_attr(feature = "rustc-dep-of-std",
+           link(name = "c", cfg(not(target_feature = "crt-static"))))]
 extern {}
 
 pub use self::net::*;

--- a/src/redox/mod.rs
+++ b/src/redox/mod.rs
@@ -377,7 +377,6 @@ extern {
                  -> ::ssize_t;
 }
 
-
 #[cfg_attr(feature = "rustc-dep-of-std",
            link(name = "c", kind = "static",
                 cfg(target_feature = "crt-static")))]


### PR DESCRIPTION
This reuses the code from musl to add support to Redox for crt-static.

Linking to `m` is also unnecessary as it is included in `c`