### PR TITLE
WIP: Support all possible netlink constants in gnu/mod.rs on musl

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -611,64 +611,7 @@ pub const IFA_F_NOPREFIXROUTE: u32 = 0x200;
 pub const IFA_F_MCAUTOJOIN: u32 = 0x400;
 pub const IFA_F_STABLE_PRIVACY: u32 = 0x800;
 
-pub const NETLINK_ROUTE: ::c_int = 0;
-pub const NETLINK_UNUSED: ::c_int = 1;
-pub const NETLINK_USERSOCK: ::c_int = 2;
-pub const NETLINK_FIREWALL: ::c_int = 3;
-pub const NETLINK_SOCK_DIAG: ::c_int = 4;
-pub const NETLINK_NFLOG: ::c_int = 5;
-pub const NETLINK_XFRM: ::c_int = 6;
-pub const NETLINK_SELINUX: ::c_int = 7;
-pub const NETLINK_ISCSI: ::c_int = 8;
-pub const NETLINK_AUDIT: ::c_int = 9;
-pub const NETLINK_FIB_LOOKUP: ::c_int = 10;
-pub const NETLINK_CONNECTOR: ::c_int = 11;
-pub const NETLINK_NETFILTER: ::c_int = 12;
-pub const NETLINK_IP6_FW: ::c_int = 13;
-pub const NETLINK_DNRTMSG: ::c_int = 14;
-pub const NETLINK_KOBJECT_UEVENT: ::c_int = 15;
-pub const NETLINK_GENERIC: ::c_int = 16;
-pub const NETLINK_SCSITRANSPORT: ::c_int = 18;
-pub const NETLINK_ECRYPTFS: ::c_int = 19;
-pub const NETLINK_RDMA: ::c_int = 20;
-pub const NETLINK_CRYPTO: ::c_int = 21;
-pub const NETLINK_INET_DIAG: ::c_int = NETLINK_SOCK_DIAG;
-
 pub const MAX_LINKS: ::c_int = 32;
-
-pub const NLM_F_REQUEST: ::c_int = 1;
-pub const NLM_F_MULTI: ::c_int = 2;
-pub const NLM_F_ACK: ::c_int = 4;
-pub const NLM_F_ECHO: ::c_int = 8;
-pub const NLM_F_DUMP_INTR: ::c_int = 16;
-pub const NLM_F_DUMP_FILTERED: ::c_int = 32;
-
-pub const NLM_F_ROOT: ::c_int = 0x100;
-pub const NLM_F_MATCH: ::c_int = 0x200;
-pub const NLM_F_ATOMIC: ::c_int = 0x400;
-pub const NLM_F_DUMP: ::c_int = NLM_F_ROOT | NLM_F_MATCH;
-
-pub const NLM_F_REPLACE: ::c_int = 0x100;
-pub const NLM_F_EXCL: ::c_int = 0x200;
-pub const NLM_F_CREATE: ::c_int = 0x400;
-pub const NLM_F_APPEND: ::c_int = 0x800;
-
-pub const NETLINK_ADD_MEMBERSHIP: ::c_int = 1;
-pub const NETLINK_DROP_MEMBERSHIP: ::c_int = 2;
-pub const NETLINK_PKTINFO: ::c_int = 3;
-pub const NETLINK_BROADCAST_ERROR: ::c_int = 4;
-pub const NETLINK_NO_ENOBUFS: ::c_int = 5;
-pub const NETLINK_RX_RING: ::c_int = 6;
-pub const NETLINK_TX_RING: ::c_int = 7;
-pub const NETLINK_LISTEN_ALL_NSID: ::c_int = 8;
-pub const NETLINK_LIST_MEMBERSHIPS: ::c_int = 9;
-pub const NETLINK_CAP_ACK: ::c_int = 10;
-
-pub const NLA_F_NESTED: ::c_int = 1 << 15;
-pub const NLA_F_NET_BYTEORDER: ::c_int = 1 << 14;
-pub const NLA_TYPE_MASK: ::c_int = !(NLA_F_NESTED | NLA_F_NET_BYTEORDER);
-
-pub const NLA_ALIGNTO: ::c_int = 4;
 
 pub const GENL_UNS_ADMIN_PERM: ::c_int = 0x10;
 
@@ -928,12 +871,6 @@ cfg_if! {
     }
 }
 pub const PTHREAD_MUTEX_ADAPTIVE_NP: ::c_int = 3;
