### PR TITLE
Fix linux 'others'

### DIFF
--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -2724,6 +2724,10 @@ cfg_if! {
     } else if #[cfg(target_env = "gnu")] {
         mod gnu;
         pub use self::gnu::*;
+    } else {
+        // Similar to previous 'others'
+        mod gnu;
+        pub use self::gnu::*;
     }
 }
 


### PR DESCRIPTION
Hi there,

We observed a bunch of CI failure due to a recent breaking change in commit 65f23e6aca49ab91325fe26ed3bee0463990680f . It changed the behavior of linux but not `musl` or `gnu`. In `src/unix/linux_like/linux/mod.rs`

```diff
@@ -2721,9 +2647,16 @@ cfg_if! {
     if #[cfg(target_env = "musl")] {
         mod musl;
         pub use self::musl::*;
+    } else if #[cfg(target_env = "gnu")] {
+        mod gnu;
+        pub use self::gnu::*;
-    } else if #[cfg(any(target_arch = "mips",
-                        target_arch = "mips64"))] {
-        mod mips;
-        pub use self::mips::*;
-    } else if #[cfg(any(target_arch = "s390x"))] {
-        mod s390x;
-        pub use self::s390x::*;
-    } else {
-        mod other;
-        pub use self::other::*;
     }
 }
```

In the past, `others` catches everything except for `musl` `mips` `mips64` `s390x`, but now it no longer exists. So this commit removes support to `others`. However, many platforms are `linux` but not in `musl` or `gnu` and they depends on this branch. This PR helps fix it. We'd like to see an immediate update on crates.io with version bumped to 0.2.60 to solve a lot of building failures... Thanks!

Best,
Yu