### PR TITLE
Bump to 0.2.53

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.52"
+version = "0.2.53"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This adds more WASI support, and in particular adds support for WASI
being a target_os rather than a target_env, which relates to this PR:

https://github.com/rust-lang/rust/pull/60117