### PR TITLE
Add FIONCLEX and other FIO* constants for Linux, DragonFly and OpenBSD

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1704,11 +1704,6 @@ pub const TIOCPTYGRANT: ::c_uint = 0x20007454;
 pub const TIOCPTYGNAME: ::c_uint = 0x40807453;
 pub const TIOCPTYUNLK: ::c_uint = 0x20007452;
 
-pub const FIONCLEX: ::c_uint = 0x20006602;
-pub const FIONREAD: ::c_ulong = 0x4004667f;
-pub const FIOASYNC: ::c_ulong = 0x8004667d;
-pub const FIOSETOWN: ::c_ulong = 0x8004667c;
-pub const FIOGETOWN: ::c_ulong = 0x4004667b;
 pub const FIODTYPE: ::c_ulong = 0x4004667a;
 
 pub const B0: speed_t = 0;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -540,9 +540,6 @@ pub const TIOCSIG: ::c_uint = 0x2004745f;
 pub const TIOCM_DCD: ::c_int = 0x40;
 pub const H4DISC: ::c_int = 0x7;
 
-pub const FIODTYPE: ::c_ulong = 0x4004667a;
-pub const FIOGETLBA: ::c_ulong = 0x40046679;
-pub const FIODGNAME: ::c_ulong = 0x80106678;
 pub const FIONWRITE: ::c_ulong = 0x40046677;
 pub const FIONSPACE: ::c_ulong = 0x40046676;
 pub const FIOSEEKDATA: ::c_ulong = 0xc0086661;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -540,11 +540,6 @@ pub const TIOCSIG: ::c_uint = 0x2004745f;
 pub const TIOCM_DCD: ::c_int = 0x40;
 pub const H4DISC: ::c_int = 0x7;
 
-pub const FIONCLEX: ::c_ulong = 0x20006602;
-pub const FIONREAD: ::c_ulong = 0x4004667f;
-pub const FIOASYNC: ::c_ulong = 0x8004667d;
-pub const FIOSETOWN: ::c_ulong = 0x8004667c;
-pub const FIOGETOWN: ::c_ulong = 0x4004667b;
 pub const FIODTYPE: ::c_ulong = 0x4004667a;
 pub const FIOGETLBA: ::c_ulong = 0x40046679;
 pub const FIODGNAME: ::c_ulong = 0x80106678;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -997,6 +997,10 @@ pub const SLIPDISC: ::c_int = 0x4;
 pub const PPPDISC: ::c_int = 0x5;
 pub const NETGRAPHDISC: ::c_int = 0x6;
 
+pub const FIODTYPE: ::c_ulong = 0x4004667a;
+pub const FIOGETLBA: ::c_ulong = 0x40046679;
+pub const FIODGNAME: ::c_ulong = 0x80106678;
+
 pub const B0: speed_t = 0;
 pub const B50: speed_t = 50;
 pub const B75: speed_t = 75;

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -233,7 +233,12 @@ pub const LC_TIME: ::c_int = 5;
 pub const LC_MESSAGES: ::c_int = 6;
 
 pub const FIOCLEX: ::c_ulong = 0x20006601;
+pub const FIONCLEX: ::c_ulong = 0x20006602;
+pub const FIONREAD: ::c_ulong = 0x4004667f;
 pub const FIONBIO: ::c_ulong = 0x8004667e;
+pub const FIOASYNC: ::c_ulong = 0x8004667d;
+pub const FIOSETOWN: ::c_ulong = 0x8004667c;
+pub const FIOGETOWN: ::c_ulong = 0x4004667b;
 
 pub const PATH_MAX: ::c_int = 1024;
 

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1347,14 +1347,9 @@ pub const CHWFLOW: ::tcflag_t = ::MDMBUF | ::CRTSCTS | ::CDTRCTS;
 pub const SOCK_CLOEXEC: ::c_int = 0x10000000;
 pub const SOCK_NONBLOCK: ::c_int = 0x20000000;
 
-pub const FIONCLEX: ::c_ulong = 0x20006602;
 // Uncomment on next NetBSD release
 // pub const FIOSEEKDATA: ::c_ulong = 0xc0086661;
 // pub const FIOSEEKHOLE: ::c_ulong = 0xc0086662;
