### PR TITLE
Add musl support for MIPS64 & bump to 0.2.63

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.62"
+version = "0.2.63"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -204,6 +204,8 @@ i686-unknown-netbsd \
 i686-unknown-openbsd \
 mips-unknown-linux-uclibc \
 mipsel-unknown-linux-uclibc \
+mips64-unknown-linux-muslabi64 \
+mips64el-unknown-linux-muslabi64 \
 nvptx64-nvidia-cuda \
 powerpc-unknown-linux-gnuspe \
 powerpc-unknown-netbsd \

--- a/ci/docker/mips64-unknown-linux-muslabi64/Dockerfile
+++ b/ci/docker/mips64-unknown-linux-muslabi64/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:19.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  gcc make libc6-dev git curl ca-certificates \
+  gcc-mips64-linux-gnuabi64 qemu-user
+
+COPY install-musl.sh /
+RUN sh /install-musl.sh mips64
+
+# FIXME: shouldn't need the `-lgcc` here, shouldn't that be in libstd?
+ENV PATH=$PATH:/musl-mips64/bin:/rust/bin \
+    CC_mips64_unknown_linux_muslabi64=musl-gcc \
+    RUSTFLAGS='-Clink-args=-lgcc' \
+    CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_LINKER=musl-gcc \
+    CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_RUNNER="qemu-mips64 -L /musl-mips64"

--- a/ci/docker/mips64el-unknown-linux-muslabi64/Dockerfile
+++ b/ci/docker/mips64el-unknown-linux-muslabi64/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:19.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  gcc make libc6-dev git curl ca-certificates \
+  gcc-mips64el-linux-gnuabi64 qemu-user
+
+COPY install-musl.sh /
+RUN sh /install-musl.sh mips64el
+
+# FIXME: shouldn't need the `-lgcc` here, shouldn't that be in libstd?
+ENV PATH=$PATH:/musl-mips64el/bin:/rust/bin \
+    CC_mips64el_unknown_linux_muslabi64=musl-gcc \
+    RUSTFLAGS='-Clink-args=-lgcc' \
+    CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_MUSLABI64_LINKER=musl-gcc \
+    CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_MUSLABI64_RUNNER="qemu-mips64el -L /musl-mips64el"

--- a/ci/install-musl.sh
+++ b/ci/install-musl.sh
@@ -46,6 +46,20 @@ case ${1} in
         ./configure --prefix="/musl-${musl_arch}"
         make install -j4
         ;;
+    mips64)
+        musl_arch=mips64
+        kernel_arch=mips
+        CC=mips64-linux-gnuabi64-gcc CFLAGS="-march=mips64r2 -mabi=64" \
+          ./configure --prefix="/musl-${musl_arch}" --enable-wrapper=yes
+        make install -j4
+        ;;
+    mips64el)
+        musl_arch=mips64el
+        kernel_arch=mips
+        CC=mips64el-linux-gnuabi64-gcc CFLAGS="-march=mips64r2 -mabi=64" \
+          ./configure --prefix="/musl-${musl_arch}" --enable-wrapper=yes
+        make install -j4
+        ;;
     *)
         echo "Unknown target arch: \"${1}\""
         exit 1

--- a/src/unix/linux_like/linux/musl/b64/aarch64.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64.rs
@@ -49,6 +49,36 @@ s! {
         __unused: [::c_uint; 2],
     }
 
+    pub struct statfs {
+        pub f_type: ::c_ulong,
+        pub f_bsize: ::c_ulong,
+        pub f_blocks: ::fsblkcnt_t,
+        pub f_bfree: ::fsblkcnt_t,
+        pub f_bavail: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
+        pub f_fsid: ::fsid_t,
+        pub f_namelen: ::c_ulong,
+        pub f_frsize: ::c_ulong,
+        pub f_flags: ::c_ulong,
+        pub f_spare: [::c_ulong; 4],
+    }
+
+    pub struct statfs64 {
+        pub f_type: ::c_ulong,
+        pub f_bsize: ::c_ulong,
+        pub f_blocks: ::fsblkcnt_t,
+        pub f_bfree: ::fsblkcnt_t,
+        pub f_bavail: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
+        pub f_fsid: ::fsid_t,
+        pub f_namelen: ::c_ulong,
+        pub f_frsize: ::c_ulong,
+        pub f_flags: ::c_ulong,
+        pub f_spare: [::c_ulong; 4],
+    }
+
     pub struct ipc_perm {
         pub __ipc_perm_key: ::key_t,
         pub uid: ::uid_t,
@@ -62,15 +92,36 @@ s! {
     }
 }
 
+pub const O_ASYNC: ::c_int = 0x2000;
+pub const O_APPEND: ::c_int = 1024;
+pub const O_CREAT: ::c_int = 64;
+pub const O_EXCL: ::c_int = 128;
+pub const O_NOCTTY: ::c_int = 256;
+pub const O_NONBLOCK: ::c_int = 2048;
+pub const O_SYNC: ::c_int = 1052672;
+pub const O_RSYNC: ::c_int = 1052672;
+pub const O_DSYNC: ::c_int = 4096;
 pub const O_DIRECT: ::c_int = 0x10000;
 pub const O_DIRECTORY: ::c_int = 0x4000;
 pub const O_LARGEFILE: ::c_int = 0x20000;
 pub const O_NOFOLLOW: ::c_int = 0x8000;
+pub const POLLWRNORM: ::c_short = 0x100;
+pub const POLLWRBAND: ::c_short = 0x200;
 
 pub const MINSIGSTKSZ: ::size_t = 6144;
 pub const SIGSTKSZ: ::size_t = 12288;
 
 pub const MADV_SOFT_OFFLINE: ::c_int = 101;
+pub const MAP_ANON: ::c_int = 0x0020;
+pub const MAP_GROWSDOWN: ::c_int = 0x0100;
+pub const MAP_DENYWRITE: ::c_int = 0x0800;
+pub const MAP_EXECUTABLE: ::c_int = 0x01000;
+pub const MAP_LOCKED: ::c_int = 0x02000;
+pub const MAP_NORESERVE: ::c_int = 0x04000;
+pub const MAP_POPULATE: ::c_int = 0x08000;
+pub const MAP_NONBLOCK: ::c_int = 0x010000;
+pub const MAP_STACK: ::c_int = 0x020000;
+pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const SYS_io_setup: ::c_long = 0;
 pub const SYS_io_destroy: ::c_long = 1;
 pub const SYS_io_submit: ::c_long = 2;
@@ -341,6 +392,87 @@ pub const SYS_pkey_mprotect: ::c_long = 288;
 pub const SYS_pkey_alloc: ::c_long = 289;
 pub const SYS_pkey_free: ::c_long = 290;
 
+pub const ENAMETOOLONG: ::c_int = 36;
+pub const ENOLCK: ::c_int = 37;
+pub const ENOSYS: ::c_int = 38;
+pub const ENOTEMPTY: ::c_int = 39;
+pub const ELOOP: ::c_int = 40;
+pub const ENOMSG: ::c_int = 42;
+pub const EIDRM: ::c_int = 43;
+pub const ECHRNG: ::c_int = 44;
+pub const EL2NSYNC: ::c_int = 45;
+pub const EL3HLT: ::c_int = 46;
+pub const EL3RST: ::c_int = 47;
+pub const ELNRNG: ::c_int = 48;
+pub const EUNATCH: ::c_int = 49;
+pub const ENOCSI: ::c_int = 50;
+pub const EL2HLT: ::c_int = 51;
+pub const EBADE: ::c_int = 52;
+pub const EBADR: ::c_int = 53;
+pub const EXFULL: ::c_int = 54;
+pub const ENOANO: ::c_int = 55;
+pub const EBADRQC: ::c_int = 56;
+pub const EBADSLT: ::c_int = 57;
+pub const EMULTIHOP: ::c_int = 72;
+pub const EBADMSG: ::c_int = 74;
+pub const EOVERFLOW: ::c_int = 75;
+pub const ENOTUNIQ: ::c_int = 76;
+pub const EBADFD: ::c_int = 77;
+pub const EREMCHG: ::c_int = 78;
+pub const ELIBACC: ::c_int = 79;
+pub const ELIBBAD: ::c_int = 80;
+pub const ELIBSCN: ::c_int = 81;
+pub const ELIBMAX: ::c_int = 82;
+pub const ELIBEXEC: ::c_int = 83;
+pub const EILSEQ: ::c_int = 84;
+pub const ERESTART: ::c_int = 85;
+pub const ESTRPIPE: ::c_int = 86;
+pub const EUSERS: ::c_int = 87;
+pub const ENOTSOCK: ::c_int = 88;
+pub const EDESTADDRREQ: ::c_int = 89;
+pub const EMSGSIZE: ::c_int = 90;
+pub const EPROTOTYPE: ::c_int = 91;
+pub const ENOPROTOOPT: ::c_int = 92;
+pub const EPROTONOSUPPORT: ::c_int = 93;
+pub const ESOCKTNOSUPPORT: ::c_int = 94;
+pub const EOPNOTSUPP: ::c_int = 95;
+pub const ENOTSUP: ::c_int = EOPNOTSUPP;
+pub const EPFNOSUPPORT: ::c_int = 96;
+pub const EAFNOSUPPORT: ::c_int = 97;
+pub const EADDRINUSE: ::c_int = 98;
+pub const EADDRNOTAVAIL: ::c_int = 99;
+pub const ENETDOWN: ::c_int = 100;
+
+pub const F_GETLK: ::c_int = 5;
+pub const F_GETOWN: ::c_int = 9;
+pub const F_SETLK: ::c_int = 6;
+pub const F_SETLKW: ::c_int = 7;
+pub const F_SETOWN: ::c_int = 8;
+
+pub const SIGCHLD: ::c_int = 17;
+pub const SIGBUS: ::c_int = 7;
+pub const SIGTTIN: ::c_int = 21;
+pub const SIGTTOU: ::c_int = 22;
+pub const SIGXCPU: ::c_int = 24;
+pub const SIGXFSZ: ::c_int = 25;
+pub const SIGVTALRM: ::c_int = 26;
+pub const SIGPROF: ::c_int = 27;
+pub const SIGWINCH: ::c_int = 28;
+pub const SIGUSR1: ::c_int = 10;
+pub const SIGUSR2: ::c_int = 12;
+pub const SIGCONT: ::c_int = 18;
+pub const SIGSTOP: ::c_int = 19;
+pub const SIGTSTP: ::c_int = 20;
+pub const SIGURG: ::c_int = 23;
+pub const SIGIO: ::c_int = 29;
+pub const SIGSYS: ::c_int = 31;
+pub const SIGSTKFLT: ::c_int = 16;
+pub const SIGPOLL: ::c_int = 29;
+pub const SIGPWR: ::c_int = 30;
+pub const SIG_SETMASK: ::c_int = 2;
+pub const SIG_BLOCK: ::c_int = 0x000000;
+pub const SIG_UNBLOCK: ::c_int = 0x01;
+
 pub const RLIMIT_NLIMITS: ::c_int = 15;
 pub const TIOCINQ: ::c_int = ::FIONREAD;
 pub const MCL_CURRENT: ::c_int = 0x0001;
@@ -417,6 +549,31 @@ pub const FIONCLEX: ::c_int = 0x5450;
 pub const FIONBIO: ::c_int = 0x5421;
 pub const EDEADLK: ::c_int = 35;
 pub const EDEADLOCK: ::c_int = EDEADLK;
