### PR TITLE
Add powerpc64-unknown-freebsd target

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -61,7 +61,6 @@ test_target() {
 }
 
 RUST_LINUX_TARGETS="\
-aarch64-unknown-freebsd \
 aarch64-linux-android \
 aarch64-unknown-linux-gnu \
 arm-linux-androideabi \
@@ -82,7 +81,6 @@ mipsel-unknown-linux-gnu \
 mipsel-unknown-linux-gnu \
 mipsel-unknown-linux-musl \
 powerpc-unknown-linux-gnu \
-powerpc64-unknown-freebsd \
 powerpc64-unknown-linux-gnu \
 powerpc64le-unknown-linux-gnu \
 s390x-unknown-linux-gnu \
@@ -113,10 +111,12 @@ x86_64-unknown-cloudabi \
 "
 
 RUST_NIGHTLY_LINUX_TARGETS="\
+aarch64-unknown-freebsd \
 aarch64-fuchsia \
 armv5te-unknown-linux-gnueabi \
 armv5te-unknown-linux-musleabi \
 i686-pc-windows-gnu \
+powerpc64-unknown-freebsd \
 wasm32-wasi \
 x86_64-fortanix-unknown-sgx \
 x86_64-fuchsia \

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -81,6 +81,7 @@ mipsel-unknown-linux-gnu \
 mipsel-unknown-linux-gnu \
 mipsel-unknown-linux-musl \
 powerpc-unknown-linux-gnu \
+powerpc64-unknown-freebsd \
 powerpc64-unknown-linux-gnu \
 powerpc64le-unknown-linux-gnu \
 s390x-unknown-linux-gnu \

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -61,6 +61,7 @@ test_target() {
 }
 
 RUST_LINUX_TARGETS="\
+aarch64-unknown-freebsd \
 aarch64-linux-android \
 aarch64-unknown-linux-gnu \
 arm-linux-androideabi \

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -111,12 +111,10 @@ x86_64-unknown-cloudabi \
 "
 
 RUST_NIGHTLY_LINUX_TARGETS="\
-aarch64-unknown-freebsd \
 aarch64-fuchsia \
 armv5te-unknown-linux-gnueabi \
 armv5te-unknown-linux-musleabi \
 i686-pc-windows-gnu \
-powerpc64-unknown-freebsd \
 wasm32-wasi \
 x86_64-fortanix-unknown-sgx \
 x86_64-fuchsia \
@@ -172,6 +170,7 @@ done
 RUST_LINUX_NO_CORE_TARGETS="\
 aarch64-pc-windows-msvc \
 aarch64-unknown-cloudabi \
+aarch64-unknown-freebsd \
 aarch64-unknown-hermit \
 aarch64-unknown-netbsd \
 aarch64-unknown-openbsd \
@@ -191,6 +190,7 @@ mipsel-unknown-linux-uclibc \
 nvptx64-nvidia-cuda \
 powerpc-unknown-linux-gnuspe \
 powerpc-unknown-netbsd \
+powerpc64-unknown-freebsd \
 riscv32imac-unknown-none-elf \
 riscv32imc-unknown-none-elf \
 sparc64-unknown-netbsd \


### PR DESCRIPTION
Per https://github.com/rust-lang-nursery/stdsimd/pull/765 add powerpc64-unknown-freebsd to prevent further breakages.