### PR TITLE
Remove new field from ucontext_t for compatibility with earlier glibc versions

### DIFF
--- a/ci/style.rs
+++ b/ci/style.rs
@@ -117,7 +117,7 @@ fn check_style(file: &str, path: &Path, err: &mut Errors) {
         } else {
             prev_blank = false;
         }
-        if line != line.trim_right() {
+        if line != line.trim_end() {
             err.error(path, i, "trailing whitespace");
         }
         if line.contains("\t") {
@@ -139,7 +139,7 @@ fn check_style(file: &str, path: &Path, err: &mut Errors) {
             }
         }
 
-        let line = line.trim_left();
+        let line = line.trim_start();
         let is_pub = line.starts_with("pub ");
         let line = if is_pub {&line[4..]} else {line};
 

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1950,6 +1950,7 @@ fn test_linux(target: &str) {
                "syslog.h",
                "termios.h",
                "time.h",
+               "ucontext.h",
                "unistd.h",
                "utime.h",
                "utmp.h",
@@ -1967,10 +1968,6 @@ fn test_linux(target: &str) {
                // <execinfo.h> is not supported by musl:
                // https://www.openwall.com/lists/musl/2015/04/09/3
                [!musl]: "execinfo.h",
-               // ucontext_t added a new field as of glibc 2.28; our struct definition is
-               // conservative and omits the field, but that means the size doesn't match for newer
-               // glibcs
-               [!gnu]: "ucontext.h",
     }
 
     // Include linux headers at the end:
@@ -2100,6 +2097,11 @@ fn test_linux(target: &str) {
 
             // FIXME: musl version using by mips build jobs 1.0.15 is ancient:
             "ifmap" | "ifreq" | "ifconf" if mips32_musl => true,
+
+            // ucontext_t added a new field as of glibc 2.28; our struct definition is
+            // conservative and omits the field, but that means the size doesn't match for newer
+            // glibcs (see https://github.com/rust-lang/libc/issues/1410)
+            "ucontext_t" if gnu => true,
 
             _ => false,
         }

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2098,6 +2098,7 @@ fn test_linux(target: &str) {
             // FIXME: musl version using by mips build jobs 1.0.15 is ancient:
             "ifmap" | "ifreq" | "ifconf" if mips32_musl => true,
 
+            // FIXME: remove once Ubuntu 20.04 LTS is released, somewhere in 2020.
             // ucontext_t added a new field as of glibc 2.28; our struct definition is
             // conservative and omits the field, but that means the size doesn't match for newer
             // glibcs (see https://github.com/rust-lang/libc/issues/1410)

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1950,7 +1950,6 @@ fn test_linux(target: &str) {
                "syslog.h",
                "termios.h",
                "time.h",
-               "ucontext.h",
                "unistd.h",
                "utime.h",
                "utmp.h",
@@ -1968,6 +1967,10 @@ fn test_linux(target: &str) {
                // <execinfo.h> is not supported by musl:
                // https://www.openwall.com/lists/musl/2015/04/09/3
                [!musl]: "execinfo.h",
+               // ucontext_t added a new field as of glibc 2.28; our struct definition is
+               // conservative and omits the field, but that means the size doesn't match for newer
+               // glibcs
+               [!gnu]: "ucontext.h",
     }
 
     // Include linux headers at the end:

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -286,7 +286,9 @@ s_no_extra_traits! {
         pub uc_sigmask: ::sigset_t,
         __private: [u8; 512],
         // FIXME: the shadow stack field requires glibc >= 2.28.
-        // Re-add once we drop compatibility with glibc versions older than 2.28.
+        // Re-add once we drop compatibility with glibc versions older than
+        // 2.28.
+        //
         // __ssp: [::c_ulonglong; 4],
     }
 }

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -285,6 +285,9 @@ s_no_extra_traits! {
         pub uc_mcontext: mcontext_t,
         pub uc_sigmask: ::sigset_t,
         __private: [u8; 512],
+        // FIXME: the shadow stack field requires glibc >= 2.28.
+        // Re-add once we drop compatibility with glibc versions older than 2.28.
+        // __ssp: [::c_ulonglong; 4],
     }
 }
 

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -285,7 +285,6 @@ s_no_extra_traits! {
         pub uc_mcontext: mcontext_t,
         pub uc_sigmask: ::sigset_t,
         __private: [u8; 512],
-        __ssp: [::c_ulonglong; 4],
     }
 }
 


### PR DESCRIPTION
Per discussion in #1410 with @gnzlbg, this is necessary to avoid struct size mismatches between Rust and C on systems with glibc < 2.28.