### PR TITLE
Bump version to 0.2.61

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.60"
+version = "0.2.61"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Releasing a version now will allow Redox compilation to work again, as it will include #1438 