### PR TITLE
Remove sendfile() from Fuchsia

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -4234,10 +4234,6 @@ extern {
     pub fn sched_setscheduler(pid: ::pid_t,
                               policy: ::c_int,
                               param: *const ::sched_param) -> ::c_int;
-    pub fn sendfile(out_fd: ::c_int,
-                    in_fd: ::c_int,
-                    offset: *mut off_t,
-                    count: ::size_t) -> ::ssize_t;
     pub fn sigsuspend(mask: *const ::sigset_t) -> ::c_int;
     pub fn getgrgid_r(gid: ::gid_t,
                       grp: *mut ::group,


### PR DESCRIPTION
#849 moved Fuchsia into its own module, but it was not checked whether it actually supports all these functions.
[This commit](https://fuchsia.googlesource.com/fuchsia/+/4de4800d4aa442f38cb6be2876b7a6d9f49e219b%5E%21/#F0) shows that the Linux `sendfile()` is not available on Fuchsia.
Furthermore, it is not listed in the [Zircon System Calls](https://fuchsia.dev/fuchsia-src/zircon/syscalls.md) page.