### PR TITLE
MinGW: also copy libmingwex.a from C toolchain

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
   - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
   - set PATH=%PATH%;C:\Program Files (x86)\Rust\bin
-  - if defined MSYS_BITS for %%I in (crt2.o dllcrt2.o libmsvcrt.a) do xcopy /Y "C:\msys64\mingw%MSYS_BITS%\%ARCH%-w64-mingw32\lib\%%I" "C:\Program Files (x86)\Rust\lib\rustlib\%TARGET%\lib"
+  - if defined MSYS_BITS for %%I in (crt2.o dllcrt2.o libmingwex.a libmsvcrt.a) do xcopy /Y "C:\msys64\mingw%MSYS_BITS%\%ARCH%-w64-mingw32\lib\%%I" "C:\Program Files (x86)\Rust\lib\rustlib\%TARGET%\lib"
   - rustc -V
   - cargo -V
 


### PR DESCRIPTION
Fixes recent CI error:
```
note: C:\Program Files (x86)\Rust\lib\rustlib\i686-pc-windows-gnu\lib/libmsvcrt.a(dyims01169.o):(.text+0x0): multiple definition of `longjmp'
          C:\Program Files (x86)\Rust\lib\rustlib\i686-pc-windows-gnu\lib/libmingwex.a(lib32_libmingwex_a-mingw_getsp.o):mingw_getsp.S:(.text+0x5): first defined here
```

Successful build: https://ci.appveyor.com/project/mati865/libc/builds/26425673
It also should be added to Azure in https://github.com/rust-lang/libc/pull/1376