### PR TITLE
Deprecate _pad field on siginfo_t

### DIFF
--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -48,6 +48,7 @@ s! {
         pub si_signo: ::c_int,
         pub si_errno: ::c_int,
         pub si_code: ::c_int,
+        #[deprecated(since="0.2.54", note="Please leave a comment on https://github.com/rust-lang/libc/pull/1316 if you're using this field")]
         pub _pad: [::c_int; 29],
         #[cfg(target_arch = "x86_64")]
         _align: [u64; 0],

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -61,19 +61,6 @@ s! {
         _align: [usize; 0],
     }
 
-    impl siginfo_t {
-        pub unsafe fn si_addr(&self) -> *mut ::c_void {
-            #[repr(C)]
-            struct siginfo_sigfault {
-                _si_signo: ::c_int,
-                _si_errno: ::c_int,
-                _si_code: ::c_int,
-                si_addr: *mut ::c_void
-            }
-            (*(self as *const siginfo_t as *const siginfo_sigfault)).si_addr
-        }
-    }
-
     pub struct glob64_t {
         pub gl_pathc: ::size_t,
         pub gl_pathv: *mut *mut ::c_char,
@@ -210,6 +197,19 @@ s! {
         pub rt_mtu: ::c_ulong,
         pub rt_window: ::c_ulong,
         pub rt_irtt: ::c_ushort,
+    }
+}
+
+impl siginfo_t {
+    pub unsafe fn si_addr(&self) -> *mut ::c_void {
+        #[repr(C)]
+        struct siginfo_sigfault {
+            _si_signo: ::c_int,
+            _si_errno: ::c_int,
+            _si_code: ::c_int,
+            si_addr: *mut ::c_void
+        }
+        (*(self as *const siginfo_t as *const siginfo_sigfault)).si_addr
     }
 }
 

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -48,12 +48,30 @@ s! {
         pub si_signo: ::c_int,
         pub si_errno: ::c_int,
         pub si_code: ::c_int,
-        #[deprecated(since="0.2.54", note="Please leave a comment on https://github.com/rust-lang/libc/pull/1316 if you're using this field")]
+        #[deprecated(
+            since="0.2.54",
+            note="Please leave a comment on \
+                https://github.com/rust-lang/libc/pull/1316 if you're using \
+                this field"
+        )]
         pub _pad: [::c_int; 29],
         #[cfg(target_arch = "x86_64")]
         _align: [u64; 0],
         #[cfg(not(target_arch = "x86_64"))]
         _align: [usize; 0],
+    }
+
+    impl siginfo_t {
+        pub unsafe fn si_addr(&self) -> *mut ::c_void {
+            #[repr(C)]
+            struct siginfo_sigfault {
+                _si_signo: ::c_int,
+                _si_errno: ::c_int,
+                _si_code: ::c_int,
+                si_addr: *mut ::c_void
+            }
+            (*(self as *const siginfo_t as *const siginfo_sigfault)).si_addr
+        }
     }
 
     pub struct glob64_t {


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/libc/pull/1316