-pub const FIONREAD: ::c_ulong = 0x4004667f;
-pub const FIOASYNC: ::c_ulong = 0x8004667d;
-pub const FIOSETOWN: ::c_ulong = 0x8004667c;
-pub const FIOGETOWN: ::c_ulong = 0x4004667b;
 pub const OFIOGETBMAP: ::c_ulong = 0xc004667a;
 pub const FIOGETBMAP: ::c_ulong = 0xc008667a;
 pub const FIONWRITE: ::c_ulong = 0x40046679;

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -785,6 +785,7 @@ pub const PTHREAD_MUTEX_ERRORCHECK: ::c_int = 2;
 pub const PTHREAD_MUTEX_DEFAULT: ::c_int = PTHREAD_MUTEX_NORMAL;
 
 pub const FIOCLEX: ::c_int = 0x5451;
+pub const FIONCLEX: ::c_int = 0x5450;
 
 pub const SIGCHLD: ::c_int = 17;
 pub const SIGBUS: ::c_int = 7;

--- a/src/unix/linux_like/linux/gnu/b32/arm.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm.rs
@@ -322,6 +322,7 @@ pub const SOCK_STREAM: ::c_int = 1;
 pub const SOCK_DGRAM: ::c_int = 2;
 
 pub const FIOCLEX: ::c_ulong = 0x5451;
+pub const FIONCLEX: ::c_ulong = 0x5450;
 pub const FIONBIO: ::c_ulong = 0x5421;
 
 pub const MCL_CURRENT: ::c_int = 0x0001;

--- a/src/unix/linux_like/linux/gnu/b32/mips.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips.rs
@@ -698,6 +698,7 @@ pub const SO_ATTACH_BPF: ::c_int = 50;
 pub const SO_DETACH_BPF: ::c_int = SO_DETACH_FILTER;
 
 pub const FIOCLEX: ::c_ulong = 0x6601;
+pub const FIONCLEX: ::c_ulong = 0x6602;
 pub const FIONBIO: ::c_ulong = 0x667e;
 
 pub const SA_SIGINFO: ::c_int = 0x00000008;

--- a/src/unix/linux_like/linux/gnu/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/gnu/b32/powerpc.rs
@@ -324,6 +324,7 @@ pub const SOCK_STREAM: ::c_int = 1;
 pub const SOCK_DGRAM: ::c_int = 2;
 
 pub const FIOCLEX: ::c_ulong = 0x20006601;
+pub const FIONCLEX: ::c_ulong = 0x20006602;
 pub const FIONBIO: ::c_ulong = 0x8004667e;
 
 pub const MCL_CURRENT: ::c_int = 0x2000;

--- a/src/unix/linux_like/linux/gnu/b32/x86.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86.rs
@@ -529,6 +529,7 @@ pub const F_GETOWN: ::c_int = 9;
 pub const F_SETOWN: ::c_int = 8;
 
 pub const FIOCLEX: ::c_ulong = 0x5451;
+pub const FIONCLEX: ::c_ulong = 0x5450;
 pub const FIONBIO: ::c_ulong = 0x5421;
 
 pub const PTRACE_GETFPXREGS: ::c_uint = 18;

--- a/src/unix/linux_like/linux/gnu/b64/aarch64.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64.rs
@@ -529,6 +529,7 @@ pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const EDEADLOCK: ::c_int = 35;
 
 pub const FIOCLEX: ::c_ulong = 0x5451;
+pub const FIONCLEX: ::c_ulong = 0x5450;
 pub const FIONBIO: ::c_ulong = 0x5421;
 
 pub const MCL_CURRENT: ::c_int = 0x0001;

--- a/src/unix/linux_like/linux/gnu/b64/mips64.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mips64.rs
@@ -785,6 +785,7 @@ pub const SO_ATTACH_BPF: ::c_int = 50;
 pub const SO_DETACH_BPF: ::c_int = SO_DETACH_FILTER;
 
 pub const FIOCLEX: ::c_ulong = 0x6601;
+pub const FIONCLEX: ::c_ulong = 0x6602;
 pub const FIONBIO: ::c_ulong = 0x667e;
 
 pub const SA_ONSTACK: ::c_int = 0x08000000;

