### PR TITLE
Bump version to 0.2.55

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.54"
+version = "0.2.55"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This will bring in support for redox as part of the unix target_family, thus allowing https://github.com/rust-lang/rust/pull/60547 to move forward