-
-f! {
-    pub fn NLA_ALIGN(len: ::c_int) -> ::c_int {
-        return ((len) + NLA_ALIGNTO - 1) & !(NLA_ALIGNTO - 1)
-    }
-}
 
 extern {
     pub fn sendmmsg(sockfd: ::c_int, msgvec: *mut ::mmsghdr, vlen: ::c_uint,

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1897,6 +1897,64 @@ pub const NDA_PORT: ::c_ushort = 6;
 pub const NDA_VNI: ::c_ushort = 7;
 pub const NDA_IFINDEX: ::c_ushort = 8;
 
+// linux/netlink.h
+pub const NLA_ALIGNTO: ::c_int = 4;
+
+pub const NETLINK_ROUTE: ::c_int = 0;
+pub const NETLINK_UNUSED: ::c_int = 1;
+pub const NETLINK_USERSOCK: ::c_int = 2;
+pub const NETLINK_FIREWALL: ::c_int = 3;
+pub const NETLINK_SOCK_DIAG: ::c_int = 4;
+pub const NETLINK_NFLOG: ::c_int = 5;
+pub const NETLINK_XFRM: ::c_int = 6;
+pub const NETLINK_SELINUX: ::c_int = 7;
+pub const NETLINK_ISCSI: ::c_int = 8;
+pub const NETLINK_AUDIT: ::c_int = 9;
+pub const NETLINK_FIB_LOOKUP: ::c_int = 10;
+pub const NETLINK_CONNECTOR: ::c_int = 11;
+pub const NETLINK_NETFILTER: ::c_int = 12;
+pub const NETLINK_IP6_FW: ::c_int = 13;
+pub const NETLINK_DNRTMSG: ::c_int = 14;
+pub const NETLINK_KOBJECT_UEVENT: ::c_int = 15;
+pub const NETLINK_GENERIC: ::c_int = 16;
+pub const NETLINK_SCSITRANSPORT: ::c_int = 18;
+pub const NETLINK_ECRYPTFS: ::c_int = 19;
+pub const NETLINK_RDMA: ::c_int = 20;
+pub const NETLINK_CRYPTO: ::c_int = 21;
+pub const NETLINK_INET_DIAG: ::c_int = NETLINK_SOCK_DIAG;
+
+pub const NLM_F_REQUEST: ::c_int = 1;
+pub const NLM_F_MULTI: ::c_int = 2;
+pub const NLM_F_ACK: ::c_int = 4;
+pub const NLM_F_ECHO: ::c_int = 8;
+pub const NLM_F_DUMP_INTR: ::c_int = 16;
+pub const NLM_F_DUMP_FILTERED: ::c_int = 32;
+
+pub const NLM_F_ROOT: ::c_int = 0x100;
+pub const NLM_F_MATCH: ::c_int = 0x200;
+pub const NLM_F_ATOMIC: ::c_int = 0x400;
+pub const NLM_F_DUMP: ::c_int = NLM_F_ROOT | NLM_F_MATCH;
+
+pub const NLM_F_REPLACE: ::c_int = 0x100;
+pub const NLM_F_EXCL: ::c_int = 0x200;
+pub const NLM_F_CREATE: ::c_int = 0x400;
+pub const NLM_F_APPEND: ::c_int = 0x800;
+
+pub const NETLINK_ADD_MEMBERSHIP: ::c_int = 1;
+pub const NETLINK_DROP_MEMBERSHIP: ::c_int = 2;
+pub const NETLINK_PKTINFO: ::c_int = 3;
+pub const NETLINK_BROADCAST_ERROR: ::c_int = 4;
+pub const NETLINK_NO_ENOBUFS: ::c_int = 5;
+pub const NETLINK_RX_RING: ::c_int = 6;
+pub const NETLINK_TX_RING: ::c_int = 7;
+pub const NETLINK_LISTEN_ALL_NSID: ::c_int = 8;
+pub const NETLINK_LIST_MEMBERSHIPS: ::c_int = 9;
+pub const NETLINK_CAP_ACK: ::c_int = 10;
+
+pub const NLA_F_NESTED: ::c_int = 1 << 15;
+pub const NLA_F_NET_BYTEORDER: ::c_int = 1 << 14;
+pub const NLA_TYPE_MASK: ::c_int = !(NLA_F_NESTED | NLA_F_NET_BYTEORDER);
+
 // linux/rtnetlink.h
 pub const TCA_UNSPEC: ::c_ushort = 0;
 pub const TCA_KIND: ::c_ushort = 1;
@@ -2121,6 +2179,10 @@ pub const FUTEX_CMD_MASK: ::c_int =
     !(FUTEX_PRIVATE_FLAG | FUTEX_CLOCK_REALTIME);
 
 f! {
+    pub fn NLA_ALIGN(len: ::c_int) -> ::c_int {
+        return ((len) + NLA_ALIGNTO - 1) & !(NLA_ALIGNTO - 1)
+    }
+
     pub fn CMSG_NXTHDR(mhdr: *const msghdr,
                        cmsg: *const cmsghdr) -> *mut cmsghdr {
         if ((*cmsg).cmsg_len as usize) < ::mem::size_of::<cmsghdr>() {


### PR DESCRIPTION
This PR is meant to discover which netlink constants need to be gated in `gnu/mod.rs` and which ones are okay in `mod.rs` for Linux. It seems many of the early constants added were defaulted to GNU only which is not necessarily needed. This will probably fail CI a few times before I am able to remove WIP.