--- a/src/unix/linux_like/linux/gnu/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/gnu/b64/powerpc64.rs
@@ -545,6 +545,7 @@ pub const EISNAM: ::c_int = 120;
 pub const EREMOTEIO: ::c_int = 121;
 
 pub const FIOCLEX: ::c_ulong = 0x20006601;
+pub const FIONCLEX: ::c_ulong = 0x20006602;
 pub const FIONBIO: ::c_ulong = 0x8004667e;
 
 pub const MCL_CURRENT: ::c_int = 0x2000;

--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -333,6 +333,7 @@ pub const ENOSYS: ::c_int = 38;
 pub const ENOTCONN: ::c_int = 107;
 pub const ETIMEDOUT: ::c_int = 110;
 pub const FIOCLEX: ::c_ulong = 0x5451;
+pub const FIONCLEX: ::c_ulong = 0x5450;
 pub const FIONBIO: ::c_ulong = 0x5421;
 pub const O_APPEND: ::c_int = 1024;
 pub const O_CREAT: ::c_int = 64;

--- a/src/unix/linux_like/linux/gnu/b64/sparc64.rs
+++ b/src/unix/linux_like/linux/gnu/b64/sparc64.rs
@@ -497,6 +497,7 @@ pub const SO_RCVTIMEO: ::c_int = 0x2000;
 pub const SO_SNDTIMEO: ::c_int = 0x4000;
 
 pub const FIOCLEX: ::c_ulong = 0x20006601;
+pub const FIONCLEX: ::c_ulong = 0x20006602;
 pub const FIONBIO: ::c_ulong = 0x8004667e;
 
 pub const MCL_CURRENT: ::c_int = 0x2000;

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -692,6 +692,7 @@ pub const EISNAM: ::c_int = 120;
 pub const EREMOTEIO: ::c_int = 121;
 
 pub const FIOCLEX: ::c_ulong = 0x5451;
+pub const FIONCLEX: ::c_ulong = 0x5450;
 pub const FIONBIO: ::c_ulong = 0x5421;
 
 pub const PTRACE_GETFPREGS: ::c_uint = 14;

--- a/src/unix/linux_like/linux/musl/b32/arm.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm.rs
@@ -162,6 +162,7 @@ pub const O_ASYNC: ::c_int = 0x2000;
 pub const O_LARGEFILE: ::c_int = 0o400000;
 
 pub const FIOCLEX: ::c_int = 0x5451;
+pub const FIONCLEX: ::c_int = 0x5450;
 pub const FIONBIO: ::c_int = 0x5421;
 
 pub const RLIMIT_RSS: ::c_int = 5;

--- a/src/unix/linux_like/linux/musl/b32/mips.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips.rs
@@ -173,6 +173,7 @@ pub const O_ASYNC: ::c_int = 0o10000;
 pub const O_LARGEFILE: ::c_int = 0x2000;
 
 pub const FIOCLEX: ::c_int = 0x6601;
+pub const FIONCLEX: ::c_int = 0x6602;
 pub const FIONBIO: ::c_int = 0x667E;
 
 pub const RLIMIT_RSS: ::c_int = 7;

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -166,6 +166,7 @@ pub const O_ASYNC: ::c_int = 0x2000;
 pub const O_LARGEFILE: ::c_int = 0x10000;
 
 pub const FIOCLEX: ::c_int = 0x20006601;
+pub const FIONCLEX: ::c_int = 0x20006602;
 pub const FIONBIO: ::c_int = 0x8004667E;
 
 pub const RLIMIT_RSS: ::c_int = 5;

--- a/src/unix/linux_like/linux/musl/b32/x86.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86.rs
@@ -222,6 +222,7 @@ pub const O_ASYNC: ::c_int = 0x2000;
 pub const O_LARGEFILE: ::c_int = 0o0100000;
 
 pub const FIOCLEX: ::c_int = 0x5451;
+pub const FIONCLEX: ::c_int = 0x5450;
 pub const FIONBIO: ::c_int = 0x5421;
 
 pub const RLIMIT_RSS: ::c_int = 5;

