### PR TITLE
several const ioctl() BPF aren't defined on OpenBSD

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -264,6 +264,7 @@ fn test_openbsd(target: &str) {
         "netinet/ip.h",
         "netinet/tcp.h",
         "netinet/udp.h",
+        "net/bpf.h",
         "resolv.h",
         "pthread.h",
         "dlfcn.h",

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1761,6 +1761,11 @@ pub const TIOCPTYGRANT: ::c_uint = 0x20007454;
 pub const TIOCPTYGNAME: ::c_uint = 0x40807453;
 pub const TIOCPTYUNLK: ::c_uint = 0x20007452;
 
+pub const BIOCGRSIG: ::c_ulong = 0x40044272;
+pub const BIOCSRSIG: ::c_ulong = 0x80044273;
+pub const BIOCSDLT: ::c_ulong = 0x80044278;
+pub const BIOCGSEESENT: ::c_ulong = 0x40044276;
+pub const BIOCSSEESENT: ::c_ulong = 0x80044277;
 pub const BIOCGDLTLIST: ::c_ulong = 0xc00c4279;
 
 pub const FIODTYPE: ::c_ulong = 0x4004667a;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1009,6 +1009,11 @@ pub const SLIPDISC: ::c_int = 0x4;
 pub const PPPDISC: ::c_int = 0x5;
 pub const NETGRAPHDISC: ::c_int = 0x6;
 
+pub const BIOCGRSIG: ::c_ulong = 0x40044272;
+pub const BIOCSRSIG: ::c_ulong = 0x80044273;
+pub const BIOCSDLT: ::c_ulong = 0x80044278;
+pub const BIOCGSEESENT: ::c_ulong = 0x40044276;
+pub const BIOCSSEESENT: ::c_ulong = 0x80044277;
 pub const BIOCSETF: ::c_ulong = 0x80104267;
 pub const BIOCGDLTLIST: ::c_ulong = 0xc0104279;
 pub const BIOCSRTIMEOUT: ::c_ulong = 0x8010426d;

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -446,13 +446,8 @@ pub const BIOCSETIF: ::c_ulong = 0x8020426c;
 pub const BIOCGSTATS: ::c_ulong = 0x4008426f;
 pub const BIOCIMMEDIATE: ::c_ulong = 0x80044270;
 pub const BIOCVERSION: ::c_ulong = 0x40044271;
-pub const BIOCGRSIG: ::c_ulong = 0x40044272;
-pub const BIOCSRSIG: ::c_ulong = 0x80044273;
 pub const BIOCGHDRCMPLT: ::c_ulong = 0x40044274;
 pub const BIOCSHDRCMPLT: ::c_ulong = 0x80044275;
-pub const BIOCGSEESENT: ::c_ulong  = 0x40044276;
-pub const BIOCSSEESENT: ::c_ulong  = 0x80044277;
-pub const BIOCSDLT: ::c_ulong = 0x80044278;
 pub const SIOCGIFADDR: ::c_ulong = 0xc0206921;
 
 f! {

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1077,6 +1077,12 @@ pub const FD_SETSIZE: usize = 0x100;
 
 pub const ST_NOSUID: ::c_ulong = 8;
 
+pub const BIOCGRSIG: ::c_ulong = 0x40044272;
+pub const BIOCSRSIG: ::c_ulong = 0x80044273;
+pub const BIOCSDLT: ::c_ulong = 0x80044278;
+pub const BIOCGSEESENT: ::c_ulong = 0x40044276;
+pub const BIOCSSEESENT: ::c_ulong = 0x80044277;
+
 cfg_if! {
     if #[cfg(any(target_arch = "sparc", target_arch = "sparc64",
                  target_arch = "x86", target_arch = "x86_64"))] {

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1307,6 +1307,10 @@ pub const SOCK_CLOEXEC: ::c_int = 0x8000;
 pub const SOCK_NONBLOCK: ::c_int = 0x4000;
 pub const SOCK_DNS: ::c_int = 0x1000;
 
+pub const BIOCGRSIG: ::c_ulong = 0x40044273;
+pub const BIOCSRSIG: ::c_ulong = 0x80044272;
+pub const BIOCSDLT: ::c_ulong = 0x8004427a;
+
 pub const PTRACE_FORK: ::c_int = 0x0002;
 
 pub const WCONTINUED: ::c_int = 8;


### PR DESCRIPTION
unbreak OpenBSD after #1448 