### PR TITLE
Re-add PTRACE_DETACH for mips64 GNU targets

### DIFF
--- a/src/unix/linux_like/linux/gnu/b64/mips64.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mips64.rs
@@ -831,6 +831,7 @@ pub const TCSAFLUSH: ::c_int = 0x5410;
 
 pub const PTRACE_GETFPREGS: ::c_uint = 14;
 pub const PTRACE_SETFPREGS: ::c_uint = 15;
+pub const PTRACE_DETACH: ::c_uint = 17;
 pub const PTRACE_GETFPXREGS: ::c_uint = 18;
 pub const PTRACE_SETFPXREGS: ::c_uint = 19;
 pub const PTRACE_GETREGS: ::c_uint = 12;


### PR DESCRIPTION
During the refactor in 4bd419eb, `PTRACE_DETACH` was accidentally removed on
these targets. This re-adds it.

Fixes brokenness encountered during nix-rust/nix#1035

CC @asomers 
