### PR TITLE
Deprecate `use_std` cargo feature: use `std` instead .

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,13 @@ appveyor = { repository = "rust-lang/libc", project_name = "rust-lang-libs/libc"
 rustc-std-workspace-core = { version = "1.0.0", optional = true }
 
 [features]
-default = ["use_std"]
-use_std = []
+default = ["std"]
+std = []
 align = []
 rustc-dep-of-std = ['align', 'rustc-std-workspace-core']
 extra_traits = []
+# use_std is deprecated, use `std` instead
+use_std = [ 'std' ]
 
 [workspace]
 members = ["libc-test"]

--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ libc = "0.2"
 
 ## Features
 
-* `use_std`: by default `libc` links to the standard library. Disable this
+* `std`: by default `libc` links to the standard library. Disable this
   feature remove this dependency and be able to use `libc` in `#![no_std]`
   crates.
 
 * `extra_traits`: all `struct`s implemented in `libc` are `Copy` and `Clone`.
   This feature derives `Debug`, `Eq`, `Hash`, and `PartialEq`.
+
+* **deprecated**: `use_std` is deprecated, and is equivalent to `std`.
 
 ## Rust version support
 

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,13 @@ fn main() {
         std::env::var("CARGO_FEATURE_RUSTC_DEP_OF_STD").is_ok();
     let align_cargo_feature = std::env::var("CARGO_FEATURE_ALIGN").is_ok();
 
+    if std::env::var("CARGO_FEATURE_USE_STD").is_ok() {
+        println!(
+            "cargo:warning=\"libc's use_std cargo feature is deprecated since libc 0.2.55; \
+             please consider using the `std` cargo feature instead\""
+        );
+    }
+
     // Rust >= 1.15 supports private module use:
     if rustc_minor_ver >= 15 || rustc_dep_of_std {
         println!("cargo:rustc-cfg=libc_priv_mod_use");

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -13,8 +13,8 @@ cc = "1.0"
 ctest = "0.2"
 
 [features]
-default = [ "use_std" ]
-use_std = [ "libc/use_std" ]
+default = [ "std" ]
+std = [ "libc/std" ]
 align = [ "libc/align" ]
 extra_traits = [ "libc/extra_traits" ]
 

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -307,7 +307,7 @@ pub const ATF_USETRAILERS: ::c_int = 0x10;
 cfg_if! {
     if #[cfg(target_os = "l4re")] {
         // required libraries for L4Re are linked externally, ATM
-    } else if #[cfg(feature = "use_std")] {
+    } else if #[cfg(feature = "std")] {
         // cargo build, don't pull in anything extra as the libstd dep
         // already pulls in all libs.
     } else if #[cfg(target_env = "musl")] {


### PR DESCRIPTION
Related to #657 .