### PR TITLE
define KERN_TIMEOUT_STATS and incr KERN_MAXID on OpenBSD

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1183,7 +1183,8 @@ pub const KERN_CONSBUF: ::c_int = 83;
 pub const KERN_AUDIO: ::c_int = 84;
 pub const KERN_CPUSTATS: ::c_int = 85;
 pub const KERN_PFSTATUS: ::c_int = 86;
-pub const KERN_MAXID: ::c_int = 87;
+pub const KERN_TIMEOUT_STATS: ::c_int = 87;
+pub const KERN_MAXID: ::c_int = 88;
 
 pub const KERN_PROC_ALL: ::c_int = 0;
 pub const KERN_PROC_PID: ::c_int = 1;


### PR DESCRIPTION
`KERN_TIMEOUT_STATS` has been defined in [sys/sysctl.h (1.194)](https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/sys/sys/sysctl.h?rev=1.194&content-type=text/x-cvsweb-markup)