### PR TITLE
Link to Windows debug CRTs when crt-debug target_feature is present.

### DIFF
--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -193,8 +193,10 @@ pub const SIG_ERR: ::c_int = -1;
 
 // inline comment below appeases style checker
 #[cfg(all(target_env = "msvc", feature = "rustc-dep-of-std"))] // " if "
-#[link(name = "msvcrt", cfg(not(target_feature = "crt-static")))]
-#[link(name = "libcmt", cfg(target_feature = "crt-static"))]
+#[link(name = "msvcrt", cfg(all(not(target_feature = "crt-static"), not(target_feature = "crt-debug"))))]
+#[link(name = "msvcrtd", cfg(all(not(target_feature = "crt-static"), target_feature = "crt-debug")))]
+#[link(name = "libcmt", cfg(all(target_feature = "crt-static", not(target_feature = "crt-debug"))))]
+#[link(name = "libcmtd", cfg(all(target_feature = "crt-static", target_feature = "crt-debug")))]
 extern {}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]


### PR DESCRIPTION
Relies on https://github.com/rust-lang/rust/pull/62534 in order to fix https://github.com/rust-lang/rust/issues/39016.