--- a/src/unix/linux_like/linux/musl/b64/aarch64.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64.rs
@@ -424,6 +424,7 @@ pub const B3500000: ::speed_t = 0o010016;
 pub const B4000000: ::speed_t = 0o010017;
 
 pub const FIOCLEX: ::c_int = 0x5451;
+pub const FIONCLEX: ::c_int = 0x5450;
 pub const FIONBIO: ::c_int = 0x5421;
 pub const EDEADLK: ::c_int = 35;
 pub const EDEADLOCK: ::c_int = EDEADLK;

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -448,6 +448,7 @@ pub const SYS_pwritev2: ::c_long = 381;
 pub const SYS_kexec_file_load: ::c_long = 382;
 
 pub const FIOCLEX: ::c_int = 0x20006601;
+pub const FIONCLEX: ::c_int = 0x20006602;
 pub const FIONBIO: ::c_int = 0x8004667e;
 pub const EDEADLK: ::c_int = 58;
 pub const EDEADLOCK: ::c_int = EDEADLK;

--- a/src/unix/linux_like/linux/musl/b64/x86_64.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64.rs
@@ -584,6 +584,7 @@ pub const B3500000: ::speed_t = 0o010016;
 pub const B4000000: ::speed_t = 0o010017;
 
 pub const FIOCLEX: ::c_int = 0x5451;
+pub const FIONCLEX: ::c_int = 0x5450;
 pub const FIONBIO: ::c_int = 0x5421;
 pub const EDEADLK: ::c_int = 35;
 pub const EDEADLOCK: ::c_int = EDEADLK;

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -408,6 +408,7 @@ pub const SEEK_END: ::c_int = 2;
 
 pub const FIONBIO: ::c_ulong = 1;
 pub const FIOCLEX: ::c_ulong = 0x20006601;
+pub const FIONCLEX: ::c_ulong = 0x20006602;
 
 pub const S_BLKSIZE: ::mode_t = 1024;
 pub const S_IREAD: ::mode_t = 256;

--- a/src/unix/uclibc/arm/mod.rs
+++ b/src/unix/uclibc/arm/mod.rs
@@ -394,6 +394,7 @@ pub const FF1: ::c_int = 0x8000;
 pub const FFDLY: ::c_int = 0x8000;
 pub const FIONBIO: ::c_ulong = 0x5421;
 pub const FIOCLEX: ::c_ulong = 0x5451;
+pub const FIONCLEX: ::c_ulong = 0x5450;
 pub const FLUSHO: ::tcflag_t = 0x1000;
 pub const F_GETLK: ::c_int = 0x5;
 pub const F_SETLK: ::c_int = 0x6;

--- a/src/unix/uclibc/mips/mod.rs
+++ b/src/unix/uclibc/mips/mod.rs
@@ -224,6 +224,7 @@ pub const SO_MAX_PACING_RATE: ::c_int = 47;
 pub const SO_BPF_EXTENSIONS: ::c_int = 48;
 
 pub const FIOCLEX: ::c_ulong = 0x6601;
+pub const FIONCLEX: ::c_ulong = 0x6602;
 pub const FIONBIO: ::c_ulong = 0x667e;
 
 pub const SA_ONSTACK: ::c_uint = 0x08000000;


### PR DESCRIPTION
[OpenBSD header](https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/sys/sys/filio.h?annotate=1.5) | [DragonFly header](http://gitweb.dragonflybsd.org/dragonfly.git/blame/refs/heads/master:/sys/sys/filio.h) | [Linux search](https://github.com/torvalds/linux/search?q=FIONCLEX+FIOQSIZE&unscoped_q=FIONCLEX+FIOQSIZE&type=Code)
For Linux I've used [godbolt compiler explorer](https://godbolt.org/z/h-C7qM) to get final values where possible.

Wile this crate has FIOCLEX for Fuchsia, Emscripten and Redox, I've not added FIONCLEX for them because those targets appear to support neither.
I started adding FIOASYNC, FIOSETOWN and FIOGETOWN for all the Linux architectures, but gave up when I realized FIOASYNC is kind of deprecated and the other two useless without more symbols. If anybody is interested I have a [branch with how far I got](https://github.com/tormol/rust-libc/tree/sigio).