### PR TITLE
[Draft] Add __int128 to unix targets

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -177,6 +177,14 @@ fn test_apple(target: &str) {
         }
     });
 
+    cfg.skip_field(move |struct_, field| {
+        match (struct_, field) {
+            // __int128 does not have fields in C
+            ("__int128", "value") => true,
+            _ => false,
+        }
+    });
+
     cfg.skip_field_type(move |struct_, field| {
         match (struct_, field) {
             // FIXME: actually a union
@@ -198,7 +206,7 @@ fn test_apple(target: &str) {
     cfg.type_name(move |ty, is_struct, is_union| {
         match ty {
             // Just pass all these through, no need for a "struct" prefix
-            "FILE" | "DIR" | "Dl_info" => ty.to_string(),
+            "FILE" | "DIR" | "Dl_info" | "__int128" => ty.to_string(),
 
             // OSX calls this something else
             "sighandler_t" => "sig_t".to_string(),

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -38,6 +38,11 @@ impl ::Clone for DIR {
 }
 pub type locale_t = *mut :: c_void;
 
+#[cfg(target_pointer_width = "64")]
+#[repr(C, align(16))]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct __int128{ pub value: i128 }
+
 s! {
     pub struct group {
         pub gr_name: *mut ::c_char,


### PR DESCRIPTION
This PR is for testing purposes only for now.

AFAICT, the ABI is wrong (AGGREGATE due to repr(C) vs SCALAR for __int128), but on my laptop ctest does not report any errors.