### PR TITLE
Update minor patch version to 0.2.63

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.62"
+version = "0.2.63"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
it will permit to me to [update several projects](https://github.com/openbsd/ports/blob/5ff04b132c6718b4ca7401ce289a6f5db801e2ee/lang/rust/Makefile#L5) on OpenBSD ports tree to build on `sparc64-unknown-openbsd` target.