### PR TITLE
Define newlib socket types by target arch

### DIFF
--- a/src/unix/newlib/aarch64/mod.rs
+++ b/src/unix/newlib/aarch64/mod.rs
@@ -3,3 +3,31 @@ pub type wchar_t = u32;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
+
+s! {
+    pub struct sockaddr {
+        pub sa_len: u8,
+        pub sa_family: ::sa_family_t,
+        pub sa_data: [::c_char; 14],
+    }
+
+    pub struct sockaddr_in6 {
+        pub sin6_len: u8,
+        pub sin6_family: ::sa_family_t,
+        pub sin6_port: ::in_port_t,
+        pub sin6_flowinfo: u32,
+        pub sin6_addr: ::in6_addr,
+        pub sin6_scope_id: u32,
+    }
+
+    pub struct sockaddr_in {
+        pub sin_len: u8,
+        pub sin_family: ::sa_family_t,
+        pub sin_port: ::in_port_t,
+        pub sin_addr: ::in_addr,
+        pub sin_zero: [::c_char; 8],
+    }
+}
+
+pub const POLLOUT: ::c_short = 0x4;
+pub const POLLHUP: ::c_short = 0x10;

--- a/src/unix/newlib/arm/mod.rs
+++ b/src/unix/newlib/arm/mod.rs
@@ -3,3 +3,33 @@ pub type wchar_t = u32;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
+
+s! {
+    pub struct sockaddr {
+        pub sa_family: ::sa_family_t,
+        pub sa_data: [::c_char; 14],
+    }
+
+    pub struct sockaddr_in6 {
+        pub sin6_family: ::sa_family_t,
+        pub sin6_port: ::in_port_t,
+        pub sin6_flowinfo: u32,
+        pub sin6_addr: ::in6_addr,
+        pub sin6_scope_id: u32,
+    }
+
+    pub struct sockaddr_in {
+        pub sin_family: ::sa_family_t,
+        pub sin_port: ::in_port_t,
+        pub sin_addr: ::in_addr,
+        pub sin_zero: [u8; 8],
+    }
+
+    pub struct sockaddr_storage {
+        pub ss_family: ::sa_family_t,
+        pub __ss_padding: [u8; 26],
+    }
+}
+
+pub const POLLOUT: ::c_short = 0x10;
+pub const POLLHUP: ::c_short = 0x4;

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -25,29 +25,6 @@ pub type time_t = i32;
 pub type useconds_t = u32;
 
 s! {
-    pub struct sockaddr {
-        pub sa_len: u8,
-        pub sa_family: sa_family_t,
-        pub sa_data: [::c_char; 14],
-    }
-
-    pub struct sockaddr_in6 {
-        pub sin6_len: u8,
-        pub sin6_family: sa_family_t,
-        pub sin6_port: ::in_port_t,
-        pub sin6_flowinfo: u32,
-        pub sin6_addr: ::in6_addr,
-        pub sin6_scope_id: u32,
-    }
-
-    pub struct sockaddr_in {
-        pub sin_len: u8,
-        pub sin_family: ::sa_family_t,
-        pub sin_port: ::in_port_t,
-        pub sin_addr: ::in_addr,
-        pub sin_zero: [::c_char; 8],
-    }
-
     pub struct addrinfo {
         pub ai_flags: ::c_int,
         pub ai_family: ::c_int,
@@ -389,9 +366,7 @@ pub const O_CLOEXEC: ::c_int = 0x80000;
 
 pub const POLLIN: ::c_short = 0x1;
 pub const POLLPRI: ::c_short = 0x2;
-pub const POLLOUT: ::c_short = 0x4;
 pub const POLLERR: ::c_short = 0x8;
-pub const POLLHUP: ::c_short = 0x10;
 pub const POLLNVAL: ::c_short = 0x20;
 
 pub const RTLD_LAZY: ::c_int = 0x1;


### PR DESCRIPTION
This is a follow-up to https://github.com/rust-lang/libc/pull/1477. As mentioned in that PR, the primary (only?) users of these newlib definitions are myself and @leo60228. This PR makes it so that my arm-based 3DS target keeps using the old socket definitions while leo's aarch64-based Switch target uses the BSD versions.

The 3DS also has inverted definitions for `POLLHUP` and `POLLOUT` for whatever reason, so I figured I'd take care of that here too.