### PR TITLE
linux/musl: Add SEEK_HOLE and SEEK_DATA constants

### DIFF
--- a/src/unix/notbsd/linux/musl/mod.rs
+++ b/src/unix/notbsd/linux/musl/mod.rs
@@ -279,6 +279,9 @@ pub const PTRACE_PEEKSIGINFO: ::c_int = 0x4209;
 
 pub const EPOLLWAKEUP: ::c_int = 0x20000000;
 
+pub const SEEK_DATA: ::c_int = 3;
+pub const SEEK_HOLE: ::c_int = 4;
+
 pub const EFD_NONBLOCK: ::c_int = ::O_NONBLOCK;
 
 pub const SFD_NONBLOCK: ::c_int = ::O_NONBLOCK;


### PR DESCRIPTION
They are defined since Linux 3.1 but not in musl yet.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>