+pub const SA_ONSTACK: ::c_int = 0x08000000;
+pub const SA_SIGINFO: ::c_int = 0x00000004;
+pub const SA_NOCLDWAIT: ::c_int = 0x00000002;
+pub const SOCK_STREAM: ::c_int = 1;
+pub const SOCK_DGRAM: ::c_int = 2;
+pub const SOL_SOCKET: ::c_int = 1;
+pub const SO_REUSEADDR: ::c_int = 2;
+pub const SO_TYPE: ::c_int = 3;
+pub const SO_ERROR: ::c_int = 4;
+pub const SO_DONTROUTE: ::c_int = 5;
+pub const SO_BROADCAST: ::c_int = 6;
+pub const SO_SNDBUF: ::c_int = 7;
+pub const SO_RCVBUF: ::c_int = 8;
+pub const SO_KEEPALIVE: ::c_int = 9;
+pub const SO_OOBINLINE: ::c_int = 10;
+pub const SO_NO_CHECK: ::c_int = 11;
+pub const SO_PRIORITY: ::c_int = 12;
+pub const SO_LINGER: ::c_int = 13;
+pub const SO_BSDCOMPAT: ::c_int = 14;
+pub const SO_REUSEPORT: ::c_int = 15;
+pub const SO_ACCEPTCONN: ::c_int = 30;
+pub const SO_SNDBUFFORCE: ::c_int = 32;
+pub const SO_RCVBUFFORCE: ::c_int = 33;
+pub const SO_PROTOCOL: ::c_int = 38;
+pub const SO_DOMAIN: ::c_int = 39;
 pub const SO_PASSCRED: ::c_int = 16;
 pub const SO_PEERCRED: ::c_int = 17;
 pub const SO_RCVLOWAT: ::c_int = 18;
@@ -424,6 +581,7 @@ pub const SO_SNDLOWAT: ::c_int = 19;
 pub const SO_RCVTIMEO: ::c_int = 20;
 pub const SO_SNDTIMEO: ::c_int = 21;
 pub const EXTPROC: ::tcflag_t = 0x00010000;
+pub const VEOF: usize = 4;
 pub const VEOL: usize = 11;
 pub const VEOL2: usize = 16;
 pub const VMIN: usize = 6;
@@ -475,6 +633,8 @@ pub const TIOCM_RNG: ::c_int = 0x080;
 pub const TIOCM_DSR: ::c_int = 0x100;
 pub const TIOCM_CD: ::c_int = TIOCM_CAR;
 pub const TIOCM_RI: ::c_int = TIOCM_RNG;
