### PR TITLE
Adding UTIME_NOW and UTIME_OMIT to dragonfly

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1002,6 +1002,10 @@ pub const SF_NOHISTORY: ::c_ulong = 0x00400000;
 pub const SF_CACHE:     ::c_ulong = 0x00800000;
 pub const SF_XLINK:     ::c_ulong = 0x01000000;
 
+// timespec constants
+pub const UTIME_OMIT: c_long = -2;
+pub const UTIME_NOW: c_long = -1;
+
 fn _CMSG_ALIGN(n: usize) -> usize {
     (n + 3) & !3
 }

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -370,6 +370,9 @@ pub const RLIMIT_MSGQUEUE: ::c_int = 12;
 pub const RLIMIT_NICE: ::c_int = 13;
 pub const RLIMIT_RTPRIO: ::c_int = 14;
 
+pub const UTIME_OMIT: c_long = 1073741822;
+pub const UTIME_NOW: c_long = 1073741823;
+
 extern {
     pub fn sendmmsg(sockfd: ::c_int, msgvec: *mut ::mmsghdr, vlen: ::c_uint,
                     flags: ::c_uint) -> ::c_int;

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -370,9 +370,6 @@ pub const RLIMIT_MSGQUEUE: ::c_int = 12;
 pub const RLIMIT_NICE: ::c_int = 13;
 pub const RLIMIT_RTPRIO: ::c_int = 14;
 
-pub const UTIME_OMIT: c_long = 1073741822;
-pub const UTIME_NOW: c_long = 1073741823;
-
 extern {
     pub fn sendmmsg(sockfd: ::c_int, msgvec: *mut ::mmsghdr, vlen: ::c_uint,
                     flags: ::c_uint) -> ::c_int;


### PR DESCRIPTION
Verified in both repos:
 - [musl](https://git.musl-libc.org/cgit/musl/tree/include/sys/stat.h#n70)
 - [dragonfly](https://github.com/DragonFlyBSD/DragonFlyBSD/blob/e7ab884bd49753f8884eb597d10d6569a08fa0df/sys/sys/stat.h#L250)