### PR TITLE
UTIME_OMIT and UTIME_NOW values are inverted on OpenBSD. correct it

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -748,8 +748,8 @@ pub const ELAST : ::c_int = 95;
 
 pub const F_DUPFD_CLOEXEC : ::c_int = 10;
 
-pub const UTIME_OMIT: c_long = -2;
-pub const UTIME_NOW: c_long = -1;
+pub const UTIME_OMIT: c_long = -1;
+pub const UTIME_NOW: c_long = -2;
 
 pub const AT_FDCWD: ::c_int = -100;
 pub const AT_EACCESS: ::c_int = 0x01;


### PR DESCRIPTION
unbreak OpenBSD after #1474 