+
+pub const EHWPOISON: ::c_int = 133;
 
 extern {
     pub fn ioctl(fd: ::c_int, request: ::c_int, ...) -> ::c_int;

--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -1,0 +1,753 @@
+pub type c_char = i8;
+pub type wchar_t = i32;
+pub type __u64 = ::c_ulong;
+pub type nlink_t = u64;
+pub type blksize_t = i64;
+
+s! {
+    pub struct stat {
+        pub st_dev: ::dev_t,
+        __pad1: [::c_int; 3],
+        pub st_ino: ::ino_t,
+        pub st_mode: ::mode_t,
+        pub st_nlink: ::nlink_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        __pad2: [::c_uint; 2],
+        pub st_size: ::off_t,
+        __pad3: ::c_int,
+        pub st_atime: ::time_t,
+        pub st_atime_nsec: ::c_long,
+        pub st_mtime: ::time_t,
+        pub st_mtime_nsec: ::c_long,
+        pub st_ctime: ::time_t,
+        pub st_ctime_nsec: ::c_long,
+        pub st_blksize: ::blksize_t,
+        __pad4: ::c_uint,
+        pub st_blocks: ::blkcnt_t,
+        __pad5: [::c_int; 14],
+    }
+
+    pub struct stat64 {
+        pub st_dev: ::dev_t,
+        __pad1: [::c_int; 3],
+        pub st_ino: ::ino_t,
+        pub st_mode: ::mode_t,
+        pub st_nlink: ::nlink_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        __pad2: [::c_uint; 2],
+        pub st_size: ::off_t,
+        __pad3: ::c_int,
+        pub st_atime: ::time_t,
+        pub st_atime_nsec: ::c_long,
+        pub st_mtime: ::time_t,
+        pub st_mtime_nsec: ::c_long,
+        pub st_ctime: ::time_t,
+        pub st_ctime_nsec: ::c_long,
+        pub st_blksize: ::blksize_t,
+        __pad4: ::c_uint,
+        pub st_blocks: ::blkcnt_t,
+        __pad5: [::c_int; 14],
+    }
+
+    pub struct statfs {
+        pub f_type: ::c_ulong,
+        pub f_bsize: ::c_ulong,
+        pub f_blocks: ::fsblkcnt_t,
+        pub f_bfree: ::fsblkcnt_t,
+        pub f_bavail: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
+        pub f_fsid: ::fsid_t,
+        pub f_namelen: ::c_ulong,
+        pub f_frsize: ::c_ulong,
+        pub f_flags: ::c_ulong,
+        pub f_spare: [::c_ulong; 5],
+    }
+
+    pub struct statfs64 {
+        pub f_type: ::c_ulong,
+        pub f_bsize: ::c_ulong,
+        pub f_blocks: ::fsblkcnt_t,
+        pub f_bfree: ::fsblkcnt_t,
+        pub f_bavail: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
+        pub f_fsid: ::fsid_t,
+        pub f_namelen: ::c_ulong,
+        pub f_frsize: ::c_ulong,
+        pub f_flags: ::c_ulong,
+        pub f_spare: [::c_ulong; 5],
+    }
+
+    pub struct ipc_perm {
+        pub __ipc_perm_key: ::key_t,
+        pub uid: ::uid_t,
+        pub gid: ::gid_t,
+        pub cuid: ::uid_t,
+        pub cgid: ::gid_t,
+        pub mode: ::mode_t,
+        pub __seq: ::c_int,
+        __pad1: ::c_int,
+        __unused1: ::c_ulong,
+        __unused2: ::c_ulong
+    }
+}
+
+pub const SIGSTKSZ: ::size_t = 8192;
+pub const MINSIGSTKSZ: ::size_t = 2048;
+
+pub const SYS_read: ::c_long = 5000 + 0;
+pub const SYS_write: ::c_long = 5000 + 1;
+pub const SYS_open: ::c_long = 5000 + 2;
+pub const SYS_close: ::c_long = 5000 + 3;
+pub const SYS_stat: ::c_long = 5000 + 4;
+pub const SYS_fstat: ::c_long = 5000 + 5;
+pub const SYS_lstat: ::c_long = 5000 + 6;
+pub const SYS_poll: ::c_long = 5000 + 7;
+pub const SYS_lseek: ::c_long = 5000 + 8;
+pub const SYS_mmap: ::c_long = 5000 + 9;
+pub const SYS_mprotect: ::c_long = 5000 +  10;
+pub const SYS_munmap: ::c_long = 5000 +  11;
+pub const SYS_brk: ::c_long = 5000 +  12;
+pub const SYS_rt_sigaction: ::c_long = 5000 +  13;
+pub const SYS_rt_sigprocmask: ::c_long = 5000 +  14;
+pub const SYS_ioctl: ::c_long = 5000 +  15;
+pub const SYS_pread64: ::c_long = 5000 +  16;
+pub const SYS_pwrite64: ::c_long = 5000 +  17;
+pub const SYS_readv: ::c_long = 5000 +  18;
+pub const SYS_writev: ::c_long = 5000 +  19;
+pub const SYS_access: ::c_long = 5000 +  20;
+pub const SYS_pipe: ::c_long = 5000 +  21;
+pub const SYS__newselect: ::c_long = 5000 +  22;
+pub const SYS_sched_yield: ::c_long = 5000 +  23;
+pub const SYS_mremap: ::c_long = 5000 +  24;
+pub const SYS_msync: ::c_long = 5000 +  25;
+pub const SYS_mincore: ::c_long = 5000 +  26;
+pub const SYS_madvise: ::c_long = 5000 +  27;
+pub const SYS_shmget: ::c_long = 5000 +  28;
+pub const SYS_shmat: ::c_long = 5000 +  29;
+pub const SYS_shmctl: ::c_long = 5000 +  30;
+pub const SYS_dup: ::c_long = 5000 +  31;
+pub const SYS_dup2: ::c_long = 5000 +  32;
+pub const SYS_pause: ::c_long = 5000 +  33;
+pub const SYS_nanosleep: ::c_long = 5000 +  34;
+pub const SYS_getitimer: ::c_long = 5000 +  35;
+pub const SYS_setitimer: ::c_long = 5000 +  36;
+pub const SYS_alarm: ::c_long = 5000 +  37;
+pub const SYS_getpid: ::c_long = 5000 +  38;
+pub const SYS_sendfile: ::c_long = 5000 +  39;
+pub const SYS_socket: ::c_long = 5000 +  40;
+pub const SYS_connect: ::c_long = 5000 +  41;
+pub const SYS_accept: ::c_long = 5000 +  42;
+pub const SYS_sendto: ::c_long = 5000 +  43;
+pub const SYS_recvfrom: ::c_long = 5000 +  44;
+pub const SYS_sendmsg: ::c_long = 5000 +  45;
+pub const SYS_recvmsg: ::c_long = 5000 +  46;
+pub const SYS_shutdown: ::c_long = 5000 +  47;
+pub const SYS_bind: ::c_long = 5000 +  48;
+pub const SYS_listen: ::c_long = 5000 +  49;
+pub const SYS_getsockname: ::c_long = 5000 +  50;
+pub const SYS_getpeername: ::c_long = 5000 +  51;
+pub const SYS_socketpair: ::c_long = 5000 +  52;
+pub const SYS_setsockopt: ::c_long = 5000 +  53;
+pub const SYS_getsockopt: ::c_long = 5000 +  54;
+pub const SYS_clone: ::c_long = 5000 +  55;
+pub const SYS_fork: ::c_long = 5000 +  56;
+pub const SYS_execve: ::c_long = 5000 +  57;
+pub const SYS_exit: ::c_long = 5000 +  58;
+pub const SYS_wait4: ::c_long = 5000 +  59;
+pub const SYS_kill: ::c_long = 5000 +  60;
+pub const SYS_uname: ::c_long = 5000 +  61;
+pub const SYS_semget: ::c_long = 5000 +  62;
+pub const SYS_semop: ::c_long = 5000 +  63;
+pub const SYS_semctl: ::c_long = 5000 +  64;
+pub const SYS_shmdt: ::c_long = 5000 +  65;
+pub const SYS_msgget: ::c_long = 5000 +  66;
+pub const SYS_msgsnd: ::c_long = 5000 +  67;
+pub const SYS_msgrcv: ::c_long = 5000 +  68;
+pub const SYS_msgctl: ::c_long = 5000 +  69;
+pub const SYS_fcntl: ::c_long = 5000 +  70;
+pub const SYS_flock: ::c_long = 5000 +  71;
+pub const SYS_fsync: ::c_long = 5000 +  72;
+pub const SYS_fdatasync: ::c_long = 5000 +  73;
+pub const SYS_truncate: ::c_long = 5000 +  74;
+pub const SYS_ftruncate: ::c_long = 5000 +  75;
+pub const SYS_getdents: ::c_long = 5000 +  76;
+pub const SYS_getcwd: ::c_long = 5000 +  77;
+pub const SYS_chdir: ::c_long = 5000 +  78;
+pub const SYS_fchdir: ::c_long = 5000 +  79;
+pub const SYS_rename: ::c_long = 5000 +  80;
+pub const SYS_mkdir: ::c_long = 5000 +  81;
+pub const SYS_rmdir: ::c_long = 5000 +  82;
+pub const SYS_creat: ::c_long = 5000 +  83;
+pub const SYS_link: ::c_long = 5000 +  84;
+pub const SYS_unlink: ::c_long = 5000 +  85;
+pub const SYS_symlink: ::c_long = 5000 +  86;
+pub const SYS_readlink: ::c_long = 5000 +  87;
+pub const SYS_chmod: ::c_long = 5000 +  88;
+pub const SYS_fchmod: ::c_long = 5000 +  89;
+pub const SYS_chown: ::c_long = 5000 +  90;
+pub const SYS_fchown: ::c_long = 5000 +  91;
+pub const SYS_lchown: ::c_long = 5000 +  92;
+pub const SYS_umask: ::c_long = 5000 +  93;
+pub const SYS_gettimeofday: ::c_long = 5000 +  94;
+pub const SYS_getrlimit: ::c_long = 5000 +  95;
+pub const SYS_getrusage: ::c_long = 5000 +  96;
+pub const SYS_sysinfo: ::c_long = 5000 +  97;
+pub const SYS_times: ::c_long = 5000 +  98;
+pub const SYS_ptrace: ::c_long = 5000 +  99;
+pub const SYS_getuid: ::c_long = 5000 + 100;
+pub const SYS_syslog: ::c_long = 5000 + 101;
+pub const SYS_getgid: ::c_long = 5000 + 102;
+pub const SYS_setuid: ::c_long = 5000 + 103;
+pub const SYS_setgid: ::c_long = 5000 + 104;
+pub const SYS_geteuid: ::c_long = 5000 + 105;
+pub const SYS_getegid: ::c_long = 5000 + 106;
+pub const SYS_setpgid: ::c_long = 5000 + 107;
+pub const SYS_getppid: ::c_long = 5000 + 108;
+pub const SYS_getpgrp: ::c_long = 5000 + 109;
+pub const SYS_setsid: ::c_long = 5000 + 110;
+pub const SYS_setreuid: ::c_long = 5000 + 111;
+pub const SYS_setregid: ::c_long = 5000 + 112;
+pub const SYS_getgroups: ::c_long = 5000 + 113;
+pub const SYS_setgroups: ::c_long = 5000 + 114;
+pub const SYS_setresuid: ::c_long = 5000 + 115;
+pub const SYS_getresuid: ::c_long = 5000 + 116;
+pub const SYS_setresgid: ::c_long = 5000 + 117;
+pub const SYS_getresgid: ::c_long = 5000 + 118;
+pub const SYS_getpgid: ::c_long = 5000 + 119;
+pub const SYS_setfsuid: ::c_long = 5000 + 120;
+pub const SYS_setfsgid: ::c_long = 5000 + 121;
+pub const SYS_getsid: ::c_long = 5000 + 122;
+pub const SYS_capget: ::c_long = 5000 + 123;
+pub const SYS_capset: ::c_long = 5000 + 124;
+pub const SYS_rt_sigpending: ::c_long = 5000 + 125;
+pub const SYS_rt_sigtimedwait: ::c_long = 5000 + 126;
+pub const SYS_rt_sigqueueinfo: ::c_long = 5000 + 127;
+pub const SYS_rt_sigsuspend: ::c_long = 5000 + 128;
+pub const SYS_sigaltstack: ::c_long = 5000 + 129;
+pub const SYS_utime: ::c_long = 5000 + 130;
+pub const SYS_mknod: ::c_long = 5000 + 131;
+pub const SYS_personality: ::c_long = 5000 + 132;
+pub const SYS_ustat: ::c_long = 5000 + 133;
+pub const SYS_statfs: ::c_long = 5000 + 134;
+pub const SYS_fstatfs: ::c_long = 5000 + 135;
+pub const SYS_sysfs: ::c_long = 5000 + 136;
+pub const SYS_getpriority: ::c_long = 5000 + 137;
+pub const SYS_setpriority: ::c_long = 5000 + 138;
+pub const SYS_sched_setparam: ::c_long = 5000 + 139;
+pub const SYS_sched_getparam: ::c_long = 5000 + 140;
+pub const SYS_sched_setscheduler: ::c_long = 5000 + 141;
+pub const SYS_sched_getscheduler: ::c_long = 5000 + 142;
+pub const SYS_sched_get_priority_max: ::c_long = 5000 + 143;
+pub const SYS_sched_get_priority_min: ::c_long = 5000 + 144;
+pub const SYS_sched_rr_get_interval: ::c_long = 5000 + 145;
+pub const SYS_mlock: ::c_long = 5000 + 146;
+pub const SYS_munlock: ::c_long = 5000 + 147;
+pub const SYS_mlockall: ::c_long = 5000 + 148;
+pub const SYS_munlockall: ::c_long = 5000 + 149;
+pub const SYS_vhangup: ::c_long = 5000 + 150;
+pub const SYS_pivot_root: ::c_long = 5000 + 151;
+pub const SYS__sysctl: ::c_long = 5000 + 152;
+pub const SYS_prctl: ::c_long = 5000 + 153;
+pub const SYS_adjtimex: ::c_long = 5000 + 154;
+pub const SYS_setrlimit: ::c_long = 5000 + 155;
+pub const SYS_chroot: ::c_long = 5000 + 156;
+pub const SYS_sync: ::c_long = 5000 + 157;
+pub const SYS_acct: ::c_long = 5000 + 158;
+pub const SYS_settimeofday: ::c_long = 5000 + 159;
+pub const SYS_mount: ::c_long = 5000 + 160;
+pub const SYS_umount2: ::c_long = 5000 + 161;
+pub const SYS_swapon: ::c_long = 5000 + 162;
+pub const SYS_swapoff: ::c_long = 5000 + 163;
+pub const SYS_reboot: ::c_long = 5000 + 164;
+pub const SYS_sethostname: ::c_long = 5000 + 165;
+pub const SYS_setdomainname: ::c_long = 5000 + 166;
+pub const SYS_create_module: ::c_long = 5000 + 167;
+pub const SYS_init_module: ::c_long = 5000 + 168;
+pub const SYS_delete_module: ::c_long = 5000 + 169;
+pub const SYS_get_kernel_syms: ::c_long = 5000 + 170;
+pub const SYS_query_module: ::c_long = 5000 + 171;
+pub const SYS_quotactl: ::c_long = 5000 + 172;
+pub const SYS_nfsservctl: ::c_long = 5000 + 173;
+pub const SYS_getpmsg: ::c_long = 5000 + 174;
+pub const SYS_putpmsg: ::c_long = 5000 + 175;
+pub const SYS_afs_syscall: ::c_long = 5000 + 176;
+pub const SYS_gettid: ::c_long = 5000 + 178;
+pub const SYS_readahead: ::c_long = 5000 + 179;
+pub const SYS_setxattr: ::c_long = 5000 + 180;
+pub const SYS_lsetxattr: ::c_long = 5000 + 181;
+pub const SYS_fsetxattr: ::c_long = 5000 + 182;
+pub const SYS_getxattr: ::c_long = 5000 + 183;
+pub const SYS_lgetxattr: ::c_long = 5000 + 184;
+pub const SYS_fgetxattr: ::c_long = 5000 + 185;
+pub const SYS_listxattr: ::c_long = 5000 + 186;
+pub const SYS_llistxattr: ::c_long = 5000 + 187;
+pub const SYS_flistxattr: ::c_long = 5000 + 188;
+pub const SYS_removexattr: ::c_long = 5000 + 189;
+pub const SYS_lremovexattr: ::c_long = 5000 + 190;
+pub const SYS_fremovexattr: ::c_long = 5000 + 191;
+pub const SYS_tkill: ::c_long = 5000 + 192;
+pub const SYS_futex: ::c_long = 5000 + 194;
+pub const SYS_sched_setaffinity: ::c_long = 5000 + 195;
+pub const SYS_sched_getaffinity: ::c_long = 5000 + 196;
+pub const SYS_cacheflush: ::c_long = 5000 + 197;
+pub const SYS_cachectl: ::c_long = 5000 + 198;
+pub const SYS_sysmips: ::c_long = 5000 + 199;
+pub const SYS_io_setup: ::c_long = 5000 + 200;
+pub const SYS_io_destroy: ::c_long = 5000 + 201;
+pub const SYS_io_getevents: ::c_long = 5000 + 202;
+pub const SYS_io_submit: ::c_long = 5000 + 203;
+pub const SYS_io_cancel: ::c_long = 5000 + 204;
+pub const SYS_exit_group: ::c_long = 5000 + 205;
+pub const SYS_lookup_dcookie: ::c_long = 5000 + 206;
+pub const SYS_epoll_create: ::c_long = 5000 + 207;
+pub const SYS_epoll_ctl: ::c_long = 5000 + 208;
+pub const SYS_epoll_wait: ::c_long = 5000 + 209;
+pub const SYS_remap_file_pages: ::c_long = 5000 + 210;
+pub const SYS_rt_sigreturn: ::c_long = 5000 + 211;
+pub const SYS_set_tid_address: ::c_long = 5000 + 212;
+pub const SYS_restart_syscall: ::c_long = 5000 + 213;
+pub const SYS_semtimedop: ::c_long = 5000 + 214;
+pub const SYS_fadvise64: ::c_long = 5000 + 215;
+pub const SYS_timer_create: ::c_long = 5000 + 216;
+pub const SYS_timer_settime: ::c_long = 5000 + 217;
+pub const SYS_timer_gettime: ::c_long = 5000 + 218;
+pub const SYS_timer_getoverrun: ::c_long = 5000 + 219;
+pub const SYS_timer_delete: ::c_long = 5000 + 220;
+pub const SYS_clock_settime: ::c_long = 5000 + 221;
+pub const SYS_clock_gettime: ::c_long = 5000 + 222;
+pub const SYS_clock_getres: ::c_long = 5000 + 223;
+pub const SYS_clock_nanosleep: ::c_long = 5000 + 224;
+pub const SYS_tgkill: ::c_long = 5000 + 225;
+pub const SYS_utimes: ::c_long = 5000 + 226;
+pub const SYS_mbind: ::c_long = 5000 + 227;
+pub const SYS_get_mempolicy: ::c_long = 5000 + 228;
+pub const SYS_set_mempolicy: ::c_long = 5000 + 229;
+pub const SYS_mq_open: ::c_long = 5000 + 230;
+pub const SYS_mq_unlink: ::c_long = 5000 + 231;
+pub const SYS_mq_timedsend: ::c_long = 5000 + 232;
+pub const SYS_mq_timedreceive: ::c_long = 5000 + 233;
+pub const SYS_mq_notify: ::c_long = 5000 + 234;
+pub const SYS_mq_getsetattr: ::c_long = 5000 + 235;
+pub const SYS_vserver: ::c_long = 5000 + 236;
+pub const SYS_waitid: ::c_long = 5000 + 237;
+/* pub const SYS_sys_setaltroot: ::c_long = 5000 + 238; */
+pub const SYS_add_key: ::c_long = 5000 + 239;
+pub const SYS_request_key: ::c_long = 5000 + 240;
+pub const SYS_keyctl: ::c_long = 5000 + 241;
+pub const SYS_set_thread_area: ::c_long = 5000 + 242;
+pub const SYS_inotify_init: ::c_long = 5000 + 243;
+pub const SYS_inotify_add_watch: ::c_long = 5000 + 244;
+pub const SYS_inotify_rm_watch: ::c_long = 5000 + 245;
+pub const SYS_migrate_pages: ::c_long = 5000 + 246;
+pub const SYS_openat: ::c_long = 5000 + 247;
+pub const SYS_mkdirat: ::c_long = 5000 + 248;
+pub const SYS_mknodat: ::c_long = 5000 + 249;
+pub const SYS_fchownat: ::c_long = 5000 + 250;
+pub const SYS_futimesat: ::c_long = 5000 + 251;
+pub const SYS_newfstatat: ::c_long = 5000 + 252;
+pub const SYS_unlinkat: ::c_long = 5000 + 253;
+pub const SYS_renameat: ::c_long = 5000 + 254;
+pub const SYS_linkat: ::c_long = 5000 + 255;
+pub const SYS_symlinkat: ::c_long = 5000 + 256;
+pub const SYS_readlinkat: ::c_long = 5000 + 257;
+pub const SYS_fchmodat: ::c_long = 5000 + 258;
+pub const SYS_faccessat: ::c_long = 5000 + 259;
+pub const SYS_pselect6: ::c_long = 5000 + 260;
+pub const SYS_ppoll: ::c_long = 5000 + 261;
+pub const SYS_unshare: ::c_long = 5000 + 262;
+pub const SYS_splice: ::c_long = 5000 + 263;
+pub const SYS_sync_file_range: ::c_long = 5000 + 264;
+pub const SYS_tee: ::c_long = 5000 + 265;
+pub const SYS_vmsplice: ::c_long = 5000 + 266;
+pub const SYS_move_pages: ::c_long = 5000 + 267;
+pub const SYS_set_robust_list: ::c_long = 5000 + 268;
+pub const SYS_get_robust_list: ::c_long = 5000 + 269;
+pub const SYS_kexec_load: ::c_long = 5000 + 270;
+pub const SYS_getcpu: ::c_long = 5000 + 271;
+pub const SYS_epoll_pwait: ::c_long = 5000 + 272;
+pub const SYS_ioprio_set: ::c_long = 5000 + 273;
+pub const SYS_ioprio_get: ::c_long = 5000 + 274;
+pub const SYS_utimensat: ::c_long = 5000 + 275;
+pub const SYS_signalfd: ::c_long = 5000 + 276;
+pub const SYS_timerfd: ::c_long = 5000 + 277;
+pub const SYS_eventfd: ::c_long = 5000 + 278;
+pub const SYS_fallocate: ::c_long = 5000 + 279;
+pub const SYS_timerfd_create: ::c_long = 5000 + 280;
+pub const SYS_timerfd_gettime: ::c_long = 5000 + 281;
+pub const SYS_timerfd_settime: ::c_long = 5000 + 282;
+pub const SYS_signalfd4: ::c_long = 5000 + 283;
+pub const SYS_eventfd2: ::c_long = 5000 + 284;
+pub const SYS_epoll_create1: ::c_long = 5000 + 285;
+pub const SYS_dup3: ::c_long = 5000 + 286;
+pub const SYS_pipe2: ::c_long = 5000 + 287;
+pub const SYS_inotify_init1: ::c_long = 5000 + 288;
+pub const SYS_preadv: ::c_long = 5000 + 289;
+pub const SYS_pwritev: ::c_long = 5000 + 290;
+pub const SYS_rt_tgsigqueueinfo: ::c_long = 5000 + 291;
+pub const SYS_perf_event_open: ::c_long = 5000 + 292;
+pub const SYS_accept4: ::c_long = 5000 + 293;
+pub const SYS_recvmmsg: ::c_long = 5000 + 294;
+pub const SYS_fanotify_init: ::c_long = 5000 + 295;
+pub const SYS_fanotify_mark: ::c_long = 5000 + 296;
+pub const SYS_prlimit64: ::c_long = 5000 + 297;
+pub const SYS_name_to_handle_at: ::c_long = 5000 + 298;
+pub const SYS_open_by_handle_at: ::c_long = 5000 + 299;
+pub const SYS_clock_adjtime: ::c_long = 5000 + 300;
+pub const SYS_syncfs: ::c_long = 5000 + 301;
+pub const SYS_sendmmsg: ::c_long = 5000 + 302;
+pub const SYS_setns: ::c_long = 5000 + 303;
+pub const SYS_process_vm_readv: ::c_long = 5000 + 304;
+pub const SYS_process_vm_writev: ::c_long = 5000 + 305;
+pub const SYS_kcmp: ::c_long = 5000 + 306;
+pub const SYS_finit_module: ::c_long = 5000 + 307;
+pub const SYS_getdents64: ::c_long = 5000 + 308;
+pub const SYS_sched_setattr: ::c_long = 5000 + 309;
+pub const SYS_sched_getattr: ::c_long = 5000 + 310;
+pub const SYS_renameat2: ::c_long = 5000 + 311;
+pub const SYS_seccomp: ::c_long = 5000 + 312;
+pub const SYS_getrandom: ::c_long = 5000 + 313;
+pub const SYS_memfd_create: ::c_long = 5000 + 314;
+pub const SYS_bpf: ::c_long = 5000 + 315;
+pub const SYS_execveat: ::c_long = 5000 + 316;
+pub const SYS_userfaultfd: ::c_long = 5000 + 317;
+pub const SYS_membarrier: ::c_long = 5000 + 318;
+pub const SYS_mlock2: ::c_long = 5000 + 319;
+pub const SYS_copy_file_range: ::c_long = 5000 + 320;
+pub const SYS_preadv2: ::c_long = 5000 + 321;
+pub const SYS_pwritev2: ::c_long = 5000 + 322;
+pub const SYS_pkey_mprotect: ::c_long = 5000 + 323;
+pub const SYS_pkey_alloc: ::c_long = 5000 + 324;
+pub const SYS_pkey_free: ::c_long = 5000 + 325;
+
+pub const O_DIRECT: ::c_int = 0x8000;
+pub const O_DIRECTORY: ::c_int = 0x10000;
+pub const O_NOFOLLOW: ::c_int = 0x20000;
+
+pub const O_APPEND: ::c_int = 8;
+pub const O_CREAT: ::c_int = 256;
+pub const O_EXCL: ::c_int = 1024;
+pub const O_NOCTTY: ::c_int = 2048;
+pub const O_NONBLOCK: ::c_int = 128;
+pub const O_SYNC: ::c_int = 0x4010;
+pub const O_RSYNC: ::c_int = 0x4010;
+pub const O_DSYNC: ::c_int = 0x10;
+pub const O_ASYNC: ::c_int = 0x1000;
+
+pub const EDEADLK: ::c_int = 45;
+pub const ENAMETOOLONG: ::c_int = 78;
+pub const ENOLCK: ::c_int = 46;
+pub const ENOSYS: ::c_int = 89;
+pub const ENOTEMPTY: ::c_int = 93;
+pub const ELOOP: ::c_int = 90;
+pub const ENOMSG: ::c_int = 35;
+pub const EIDRM: ::c_int = 36;
+pub const ECHRNG: ::c_int = 37;
+pub const EL2NSYNC: ::c_int = 38;
+pub const EL3HLT: ::c_int = 39;
+pub const EL3RST: ::c_int = 40;
+pub const ELNRNG: ::c_int = 41;
+pub const EUNATCH: ::c_int = 42;
+pub const ENOCSI: ::c_int = 43;
+pub const EL2HLT: ::c_int = 44;
+pub const EBADE: ::c_int = 50;
+pub const EBADR: ::c_int = 51;
+pub const EXFULL: ::c_int = 52;
+pub const ENOANO: ::c_int = 53;
+pub const EBADRQC: ::c_int = 54;
+pub const EBADSLT: ::c_int = 55;
+pub const EDEADLOCK: ::c_int = 56;
+pub const EMULTIHOP: ::c_int = 74;
+pub const EOVERFLOW: ::c_int = 79;
+pub const ENOTUNIQ: ::c_int = 80;
+pub const EBADFD: ::c_int = 81;
+pub const EBADMSG: ::c_int = 77;
+pub const EREMCHG: ::c_int = 82;
+pub const ELIBACC: ::c_int = 83;
+pub const ELIBBAD: ::c_int = 84;
+pub const ELIBSCN: ::c_int = 85;
+pub const ELIBMAX: ::c_int = 86;
+pub const ELIBEXEC: ::c_int = 87;
+pub const EILSEQ: ::c_int = 88;
+pub const ERESTART: ::c_int = 91;
+pub const ESTRPIPE: ::c_int = 92;
+pub const EUSERS: ::c_int = 94;
+pub const ENOTSOCK: ::c_int = 95;
+pub const EDESTADDRREQ: ::c_int = 96;
+pub const EMSGSIZE: ::c_int = 97;
+pub const EPROTOTYPE: ::c_int = 98;
+pub const ENOPROTOOPT: ::c_int = 99;
+pub const EPROTONOSUPPORT: ::c_int = 120;
+pub const ESOCKTNOSUPPORT: ::c_int = 121;
+pub const EOPNOTSUPP: ::c_int = 122;
+pub const EPFNOSUPPORT: ::c_int = 123;
+pub const EAFNOSUPPORT: ::c_int = 124;
+pub const EADDRINUSE: ::c_int = 125;
+pub const EADDRNOTAVAIL: ::c_int = 126;
+pub const ENETDOWN: ::c_int = 127;
+pub const ENETUNREACH: ::c_int = 128;
+pub const ENETRESET: ::c_int = 129;
+pub const ECONNABORTED: ::c_int = 130;
+pub const ECONNRESET: ::c_int = 131;
+pub const ENOBUFS: ::c_int = 132;
+pub const EISCONN: ::c_int = 133;
+pub const ENOTCONN: ::c_int = 134;
+pub const ESHUTDOWN: ::c_int = 143;
+pub const ETOOMANYREFS: ::c_int = 144;
+pub const ETIMEDOUT: ::c_int = 145;
+pub const ECONNREFUSED: ::c_int = 146;
+pub const EHOSTDOWN: ::c_int = 147;
+pub const EHOSTUNREACH: ::c_int = 148;
+pub const EALREADY: ::c_int = 149;
+pub const EINPROGRESS: ::c_int = 150;
+pub const ESTALE: ::c_int = 151;
+pub const EUCLEAN: ::c_int = 135;
+pub const ENOTNAM: ::c_int = 137;
+pub const ENAVAIL: ::c_int = 138;
+pub const EISNAM: ::c_int = 139;
+pub const EREMOTEIO: ::c_int = 140;
+pub const EDQUOT: ::c_int = 1133;
+pub const ENOMEDIUM: ::c_int = 159;
+pub const EMEDIUMTYPE: ::c_int = 160;
+pub const ECANCELED: ::c_int = 158;
+pub const ENOKEY: ::c_int = 161;
+pub const EKEYEXPIRED: ::c_int = 162;
+pub const EKEYREVOKED: ::c_int = 163;
+pub const EKEYREJECTED: ::c_int = 164;
+pub const EOWNERDEAD: ::c_int = 165;
+pub const ENOTRECOVERABLE: ::c_int = 166;
+pub const ERFKILL: ::c_int = 167;
+
+pub const MAP_NORESERVE: ::c_int = 0x400;
+pub const MAP_ANON: ::c_int = 0x800;
+pub const MAP_GROWSDOWN: ::c_int = 0x1000;
+pub const MAP_DENYWRITE: ::c_int = 0x2000;
+pub const MAP_EXECUTABLE: ::c_int = 0x4000;
+pub const MAP_LOCKED: ::c_int = 0x8000;
+pub const MAP_POPULATE: ::c_int = 0x10000;
+pub const MAP_NONBLOCK: ::c_int = 0x20000;
+pub const MAP_STACK: ::c_int = 0x40000;
+pub const MAP_HUGETLB: ::c_int = 0x080000;
+
+pub const SOCK_STREAM: ::c_int = 2;
+pub const SOCK_DGRAM: ::c_int = 1;
+
+pub const SOL_SOCKET: ::c_int = 0xffff;
+
+pub const SO_REUSEADDR: ::c_int = 0x0004;
+pub const SO_KEEPALIVE: ::c_int = 0x0008;
+pub const SO_DONTROUTE: ::c_int = 0x0010;
+pub const SO_BROADCAST: ::c_int = 0x0020;
+pub const SO_LINGER: ::c_int = 0x0080;
+pub const SO_OOBINLINE: ::c_int = 0x0100;
+pub const SO_REUSEPORT: ::c_int = 0x0200;
+pub const SO_TYPE: ::c_int = 0x1008;
+pub const SO_ERROR: ::c_int = 0x1007;
+pub const SO_SNDBUF: ::c_int = 0x1001;
+pub const SO_RCVBUF: ::c_int = 0x1002;
+pub const SO_SNDLOWAT: ::c_int = 0x1003;
+pub const SO_RCVLOWAT: ::c_int = 0x1004;
+pub const SO_SNDTIMEO: ::c_int = 0x1005;
+pub const SO_RCVTIMEO: ::c_int = 0x1006;
+pub const SO_ACCEPTCONN: ::c_int = 0x1009;
+pub const SO_PROTOCOL: ::c_int = 0x1028;
+pub const SO_DOMAIN: ::c_int = 0x1029;
+pub const SO_NO_CHECK: ::c_int = 11;
+pub const SO_PRIORITY: ::c_int = 12;
+pub const SO_BSDCOMPAT: ::c_int = 14;
+pub const SO_PASSCRED: ::c_int = 17;
+pub const SO_PEERCRED: ::c_int = 18;
+pub const SO_SECURITY_AUTHENTICATION: ::c_int = 22;
+pub const SO_SECURITY_ENCRYPTION_TRANSPORT: ::c_int = 23;
+pub const SO_SECURITY_ENCRYPTION_NETWORK: ::c_int = 24;
+pub const SO_ATTACH_FILTER: ::c_int = 26;
+pub const SO_DETACH_FILTER: ::c_int = 27;
+pub const SO_GET_FILTER: ::c_int = SO_ATTACH_FILTER;
+pub const SO_PEERNAME: ::c_int = 28;
+pub const SO_PEERSEC: ::c_int = 30;
+pub const SO_SNDBUFFORCE: ::c_int = 31;
+pub const SO_RCVBUFFORCE: ::c_int = 33;
+pub const SO_PASSSEC: ::c_int = 34;
+pub const SO_TIMESTAMPNS: ::c_int = 35;
+pub const SCM_TIMESTAMPNS: ::c_int = SO_TIMESTAMPNS;
+pub const SO_WIFI_STATUS: ::c_int = 41;
+pub const SCM_WIFI_STATUS: ::c_int = SO_WIFI_STATUS;
+pub const SO_NOFCS: ::c_int = 43;
+pub const SO_LOCK_FILTER: ::c_int = 44;
+pub const SO_SELECT_ERR_QUEUE: ::c_int = 45;
+pub const SO_MAX_PACING_RATE: ::c_int = 47;
+pub const SO_BPF_EXTENSIONS: ::c_int = 48;
+pub const SO_INCOMING_CPU: ::c_int = 49;
+pub const SO_ATTACH_BPF: ::c_int = 50;
+pub const SO_DETACH_BPF: ::c_int = SO_DETACH_FILTER;
+
+pub const FIOCLEX: ::c_int = 0x6601;
+pub const FIONCLEX: ::c_int = 0x6602;
+pub const FIONBIO: ::c_int = 0x667e;
+
+pub const SA_ONSTACK: ::c_int = 0x08000000;
+pub const SA_SIGINFO: ::c_int = 0x00000008;
+pub const SA_NOCLDWAIT: ::c_int = 0x00010000;
+
+pub const SIGCHLD: ::c_int = 18;
+pub const SIGBUS: ::c_int = 10;
+pub const SIGTTIN: ::c_int = 26;
+pub const SIGTTOU: ::c_int = 27;
+pub const SIGXCPU: ::c_int = 30;
+pub const SIGXFSZ: ::c_int = 31;
+pub const SIGVTALRM: ::c_int = 28;
+pub const SIGPROF: ::c_int = 29;
+pub const SIGWINCH: ::c_int = 20;
+pub const SIGUSR1: ::c_int = 16;
+pub const SIGUSR2: ::c_int = 17;
+pub const SIGCONT: ::c_int = 25;
+pub const SIGSTOP: ::c_int = 23;
+pub const SIGTSTP: ::c_int = 24;
+pub const SIGURG: ::c_int = 21;
+pub const SIGIO: ::c_int = 22;
+pub const SIGSYS: ::c_int = 12;
+pub const SIGPOLL: ::c_int = 22;
+pub const SIGPWR: ::c_int = 19;
+pub const SIG_SETMASK: ::c_int = 3;
+pub const SIG_BLOCK: ::c_int = 0x1;
+pub const SIG_UNBLOCK: ::c_int = 0x2;
+
+pub const POLLWRNORM: ::c_short = 0x004;
+pub const POLLWRBAND: ::c_short = 0x100;
+
+pub const VEOF: usize = 16;
+pub const VEOL: usize = 17;
+pub const VEOL2: usize = 6;
+pub const VMIN: usize = 4;
+pub const IEXTEN: ::tcflag_t = 0x00000100;
+pub const TOSTOP: ::tcflag_t = 0x00008000;
+pub const FLUSHO: ::tcflag_t = 0x00002000;
+pub const EXTPROC: ::tcflag_t = 0o200000;
+
+pub const F_GETLK: ::c_int = 14;
+pub const F_GETOWN: ::c_int = 23;
+pub const F_SETOWN: ::c_int = 24;
+pub const F_SETLK: ::c_int = 6;
+pub const F_SETLKW: ::c_int = 7;
+
+pub const TCGETS: ::c_ulong = 0x540d;
+pub const TCSETS: ::c_ulong = 0x540e;
+pub const TCSETSW: ::c_ulong = 0x540f;
+pub const TCSETSF: ::c_ulong = 0x5410;
+pub const TCGETA: ::c_ulong = 0x5401;
+pub const TCSETA: ::c_ulong = 0x5402;
+pub const TCSETAW: ::c_ulong = 0x5403;
+pub const TCSETAF: ::c_ulong = 0x5404;
+pub const TCSBRK: ::c_ulong = 0x5405;
+pub const TCXONC: ::c_ulong = 0x5406;
+pub const TCFLSH: ::c_ulong = 0x5407;
+pub const TIOCGSOFTCAR: ::c_ulong = 0x5481;
+pub const TIOCSSOFTCAR: ::c_ulong = 0x5482;
+pub const TIOCINQ: ::c_ulong = 0x467f;
+pub const TIOCLINUX: ::c_ulong = 0x5483;
+pub const TIOCGSERIAL: ::c_ulong = 0x5484;
+pub const TIOCEXCL: ::c_ulong = 0x740d;
+pub const TIOCNXCL: ::c_ulong = 0x740e;
+pub const TIOCSCTTY: ::c_ulong = 0x5480;
+pub const TIOCGPGRP: ::c_ulong = 0x40047477;
+pub const TIOCSPGRP: ::c_ulong = 0x80047476;
+pub const TIOCOUTQ: ::c_ulong = 0x7472;
+pub const TIOCSTI: ::c_ulong = 0x5472;
+pub const TIOCGWINSZ: ::c_ulong = 0x40087468;
+pub const TIOCSWINSZ: ::c_ulong = 0x80087467;
+pub const TIOCMGET: ::c_ulong = 0x741d;
+pub const TIOCMBIS: ::c_ulong = 0x741b;
+pub const TIOCMBIC: ::c_ulong = 0x741c;
+pub const TIOCMSET: ::c_ulong = 0x741a;
+pub const FIONREAD: ::c_ulong = 0x467f;
+pub const TIOCCONS: ::c_ulong = 0x80047478;
+
+pub const MCL_CURRENT: ::c_int = 0x0001;
+pub const MCL_FUTURE: ::c_int = 0x0002;
+
+pub const CBAUD: ::tcflag_t = 0o0010017;
+pub const TAB1: ::tcflag_t = 0x00000800;
+pub const TAB2: ::tcflag_t = 0x00001000;
+pub const TAB3: ::tcflag_t = 0x00001800;
+pub const CR1: ::tcflag_t = 0x00000200;
+pub const CR2: ::tcflag_t = 0x00000400;
+pub const CR3: ::tcflag_t = 0x00000600;
+pub const FF1: ::tcflag_t = 0x00008000;
+pub const BS1: ::tcflag_t = 0x00002000;
+pub const VT1: ::tcflag_t = 0x00004000;
+pub const VWERASE: usize = 14;
+pub const VREPRINT: usize = 12;
+pub const VSUSP: usize = 10;
+pub const VSTART: usize = 8;
+pub const VSTOP: usize = 9;
+pub const VDISCARD: usize = 13;
+pub const VTIME: usize = 5;
+pub const IXON: ::tcflag_t = 0x00000400;
+pub const IXOFF: ::tcflag_t = 0x00001000;
+pub const ONLCR: ::tcflag_t = 0x4;
+pub const CSIZE: ::tcflag_t = 0x00000030;
+pub const CS6: ::tcflag_t = 0x00000010;
+pub const CS7: ::tcflag_t = 0x00000020;
+pub const CS8: ::tcflag_t = 0x00000030;
+pub const CSTOPB: ::tcflag_t = 0x00000040;
+pub const CREAD: ::tcflag_t = 0x00000080;
+pub const PARENB: ::tcflag_t = 0x00000100;
+pub const PARODD: ::tcflag_t = 0x00000200;
+pub const HUPCL: ::tcflag_t = 0x00000400;
+pub const CLOCAL: ::tcflag_t = 0x00000800;
+pub const ECHOKE: ::tcflag_t = 0x00000800;
+pub const ECHOE: ::tcflag_t = 0x00000010;
+pub const ECHOK: ::tcflag_t = 0x00000020;
+pub const ECHONL: ::tcflag_t = 0x00000040;
+pub const ECHOPRT: ::tcflag_t = 0x00000400;
+pub const ECHOCTL: ::tcflag_t = 0x00000200;
+pub const ISIG: ::tcflag_t = 0x00000001;
+pub const ICANON: ::tcflag_t = 0x00000002;
+pub const PENDIN: ::tcflag_t = 0x00004000;
+pub const NOFLSH: ::tcflag_t = 0x00000080;
+pub const CIBAUD: ::tcflag_t = 0o02003600000;
+pub const CBAUDEX: ::tcflag_t = 0o010000;
+pub const VSWTC: usize = 7;
+pub const OLCUC:  ::tcflag_t = 0o000002;
+pub const NLDLY:  ::tcflag_t = 0o000400;
+pub const CRDLY:  ::tcflag_t = 0o003000;
+pub const TABDLY: ::tcflag_t = 0o014000;
+pub const BSDLY:  ::tcflag_t = 0o020000;
+pub const FFDLY:  ::tcflag_t = 0o100000;
+pub const VTDLY:  ::tcflag_t = 0o040000;
+pub const XTABS:  ::tcflag_t = 0o014000;
+
+pub const BOTHER: ::speed_t = 0o010000;
+pub const B57600: ::speed_t = 0o010001;
+pub const B115200: ::speed_t = 0o010002;
+pub const B230400: ::speed_t = 0o010003;
+pub const B460800: ::speed_t = 0o010004;
+pub const B500000: ::speed_t = 0o010005;
+pub const B576000: ::speed_t = 0o010006;
+pub const B921600: ::speed_t = 0o010007;
+pub const B1000000: ::speed_t = 0o010010;
+pub const B1152000: ::speed_t = 0o010011;
+pub const B1500000: ::speed_t = 0o010012;
+pub const B2000000: ::speed_t = 0o010013;
+pub const B2500000: ::speed_t = 0o010014;
+pub const B3000000: ::speed_t = 0o010015;
+pub const B3500000: ::speed_t = 0o010016;
+pub const B4000000: ::speed_t = 0o010017;
+
+pub const TIOCM_ST: ::c_int = 0x010;
+pub const TIOCM_SR: ::c_int = 0x020;
+pub const TIOCM_CTS: ::c_int = 0x040;
+pub const TIOCM_CAR: ::c_int = 0x100;
+pub const TIOCM_RNG: ::c_int = 0x200;
+pub const TIOCM_DSR: ::c_int = 0x400;
+
+pub const EHWPOISON: ::c_int = 168;
+
+extern {
+    pub fn ioctl(fd: ::c_int, request: ::c_int, ...) -> ::c_int;
+}

--- a/src/unix/linux_like/linux/musl/b64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/mod.rs
@@ -124,6 +124,9 @@ cfg_if! {
     if #[cfg(target_arch = "aarch64")] {
         mod aarch64;
         pub use self::aarch64::*;
+    } else if #[cfg(target_arch = "mips64")] {
+        mod mips64;
+        pub use self::mips64::*;
     } else if #[cfg(any(target_arch = "powerpc64"))] {
         mod powerpc64;
         pub use self::powerpc64::*;

