### PR TITLE
skip roundtrip on few structs on OpenBSD

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -369,6 +369,11 @@ fn test_openbsd(target: &str) {
         (struct_ == "siginfo_t" && field == "si_addr")
     });
 
+    cfg.skip_roundtrip(move |s| match s {
+        "dirent" | "utsname" | "utmp" => true,
+        _ => false,
+    });
+
     cfg.generate("../src/lib.rs", "main.rs");
 }
 


### PR DESCRIPTION
skip roundtrip on some structs on OpenBSD. it is mostly the same than other targets: dirent, utsname, utmp.