### PR TITLE
Bump to 0.2.59

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.58"
+version = "0.2.59"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
I've added some code to libc for my library and to be able to release the next version of my library, I need the new constants exposed by my PR to be available in crates.io. Would a new release soon be possible?