### PR TITLE
Fix FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 task:
-  name: stable x86_64-unknown-freebsd-11
+  name: stable x86_64-unknown-freebsd
   freebsd_instance:
     image: freebsd-11-3-stable-amd64-v20190801
   setup_script:
@@ -11,6 +11,21 @@ task:
   test_script:
     - . $HOME/.cargo/env
     - sh ci/run.sh x86_64-unknown-freebsd
+
+
+task:
+  name: stable x86_64-unknown-freebsd-11
+  freebsd_instance:
+    image: freebsd-11-3-stable-amd64-v20190801
+  setup_script:
+    - pkg install -y curl
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh -y
+    - . $HOME/.cargo/env
+    - rustup default stable
+  test_script:
+    - . $HOME/.cargo/env
+    - LIBC_CI=1 sh ci/run.sh x86_64-unknown-freebsd
     
 task:
   name: nightly x86_64-unknown-freebsd-12
@@ -24,4 +39,4 @@ task:
     - rustup default nightly
   test_script:
     - . $HOME/.cargo/env
-    - sh ci/run.sh x86_64-unknown-freebsd
+    - LIBC_CI=1 sh ci/run.sh x86_64-unknown-freebsd

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,19 +1,4 @@
 task:
-  name: stable x86_64-unknown-freebsd
-  freebsd_instance:
-    image: freebsd-11-3-stable-amd64-v20190801
-  setup_script:
-    - pkg install -y curl
-    - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh -y
-    - . $HOME/.cargo/env
-    - rustup default stable
-  test_script:
-    - . $HOME/.cargo/env
-    - sh ci/run.sh x86_64-unknown-freebsd
-
-
-task:
   name: stable x86_64-unknown-freebsd-11
   freebsd_instance:
     image: freebsd-11-3-stable-amd64-v20190801
@@ -26,6 +11,7 @@ task:
   test_script:
     - . $HOME/.cargo/env
     - LIBC_CI=1 sh ci/run.sh x86_64-unknown-freebsd
+    - sh ci/run.sh x86_64-unknown-freebsd
     
 task:
   name: nightly x86_64-unknown-freebsd-12
@@ -40,3 +26,4 @@ task:
   test_script:
     - . $HOME/.cargo/env
     - LIBC_CI=1 sh ci/run.sh x86_64-unknown-freebsd
+    - sh ci/run.sh x86_64-unknown-freebsd

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.61"
+version = "0.2.62"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/build.rs
+++ b/build.rs
@@ -21,17 +21,11 @@ fn main() {
     //
     // On CI, we detect the actual FreeBSD version and match its ABI exactly,
     // running tests to ensure that the ABI is correct.
-    #[cfg(target_os = "freebsd")]
     match which_freebsd() {
         Some(11) if libc_ci => println!("cargo:rustc-cfg=freebsd11"),
         Some(12) if libc_ci => println!("cargo:rustc-cfg=freebsd12"),
         Some(13) if libc_ci => println!("cargo:rustc-cfg=freebsd13"),
-        Some(_) => println!("cargo:rustc-cfg=freebsd11"),
-        None =>
-        /* not FreeBSD - nothing to do here */
-        {
-            ()
-        }
+        Some(_) | None => println!("cargo:rustc-cfg=freebsd11"),
     }
 
     // Rust >= 1.15 supports private module use:
@@ -94,7 +88,6 @@ fn rustc_minor_version() -> Option<u32> {
     otry!(pieces.next()).parse().ok()
 }
 
-#[cfg(target_os = "freebsd")]
 fn which_freebsd() -> Option<i32> {
     let output = std::process::Command::new("freebsd-version").output().ok();
     if output.is_none() {

--- a/ci/azure.yml
+++ b/ci/azure.yml
@@ -15,7 +15,7 @@ jobs:
       vmImage: ubuntu-16.04
     steps:
       - template: azure-install-rust.yml
-      - bash: sh ./ci/run-docker.sh $TARGET
+      - bash: LIBC_CI=1 sh ./ci/run-docker.sh $TARGET
         displayName: Execute run-docker.sh
     strategy:
       matrix:
@@ -30,7 +30,7 @@ jobs:
       vmImage: ubuntu-16.04
     steps:
       - template: azure-install-rust.yml
-      - bash: sh ./ci/run-docker.sh $TARGET
+      - bash: LIBC_CI=1 sh ./ci/run-docker.sh $TARGET
         displayName: Execute run-docker.sh
     strategy:
       matrix:
@@ -88,7 +88,7 @@ jobs:
       vmImage: macos-10.14
     steps:
       - template: azure-install-rust.yml
-      - bash: sh ./ci/run.sh $TARGET
+      - bash: LIBC_CI=1 sh ./ci/run.sh $TARGET
         displayName: Execute run.sh
     strategy:
       matrix:
@@ -100,7 +100,7 @@ jobs:
       vmImage: macos-10.13
     steps:
       - template: azure-install-rust.yml
-      - bash: sh ./ci/run.sh $TARGET
+      - bash: LIBC_CI=1 sh ./ci/run.sh $TARGET
         displayName: Execute run.sh
     strategy:
       matrix:
@@ -112,7 +112,7 @@ jobs:
       vmImage: vs2017-win2016
     steps:
       - template: azure-install-rust.yml
-      - bash: sh ./ci/run.sh $TARGET
+      - bash: LIBC_CI=1 sh ./ci/run.sh $TARGET
         displayName: Execute run.sh
     strategy:
       matrix:

--- a/ci/dox.sh
+++ b/ci/dox.sh
@@ -47,6 +47,9 @@ while read -r target; do
 
     rustup target add "${target}" || true
 
+    # Enable extra configuration flags:
+    export RUSTDOCFLAGS="--cfg freebsd11"
+
     # If cargo doc fails, then try xargo:
     if ! cargo doc --target "${target}" \
              --no-default-features  --features extra_traits ; then

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -23,6 +23,7 @@ run() {
     docker run \
       --rm \
       --user "$(id -u)":"$(id -g)" \
+      --env LIBC_CI \
       --env CARGO_HOME=/cargo \
       --env CARGO_TARGET_DIR=/checkout/target \
       --volume "$(dirname "$(dirname "$(command -v cargo)")")":/cargo \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -87,8 +87,6 @@ if [ "$TARGET" = "x86_64-unknown-linux-gnux32" ]; then
   opt="--release"
 fi
 
-export LIBC_CI=1
-
 cargo test -vv $opt --no-default-features --manifest-path libc-test/Cargo.toml \
       --target "${TARGET}"
 

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1334,9 +1334,11 @@ cfg_if! {
     } else if #[cfg(freebsd13)] {
         mod freebsd12;
         pub use self::freebsd12::*;
-    } else {
+    } else if #[cfg(freebsd11)] {
         mod freebsd11;
         pub use self::freebsd11::*;
+    } else {
+        // Unknown freebsd version
     }
 }
 


### PR DESCRIPTION
#1440 broke FreeBSD by changing `libc` FreeBSD targets to require a `cfg(freebsdXX)` to be defined, but not updating `build.rs` to define `freebsd11` when `LIBC_CI` is not available. Since `LIBC_CI` is always defined on CI, this issue went undetected.

This PR fixes that issue in the `build.rs` and introduces a build task that tests FreeBSD without `LIBC_CI` on FreeBSD11, although I'm  not sure this would have caught the issue in #1466 .

Closes #1466 .