### PR TITLE
Adding UTIME_NOW and UTIME_OMIT to OSes which support utimensat

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -2823,6 +2823,9 @@ pub const P_ALL: idtype_t = 0;
 pub const P_PID: idtype_t = 1;
 pub const P_PGID: idtype_t = 2;
 
+pub const UTIME_OMIT: c_long = -2;
+pub const UTIME_NOW: c_long = -1;
+
 pub const XATTR_NOFOLLOW: ::c_int = 0x0001;
 pub const XATTR_CREATE: ::c_int = 0x0002;
 pub const XATTR_REPLACE: ::c_int = 0x0004;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1041,6 +1041,9 @@ pub const P_PID: idtype_t = 0;
 pub const P_PGID: idtype_t = 2;
 pub const P_ALL: idtype_t = 7;
 
+pub const UTIME_OMIT: c_long = -2;
+pub const UTIME_NOW: c_long = -1;
+
 pub const B460800: ::speed_t = 460800;
 pub const B921600: ::speed_t = 921600;
 

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1357,6 +1357,9 @@ pub const P_ALL: idtype_t = 0;
 pub const P_PID: idtype_t = 1;
 pub const P_PGID: idtype_t = 4;
 
+pub const UTIME_OMIT: c_long = 1073741822;
+pub const UTIME_NOW: c_long = 1073741823;
+
 pub const B460800: ::speed_t = 460800;
 pub const B921600: ::speed_t = 921600;
 

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -748,6 +748,9 @@ pub const ELAST : ::c_int = 95;
 
 pub const F_DUPFD_CLOEXEC : ::c_int = 10;
 
+pub const UTIME_OMIT: c_long = -2;
+pub const UTIME_NOW: c_long = -1;
+
 pub const AT_FDCWD: ::c_int = -100;
 pub const AT_EACCESS: ::c_int = 0x01;
 pub const AT_SYMLINK_NOFOLLOW: ::c_int = 0x02;

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -1039,6 +1039,9 @@ pub const P_ALL: idtype_t = 0;
 pub const P_PID: idtype_t = 1;
 pub const P_PGID: idtype_t = 2;
 
+pub const UTIME_OMIT: c_long = 1000000001;
+pub const UTIME_NOW: c_long = 1000000000;
+
 pub const VINTR: usize = 0;
 pub const VQUIT: usize = 1;
 pub const VERASE: usize = 2;

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -965,6 +965,9 @@ pub const P_CTID: idtype_t = 13;
 pub const P_CPUID: idtype_t = 14;
 pub const P_PSETID: idtype_t = 15;
 
+pub const UTIME_OMIT: c_long = -2;
+pub const UTIME_NOW: c_long = -1;
+
 pub const PROT_NONE: ::c_int = 0;
 pub const PROT_READ: ::c_int = 1;
 pub const PROT_WRITE: ::c_int = 2;

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -337,7 +337,6 @@ pub const AT_REMOVEDIR: c_int = 0x4;
 pub const UTIME_OMIT: c_long = 1073741822;
 pub const UTIME_NOW: c_long = 1073741823;
 
-
 pub const E2BIG: c_int = __WASI_E2BIG as c_int;
 pub const EACCES: c_int = __WASI_EACCES as c_int;
 pub const EADDRINUSE: c_int = __WASI_EADDRINUSE as c_int;

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -334,6 +334,9 @@ pub const AT_EACCESS: c_int = 0x0;
 pub const AT_SYMLINK_NOFOLLOW: c_int = 0x1;
 pub const AT_SYMLINK_FOLLOW: c_int = 0x2;
 pub const AT_REMOVEDIR: c_int = 0x4;
+pub const UTIME_OMIT: c_long = 1073741822;
+pub const UTIME_NOW: c_long = 1073741823;
+
 
 pub const E2BIG: c_int = __WASI_E2BIG as c_int;
 pub const EACCES: c_int = __WASI_EACCES as c_int;


### PR DESCRIPTION
I've managed to verify a handful of these:

- [FreeBSD](https://github.com/freebsd/freebsd/blob/1d6e4247415d264485ee94b59fdbc12e0c566fd0/tools/build/stat.h#L35)
- [NetBSD](https://github.com/NetBSD/src/blob/64b8a48e1288eb3902ed73113d157af50b2ec596/sys/sys/stat.h#L235)
 - [Apple](https://opensource.apple.com/source/xnu/xnu-4903.221.2/bsd/sys/stat.h.auto.html)


I'm less confident in these:
 - [Haiku](https://github.com/haiku/haiku/blob/abb59d7351c7ddb50c63c40430a82d94fa61917a/headers/posix/sys/stat.h#L105)
   - I could be wrong on this one: https://github.com/haiku/haiku/search?q=UTIME_NOW&unscoped_q=UTIME_NOW
 - [WASI](https://github.com/CraneStation/wasi-libc/blob/24792713d7e31cf593d7e19b943ef0c3aa26ef63/libc-top-half/musl/include/sys/stat.h#L71)
  - I could be wrong on this one: https://github.com/CraneStation/wasi-libc/search?q=UTIME_NOW&unscoped_q=UTIME_NOW
 - [Solarish](https://github.com/illumos/illumos-gate/blob/4e0c5eff9af325c80994e9527b7cb8b3a1ffd1d4/usr/src/uts/common/sys/stat.h#L478) 

