### PR TITLE
Support calls to the SunOS Doors API

### DIFF
--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1862,14 +1862,6 @@ f! {
     }
 }
 
-pub type door_server_proc_t = extern fn(
-    cookie: *const ::c_void,
-    argp: *const ::c_char,
-    arg_size: ::size_t,
-    dp: *const door_desc_t,
-    n_desc: ::c_uint
-);
-
 extern {
     pub fn getrlimit(resource: ::c_int, rlim: *mut ::rlimit) -> ::c_int;
     pub fn setrlimit(resource: ::c_int, rlim: *const ::rlimit) -> ::c_int;
@@ -2144,8 +2136,17 @@ extern {
     pub fn uname(buf: *mut ::utsname) -> ::c_int;
     pub fn pipe2(fds: *mut ::c_int, flags: ::c_int) -> ::c_int;
     pub fn door_call(d: ::c_int, params: *const door_arg_t) -> ::c_int;
-    pub fn door_return(data_ptr: *const ::c_char, data_size: ::size_t, desc_ptr: *const door_desc_t, num_desc: ::c_uint);
-    pub fn door_create(server_procedure: door_server_proc_t, cookie: *const ::c_void, attributes: door_attr_t) -> ::c_int;
+    pub fn door_return(data_ptr: *const ::c_char,
+                       data_size: ::size_t,
+                       desc_ptr: *const door_desc_t,
+                       num_desc: ::c_uint);
+    pub fn door_create(server_procedure: extern fn(cookie: *const ::c_void,
+                                                   argp: *const ::c_char,
+                                                   arg_size: ::size_t,
+                                                   dp: *const door_desc_t,
+                                                   n_desc: ::c_uint),
+                       cookie: *const ::c_void,
+                       attributes: door_attr_t) -> ::c_int;
     pub fn fattach(fildes: ::c_int, path: *const ::c_char) -> ::c_int;
 }
 


### PR DESCRIPTION
Doors are a lightweight IPC mechanism available in libc on Solaris & illumos. They are like unix domain sockets, but faster and more pleasant to work with.

* Brief introduction: ["Doors" in SolarisTM: Lightweight RPC using File Descriptors](http://www.kohala.com/start/papers.others/doors.html)
* Relevant manual pages: [DOOR_CALL(3C)](https://illumos.org/man/3C/door_call), [DOOR_CREATE(3C)](https://illumos.org/man/3C/door_create)
* Tutorial I wrote: ["Revolving Doors": A tutorial on the Illumos Doors API](https://github.com/robertdfrench/revolving-door)

Marking this as a draft until I have included the full api.