### PR TITLE
Bump to 0.2.52

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.51"
+version = "0.2.52"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This will allow the crt-static feature to be utilized correctly on Redox, #1322 