### PR TITLE
[breaking change] gettimeofday 2nd argument incorrect in some targets

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -315,9 +315,6 @@ fn test_openbsd(target: &str) {
         match name {
             "execv" | "execve" | "execvp" | "execvpe" => true,
 
-            // typed 2nd arg
-            "gettimeofday" => true,
-
             // Removed in OpenBSD 6.5
             // https://marc.info/?l=openbsd-cvs&m=154723400730318
             "mincore" => true,
@@ -1113,9 +1110,8 @@ fn test_dragonflybsd(target: &str) {
 
             "getrlimit" | "getrlimit64" |    // non-int in 1st arg
             "setrlimit" | "setrlimit64" |    // non-int in 1st arg
-            "prlimit" | "prlimit64" |        // non-int in 2nd arg
-            // typed 2nd arg on linux
-            "gettimeofday" => true,
+            "prlimit" | "prlimit64"        // non-int in 2nd arg
+             => true,
 
             _ => false,
         }
@@ -1460,10 +1456,6 @@ fn test_android(target: &str) {
             "execvp" |
             "execvpe" |
             "fexecve" => true,
-
-            // typed 2nd arg on android
-            // FIXME: still necessary?
-            "gettimeofday" => true,
 
             // not declared in newer android toolchains
             // FIXME: still necessary?
@@ -1814,9 +1806,6 @@ fn test_freebsd(target: &str) {
             "execvp" |
             "execvpe" |
             "fexecve" => true,
-
-            // FIXME: for some reason, our signature is wrong
-            "gettimeofday" => true,
 
             // The `uname` function in freebsd is now an inline wrapper that
             // delegates to another, but the symbol still exists, so don't check
@@ -2700,10 +2689,6 @@ fn test_linux(target: &str) {
             // send*/recv* syscalls
             // FIXME: is this necessary?
             "sendmmsg" | "recvmmsg" if musl => true,
-
-            // typed 2nd arg on linux
-            // FIXME: is this necessary?
-            "gettimeofday" => true,
 
             // FIXME: is this necessary?
             "dladdr" if musl => true, // const-ness only added recently

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -3045,6 +3045,8 @@ extern {
 
     pub fn lutimes(file: *const ::c_char, times: *const ::timeval) -> ::c_int;
 
+    pub fn gettimeofday(tp: *mut ::timeval,
+                        tz: *mut ::c_void) -> ::c_int;
     pub fn getutxent() -> *mut utmpx;
     pub fn getutxid(ut: *const utmpx) -> *mut utmpx;
     pub fn getutxline(ut: *const utmpx) -> *mut utmpx;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1095,7 +1095,8 @@ extern {
                     -> ::c_int;
 
     pub fn daemon(nochdir: ::c_int, noclose: ::c_int) -> ::c_int;
-
+    pub fn gettimeofday(tp: *mut ::timeval,
+                        tz: *mut ::timezone) -> ::c_int;
     pub fn accept4(s: ::c_int, addr: *mut ::sockaddr,
                    addrlen: *mut ::socklen_t, flags: ::c_int) -> ::c_int;
     pub fn aio_read(aiocbp: *mut aiocb) -> ::c_int;

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1492,6 +1492,9 @@ extern {
 
     #[link_name = "__lutimes50"]
     pub fn lutimes(file: *const ::c_char, times: *const ::timeval) -> ::c_int;
+    #[link_name = "__gettimeofday50"]
+    pub fn gettimeofday(tp: *mut ::timeval,
+                        tz: *mut ::c_void) -> ::c_int;
     pub fn getnameinfo(sa: *const ::sockaddr,
                        salen: ::socklen_t,
                        host: *mut ::c_char,

--- a/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
@@ -895,6 +895,8 @@ f! {
 }
 
 extern {
+    pub fn gettimeofday(tp: *mut ::timeval,
+                        tz: *mut ::timezone) -> ::c_int;
     pub fn chflags(path: *const ::c_char, flags: ::c_uint) -> ::c_int;
     pub fn fchflags(fd: ::c_int, flags: ::c_uint) -> ::c_int;
     pub fn chflagsat(fd: ::c_int, path: *const ::c_char, flags: ::c_uint,

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -1264,7 +1264,8 @@ extern {
                                           errno: ::c_int) -> ::c_int>,
                 pglob: *mut ::glob_t) -> ::c_int;
     pub fn globfree(pglob: *mut ::glob_t);
-
+    pub fn gettimeofday(tp: *mut ::timeval,
+                        tz: *mut ::c_void) -> ::c_int;
     pub fn posix_madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int)
                          -> ::c_int;
 

--- a/src/unix/hermit/mod.rs
+++ b/src/unix/hermit/mod.rs
@@ -981,6 +981,8 @@ extern {
 
     pub fn clock_gettime(clock_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
 
+    pub fn gettimeofday(tp: *mut ::timeval,
+                        tz: *mut ::c_void) -> ::c_int;
     pub fn getpwuid_r(uid: ::uid_t, pwd: *mut passwd, buf: *mut ::c_char,
         buflen: ::size_t, result: *mut *mut passwd) -> ::c_int;
 

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -849,17 +849,6 @@ extern {
 
     pub fn flock(fd: ::c_int, operation: ::c_int) -> ::c_int;
 
-    #[cfg_attr(target_os = "netbsd", link_name = "__gettimeofday50")]
-    #[deprecated(
-        since="0.2.54",
-        note=
-            "The signature of this function is incorrect. \
-             If you are using it, please report that in the following issue \
-             so that we can evaluate the impact of fixing it: \
-             https://github.com/rust-lang/libc/issues/1338"
-    )]
-    pub fn gettimeofday(tp: *mut ::timeval,
-                        tz: *mut ::c_void) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__times13")]
     pub fn times(buf: *mut ::tms) -> ::clock_t;
 

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -623,6 +623,8 @@ extern {
     pub fn fexecve(fd: ::c_int, argv: *const *const ::c_char,
                    envp: *const *const ::c_char)
                    -> ::c_int;
+    pub fn gettimeofday(tp: *mut ::timeval,
+                        tz: *mut ::c_void) -> ::c_int;
     #[cfg_attr(target_os = "solaris", link_name = "__posix_getgrgid_r")]
     pub fn getgrgid_r(gid: ::gid_t,
                       grp: *mut ::group,

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -1924,6 +1924,8 @@ extern {
 }
 
 extern {
+    pub fn gettimeofday(tp: *mut ::timeval,
+                        tz: *mut ::timezone) -> ::c_int;
     pub fn madvise(addr: *const ::c_void, len: ::size_t, advice: ::c_int)
                    -> ::c_int;
     pub fn ioctl(fd: ::c_int, request: ::c_int, ...) -> ::c_int;

--- a/src/unix/notbsd/emscripten/mod.rs
+++ b/src/unix/notbsd/emscripten/mod.rs
@@ -1689,6 +1689,9 @@ extern {
     pub fn rand() -> ::c_int;
     pub fn srand(seed: ::c_uint);
 
+    pub fn gettimeofday(tp: *mut ::timeval,
+                        tz: *mut ::c_void) -> ::c_int;
+
     pub fn setpwent();
     pub fn endpwent();
     pub fn getpwent() -> *mut passwd;

--- a/src/unix/notbsd/linux/musl/mod.rs
+++ b/src/unix/notbsd/linux/musl/mod.rs
@@ -322,6 +322,8 @@ pub const SO_PEEK_OFF: ::c_int = 42;
 pub const SO_BUSY_POLL: ::c_int = 46;
 
 extern {
+    pub fn gettimeofday(tp: *mut ::timeval,
+                        tz: *mut ::c_void) -> ::c_int;
     pub fn ptrace(request: ::c_int, ...) -> ::c_long;
     pub fn getpriority(which: ::c_int, who: ::id_t) -> ::c_int;
     pub fn setpriority(which: ::c_int, who: ::id_t, prio: ::c_int) -> ::c_int;

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -916,6 +916,8 @@ extern {
     pub fn endutxent();
     pub fn getpt() -> ::c_int;
     pub fn mallopt(param: ::c_int, value: ::c_int) -> ::c_int;
+    pub fn gettimeofday(tp: *mut ::timeval,
+                        tz: *mut ::timezone) -> ::c_int;
 }
 
 #[link(name = "util")]

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -1265,7 +1265,6 @@ extern {
                     pshared: ::c_int,
                     value: ::c_uint)
                     -> ::c_int;
-
     pub fn fdatasync(fd: ::c_int) -> ::c_int;
     pub fn mincore(addr: *mut ::c_void, len: ::size_t,
                    vec: *mut ::c_uchar) -> ::c_int;

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -584,5 +584,7 @@ extern {
                   iovcnt: ::c_int) -> ::ssize_t;
 
     // time.h
+    pub fn gettimeofday(tp: *mut ::timeval,
+                        tz: *mut ::timezone) -> ::c_int;
     pub fn clock_gettime(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
 }

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1800,6 +1800,8 @@ extern {
     pub fn rand() -> ::c_int;
     pub fn srand(seed: ::c_uint);
 
+    pub fn gettimeofday(tp: *mut ::timeval,
+                        tz: *mut ::c_void) -> ::c_int;
     pub fn getifaddrs(ifap: *mut *mut ::ifaddrs) -> ::c_int;
     pub fn freeifaddrs(ifa: *mut ::ifaddrs);
 

--- a/src/unix/uclibc/mod.rs
+++ b/src/unix/uclibc/mod.rs
@@ -1500,6 +1500,8 @@ extern {
     pub fn srand(seed: ::c_uint);
 
     pub fn fdatasync(fd: ::c_int) -> ::c_int;
+    pub fn gettimeofday(tp: *mut ::timeval,
+                        tz: *mut ::timezone) -> ::c_int;
     pub fn mincore(addr: *mut ::c_void, len: ::size_t,
                    vec: *mut ::c_uchar) -> ::c_int;
     pub fn clock_getres(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;


### PR DESCRIPTION
The second argument of `gettimeofday` was a `*mut c_void` on all targets,
but that type is incorrect in the following targets, where it should be
a `*mut timezone` instead:

On these other targets it appears that the signature of gettimeofday was incorrect (it takes a time-zone pointer instead of a void pointer):

*linux+gnu: http://man7.org/linux/man-pages/man2/gettimeofday.2.html
*freebsd: https://www.freebsd.org/cgi/man.cgi?query=gettimeofday&apropos=0&sektion=2&manpath=FreeBSD+11.2-stable&arch=default&format=html
*openbsd: https://man.openbsd.org/gettimeofday.2
*android: https://github.com/ricardoquesada/android-ndk/blob/master/usr/include/sys/time.h
*dragonfly: https://www.dragonflybsd.org/cgi/web-man?command=gettimeofday&section=2

This commit corrects the type on these targets, which is a breaking change. Due
to how this API is commonly used (e.g. passing `ptr::null_mut` to the second
argument), breakage should be minimal or non-existent (AFAICT only `time`, `libstd`, and `parking_lot` use this API, and they all should compile after this change). Users wanting to support both versions can just write `ptr as *mut _` instead.

Closes #1338.

---

On these targets, the signature of `gettimeofday` was correct (the second argument is a `void*`):

* macosx: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/gettimeofday.2.html
* linux+musl: http://git.musl-libc.org/cgit/musl/tree/include/sys/time.h#n11
* linux+newlib: https://chromium.googlesource.com/native_client/nacl-newlib/+/99fc6c167467b41466ec90e8260e9c49cbe3d13c/newlib/libc/include/sys/time.h#74
* netbsd: http://netbsd.gw.com/cgi-bin/man-cgi?gettimeofday+2.i386+NetBSD-8.0
* newlib: https://github.com/devkitPro/newlib/blob/devkitA64/newlib/libc/include/sys/time.h#L370
* solaris/illumos: https://illumos.org/man/3C/gettimeofday
* emscripten: https://chromium.googlesource.com/external/github.com/kripken/emscripten/+/1.35.20/system/include/libc/sys/time.h#11

cc @alexcrichton 