### PR TITLE
wasi: add c_schar definition

### DIFF
--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -2,6 +2,7 @@ pub use ffi::c_void;
 
 pub type c_char = i8;
 pub type c_uchar = u8;
+pub type c_schar = i8;
 pub type c_int = i32;
 pub type c_uint = u32;
 pub type c_short = i16;


### PR DESCRIPTION
This fixes an issue when building https://github.com/capstone-rust/capstone-rs/ for WASI.

Otherwise, I get:
~~~
error[E0412]: cannot find type `c_schar` in module `libc`
 --> /home/user/capstone-rs/target/wasm32-wasi/debug/build/capstone-sys-1019f1f8759b0d05/out/capstone.rs:4:27
  |
4 | pub type __int8_t = libc::c_schar;
  |                           ^^^^^^^ help: a type alias with a similar name exists: `c_char`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0412`.
error: Could not compile `capstone-sys`.
~~~

The file with the error is generated with bindgen:

https://github.com/capstone-rust/capstone-rs/blob/a74126cd88d683c0c16029be361ee85c12934878/capstone-sys/pre_generated/capstone.rs#L3-L5