### PR TITLE
ci: switch to the rust-lang-ci-mirrors bucket for mirrors

### DIFF
--- a/ci/docker/mips-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mips-unknown-linux-musl/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir /toolchain
 
 # Note that this originally came from:
 # https://downloads.openwrt.org/snapshots/trunk/ar71xx/generic/OpenWrt-SDK-ar71xx-generic_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2
-RUN curl --retry 5 -L https://s3-us-west-1.amazonaws.com/rust-lang-ci2/libc/OpenWrt-SDK-ar71xx-generic_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2 | \
+RUN curl --retry 5 -L https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/libc/OpenWrt-SDK-ar71xx-generic_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2 | \
     tar xjf - -C /toolchain --strip-components=1
 
 ENV PATH=$PATH:/rust/bin:/toolchain/staging_dir/toolchain-mips_34kc_gcc-5.3.0_musl-1.1.15/bin \

--- a/ci/docker/mipsel-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mipsel-unknown-linux-musl/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir /toolchain
 
 # Note that this originally came from:
 # https://downloads.openwrt.org/snapshots/trunk/malta/generic/OpenWrt-Toolchain-malta-le_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2
-RUN curl --retry 5 -L https://s3-us-west-1.amazonaws.com/rust-lang-ci2/libc/OpenWrt-Toolchain-malta-le_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2 | \
+RUN curl --retry 5 -L https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/libc/OpenWrt-Toolchain-malta-le_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2 | \
       tar xjf - -C /toolchain --strip-components=2
 
 ENV PATH=$PATH:/rust/bin:/toolchain/bin \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -5,6 +5,8 @@
 
 set -ex
 
+MIRRORS_URL="https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/libc"
+
 TARGET="${1}"
 
 # If we're going to run tests inside of a qemu image, then we don't need any of
@@ -21,21 +23,21 @@ if [ "$QEMU" != "" ]; then
     # image is .gz : download and uncompress it
     qemufile="$(echo "${QEMU%.gz}" | sed 's/\//__/g')"
     if [ ! -f "${tmpdir}/${qemufile}" ]; then
-      curl --retry 5 "https://s3-us-west-1.amazonaws.com/rust-lang-ci2/libc/${QEMU}" | \
+      curl --retry 5 "${MIRRORS_URL}/${QEMU}" | \
           gunzip -d > "${tmpdir}/${qemufile}"
     fi
   elif [ -z "${QEMU#*.xz}" ]; then
     # image is .xz : download and uncompress it
     qemufile="$(echo "${QEMU%.xz}" | sed 's/\//__/g')"
     if [ ! -f "${tmpdir}/${qemufile}" ]; then
-      curl --retry 5 "https://s3-us-west-1.amazonaws.com/rust-lang-ci2/libc/${QEMU}" | \
+      curl --retry 5 "${MIRRORS_URL}/${QEMU}" | \
           unxz > "${tmpdir}/${qemufile}"
     fi
   else
     # plain qcow2 image: just download it
     qemufile="$(echo "${QEMU}" | sed 's/\//__/g')"
     if [ ! -f "${tmpdir}/${qemufile}" ]; then
-      curl --retry 5 "https://s3-us-west-1.amazonaws.com/rust-lang-ci2/libc/${QEMU}" \
+      curl --retry 5 "${MIRRORS_URL}/${QEMU}" | \
         > "${tmpdir}/${qemufile}"
     fi
   fi


### PR DESCRIPTION
Previously mirrors were stored in the rust-lang-ci2 bucket, which is
meant to store temporary data (the CI artifacts). This switches the code
to fetch from the new mirrors bucket.

The old files won't be removed, but they won't be backed up either.

r? @gnzlbg 