### PR TITLE
add renameat2 and flags

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -978,6 +978,9 @@ extern "C" {
         needle: *const ::c_void,
         needlelen: ::size_t,
     ) -> *mut ::c_void;
+    pub fn renameat2(olddirfd: ::c_int, oldpath: *const ::c_char,
+                     newdirfd: ::c_int, newpath: *const ::c_char,
+                     flags: ::c_uint) -> ::c_int;
 }
 
 #[link(name = "util")]

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1226,9 +1226,9 @@ pub const PTHREAD_PROCESS_PRIVATE: ::c_int = 0;
 pub const PTHREAD_PROCESS_SHARED: ::c_int = 1;
 pub const __SIZEOF_PTHREAD_COND_T: usize = 48;
 
-pub const RENAME_NOREPLACE: ::c_int = 1;
-pub const RENAME_EXCHANGE: ::c_int = 2;
-pub const RENAME_WHITEOUT: ::c_int = 4;
+pub const RENAME_NOREPLACE: ::c_uint = 1;
+pub const RENAME_EXCHANGE: ::c_uint = 2;
+pub const RENAME_WHITEOUT: ::c_uint = 4;
 
 pub const SCHED_OTHER: ::c_int = 0;
 pub const SCHED_FIFO: ::c_int = 1;


### PR DESCRIPTION
This used to be PR #554.

Adapted to match the current state of *libc*. Also, adapt for the
fact that in Linux, the *flags* argument is of type *unsigned*,
not *int*.