### PR TITLE
Add F_SEAL_FUTURE_WRITE on Linux/Android

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2266,6 +2266,8 @@ fn test_linux(target: &str) {
             // Require Linux kernel 5.x:
             | "MSG_COPY"
                if musl  => true,
+            // Require Linux kernel 5.1:
+            "F_SEAL_FUTURE_WRITE" => true,
 
             // The musl version 1.0.22 used in CI does not
             // contain these glibc constants yet:

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -1050,6 +1050,8 @@ pub const F_TEST: ::c_int = 3;
 pub const F_TLOCK: ::c_int = 2;
 pub const F_ULOCK: ::c_int = 0;
 
+pub const F_SEAL_FUTURE_WRITE: ::c_int = 0x0010;
+
 pub const IFF_LOWER_UP: ::c_int = 0x10000;
 pub const IFF_DORMANT: ::c_int = 0x20000;
 pub const IFF_ECHO: ::c_int = 0x40000;


### PR DESCRIPTION
This was added in Linux 5.1 and will only show up in the next glibc
release, thus skip in tests.