### PR TITLE
Add missing TIOCGRS485, TIOCSRS485 constants to Linux

### DIFF
--- a/src/unix/notbsd/linux/musl/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/musl/b64/x86_64.rs
@@ -490,6 +490,9 @@ pub const O_DIRECTORY: ::c_int = 0x10000;
 pub const O_LARGEFILE: ::c_int = 0;
 pub const O_NOFOLLOW: ::c_int = 0x20000;
 
+pub const TIOCGRS485: ::c_int = 0x542E;
+pub const TIOCSRS485: ::c_int = 0x542F;
+
 pub const SIGSTKSZ: ::size_t = 8192;
 pub const MINSIGSTKSZ: ::size_t = 2048;
 

--- a/src/unix/notbsd/linux/other/b32/arm.rs
+++ b/src/unix/notbsd/linux/other/b32/arm.rs
@@ -252,6 +252,8 @@ pub const TIOCSPGRP: ::c_ulong = 0x5410;
 pub const TIOCOUTQ: ::c_ulong = 0x5411;
 pub const TIOCGWINSZ: ::c_ulong = 0x5413;
 pub const TIOCSWINSZ: ::c_ulong = 0x5414;
+pub const TIOCGRS485: ::c_int = 0x542E;
+pub const TIOCSRS485: ::c_int = 0x542F;
 pub const FIONREAD: ::c_ulong = 0x541B;
 
 // Syscall table

--- a/src/unix/notbsd/linux/other/b32/powerpc.rs
+++ b/src/unix/notbsd/linux/other/b32/powerpc.rs
@@ -241,6 +241,8 @@ pub const TIOCSPGRP: ::c_ulong = 0x80047476;
 pub const TIOCOUTQ: ::c_ulong = 0x40047473;
 pub const TIOCGWINSZ: ::c_ulong = 0x40087468;
 pub const TIOCSWINSZ: ::c_ulong = 0x80087467;
+pub const TIOCGRS485: ::c_int = 0x542e;
+pub const TIOCSRS485: ::c_int = 0x542f;
 pub const FIONREAD: ::c_ulong = 0x4004667f;
 
 pub const SYS_restart_syscall: ::c_long = 0;

--- a/src/unix/notbsd/linux/other/b32/x86.rs
+++ b/src/unix/notbsd/linux/other/b32/x86.rs
@@ -458,6 +458,8 @@ pub const TIOCSPGRP: ::c_ulong = 0x5410;
 pub const TIOCOUTQ: ::c_ulong = 0x5411;
 pub const TIOCGWINSZ: ::c_ulong = 0x5413;
 pub const TIOCSWINSZ: ::c_ulong = 0x5414;
+pub const TIOCGRS485: ::c_int = 0x542E;
+pub const TIOCSRS485: ::c_int = 0x542F;
 pub const FIONREAD: ::c_ulong = 0x541B;
 
 // Syscall table

--- a/src/unix/notbsd/linux/other/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/other/b64/aarch64.rs
@@ -147,6 +147,8 @@ pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 56;
 
 pub const TIOCGSOFTCAR: ::c_ulong = 0x5419;
 pub const TIOCSSOFTCAR: ::c_ulong = 0x541A;
+pub const TIOCGRS485: ::c_int = 0x542E;
+pub const TIOCSRS485: ::c_int = 0x542F;
 
 pub const RLIMIT_NOFILE: ::c_int = 7;
 pub const RLIMIT_NPROC: ::c_int = 6;

--- a/src/unix/notbsd/linux/other/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/other/b64/powerpc64.rs
@@ -344,6 +344,8 @@ pub const TIOCMBIS: ::c_ulong = 0x5416;
 pub const TIOCMBIC: ::c_ulong = 0x5417;
 pub const TIOCMSET: ::c_ulong = 0x5418;
 pub const TIOCCONS: ::c_ulong = 0x541D;
+pub const TIOCGRS485: ::c_int = 0x542E;
+pub const TIOCSRS485: ::c_int = 0x542F;
 
 pub const SFD_CLOEXEC: ::c_int = 0x080000;
 

--- a/src/unix/notbsd/linux/other/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/other/b64/x86_64.rs
@@ -332,6 +332,8 @@ cfg_if! {
 
 pub const TIOCGSOFTCAR: ::c_ulong = 0x5419;
 pub const TIOCSSOFTCAR: ::c_ulong = 0x541A;
+pub const TIOCGRS485: ::c_int = 0x542E;
+pub const TIOCSRS485: ::c_int = 0x542F;
 
 pub const RLIMIT_NOFILE: ::c_int = 7;
 pub const RLIMIT_NPROC: ::c_int = 6;


### PR DESCRIPTION
Closes #1094 .