### PR TITLE
Deprecate RLIM_NLIMITS

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1862,6 +1862,10 @@ pub const RLIMIT_RSS: ::c_int = RLIMIT_AS;
 pub const RLIMIT_MEMLOCK: ::c_int = 6;
 pub const RLIMIT_NPROC: ::c_int = 7;
 pub const RLIMIT_NOFILE: ::c_int = 8;
+#[deprecated(
+    since = "0.2.64",
+    note = "Not stable across OS versions"
+)]
 pub const RLIM_NLIMITS: ::c_int = 9;
 pub const _RLIMIT_POSIX_FLAG: ::c_int = 0x1000;
 

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -451,6 +451,10 @@ pub const ENOMEDIUM: ::c_int = 93;
 pub const EASYNC: ::c_int = 99;
 pub const ELAST: ::c_int = 99;
 pub const RLIMIT_POSIXLOCKS: ::c_int = 11;
+#[deprecated(
+    since = "0.2.64",
+    note = "Not stable across OS versions"
+)]
 pub const RLIM_NLIMITS: ::rlim_t = 12;
 
 pub const Q_GETQUOTA: ::c_int = 0x300;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -337,6 +337,10 @@ pub const RLIMIT_NPTS: ::c_int = 11;
 pub const RLIMIT_SWAP: ::c_int = 12;
 pub const RLIMIT_KQUEUES: ::c_int = 13;
 pub const RLIMIT_UMTXP: ::c_int = 14;
+#[deprecated(
+    since = "0.2.64",
+    note = "Not stable across OS versions"
+)]
 pub const RLIM_NLIMITS: ::rlim_t = 15;
 
 pub const Q_GETQUOTA: ::c_int = 0x700;

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -741,6 +741,10 @@ pub const O_RSYNC : ::c_int = 0x00020000;
 pub const MS_SYNC : ::c_int = 0x4;
 pub const MS_INVALIDATE : ::c_int = 0x2;
 
+#[deprecated(
+    since = "0.2.64",
+    note = "Not stable across OS versions"
+)]
 pub const RLIM_NLIMITS: ::c_int = 12;
 
 pub const EIDRM: ::c_int = 82;

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -757,6 +757,10 @@ pub const AT_SYMLINK_NOFOLLOW: ::c_int = 0x02;
 pub const AT_SYMLINK_FOLLOW: ::c_int = 0x04;
 pub const AT_REMOVEDIR: ::c_int = 0x08;
 
+#[deprecated(
+    since = "0.2.64",
+    note = "Not stable across OS versions"
+)]
 pub const RLIM_NLIMITS: ::c_int = 9;
 
 pub const SO_TIMESTAMP: ::c_int = 0x0800;

--- a/src/unix/linux_like/linux/musl/b32/hexagon.rs
+++ b/src/unix/linux_like/linux/musl/b32/hexagon.rs
@@ -288,6 +288,10 @@ pub const RLIMIT_MEMLOCK: ::c_int = 8;
 pub const RLIMIT_NOFILE: ::c_int = 7;
 pub const RLIMIT_NPROC: ::c_int = 6;
 pub const RLIMIT_RSS: ::c_int = 5;
+#[deprecated(
+    since = "0.2.64",
+    note = "Not stable across OS versions"
+)]
 pub const RLIM_NLIMITS: ::c_int = 16;
 pub const SA_ONSTACK: ::c_int = 0x08000000;
 pub const SA_SIGINFO: ::c_int = 0x00000004;

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1199,6 +1199,10 @@ pub const RLIMIT_NOFILE: ::c_int = 5;
 pub const RLIMIT_VMEM: ::c_int = 6;
 pub const RLIMIT_AS: ::c_int = RLIMIT_VMEM;
 
+#[deprecated(
+    since = "0.2.64",
+    note = "Not stable across OS versions"
+)]
 pub const RLIM_NLIMITS: rlim_t = 7;
 pub const RLIM_INFINITY: rlim_t = 0x7fffffff;
 


### PR DESCRIPTION
This constant is not stable across OS versions, so it cannot be used in
any backwards- or forwards- compatible way.  It's typically used to size
arrays in the kernel and in debugging utilities that are closely tied to
the OS version.  Since libc is ignorant about OS versions, we shouldn't
even be defining it.