--- a/src/unix/linux_like/linux/musl/b64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/mod.rs
@@ -2,21 +2,6 @@ pub type c_long = i64;
 pub type c_ulong = u64;
 
 s! {
-    pub struct statfs64 {
-        pub f_type: ::c_ulong,
-        pub f_bsize: ::c_ulong,
-        pub f_blocks: ::fsblkcnt_t,
-        pub f_bfree: ::fsblkcnt_t,
-        pub f_bavail: ::fsblkcnt_t,
-        pub f_files: ::fsfilcnt_t,
-        pub f_ffree: ::fsfilcnt_t,
-        pub f_fsid: ::fsid_t,
-        pub f_namelen: ::c_ulong,
-        pub f_frsize: ::c_ulong,
-        pub f_flags: ::c_ulong,
-        pub f_spare: [::c_ulong; 4],
-    }
-
     pub struct statvfs64 {
         pub f_bsize: ::c_ulong,
         pub f_frsize: ::c_ulong,
@@ -73,21 +58,6 @@ s! {
         __pad2: ::c_ulong,
     }
 
-    pub struct statfs {
-        pub f_type: ::c_ulong,
-        pub f_bsize: ::c_ulong,
-        pub f_blocks: ::fsblkcnt_t,
-        pub f_bfree: ::fsblkcnt_t,
-        pub f_bavail: ::fsblkcnt_t,
-        pub f_files: ::fsfilcnt_t,
-        pub f_ffree: ::fsfilcnt_t,
-        pub f_fsid: ::fsid_t,
-        pub f_namelen: ::c_ulong,
-        pub f_frsize: ::c_ulong,
-        pub f_flags: ::c_ulong,
-        pub f_spare: [::c_ulong; 4],
-    }
-
     pub struct msghdr {
         pub msg_name: *mut ::c_void,
         pub msg_namelen: ::socklen_t,
@@ -132,185 +102,15 @@ s! {
 pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 56;
 pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
 
-pub const O_ASYNC: ::c_int = 0x2000;
-
 pub const RLIMIT_RSS: ::c_int = 5;
 pub const RLIMIT_NOFILE: ::c_int = 7;
 pub const RLIMIT_AS: ::c_int = 9;
 pub const RLIMIT_NPROC: ::c_int = 6;
 pub const RLIMIT_MEMLOCK: ::c_int = 8;
 
-pub const O_APPEND: ::c_int = 1024;
-pub const O_CREAT: ::c_int = 64;
-pub const O_EXCL: ::c_int = 128;
-pub const O_NOCTTY: ::c_int = 256;
-pub const O_NONBLOCK: ::c_int = 2048;
-pub const O_SYNC: ::c_int = 1052672;
-pub const O_RSYNC: ::c_int = 1052672;
-pub const O_DSYNC: ::c_int = 4096;
-
 pub const SOCK_NONBLOCK: ::c_int = 2048;
 
-pub const MAP_ANON: ::c_int = 0x0020;
-pub const MAP_GROWSDOWN: ::c_int = 0x0100;
-pub const MAP_DENYWRITE: ::c_int = 0x0800;
-pub const MAP_EXECUTABLE: ::c_int = 0x01000;
-pub const MAP_LOCKED: ::c_int = 0x02000;
-pub const MAP_NORESERVE: ::c_int = 0x04000;
-pub const MAP_POPULATE: ::c_int = 0x08000;
-pub const MAP_NONBLOCK: ::c_int = 0x010000;
-pub const MAP_STACK: ::c_int = 0x020000;
-
-pub const SOCK_STREAM: ::c_int = 1;
-pub const SOCK_DGRAM: ::c_int = 2;
 pub const SOCK_SEQPACKET: ::c_int = 5;
-
-pub const SOL_SOCKET: ::c_int = 1;
-
-pub const ENAMETOOLONG: ::c_int = 36;
-pub const ENOLCK: ::c_int = 37;
-pub const ENOSYS: ::c_int = 38;
-pub const ENOTEMPTY: ::c_int = 39;
-pub const ELOOP: ::c_int = 40;
-pub const ENOMSG: ::c_int = 42;
-pub const EIDRM: ::c_int = 43;
-pub const ECHRNG: ::c_int = 44;
-pub const EL2NSYNC: ::c_int = 45;
-pub const EL3HLT: ::c_int = 46;
-pub const EL3RST: ::c_int = 47;
-pub const ELNRNG: ::c_int = 48;
-pub const EUNATCH: ::c_int = 49;
-pub const ENOCSI: ::c_int = 50;
-pub const EL2HLT: ::c_int = 51;
-pub const EBADE: ::c_int = 52;
-pub const EBADR: ::c_int = 53;
-pub const EXFULL: ::c_int = 54;
-pub const ENOANO: ::c_int = 55;
-pub const EBADRQC: ::c_int = 56;
-pub const EBADSLT: ::c_int = 57;
-pub const EMULTIHOP: ::c_int = 72;
-pub const EBADMSG: ::c_int = 74;
-pub const EOVERFLOW: ::c_int = 75;
-pub const ENOTUNIQ: ::c_int = 76;
-pub const EBADFD: ::c_int = 77;
-pub const EREMCHG: ::c_int = 78;
-pub const ELIBACC: ::c_int = 79;
-pub const ELIBBAD: ::c_int = 80;
-pub const ELIBSCN: ::c_int = 81;
-pub const ELIBMAX: ::c_int = 82;
-pub const ELIBEXEC: ::c_int = 83;
-pub const EILSEQ: ::c_int = 84;
-pub const ERESTART: ::c_int = 85;
-pub const ESTRPIPE: ::c_int = 86;
-pub const EUSERS: ::c_int = 87;
-pub const ENOTSOCK: ::c_int = 88;
-pub const EDESTADDRREQ: ::c_int = 89;
-pub const EMSGSIZE: ::c_int = 90;
-pub const EPROTOTYPE: ::c_int = 91;
-pub const ENOPROTOOPT: ::c_int = 92;
-pub const EPROTONOSUPPORT: ::c_int = 93;
-pub const ESOCKTNOSUPPORT: ::c_int = 94;
-pub const EOPNOTSUPP: ::c_int = 95;
-pub const ENOTSUP: ::c_int = EOPNOTSUPP;
-pub const EPFNOSUPPORT: ::c_int = 96;
-pub const EAFNOSUPPORT: ::c_int = 97;
-pub const EADDRINUSE: ::c_int = 98;
-pub const EADDRNOTAVAIL: ::c_int = 99;
-pub const ENETDOWN: ::c_int = 100;
-pub const ENETUNREACH: ::c_int = 101;
-pub const ENETRESET: ::c_int = 102;
-pub const ECONNABORTED: ::c_int = 103;
-pub const ECONNRESET: ::c_int = 104;
-pub const ENOBUFS: ::c_int = 105;
-pub const EISCONN: ::c_int = 106;
-pub const ENOTCONN: ::c_int = 107;
-pub const ESHUTDOWN: ::c_int = 108;
-pub const ETOOMANYREFS: ::c_int = 109;
-pub const ETIMEDOUT: ::c_int = 110;
-pub const ECONNREFUSED: ::c_int = 111;
-pub const EHOSTDOWN: ::c_int = 112;
-pub const EHOSTUNREACH: ::c_int = 113;
-pub const EALREADY: ::c_int = 114;
-pub const EINPROGRESS: ::c_int = 115;
-pub const ESTALE: ::c_int = 116;
-pub const EUCLEAN: ::c_int = 117;
-pub const ENOTNAM: ::c_int = 118;
-pub const ENAVAIL: ::c_int = 119;
-pub const EISNAM: ::c_int = 120;
-pub const EREMOTEIO: ::c_int = 121;
-pub const EDQUOT: ::c_int = 122;
-pub const ENOMEDIUM: ::c_int = 123;
-pub const EMEDIUMTYPE: ::c_int = 124;
-pub const ECANCELED: ::c_int = 125;
-pub const ENOKEY: ::c_int = 126;
-pub const EKEYEXPIRED: ::c_int = 127;
-pub const EKEYREVOKED: ::c_int = 128;
-pub const EKEYREJECTED: ::c_int = 129;
-pub const EOWNERDEAD: ::c_int = 130;
-pub const ENOTRECOVERABLE: ::c_int = 131;
-pub const ERFKILL: ::c_int = 132;
-pub const EHWPOISON: ::c_int = 133;
-
-pub const SO_REUSEADDR: ::c_int = 2;
-pub const SO_TYPE: ::c_int = 3;
-pub const SO_ERROR: ::c_int = 4;
-pub const SO_DONTROUTE: ::c_int = 5;
-pub const SO_BROADCAST: ::c_int = 6;
-pub const SO_SNDBUF: ::c_int = 7;
-pub const SO_RCVBUF: ::c_int = 8;
-pub const SO_KEEPALIVE: ::c_int = 9;
-pub const SO_OOBINLINE: ::c_int = 10;
-pub const SO_NO_CHECK: ::c_int = 11;
-pub const SO_PRIORITY: ::c_int = 12;
-pub const SO_LINGER: ::c_int = 13;
-pub const SO_BSDCOMPAT: ::c_int = 14;
-pub const SO_REUSEPORT: ::c_int = 15;
-pub const SO_ACCEPTCONN: ::c_int = 30;
-pub const SO_SNDBUFFORCE: ::c_int = 32;
-pub const SO_RCVBUFFORCE: ::c_int = 33;
-pub const SO_PROTOCOL: ::c_int = 38;
-pub const SO_DOMAIN: ::c_int = 39;
-
-pub const SA_ONSTACK: ::c_int = 0x08000000;
-pub const SA_SIGINFO: ::c_int = 0x00000004;
-pub const SA_NOCLDWAIT: ::c_int = 0x00000002;
-
-pub const SIGCHLD: ::c_int = 17;
-pub const SIGBUS: ::c_int = 7;
-pub const SIGTTIN: ::c_int = 21;
-pub const SIGTTOU: ::c_int = 22;
-pub const SIGXCPU: ::c_int = 24;
-pub const SIGXFSZ: ::c_int = 25;
-pub const SIGVTALRM: ::c_int = 26;
-pub const SIGPROF: ::c_int = 27;
-pub const SIGWINCH: ::c_int = 28;
-pub const SIGUSR1: ::c_int = 10;
-pub const SIGUSR2: ::c_int = 12;
-pub const SIGCONT: ::c_int = 18;
-pub const SIGSTOP: ::c_int = 19;
-pub const SIGTSTP: ::c_int = 20;
-pub const SIGURG: ::c_int = 23;
-pub const SIGIO: ::c_int = 29;
-pub const SIGSYS: ::c_int = 31;
-pub const SIGSTKFLT: ::c_int = 16;
-pub const SIGPOLL: ::c_int = 29;
-pub const SIGPWR: ::c_int = 30;
-pub const SIG_SETMASK: ::c_int = 2;
-pub const SIG_BLOCK: ::c_int = 0x000000;
-pub const SIG_UNBLOCK: ::c_int = 0x01;
-
-pub const MAP_HUGETLB: ::c_int = 0x040000;
-
-pub const F_GETLK: ::c_int = 5;
-pub const F_GETOWN: ::c_int = 9;
-pub const F_SETLK: ::c_int = 6;
-pub const F_SETLKW: ::c_int = 7;
-pub const F_SETOWN: ::c_int = 8;
-
-pub const VEOF: usize = 4;
-
-pub const POLLWRNORM: ::c_short = 0x100;
-pub const POLLWRBAND: ::c_short = 0x200;
 
 extern {
     pub fn getrandom(

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -47,6 +47,36 @@ s! {
         __reserved: [::c_long; 3],
     }
 
+    pub struct statfs {
+        pub f_type: ::c_ulong,
+        pub f_bsize: ::c_ulong,
+        pub f_blocks: ::fsblkcnt_t,
+        pub f_bfree: ::fsblkcnt_t,
+        pub f_bavail: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
+        pub f_fsid: ::fsid_t,
+        pub f_namelen: ::c_ulong,
+        pub f_frsize: ::c_ulong,
+        pub f_flags: ::c_ulong,
+        pub f_spare: [::c_ulong; 4],
+    }
+
+    pub struct statfs64 {
+        pub f_type: ::c_ulong,
+        pub f_bsize: ::c_ulong,
+        pub f_blocks: ::fsblkcnt_t,
+        pub f_bfree: ::fsblkcnt_t,
+        pub f_bavail: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
+        pub f_fsid: ::fsid_t,
+        pub f_namelen: ::c_ulong,
+        pub f_frsize: ::c_ulong,
+        pub f_flags: ::c_ulong,
+        pub f_spare: [::c_ulong; 4],
+    }
+
     pub struct ipc_perm {
         pub __ipc_perm_key: ::key_t,
         pub uid: ::uid_t,
@@ -62,10 +92,31 @@ s! {
 
 pub const MADV_SOFT_OFFLINE: ::c_int = 101;
 pub const MAP_32BIT: ::c_int = 0x0040;
+pub const MAP_ANON: ::c_int = 0x0020;
+pub const MAP_GROWSDOWN: ::c_int = 0x0100;
+pub const MAP_DENYWRITE: ::c_int = 0x0800;
+pub const MAP_EXECUTABLE: ::c_int = 0x01000;
+pub const MAP_LOCKED: ::c_int = 0x02000;
+pub const MAP_NORESERVE: ::c_int = 0x04000;
+pub const MAP_POPULATE: ::c_int = 0x08000;
+pub const MAP_NONBLOCK: ::c_int = 0x010000;
+pub const MAP_STACK: ::c_int = 0x020000;
+pub const MAP_HUGETLB: ::c_int = 0x040000;
+pub const O_ASYNC: ::c_int = 0x2000;
+pub const O_APPEND: ::c_int = 1024;
+pub const O_CREAT: ::c_int = 64;
+pub const O_EXCL: ::c_int = 128;
+pub const O_NOCTTY: ::c_int = 256;
+pub const O_NONBLOCK: ::c_int = 2048;
+pub const O_SYNC: ::c_int = 1052672;
+pub const O_RSYNC: ::c_int = 1052672;
+pub const O_DSYNC: ::c_int = 4096;
 pub const O_DIRECT: ::c_int = 0x20000;
 pub const O_DIRECTORY: ::c_int = 0x4000;
 pub const O_LARGEFILE: ::c_int = 0x10000;
 pub const O_NOFOLLOW: ::c_int = 0x8000;
+pub const POLLWRNORM: ::c_short = 0x100;
+pub const POLLWRBAND: ::c_short = 0x200;
 
 pub const SIGSTKSZ: ::size_t = 10240;
 pub const MINSIGSTKSZ: ::size_t = 4096;
@@ -431,11 +482,117 @@ pub const SYS_preadv2: ::c_long = 380;
 pub const SYS_pwritev2: ::c_long = 381;
 pub const SYS_kexec_file_load: ::c_long = 382;
 
+pub const ENAMETOOLONG: ::c_int = 36;
+pub const ENOLCK: ::c_int = 37;
+pub const ENOSYS: ::c_int = 38;
+pub const ENOTEMPTY: ::c_int = 39;
+pub const ELOOP: ::c_int = 40;
+pub const ENOMSG: ::c_int = 42;
+pub const EIDRM: ::c_int = 43;
+pub const ECHRNG: ::c_int = 44;
+pub const EL2NSYNC: ::c_int = 45;
+pub const EL3HLT: ::c_int = 46;
+pub const EL3RST: ::c_int = 47;
+pub const ELNRNG: ::c_int = 48;
+pub const EUNATCH: ::c_int = 49;
+pub const ENOCSI: ::c_int = 50;
+pub const EL2HLT: ::c_int = 51;
+pub const EBADE: ::c_int = 52;
+pub const EBADR: ::c_int = 53;
+pub const EXFULL: ::c_int = 54;
+pub const ENOANO: ::c_int = 55;
+pub const EBADRQC: ::c_int = 56;
+pub const EBADSLT: ::c_int = 57;
+pub const EMULTIHOP: ::c_int = 72;
+pub const EBADMSG: ::c_int = 74;
+pub const EOVERFLOW: ::c_int = 75;
+pub const ENOTUNIQ: ::c_int = 76;
+pub const EBADFD: ::c_int = 77;
+pub const EREMCHG: ::c_int = 78;
+pub const ELIBACC: ::c_int = 79;
+pub const ELIBBAD: ::c_int = 80;
+pub const ELIBSCN: ::c_int = 81;
+pub const ELIBMAX: ::c_int = 82;
+pub const ELIBEXEC: ::c_int = 83;
+pub const EILSEQ: ::c_int = 84;
+pub const ERESTART: ::c_int = 85;
+pub const ESTRPIPE: ::c_int = 86;
+pub const EUSERS: ::c_int = 87;
+pub const ENOTSOCK: ::c_int = 88;
+pub const EDESTADDRREQ: ::c_int = 89;
+pub const EMSGSIZE: ::c_int = 90;
+pub const EPROTOTYPE: ::c_int = 91;
+pub const ENOPROTOOPT: ::c_int = 92;
+pub const EPROTONOSUPPORT: ::c_int = 93;
+pub const ESOCKTNOSUPPORT: ::c_int = 94;
+pub const EOPNOTSUPP: ::c_int = 95;
+pub const ENOTSUP: ::c_int = EOPNOTSUPP;
+pub const EPFNOSUPPORT: ::c_int = 96;
+pub const EAFNOSUPPORT: ::c_int = 97;
+pub const EADDRINUSE: ::c_int = 98;
+pub const EADDRNOTAVAIL: ::c_int = 99;
+pub const ENETDOWN: ::c_int = 100;
+
+pub const F_GETLK: ::c_int = 5;
+pub const F_GETOWN: ::c_int = 9;
+pub const F_SETLK: ::c_int = 6;
+pub const F_SETLKW: ::c_int = 7;
+pub const F_SETOWN: ::c_int = 8;
+
+pub const SIGCHLD: ::c_int = 17;
+pub const SIGBUS: ::c_int = 7;
+pub const SIGTTIN: ::c_int = 21;
+pub const SIGTTOU: ::c_int = 22;
+pub const SIGXCPU: ::c_int = 24;
+pub const SIGXFSZ: ::c_int = 25;
+pub const SIGVTALRM: ::c_int = 26;
+pub const SIGPROF: ::c_int = 27;
+pub const SIGWINCH: ::c_int = 28;
+pub const SIGUSR1: ::c_int = 10;
+pub const SIGUSR2: ::c_int = 12;
+pub const SIGCONT: ::c_int = 18;
+pub const SIGSTOP: ::c_int = 19;
+pub const SIGTSTP: ::c_int = 20;
+pub const SIGURG: ::c_int = 23;
+pub const SIGIO: ::c_int = 29;
+pub const SIGSYS: ::c_int = 31;
+pub const SIGSTKFLT: ::c_int = 16;
+pub const SIGPOLL: ::c_int = 29;
+pub const SIGPWR: ::c_int = 30;
+pub const SIG_SETMASK: ::c_int = 2;
+pub const SIG_BLOCK: ::c_int = 0x000000;
+pub const SIG_UNBLOCK: ::c_int = 0x01;
+
 pub const FIOCLEX: ::c_int = 0x20006601;
 pub const FIONCLEX: ::c_int = 0x20006602;
 pub const FIONBIO: ::c_int = 0x8004667e;
 pub const EDEADLK: ::c_int = 58;
 pub const EDEADLOCK: ::c_int = EDEADLK;
+pub const SA_ONSTACK: ::c_int = 0x08000000;
+pub const SA_SIGINFO: ::c_int = 0x00000004;
+pub const SA_NOCLDWAIT: ::c_int = 0x00000002;
+pub const SOCK_STREAM: ::c_int = 1;
+pub const SOCK_DGRAM: ::c_int = 2;
+pub const SOL_SOCKET: ::c_int = 1;
+pub const SO_REUSEADDR: ::c_int = 2;
+pub const SO_TYPE: ::c_int = 3;
+pub const SO_ERROR: ::c_int = 4;
+pub const SO_DONTROUTE: ::c_int = 5;
+pub const SO_BROADCAST: ::c_int = 6;
+pub const SO_SNDBUF: ::c_int = 7;
+pub const SO_RCVBUF: ::c_int = 8;
+pub const SO_KEEPALIVE: ::c_int = 9;
+pub const SO_OOBINLINE: ::c_int = 10;
+pub const SO_NO_CHECK: ::c_int = 11;
+pub const SO_PRIORITY: ::c_int = 12;
+pub const SO_LINGER: ::c_int = 13;
+pub const SO_BSDCOMPAT: ::c_int = 14;
+pub const SO_REUSEPORT: ::c_int = 15;
+pub const SO_ACCEPTCONN: ::c_int = 30;
+pub const SO_SNDBUFFORCE: ::c_int = 32;
+pub const SO_RCVBUFFORCE: ::c_int = 33;
+pub const SO_PROTOCOL: ::c_int = 38;
+pub const SO_DOMAIN: ::c_int = 39;
 pub const SO_PASSCRED: ::c_int = 20;
 pub const SO_PEERCRED: ::c_int = 21;
 pub const SO_RCVLOWAT: ::c_int = 16;
@@ -443,6 +600,7 @@ pub const SO_SNDLOWAT: ::c_int = 17;
 pub const SO_RCVTIMEO: ::c_int = 18;
 pub const SO_SNDTIMEO: ::c_int = 19;
 pub const EXTPROC: ::tcflag_t = 0x10000000;
+pub const VEOF: usize = 4;
 pub const VEOL: usize = 6;
 pub const VEOL2: usize = 8;
 pub const VMIN: usize = 5;
@@ -566,6 +724,8 @@ pub const B2500000: ::speed_t = 0o00033;
 pub const B3000000: ::speed_t = 0o00034;
 pub const B3500000: ::speed_t = 0o00035;
 pub const B4000000: ::speed_t = 0o00036;
+
+pub const EHWPOISON: ::c_int = 133;
 
 extern {
     pub fn ioctl(fd: ::c_int, request: ::c_int, ...) -> ::c_int;

--- a/src/unix/linux_like/linux/musl/b64/x86_64.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64.rs
@@ -47,6 +47,36 @@ s! {
         __reserved: [::c_long; 3],
     }
 
+    pub struct statfs {
+        pub f_type: ::c_ulong,
+        pub f_bsize: ::c_ulong,
+        pub f_blocks: ::fsblkcnt_t,
+        pub f_bfree: ::fsblkcnt_t,
+        pub f_bavail: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
+        pub f_fsid: ::fsid_t,
+        pub f_namelen: ::c_ulong,
+        pub f_frsize: ::c_ulong,
+        pub f_flags: ::c_ulong,
+        pub f_spare: [::c_ulong; 4],
+    }
+
+    pub struct statfs64 {
+        pub f_type: ::c_ulong,
+        pub f_bsize: ::c_ulong,
+        pub f_blocks: ::fsblkcnt_t,
+        pub f_bfree: ::fsblkcnt_t,
+        pub f_bavail: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
+        pub f_fsid: ::fsid_t,
+        pub f_namelen: ::c_ulong,
+        pub f_frsize: ::c_ulong,
+        pub f_flags: ::c_ulong,
+        pub f_spare: [::c_ulong; 4],
+    }
+
     pub struct mcontext_t {
         __private: [u64; 32],
     }
@@ -454,6 +484,57 @@ pub const SYS_pwritev2: ::c_long = 328;
 // FIXME syscalls 329-331 have been added in musl 1.16
 // See discussion https://github.com/rust-lang/libc/pull/699
 
+pub const ENAMETOOLONG: ::c_int = 36;
+pub const ENOLCK: ::c_int = 37;
+pub const ENOSYS: ::c_int = 38;
+pub const ENOTEMPTY: ::c_int = 39;
+pub const ELOOP: ::c_int = 40;
+pub const ENOMSG: ::c_int = 42;
+pub const EIDRM: ::c_int = 43;
+pub const ECHRNG: ::c_int = 44;
+pub const EL2NSYNC: ::c_int = 45;
+pub const EL3HLT: ::c_int = 46;
+pub const EL3RST: ::c_int = 47;
+pub const ELNRNG: ::c_int = 48;
+pub const EUNATCH: ::c_int = 49;
+pub const ENOCSI: ::c_int = 50;
+pub const EL2HLT: ::c_int = 51;
+pub const EBADE: ::c_int = 52;
+pub const EBADR: ::c_int = 53;
+pub const EXFULL: ::c_int = 54;
+pub const ENOANO: ::c_int = 55;
+pub const EBADRQC: ::c_int = 56;
+pub const EBADSLT: ::c_int = 57;
+pub const EMULTIHOP: ::c_int = 72;
+pub const EBADMSG: ::c_int = 74;
+pub const EOVERFLOW: ::c_int = 75;
+pub const ENOTUNIQ: ::c_int = 76;
+pub const EBADFD: ::c_int = 77;
+pub const EREMCHG: ::c_int = 78;
+pub const ELIBACC: ::c_int = 79;
+pub const ELIBBAD: ::c_int = 80;
+pub const ELIBSCN: ::c_int = 81;
+pub const ELIBMAX: ::c_int = 82;
+pub const ELIBEXEC: ::c_int = 83;
+pub const EILSEQ: ::c_int = 84;
+pub const ERESTART: ::c_int = 85;
+pub const ESTRPIPE: ::c_int = 86;
+pub const EUSERS: ::c_int = 87;
+pub const ENOTSOCK: ::c_int = 88;
+pub const EDESTADDRREQ: ::c_int = 89;
+pub const EMSGSIZE: ::c_int = 90;
+pub const EPROTOTYPE: ::c_int = 91;
+pub const ENOPROTOOPT: ::c_int = 92;
+pub const EPROTONOSUPPORT: ::c_int = 93;
+pub const ESOCKTNOSUPPORT: ::c_int = 94;
+pub const EOPNOTSUPP: ::c_int = 95;
+pub const ENOTSUP: ::c_int = EOPNOTSUPP;
+pub const EPFNOSUPPORT: ::c_int = 96;
+pub const EAFNOSUPPORT: ::c_int = 97;
+pub const EADDRINUSE: ::c_int = 98;
+pub const EADDRNOTAVAIL: ::c_int = 99;
+pub const ENETDOWN: ::c_int = 100;
+
 // offsets in user_regs_structs, from sys/reg.h
 pub const R15: ::c_int = 0;
 pub const R14: ::c_int = 1;
@@ -483,12 +564,63 @@ pub const ES: ::c_int = 24;
 pub const FS: ::c_int = 25;
 pub const GS: ::c_int = 26;
 
+pub const F_GETLK: ::c_int = 5;
+pub const F_GETOWN: ::c_int = 9;
+pub const F_SETLK: ::c_int = 6;
+pub const F_SETLKW: ::c_int = 7;
+pub const F_SETOWN: ::c_int = 8;
+
 pub const MADV_SOFT_OFFLINE: ::c_int = 101;
 pub const MAP_32BIT: ::c_int = 0x0040;
+pub const MAP_ANON: ::c_int = 0x0020;
+pub const MAP_GROWSDOWN: ::c_int = 0x0100;
+pub const MAP_DENYWRITE: ::c_int = 0x0800;
+pub const MAP_EXECUTABLE: ::c_int = 0x01000;
+pub const MAP_LOCKED: ::c_int = 0x02000;
+pub const MAP_NORESERVE: ::c_int = 0x04000;
+pub const MAP_POPULATE: ::c_int = 0x08000;
+pub const MAP_NONBLOCK: ::c_int = 0x010000;
+pub const MAP_STACK: ::c_int = 0x020000;
+pub const MAP_HUGETLB: ::c_int = 0x040000;
+pub const O_ASYNC: ::c_int = 0x2000;
+pub const O_APPEND: ::c_int = 1024;
+pub const O_CREAT: ::c_int = 64;
+pub const O_EXCL: ::c_int = 128;
+pub const O_NOCTTY: ::c_int = 256;
+pub const O_NONBLOCK: ::c_int = 2048;
+pub const O_SYNC: ::c_int = 1052672;
+pub const O_RSYNC: ::c_int = 1052672;
+pub const O_DSYNC: ::c_int = 4096;
 pub const O_DIRECT: ::c_int = 0x4000;
 pub const O_DIRECTORY: ::c_int = 0x10000;
 pub const O_LARGEFILE: ::c_int = 0;
 pub const O_NOFOLLOW: ::c_int = 0x20000;
+pub const POLLWRNORM: ::c_short = 0x100;
+pub const POLLWRBAND: ::c_short = 0x200;
+
+pub const SIGCHLD: ::c_int = 17;
+pub const SIGBUS: ::c_int = 7;
+pub const SIGTTIN: ::c_int = 21;
+pub const SIGTTOU: ::c_int = 22;
+pub const SIGXCPU: ::c_int = 24;
+pub const SIGXFSZ: ::c_int = 25;
+pub const SIGVTALRM: ::c_int = 26;
+pub const SIGPROF: ::c_int = 27;
+pub const SIGWINCH: ::c_int = 28;
+pub const SIGUSR1: ::c_int = 10;
+pub const SIGUSR2: ::c_int = 12;
+pub const SIGCONT: ::c_int = 18;
+pub const SIGSTOP: ::c_int = 19;
+pub const SIGTSTP: ::c_int = 20;
+pub const SIGURG: ::c_int = 23;
+pub const SIGIO: ::c_int = 29;
+pub const SIGSYS: ::c_int = 31;
+pub const SIGSTKFLT: ::c_int = 16;
+pub const SIGPOLL: ::c_int = 29;
+pub const SIGPWR: ::c_int = 30;
+pub const SIG_SETMASK: ::c_int = 2;
+pub const SIG_BLOCK: ::c_int = 0x000000;
+pub const SIG_UNBLOCK: ::c_int = 0x01;
 
 pub const TIOCGRS485: ::c_int = 0x542E;
 pub const TIOCSRS485: ::c_int = 0x542F;
@@ -572,6 +704,31 @@ pub const FIONCLEX: ::c_int = 0x5450;
 pub const FIONBIO: ::c_int = 0x5421;
 pub const EDEADLK: ::c_int = 35;
 pub const EDEADLOCK: ::c_int = EDEADLK;
+pub const SA_ONSTACK: ::c_int = 0x08000000;
+pub const SA_SIGINFO: ::c_int = 0x00000004;
+pub const SA_NOCLDWAIT: ::c_int = 0x00000002;
+pub const SOCK_STREAM: ::c_int = 1;
+pub const SOCK_DGRAM: ::c_int = 2;
+pub const SOL_SOCKET: ::c_int = 1;
+pub const SO_REUSEADDR: ::c_int = 2;
+pub const SO_TYPE: ::c_int = 3;
+pub const SO_ERROR: ::c_int = 4;
+pub const SO_DONTROUTE: ::c_int = 5;
+pub const SO_BROADCAST: ::c_int = 6;
+pub const SO_SNDBUF: ::c_int = 7;
+pub const SO_RCVBUF: ::c_int = 8;
+pub const SO_KEEPALIVE: ::c_int = 9;
+pub const SO_OOBINLINE: ::c_int = 10;
+pub const SO_NO_CHECK: ::c_int = 11;
+pub const SO_PRIORITY: ::c_int = 12;
+pub const SO_LINGER: ::c_int = 13;
+pub const SO_BSDCOMPAT: ::c_int = 14;
+pub const SO_REUSEPORT: ::c_int = 15;
+pub const SO_ACCEPTCONN: ::c_int = 30;
+pub const SO_SNDBUFFORCE: ::c_int = 32;
+pub const SO_RCVBUFFORCE: ::c_int = 33;
+pub const SO_PROTOCOL: ::c_int = 38;
+pub const SO_DOMAIN: ::c_int = 39;
 pub const SO_PASSCRED: ::c_int = 16;
 pub const SO_PEERCRED: ::c_int = 17;
 pub const SO_RCVLOWAT: ::c_int = 18;
@@ -579,6 +736,7 @@ pub const SO_SNDLOWAT: ::c_int = 19;
 pub const SO_RCVTIMEO: ::c_int = 20;
 pub const SO_SNDTIMEO: ::c_int = 21;
 pub const EXTPROC: ::tcflag_t = 0x00010000;
+pub const VEOF: usize = 4;
 pub const VEOL: usize = 11;
 pub const VEOL2: usize = 16;
 pub const VMIN: usize = 6;
@@ -627,6 +785,8 @@ pub const TIOCM_RNG: ::c_int = 0x080;
 pub const TIOCM_DSR: ::c_int = 0x100;
 pub const TIOCM_CD: ::c_int = TIOCM_CAR;
 pub const TIOCM_RI: ::c_int = TIOCM_RNG;
+
+pub const EHWPOISON: ::c_int = 133;
 
 extern {
     pub fn ioctl(fd: ::c_int, request: ::c_int, ...) -> ::c_int;

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -409,6 +409,7 @@ extern {
 cfg_if! {
     if #[cfg(any(target_arch = "x86_64",
                  target_arch = "aarch64",
+                 target_arch = "mips64",
                  target_arch = "powerpc64"))] {
         mod b64;
         pub use self::b64::*;


### PR DESCRIPTION
Tested with patched stage2; both static and dynamic binaries confirmed working.

Initial CI support in the form of no-core targets are added.