### PR TITLE
updates for vxworks

### DIFF
--- a/src/vxworks/aarch64.rs
+++ b/src/vxworks/aarch64.rs
@@ -1,3 +1,4 @@
 pub type c_char = u8;
+pub type wchar_t = u32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/vxworks/arm.rs
+++ b/src/vxworks/arm.rs
@@ -1,3 +1,4 @@
 pub type c_char = u8;
+pub type wchar_t = u32;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/vxworks/armv7.rs
+++ b/src/vxworks/armv7.rs
@@ -1,2 +1,0 @@
-pub type c_long = i32;
-pub type c_ulong = u32;

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -551,50 +551,35 @@ enum nfsstat {
     NFSERR_BAD_COOKIE = 10003,
     NFSERR_NOTSUPP = 45,
     NFSERR_TOOSMALL = 10005,
-//    NFSERR_SERVERFAULT = 10006,
     NFSERR_BADTYPE = 10007,
     NFSERR_JUKEBOX = 10008,
 }
 
 pub const S_nfsLib_NFS_OK: ::c_int = nfsstat::NFS_OK as ::c_int;
-pub const S_nfsLib_NFSERR_PERM: ::c_int =
-    nfsstat::NFSERR_PERM as ::c_int;
-pub const S_nfsLib_NFSERR_NOENT: ::c_int =
-    nfsstat::NFSERR_NOENT as ::c_int;
-pub const S_nfsLib_NFSERR_IO: ::c_int =
-    nfsstat::NFSERR_IO as ::c_int;
-pub const S_nfsLib_NFSERR_NXIO: ::c_int =
-    nfsstat::NFSERR_NXIO as ::c_int;
-pub const S_nfsLib_NFSERR_ACCESS: ::c_int =
-    nfsstat::NFSERR_ACCESS as ::c_int;
-pub const S_nfsLib_NFSERR_EXIST: ::c_int =
-    nfsstat::NFSERR_EXIST as ::c_int;
+pub const S_nfsLib_NFSERR_PERM: ::c_int = nfsstat::NFSERR_PERM as ::c_int;
+pub const S_nfsLib_NFSERR_NOENT: ::c_int = nfsstat::NFSERR_NOENT as ::c_int;
+pub const S_nfsLib_NFSERR_IO: ::c_int = nfsstat::NFSERR_IO as ::c_int;
+pub const S_nfsLib_NFSERR_NXIO: ::c_int = nfsstat::NFSERR_NXIO as ::c_int;
+pub const S_nfsLib_NFSERR_ACCESS: ::c_int = nfsstat::NFSERR_ACCESS as ::c_int;
+pub const S_nfsLib_NFSERR_EXIST: ::c_int = nfsstat::NFSERR_EXIST as ::c_int;
 pub const S_nfsLib_NFSERR_XDEV: ::c_int =
     M_nfsStat | nfsstat::NFSERR_XDEV as ::c_int;
 pub const S_nfsLib_NFSERR_NODEV: ::c_int =
     M_nfsStat | nfsstat::NFSERR_NODEV as ::c_int;
-pub const S_nfsLib_NFSERR_NOTDIR: ::c_int =
-    nfsstat::NFSERR_NOTDIR as ::c_int;
-pub const S_nfsLib_NFSERR_ISDIR: ::c_int =
-    nfsstat::NFSERR_ISDIR as ::c_int;
-pub const S_nfsLib_NFSERR_INVAL: ::c_int =
-    nfsstat::NFSERR_INVAL as ::c_int;
-pub const S_nfsLib_NFSERR_FBIG: ::c_int =
-    nfsstat::NFSERR_FBIG as ::c_int;
-pub const S_nfsLib_NFSERR_NOSPC: ::c_int =
-    nfsstat::NFSERR_NOSPC as ::c_int;
-pub const S_nfsLib_NFSERR_ROFS: ::c_int =
-    nfsstat::NFSERR_ROFS as ::c_int;
+pub const S_nfsLib_NFSERR_NOTDIR: ::c_int = nfsstat::NFSERR_NOTDIR as ::c_int;
+pub const S_nfsLib_NFSERR_ISDIR: ::c_int = nfsstat::NFSERR_ISDIR as ::c_int;
+pub const S_nfsLib_NFSERR_INVAL: ::c_int = nfsstat::NFSERR_INVAL as ::c_int;
+pub const S_nfsLib_NFSERR_FBIG: ::c_int = nfsstat::NFSERR_FBIG as ::c_int;
+pub const S_nfsLib_NFSERR_NOSPC: ::c_int = nfsstat::NFSERR_NOSPC as ::c_int;
+pub const S_nfsLib_NFSERR_ROFS: ::c_int = nfsstat::NFSERR_ROFS as ::c_int;
 pub const S_nfsLib_NFSERR_MLINK: ::c_int =
     M_nfsStat | nfsstat::NFSERR_MLINK as ::c_int;
 pub const S_nfsLib_NFSERR_NAMETOOLONG: ::c_int =
     nfsstat::NFSERR_NAMETOOLONG as ::c_int;
 pub const S_nfsLib_NFSERR_NOTEMPTY: ::c_int =
     nfsstat::NFSERR_NOTEMPTY as ::c_int;
-pub const S_nfsLib_NFSERR_DQUOT: ::c_int =
-    nfsstat::NFSERR_DQUOT as ::c_int;
-pub const S_nfsLib_NFSERR_STALE: ::c_int =
-    nfsstat::NFSERR_STALE as ::c_int;
+pub const S_nfsLib_NFSERR_DQUOT: ::c_int = nfsstat::NFSERR_DQUOT as ::c_int;
+pub const S_nfsLib_NFSERR_STALE: ::c_int = nfsstat::NFSERR_STALE as ::c_int;
 pub const S_nfsLib_NFSERR_WFLUSH: ::c_int =
     M_nfsStat | nfsstat::NFSERR_WFLUSH as ::c_int;
 pub const S_nfsLib_NFSERR_REMOTE: ::c_int =
@@ -609,8 +594,7 @@ pub const S_nfsLib_NFSERR_NOTSUPP: ::c_int =
     nfsstat::NFSERR_NOTSUPP as ::c_int;
 pub const S_nfsLib_NFSERR_TOOSMALL: ::c_int =
     M_nfsStat | nfsstat::NFSERR_TOOSMALL as ::c_int;
-pub const S_nfsLib_NFSERR_SERVERFAULT: ::c_int =
-    nfsstat::NFSERR_IO as ::c_int;
+pub const S_nfsLib_NFSERR_SERVERFAULT: ::c_int = nfsstat::NFSERR_IO as ::c_int;
 pub const S_nfsLib_NFSERR_BADTYPE: ::c_int =
     M_nfsStat | nfsstat::NFSERR_BADTYPE as ::c_int;
 pub const S_nfsLib_NFSERR_JUKEBOX: ::c_int =
@@ -666,29 +650,29 @@ pub const S_IRWXO: ::c_int = 0x0007;
 // socket.h
 pub const SOL_SOCKET: ::c_int = 0xffff;
 
-pub const SO_DEBUG: ::c_int =  0x0001;
-pub const SO_REUSEADDR: ::c_int =  0x0004;
-pub const SO_KEEPALIVE: ::c_int =  0x0008;
-pub const SO_DONTROUTE: ::c_int =  0x0010;
-pub const SO_RCVLOWAT: ::c_int =  0x0012;
-pub const SO_SNDLOWAT: ::c_int =  0x0013;
-pub const SO_SNDTIMEO: ::c_int =  0x1005;
-pub const SO_ACCEPTCONN: ::c_int =  0x001e;
-pub const SO_BROADCAST: ::c_int =  0x0020;
-pub const SO_USELOOPBACK: ::c_int =  0x0040;
-pub const SO_LINGER: ::c_int =  0x0080;
-pub const SO_REUSEPORT: ::c_int =  0x0200;
+pub const SO_DEBUG: ::c_int = 0x0001;
+pub const SO_REUSEADDR: ::c_int = 0x0004;
+pub const SO_KEEPALIVE: ::c_int = 0x0008;
+pub const SO_DONTROUTE: ::c_int = 0x0010;
+pub const SO_RCVLOWAT: ::c_int = 0x0012;
+pub const SO_SNDLOWAT: ::c_int = 0x0013;
+pub const SO_SNDTIMEO: ::c_int = 0x1005;
+pub const SO_ACCEPTCONN: ::c_int = 0x001e;
+pub const SO_BROADCAST: ::c_int = 0x0020;
+pub const SO_USELOOPBACK: ::c_int = 0x0040;
+pub const SO_LINGER: ::c_int = 0x0080;
+pub const SO_REUSEPORT: ::c_int = 0x0200;
 
-pub const SO_VLAN: ::c_int =  0x8000;
+pub const SO_VLAN: ::c_int = 0x8000;
 
-pub const SO_SNDBUF: ::c_int =  0x1001;
-pub const SO_RCVBUF: ::c_int =  0x1002;
-pub const SO_RCVTIMEO: ::c_int =  0x1006;
-pub const SO_ERROR: ::c_int =  0x1007;
-pub const SO_TYPE: ::c_int =  0x1008;
-pub const SO_BINDTODEVICE: ::c_int =  0x1010;
-pub const SO_OOBINLINE: ::c_int =  0x1011;
-pub const SO_CONNTIMEO: ::c_int =  0x100a;
+pub const SO_SNDBUF: ::c_int = 0x1001;
+pub const SO_RCVBUF: ::c_int = 0x1002;
+pub const SO_RCVTIMEO: ::c_int = 0x1006;
+pub const SO_ERROR: ::c_int = 0x1007;
+pub const SO_TYPE: ::c_int = 0x1008;
+pub const SO_BINDTODEVICE: ::c_int = 0x1010;
+pub const SO_OOBINLINE: ::c_int = 0x1011;
+pub const SO_CONNTIMEO: ::c_int = 0x100a;
 
 pub const SOCK_STREAM: ::c_int = 1;
 pub const SOCK_DGRAM: ::c_int = 2;
@@ -899,7 +883,7 @@ const PTHREAD_RWLOCKATTR_INITIALIZER: pthread_rwlockattr_t =
         rwlockAttrStatus: PTHREAD_INITIALIZED_OBJ,
         rwlockAttrPshared: 1,
         rwlockAttrMaxReaders: 0,
-        rwlockAttrConformOpt:1,
+        rwlockAttrConformOpt: 1,
     };
 pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
     rwlockSemId: null_mut(),
@@ -990,7 +974,7 @@ f! {
     }
 }
 
-extern {
+extern "C" {
     pub fn isalnum(c: c_int) -> c_int;
     pub fn isalpha(c: c_int) -> c_int;
     pub fn iscntrl(c: c_int) -> c_int;
@@ -1069,7 +1053,7 @@ extern {
     pub fn free(p: *mut c_void);
     pub fn abort() -> !;
     pub fn exit(status: c_int) -> !;
-    pub fn atexit(cb: extern fn()) -> c_int;
+    pub fn atexit(cb: extern "C" fn()) -> c_int;
     pub fn system(s: *const c_char) -> c_int;
     pub fn getenv(s: *const c_char) -> *mut c_char;
 
@@ -1127,7 +1111,7 @@ extern {
     pub fn memset(dest: *mut c_void, c: c_int, n: size_t) -> *mut c_void;
 }
 
-extern {
+extern "C" {
     pub fn getpwnam(name: *const ::c_char) -> *mut passwd;
     pub fn getpwuid(uid: ::uid_t) -> *mut passwd;
 
@@ -1399,7 +1383,7 @@ extern {
     pub fn _rtld_dladdr(addr: *const ::c_void, info: *mut Dl_info) -> ::c_int;
 }
 
-extern {
+extern "C" {
     // stdlib.h
     pub fn memalign(block_size: ::size_t, size_arg: ::size_t)
         -> *mut ::c_void;
@@ -1411,9 +1395,7 @@ extern {
     pub fn chdir(attr: *const ::c_char) -> ::c_int;
 
     // pthread.h
-    pub fn pthread_mutexattr_init(
-        attr: *mut pthread_mutexattr_t,
-    ) -> ::c_int;
+    pub fn pthread_mutexattr_init(attr: *mut pthread_mutexattr_t) -> ::c_int;
 
     // pthread.h
     pub fn pthread_mutexattr_destroy(
@@ -1475,7 +1457,7 @@ extern {
     pub fn pthread_create(
         pThread: *mut ::pthread_t,
         pAttr: *const ::pthread_attr_t,
-        start_routine: extern fn(*mut ::c_void) -> *mut ::c_void,
+        start_routine: extern "C" fn(*mut ::c_void) -> *mut ::c_void,
         value: *mut ::c_void,
     ) -> ::c_int;
 
@@ -1487,9 +1469,9 @@ extern {
 
     // int pthread_atfork (void (*)(void), void (*)(void), void (*)(void));
     pub fn pthread_atfork(
-        prepare: ::Option<unsafe extern fn()>,
-        parent: ::Option<unsafe extern fn()>,
-        child: ::Option<unsafe extern fn()>,
+        prepare: ::Option<unsafe extern "C" fn()>,
+        parent: ::Option<unsafe extern "C" fn()>,
+        child: ::Option<unsafe extern "C" fn()>,
     ) -> ::c_int;
     // stat.h
     pub fn fstat(fildes: ::c_int, buf: *mut stat) -> ::c_int;
@@ -1618,7 +1600,7 @@ extern {
     // pthread.h
     pub fn pthread_key_create(
         key: *mut ::pthread_key_t,
-        dtor: ::Option<unsafe extern fn(*mut ::c_void)>,
+        dtor: ::Option<unsafe extern "C" fn(*mut ::c_void)>,
     ) -> ::c_int;
 
     // pthread.h
@@ -2152,23 +2134,27 @@ pub fn posix_memalign(
 // epoll.h
 // Unfortunately epoll is currently only supported in the VxWorks kernel
 #[allow(unused_variables)]
-pub fn epoll_create(size: ::c_int) -> ::c_int { -1 }
+pub fn epoll_create(size: ::c_int) -> ::c_int {
+    -1
+}
 #[allow(unused_variables)]
-pub fn epoll_create1(flags: ::c_int) -> ::c_int { -1 }
+pub fn epoll_create1(flags: ::c_int) -> ::c_int {
+    -1
+}
 #[allow(unused_variables)]
 pub fn epoll_ctl(
     epfd: ::c_int,
     op: ::c_int,
     fd: ::c_int,
-    event: *mut ::epoll_event
-    ) -> ::c_int {
+    event: *mut ::epoll_event,
+) -> ::c_int {
     -1
 }
 #[allow(unused_variables)]
 pub fn epoll_create_and_ctl(
     num: ::c_int,
     fds: *mut ::c_int,
-        event: *mut ::epoll_event
+    event: *mut ::epoll_event,
 ) -> ::c_int {
     -1
 }
@@ -2177,9 +2163,9 @@ pub fn epoll_wait(
     epfd: ::c_int,
     events: *mut ::epoll_event,
     maxevents: ::c_int,
-    timeout: ::c_int
+    timeout: ::c_int,
 ) -> ::c_int {
-        -1
+    -1
 }
 
 // From sysconf.c -> doesn't seem to be supported?

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -1,3 +1,4 @@
+// Copyright (c) 2019 Wind River Systems, Inc. 
 //! Interface to VxWorks C library
 
 use core::mem::size_of;
@@ -11,6 +12,9 @@ impl ::Clone for DIR {
         *self
     }
 }
+
+// Throughout we use usize / isize for types that are
+// (unsigned) int in ILP32 and (unsigned) long in ILP64
 
 pub type c_schar = i8;
 pub type c_uchar = u8;
@@ -80,9 +84,9 @@ pub type off64_t = ::c_longlong;
 pub type off_t64 = ::c_longlong;
 
 // From b_BOOL.h
-pub type BOOL = ::c_int; // excuse me what
+pub type BOOL = ::c_int;
 
-//Straight from vxWind.h ..
+// From vxWind.h ..
 pub type _Vx_OBJ_HANDLE = ::c_int;
 pub type _Vx_TASK_ID = ::_Vx_OBJ_HANDLE;
 pub type _Vx_MSG_Q_ID = ::_Vx_OBJ_HANDLE;
@@ -100,8 +104,8 @@ pub type SD_ID = ::OBJ_HANDLE;
 pub type CONDVAR_ID = ::OBJ_HANDLE;
 
 // From vxTypes.h
-pub type _Vx_usr_arg_t = ::ssize_t; // c_int for LP32
-pub type _Vx_exit_code_t = ::ssize_t; // c_int for LP32
+pub type _Vx_usr_arg_t = ::isize;
+pub type _Vx_exit_code_t = ::isize;
 pub type _Vx_ticks_t = ::c_uint;
 pub type _Vx_ticks64_t = ::c_ulonglong;
 
@@ -112,25 +116,7 @@ pub type sa_family_t = ::c_uchar;
 
 // structs that only exist in userspace
 s! {
-    // b_struct_vx_eventsResourceCb.h
-    pub struct _Vx_EVENTS_RSRC {
-        pub registered : ::c_uint,
-        pub taskId     : ::c_int,
-        pub options    : ::c_uchar,
-        pub pad        : [::c_uchar; 3],
-    }
-
-    // b_struct_vx_semaphore.h
-    pub struct _Vx_semaphore {
-        pub magic  : ::c_uint,
-        pub semType: ::c_uint,
-        pub options: ::c_uint,
-        pub recurse: ::c_uint,
-        pub owned_k: ::c_uint, // owned_k is volatile
-        pub semId_k: ::_Vx_SEM_ID_KERNEL,
-        pub state  : ::c_uint, //state is union of _Vx_UINT and _Vx_UINT
-        pub events : ::_Vx_EVENTS_RSRC,
-    }
+    pub struct _Vx_semaphore {}
 
     // b_pthread_condattr_t.h
     pub struct pthread_condattr_t {
@@ -173,6 +159,11 @@ s! {
     }
 
     // socket.h
+    pub struct linger {
+        pub l_onoff: ::c_int,
+        pub l_linger: ::c_int,
+    }
+
     pub struct sockaddr {
         pub sa_len    : ::c_uchar,
         pub sa_family : sa_family_t,
@@ -361,6 +352,19 @@ s! {
         pub tv_nsec: ::c_long,
     }
 
+    // time.h
+    pub struct tm {
+    	pub tm_sec: ::c_int,
+    	pub tm_min: ::c_int,
+    	pub tm_hour: ::c_int,
+    	pub tm_mday: ::c_int,
+    	pub tm_mon: ::c_int,
+    	pub tm_year: ::c_int,
+    	pub tm_wday: ::c_int,
+    	pub tm_yday: ::c_int,
+    	pub tm_isdst: ::c_int,	
+    }
+
     // in.h
     pub struct in_addr {
         pub s_addr: in_addr_t,
@@ -476,7 +480,7 @@ pub const EAI_SYSTEM: ::c_int = 11;
 
 pub const RTLD_DEFAULT: *mut ::c_void = 0i64 as *mut ::c_void;
 
-//Clock Lib Stuff
+// Clock Lib Stuff
 pub const CLOCK_REALTIME: ::c_int = 0x0;
 pub const CLOCK_MONOTONIC: ::c_int = 0x1;
 pub const CLOCK_PROCESS_CPUTIME_ID: ::c_int = 0x2;
@@ -508,7 +512,7 @@ pub const EEXIST: ::c_int = 17;
 pub const ENODEV: ::c_int = 19;
 pub const EINVAL: ::c_int = 22;
 pub const EPIPE: ::c_int = 32;
-pub const ERANGE: ::c_int = 34;
+pub const ERANGE: ::c_int = 38;
 
 // ERRNO STUFF
 pub const EPERM: ::c_int = 1; /* Not owner */
@@ -647,16 +651,25 @@ pub const S_nfsLib_NFSERR_BADTYPE: ::c_int =
 pub const S_nfsLib_NFSERR_JUKEBOX: ::c_int =
     M_nfsStat | nfsstat::NFSERR_JUKEBOX as ::c_int;
 
-// IP Stuff? These are allll guesswork
+// in.h
 pub const IPPROTO_IP: ::c_int = 0;
-pub const IP_TTL: ::c_int = 4; // not sure if this is right
-pub const IP_ADD_MEMBERSHIP: ::c_int = 11;
-pub const IP_DROP_MEMBERSHIP: ::c_int = 12;
-pub const IPV6_V6ONLY: ::c_int = 26;
-pub const IP_MULTICAST_TTL: ::c_int = 33;
-pub const IP_MULTICAST_LOOP: ::c_int = 34;
-pub const IPV6_MULTICAST_LOOP: ::c_int = 19;
-pub const IPPROTO_IPV6: ::c_int = 41; // or this one, for that matter
+pub const IPPROTO_IPV6: ::c_int = 41;
+
+pub const IP_TTL: ::c_int = 4;
+pub const IP_MULTICAST_IF: ::c_int = 9;
+pub const IP_MULTICAST_TTL: ::c_int = 10;
+pub const IP_MULTICAST_LOOP: ::c_int = 11;
+pub const IP_ADD_MEMBERSHIP: ::c_int = 12;
+pub const IP_DROP_MEMBERSHIP: ::c_int = 13;
+
+// in6.h
+pub const IPV6_V6ONLY: ::c_int = 1;
+pub const IPV6_UNICAST_HOPS: ::c_int = 4;
+pub const IPV6_MULTICAST_IF: ::c_int = 9;
+pub const IPV6_MULTICAST_HOPS: ::c_int = 10;
+pub const IPV6_MULTICAST_LOOP: ::c_int = 11;
+pub const IPV6_ADD_MEMBERSHIP: ::c_int = 12;
+pub const IPV6_DROP_MEMBERSHIP: ::c_int = 13;
 
 // STAT Stuff
 pub const S_IFMT: ::c_int = 0xf000;
@@ -685,21 +698,39 @@ pub const S_IWOTH: ::c_int = 0x0002;
 pub const S_IXOTH: ::c_int = 0x0001;
 pub const S_IRWXO: ::c_int = 0x0007;
 
+// socket.h
 pub const SOL_SOCKET: ::c_int = 0xffff;
-pub const SO_BROADCAST: ::c_int = 0x001e;
-pub const SO_SNDTIMEO: ::c_int = 0x1005;
-pub const SO_RCVTIMEO: ::c_int = 0x1006;
+
+pub const SO_DEBUG: ::c_int =  0x0001;
+pub const SO_REUSEADDR: ::c_int =  0x0004;
+pub const SO_KEEPALIVE: ::c_int =  0x0008;
+pub const SO_DONTROUTE: ::c_int =  0x0010;
+pub const SO_RCVLOWAT: ::c_int =  0x0012;
+pub const SO_SNDLOWAT: ::c_int =  0x0013;
+pub const SO_SNDTIMEO: ::c_int =  0x1005;
+pub const SO_ACCEPTCONN: ::c_int =  0x001e;
+pub const SO_BROADCAST: ::c_int =  0x0020;
+pub const SO_USELOOPBACK: ::c_int =  0x0040;
+pub const SO_LINGER: ::c_int =  0x0080;
+pub const SO_REUSEPORT: ::c_int =  0x0200;
+
+pub const SO_VLAN: ::c_int =  0x8000;
+
+pub const SO_SNDBUF: ::c_int =  0x1001;
+pub const SO_RCVBUF: ::c_int =  0x1002;
+pub const SO_RCVTIMEO: ::c_int =  0x1006;
+pub const SO_ERROR: ::c_int =  0x1007;
+pub const SO_TYPE: ::c_int =  0x1008;
+pub const SO_BINDTODEVICE: ::c_int =  0x1010;
+pub const SO_OOBINLINE: ::c_int =  0x1011;
+pub const SO_CONNTIMEO: ::c_int =  0x100a;
+
 pub const SOCK_STREAM: ::c_int = 1;
 pub const SOCK_DGRAM: ::c_int = 2;
 pub const SOCK_RAW: ::c_int = 3;
 pub const SOCK_RDM: ::c_int = 4;
 pub const SOCK_SEQPACKET: ::c_int = 5;
 pub const SOCK_PACKET: ::c_int = 10;
-pub const SO_DEBUG: ::c_int = 0x0001;
-pub const SO_REUSEADDR: ::c_int = 0x0004;
-pub const SO_KEEPALIVE: ::c_int = 0x0008;
-pub const SO_DONTROUTE: ::c_int = 0x0010;
-pub const SO_RCVLOWAT: ::c_int = 0x0012;
 
 pub const _SS_MAXSIZE: usize = 128;
 pub const _SS_ALIGNSIZE: usize = size_of::<u32>();
@@ -753,7 +784,6 @@ pub const TCP_NOPUSH: ::c_int = 3;
 pub const TCP_KEEPIDLE: ::c_int = 4;
 pub const TCP_KEEPINTVL: ::c_int = 5;
 pub const TCP_KEEPCNT: ::c_int = 6;
-pub const SO_ERROR: ::c_int = 4;
 
 // IO Lib Definitions:
 
@@ -772,7 +802,7 @@ pub const FIOWRITE: ::c_int = 12;
 pub const FIODISKCHANGE: ::c_int = 13;
 pub const FIOCANCEL: ::c_int = 14;
 pub const FIOSQUEEZE: ::c_int = 15;
-pub const FIONBIO: ::c_int = -1878786032; // it goes on ...
+pub const FIONBIO: ::c_int = 16;
 pub const _POSIX_PATH_MAX: ::c_int = 256;
 
 // Some poll stuff
@@ -814,8 +844,6 @@ pub const DT_WHT: ::c_uchar = 0xE;
 
 // Other Random Stuff
 pub const VXSIM_EWOULDBLOCK: ::c_int = 70;
-pub const IPV6_ADD_MEMBERSHIP: ::c_int = 20;
-pub const IPV6_DROP_MEMBERSHIP: ::c_int = 21;
 
 pub const SIG_DFL: sighandler_t = 0 as sighandler_t;
 pub const SIG_IGN: sighandler_t = 1 as sighandler_t;
@@ -1288,6 +1316,15 @@ extern "C" {
     ) -> *mut ::c_void;
     pub fn dlclose(handle: *mut ::c_void) -> ::c_int;
     pub fn res_init() -> ::c_int;
+
+    // time.h
+    pub fn gmtime_r(time_p: *const time_t, result: *mut tm) -> *mut tm;
+    pub fn localtime_r(time_p: *const time_t, result: *mut tm) -> *mut tm;
+    pub fn mktime(tm: *mut tm) -> time_t;
+    pub fn time(time: *mut time_t) -> time_t;
+    pub fn gmtime(time_p: *const time_t) -> *mut tm;
+    pub fn localtime(time_p: *const time_t) -> *mut tm;
+    pub fn timegm(tm: *mut tm) -> time_t;
     pub fn difftime(time1: time_t, time0: time_t) -> ::c_double;
 
     pub fn mknod(
@@ -1894,7 +1931,7 @@ extern "C" {
     pub fn closedir(ptr: *mut ::DIR) -> ::c_int;
 
     pub fn pwrite64(
-        fd: ::c_int, // if you want to use fd, you gotta fix these
+        fd: ::c_int,
         buf: *const ::c_void,
         count: ::size_t,
         offset: off64_t,

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -1,4 +1,3 @@
-// Copyright (c) 2019 Wind River Systems, Inc. 
 //! Interface to VxWorks C library
 
 use core::mem::size_of;
@@ -37,25 +36,23 @@ pub type ssize_t = isize;
 
 pub type pid_t = i32;
 pub type in_addr_t = u32;
-pub type in_port_t = u16;
 pub type sighandler_t = ::size_t;
-pub type cc_t = ::c_uchar;
+pub type cpuset_t = u32;
 
 pub type blkcnt_t = ::c_long;
 pub type blksize_t = ::c_long;
 pub type ino_t = ::c_ulong;
-pub type ino32_t = u32;
 pub type off_t = ::c_longlong;
 
-pub type rlim_t = ::c_ulonglong;
+pub type rlim_t = ::c_ulong;
 pub type suseconds_t = ::c_long;
 pub type time_t = ::c_long;
-pub type wchar_t = ::c_int;
+
 pub type errno_t = ::c_int;
 
 pub type useconds_t = ::c_ulong;
 
-pub type socklen_t = ::c_int;
+pub type socklen_t = ::c_uint;
 
 pub type pthread_t = ::c_ulong;
 
@@ -69,19 +66,14 @@ pub type uid_t = ::c_ushort;
 pub type gid_t = ::c_ushort;
 pub type sigset_t = ::c_ulonglong;
 pub type key_t = ::c_long;
-pub type shmatt_t = ::c_ulong;
-
-pub type mqd_t = ::c_int;
 
 pub type nfds_t = ::c_uint;
-pub type nl_item = ::c_int;
 pub type stat64 = ::stat;
 
 pub type pthread_key_t = ::c_ulong;
 
 // From b_off_t.h
 pub type off64_t = ::c_longlong;
-pub type off_t64 = ::c_longlong;
 
 // From b_BOOL.h
 pub type BOOL = ::c_int;
@@ -109,9 +101,6 @@ pub type _Vx_exit_code_t = isize;
 pub type _Vx_ticks_t = ::c_uint;
 pub type _Vx_ticks64_t = ::c_ulonglong;
 
-// From vxTypesBase.h
-pub type va_list = *mut ::c_char;
-
 pub type sa_family_t = ::c_uchar;
 
 // structs that only exist in userspace
@@ -122,7 +111,7 @@ s! {
     pub struct pthread_condattr_t {
         pub condAttrStatus: ::c_int,
         pub condAttrPshared: ::c_int,
-        pub _CondAttrClockId: ::clockid_t,
+        pub condAttrClockId: ::clockid_t,
     }
 
     // b_pthread_cond_t.h
@@ -133,23 +122,25 @@ s! {
         pub condRefCount: ::c_int,
         pub condMutex: *mut ::pthread_mutex_t,
         pub condAttr: ::pthread_condattr_t,
-        pub condSemName: [::c_char; PTHREAD_SHARED_SEM_NAME_MAX]
+        pub condSemName: [::c_char; _PTHREAD_SHARED_SEM_NAME_MAX]
     }
 
     // b_pthread_rwlockattr_t.h
     pub struct pthread_rwlockattr_t {
         pub rwlockAttrStatus: ::c_int,
+        pub rwlockAttrPshared: ::c_int,
         pub rwlockAttrMaxReaders: ::c_uint,
+        pub rwlockAttrConformOpt: ::c_uint,
     }
 
     // b_pthread_rwlock_t.h
     pub struct pthread_rwlock_t {
         pub rwlockSemId: :: _Vx_SEM_ID,
-        pub rwlockReadersRefCount: ::c_int,
+        pub rwlockReadersRefCount: ::c_uint,
         pub rwlockValid: ::c_int,
         pub rwlockInitted: ::c_int,
         pub rwlockAttr: ::pthread_rwlockattr_t,
-        pub rwlockName: [::c_char; PTHREAD_SHARED_SEM_NAME_MAX]
+        pub rwlockSemName: [::c_char; _PTHREAD_SHARED_SEM_NAME_MAX]
     }
 
     // b_struct_timeval.h
@@ -176,11 +167,7 @@ s! {
         pub ss_family  : ::sa_family_t,
         pub __ss_pad1  : [::c_char; _SS_PAD1SIZE],
         pub __ss_align : i32,
-        // pub __ss_pad2  : [::c_char; _SS_PAD2SIZE],
-        pub __ss_pad2  : [::c_char; 32],
-        pub __ss_pad3  : [::c_char; 32],
-        pub __ss_pad4  : [::c_char; 32],
-        pub __ss_pad5  : [::c_char; _SS_PAD2SIZE - 96],
+        pub __ss_pad2  : [::c_char; _SS_PAD2SIZE],
     }
     pub struct iovec {
         pub iov_base: *mut ::c_void,
@@ -202,7 +189,7 @@ s! {
         pub cmsg_level: ::c_int,
         pub cmsg_type: ::c_int,
     }
-    
+
     // poll.h
     pub struct pollfd {
         pub fd      : ::c_int,
@@ -213,37 +200,13 @@ s! {
     // dirent.h
     pub struct dirent {
         pub d_ino  : ::ino_t,
-        // pub d_name : [::c_char; (_PARM_NAME_MAX + 1)],
-        pub d_name : [::c_char; 32],
-        pub d_name1 : [::c_char; 32],
-        pub d_name2 : [::c_char; 32],
-        pub d_name3 : [::c_char; 32],
-        pub d_name4 : [::c_char; 32],
-        pub d_name5 : [::c_char; 32],
-        pub d_name6 : [::c_char; 32],
-        pub d_name7 : [::c_char; 32],
+        pub d_name : [::c_char; _PARM_NAME_MAX + 1],
     }
-
-    pub struct dirent64 {
-        pub d_ino    : ::ino_t,
-        pub d_off    : ::off64_t,
-        pub d_reclen : u16,
-        pub d_type   : u8,
-        // pub d_name   : [::c_char; 256],
-        pub d_name   : [::c_char; 32],
-        pub d_name1   : [::c_char; 32],
-        pub d_name2   : [::c_char; 32],
-        pub d_name3   : [::c_char; 32],
-        pub d_name4   : [::c_char; 32],
-        pub d_name5   : [::c_char; 32],
-        pub d_name6   : [::c_char; 32],
-        pub d_name7   : [::c_char; 32],
-    } // Doesn't seem like it exists anymore
 
     // resource.h
     pub struct rlimit { /* Is this really needed? Questionable ... */
-                           pub rlim_cur : ::size_t,
-                           pub rlim_max : ::size_t,
+                           pub rlim_cur : ::rlim_t,
+                           pub rlim_max : ::rlim_t,
     }
 
     // stat.h
@@ -323,21 +286,11 @@ s! {
         // This field is a union of int and void * in vxworks
         // The size has been set to the larger of the two
         pub si_value : ::size_t,
-    }
-
-    pub struct ipc_perm {
-                             pub __key : key_t,
-                             pub uid   : uid_t,
-                             pub gid   : gid_t,
-                             pub cuid  : uid_t,
-                             pub cgid  : gid_t,
-                             pub mode  : ::c_ushort,
-                             pub __seq : ::c_ushort,
-    }
-
-    pub struct shmid_ds {
-        pub shm_perm  : ipc_perm,
-        pub shm_segsz : ::c_int,
+        pub si_errno : ::c_int,
+        pub si_status: ::c_int,
+        pub si_addr: *mut ::c_void,
+        pub si_uid: ::uid_t,
+        pub si_pid: ::pid_t,
     }
 
     // pthread.h (krnl)
@@ -359,7 +312,7 @@ s! {
         pub mutexCondRefCount: ::c_int,
         pub mutexSavPriority: ::c_int,
         pub mutexAttr: ::pthread_mutexattr_t,
-        pub mutexSemName: [::c_char; PTHREAD_SHARED_SEM_NAME_MAX],
+        pub mutexSemName: [::c_char; _PTHREAD_SHARED_SEM_NAME_MAX],
     }
 
     // b_struct_timespec.h
@@ -370,15 +323,15 @@ s! {
 
     // time.h
     pub struct tm {
-    	pub tm_sec: ::c_int,
-    	pub tm_min: ::c_int,
-    	pub tm_hour: ::c_int,
-    	pub tm_mday: ::c_int,
-    	pub tm_mon: ::c_int,
-    	pub tm_year: ::c_int,
-    	pub tm_wday: ::c_int,
-    	pub tm_yday: ::c_int,
-    	pub tm_isdst: ::c_int,	
+        pub tm_sec: ::c_int,
+        pub tm_min: ::c_int,
+        pub tm_hour: ::c_int,
+        pub tm_mday: ::c_int,
+        pub tm_mon: ::c_int,
+        pub tm_year: ::c_int,
+        pub tm_wday: ::c_int,
+        pub tm_yday: ::c_int,
+        pub tm_isdst: ::c_int,
     }
 
     // in.h
@@ -393,6 +346,7 @@ s! {
     }
 
     // in6.h
+    #[repr(align(4))]
     pub struct in6_addr {
         pub s6_addr: [u8; 16],
     }
@@ -438,12 +392,9 @@ s! {
     }
 
     pub struct sockaddr_un {
+        pub sun_len: u8,
         pub sun_family: sa_family_t,
-        //pub sun_path: [::c_char; 108]
-        pub sun_path: [::c_char; 32],
-        pub sun_path1: [::c_char; 32],
-        pub sun_path2: [::c_char; 32],
-        pub sun_path3: [::c_char; 12],
+        pub sun_path: [::c_char; 104]
     }
 
     pub struct passwd {
@@ -455,12 +406,11 @@ s! {
     }
 
     // epoll.h
-
-    pub struct epoll_event {
+     pub struct epoll_event {
         pub events: u32,
         pub u64: u64,
     }
-    
+
     // rtpLibCommon.h
     pub struct RTP_DESC {
         pub status    : ::c_int,
@@ -468,16 +418,8 @@ s! {
         pub entrAddr  : *mut ::c_void,
         pub initTaskId: ::TASK_ID,
         pub parentId  : ::RTP_ID,
-        //pub pathName  : [::c_char; (VX_RTP_NAME_LENGTH + 1)],
-        pub pathName  : [::c_char; 32],
-        pub pathName1  : [::c_char; 32],
-        pub pathName2  : [::c_char; 32],
-        pub pathName3  : [::c_char; 32],
-        pub pathName4  : [::c_char; 32],
-        pub pathName5  : [::c_char; 32],
-        pub pathName6  : [::c_char; 32],
-        pub pathName7  : [::c_char; 32],
-        pub taskCnt   : u32,
+        pub pathName  : [::c_char; VX_RTP_NAME_LENGTH + 1],
+        pub taskCnt   : ::c_int,
         pub textStart : *mut ::c_void,
         pub textEnd   : *mut ::c_void,
     }
@@ -503,7 +445,7 @@ pub const EAI_SYSTEM: ::c_int = 11;
 
 pub const RTLD_DEFAULT: *mut ::c_void = 0i64 as *mut ::c_void;
 
-// Clock Lib Stuff
+//Clock Lib Stuff
 pub const CLOCK_REALTIME: ::c_int = 0x0;
 pub const CLOCK_MONOTONIC: ::c_int = 0x1;
 pub const CLOCK_PROCESS_CPUTIME_ID: ::c_int = 0x2;
@@ -527,7 +469,7 @@ pub const PTHREAD_MUTEX_ERRORCHECK: ::c_int = 1;
 pub const PTHREAD_MUTEX_RECURSIVE: ::c_int = 2;
 pub const PTHREAD_MUTEX_DEFAULT: ::c_int = PTHREAD_MUTEX_NORMAL;
 pub const PTHREAD_STACK_MIN: usize = 4096;
-pub const PTHREAD_SHARED_SEM_NAME_MAX: usize = 30;
+pub const _PTHREAD_SHARED_SEM_NAME_MAX: usize = 30;
 
 pub const EFAULT: ::c_int = 14;
 pub const EBUSY: ::c_int = 16;
@@ -598,61 +540,61 @@ enum nfsstat {
     NFSERR_NOSPC = 28,
     NFSERR_ROFS = 30,
     NFSERR_MLINK = 31,
-    NFSERR_NAMETOOLONG = 63,
-    NFSERR_NOTEMPTY = 66,
-    NFSERR_DQUOT = 69,
-    NFSERR_STALE = 70,
+    NFSERR_NAMETOOLONG = 26,
+    NFSERR_NOTEMPTY = 15,
+    NFSERR_DQUOT = 83,
+    NFSERR_STALE = 88,
     NFSERR_REMOTE = 71,
     NFSERR_WFLUSH = 99,
     NFSERR_BADHANDLE = 10001,
     NFSERR_NOT_SYNC = 10002,
     NFSERR_BAD_COOKIE = 10003,
-    NFSERR_NOTSUPP = 10004,
+    NFSERR_NOTSUPP = 45,
     NFSERR_TOOSMALL = 10005,
-    NFSERR_SERVERFAULT = 10006,
+//    NFSERR_SERVERFAULT = 10006,
     NFSERR_BADTYPE = 10007,
     NFSERR_JUKEBOX = 10008,
 }
 
-pub const S_nfsLib_NFS_OK: ::c_int = M_nfsStat | nfsstat::NFS_OK as ::c_int;
+pub const S_nfsLib_NFS_OK: ::c_int = nfsstat::NFS_OK as ::c_int;
 pub const S_nfsLib_NFSERR_PERM: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_PERM as ::c_int;
+    nfsstat::NFSERR_PERM as ::c_int;
 pub const S_nfsLib_NFSERR_NOENT: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_NOENT as ::c_int;
+    nfsstat::NFSERR_NOENT as ::c_int;
 pub const S_nfsLib_NFSERR_IO: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_IO as ::c_int;
+    nfsstat::NFSERR_IO as ::c_int;
 pub const S_nfsLib_NFSERR_NXIO: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_NXIO as ::c_int;
+    nfsstat::NFSERR_NXIO as ::c_int;
 pub const S_nfsLib_NFSERR_ACCESS: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_ACCESS as ::c_int;
+    nfsstat::NFSERR_ACCESS as ::c_int;
 pub const S_nfsLib_NFSERR_EXIST: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_EXIST as ::c_int;
+    nfsstat::NFSERR_EXIST as ::c_int;
 pub const S_nfsLib_NFSERR_XDEV: ::c_int =
     M_nfsStat | nfsstat::NFSERR_XDEV as ::c_int;
 pub const S_nfsLib_NFSERR_NODEV: ::c_int =
     M_nfsStat | nfsstat::NFSERR_NODEV as ::c_int;
 pub const S_nfsLib_NFSERR_NOTDIR: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_NOTDIR as ::c_int;
+    nfsstat::NFSERR_NOTDIR as ::c_int;
 pub const S_nfsLib_NFSERR_ISDIR: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_ISDIR as ::c_int;
+    nfsstat::NFSERR_ISDIR as ::c_int;
 pub const S_nfsLib_NFSERR_INVAL: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_INVAL as ::c_int;
+    nfsstat::NFSERR_INVAL as ::c_int;
 pub const S_nfsLib_NFSERR_FBIG: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_FBIG as ::c_int;
+    nfsstat::NFSERR_FBIG as ::c_int;
 pub const S_nfsLib_NFSERR_NOSPC: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_NOSPC as ::c_int;
+    nfsstat::NFSERR_NOSPC as ::c_int;
 pub const S_nfsLib_NFSERR_ROFS: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_ROFS as ::c_int;
+    nfsstat::NFSERR_ROFS as ::c_int;
 pub const S_nfsLib_NFSERR_MLINK: ::c_int =
     M_nfsStat | nfsstat::NFSERR_MLINK as ::c_int;
 pub const S_nfsLib_NFSERR_NAMETOOLONG: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_NAMETOOLONG as ::c_int;
+    nfsstat::NFSERR_NAMETOOLONG as ::c_int;
 pub const S_nfsLib_NFSERR_NOTEMPTY: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_NOTEMPTY as ::c_int;
+    nfsstat::NFSERR_NOTEMPTY as ::c_int;
 pub const S_nfsLib_NFSERR_DQUOT: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_DQUOT as ::c_int;
+    nfsstat::NFSERR_DQUOT as ::c_int;
 pub const S_nfsLib_NFSERR_STALE: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_STALE as ::c_int;
+    nfsstat::NFSERR_STALE as ::c_int;
 pub const S_nfsLib_NFSERR_WFLUSH: ::c_int =
     M_nfsStat | nfsstat::NFSERR_WFLUSH as ::c_int;
 pub const S_nfsLib_NFSERR_REMOTE: ::c_int =
@@ -664,11 +606,11 @@ pub const S_nfsLib_NFSERR_NOT_SYNC: ::c_int =
 pub const S_nfsLib_NFSERR_BAD_COOKIE: ::c_int =
     M_nfsStat | nfsstat::NFSERR_BAD_COOKIE as ::c_int;
 pub const S_nfsLib_NFSERR_NOTSUPP: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_NOTSUPP as ::c_int;
+    nfsstat::NFSERR_NOTSUPP as ::c_int;
 pub const S_nfsLib_NFSERR_TOOSMALL: ::c_int =
     M_nfsStat | nfsstat::NFSERR_TOOSMALL as ::c_int;
 pub const S_nfsLib_NFSERR_SERVERFAULT: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_SERVERFAULT as ::c_int;
+    nfsstat::NFSERR_IO as ::c_int;
 pub const S_nfsLib_NFSERR_BADTYPE: ::c_int =
     M_nfsStat | nfsstat::NFSERR_BADTYPE as ::c_int;
 pub const S_nfsLib_NFSERR_JUKEBOX: ::c_int =
@@ -794,7 +736,7 @@ pub const AF_SOCKDEV: ::c_int = 31;
 pub const AF_TIPC: ::c_int = 33;
 pub const AF_MIPC: ::c_int = 34;
 pub const AF_MIPC_SAFE: ::c_int = 35;
-pub const AF_MAX: ::c_int = 36;
+pub const AF_MAX: ::c_int = 37;
 
 pub const SHUT_RD: ::c_int = 0;
 pub const SHUT_WR: ::c_int = 1;
@@ -838,7 +780,6 @@ pub const EPOLLRDHUP: ::c_int = 0x2000;
 pub const EPOLLONESHOT: ::c_int = 1 << 30;
 pub const EPOLLET: ::c_int = 1 << 31;
 
-
 pub const EPOLL_CTL_ADD: ::c_int = 1;
 pub const EPOLL_CTL_DEL: ::c_int = 2;
 pub const EPOLL_CTL_MOD: ::c_int = 3;
@@ -851,7 +792,7 @@ pub const POLLRDNORM: ::c_short = 0x0040;
 pub const POLLWRNORM: ::c_short = POLLOUT;
 pub const POLLRDBAND: ::c_short = 0x0080;
 pub const POLLWRBAND: ::c_short = 0x0100;
-pub const POLLER: ::c_short = 0x0008;
+pub const POLLERR: ::c_short = 0x0008;
 pub const POLLHUP: ::c_short = 0x0010;
 pub const POLLNVAL: ::c_short = 0x0020;
 
@@ -869,23 +810,12 @@ pub const F_SETLK: ::c_int = 8;
 pub const F_SETLKW: ::c_int = 9;
 pub const F_DUPFD_CLOEXEC: ::c_int = 14;
 
-//Some Dirent.h stuff
-pub const DT_UNKNOWN: ::c_uchar = 0x0;
-pub const DT_FIFO: ::c_uchar = 0x1;
-pub const DT_CHR: ::c_uchar = 0x2;
-pub const DT_DIR: ::c_uchar = 0x4;
-pub const DT_BLK: ::c_uchar = 0x6;
-pub const DT_REG: ::c_uchar = 0x8;
-pub const DT_LNK: ::c_uchar = 0xA;
-pub const DT_SOCK: ::c_uchar = 0xC;
-pub const DT_WHT: ::c_uchar = 0xE;
-
 // Other Random Stuff
 pub const VXSIM_EWOULDBLOCK: ::c_int = 70;
 
-pub const SIG_DFL: sighandler_t = 0 as sighandler_t;
-pub const SIG_IGN: sighandler_t = 1 as sighandler_t;
-pub const SIG_ERR: sighandler_t = !0 as sighandler_t;
+pub const SIG_DFL: c_int = 0;
+pub const SIG_IGN: c_int = 1;
+pub const SIG_ERR: c_int = !0;
 
 pub const SIGHUP: ::c_int = 1;
 pub const SIGINT: ::c_int = 2;
@@ -944,15 +874,15 @@ pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
     mutexValid: PTHREAD_VALID_OBJ,
     mutexInitted: PTHREAD_UNUSED_YET_OBJ,
     mutexCondRefCount: 0,
-    mutexSavPriority: 0,
+    mutexSavPriority: -1,
     mutexAttr: PTHREAD_MUTEXATTR_INITIALIZER,
-    mutexSemName: [0; PTHREAD_SHARED_SEM_NAME_MAX],
+    mutexSemName: [0; _PTHREAD_SHARED_SEM_NAME_MAX],
 };
 
 const PTHREAD_CONDATTR_INITIALIZER: pthread_condattr_t = pthread_condattr_t {
-    condAttrStatus: 0,
-    condAttrPshared: 0,
-    _CondAttrClockId: CLOCK_REALTIME,
+    condAttrStatus: 0xf70990ef,
+    condAttrPshared: 1,
+    condAttrClockId: CLOCK_REALTIME,
 };
 pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = pthread_cond_t {
     condSemId: null_mut(),
@@ -961,13 +891,15 @@ pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = pthread_cond_t {
     condRefCount: 0,
     condMutex: null_mut(),
     condAttr: PTHREAD_CONDATTR_INITIALIZER,
-    condSemName: [0; PTHREAD_SHARED_SEM_NAME_MAX],
+    condSemName: [0; _PTHREAD_SHARED_SEM_NAME_MAX],
 };
 
 const PTHREAD_RWLOCKATTR_INITIALIZER: pthread_rwlockattr_t =
     pthread_rwlockattr_t {
         rwlockAttrStatus: PTHREAD_INITIALIZED_OBJ,
+        rwlockAttrPshared: 1,
         rwlockAttrMaxReaders: 0,
+        rwlockAttrConformOpt:1,
     };
 pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
     rwlockSemId: null_mut(),
@@ -975,7 +907,7 @@ pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
     rwlockValid: PTHREAD_VALID_OBJ,
     rwlockInitted: PTHREAD_UNUSED_YET_OBJ,
     rwlockAttr: PTHREAD_RWLOCKATTR_INITIALIZER,
-    rwlockName: [0; PTHREAD_SHARED_SEM_NAME_MAX],
+    rwlockSemName: [0; _PTHREAD_SHARED_SEM_NAME_MAX],
 };
 
 pub const SEEK_SET: ::c_int = 0;
@@ -985,19 +917,19 @@ pub const SEEK_END: ::c_int = 2;
 // rtpLibCommon.h
 pub const VX_RTP_NAME_LENGTH: usize = 255;
 
-//Some unsupported stuff
-pub const _SC_GETPW_R_SIZE_MAX: ::c_int = -1; // Via unistd.h
-pub const _SC_PAGESIZE: ::c_int = 64;
+// h/public/unistd.h
+pub const _SC_GETPW_R_SIZE_MAX: ::c_int = 21; // Via unistd.h
+pub const _SC_PAGESIZE: ::c_int = 39;
 pub const O_ACCMODE: ::c_int = 3;
 pub const O_CLOEXEC: ::c_int = 0x100000; // fcntlcom
 pub const O_EXCL: ::c_int = 0x0800;
 pub const O_CREAT: ::c_int = 0x0200;
 pub const O_TRUNC: ::c_int = 0x0400;
 pub const O_APPEND: ::c_int = 0x0008;
-pub const O_RDWR: ::c_int = 2;
-pub const O_WRONLY: ::c_int = 1;
+pub const O_RDWR: ::c_int = 0x0002;
+pub const O_WRONLY: ::c_int = 0x0001;
 pub const O_RDONLY: ::c_int = 0;
-pub const O_NONBLOCK: ::c_int = 0x4;
+pub const O_NONBLOCK: ::c_int = 0x4000;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum FILE {}
@@ -1016,7 +948,49 @@ impl ::Clone for fpos_t {
     }
 }
 
-extern "C" {
+f! {
+    pub fn CMSG_ALIGN(len: usize) -> usize {
+        len + ::mem::size_of::<usize>() - 1 & !(::mem::size_of::<usize>() - 1)
+    }
+
+    pub fn CMSG_NXTHDR(mhdr: *const msghdr,
+                       cmsg: *const cmsghdr) -> *mut cmsghdr {
+        let next = cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize)
+            + CMSG_ALIGN(::mem::size_of::<::cmsghdr>());
+        let max = (*mhdr).msg_control as usize
+            + (*mhdr).msg_controllen as usize;
+        if next <= max {
+            (cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize))
+                as *mut ::cmsghdr
+        } else {
+            0 as *mut ::cmsghdr
+        }
+    }
+
+    pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
+        if (*mhdr).msg_controllen as usize > 0  {
+            (*mhdr).msg_control as *mut cmsghdr
+        } else {
+            0 as *mut cmsghdr
+        }
+    }
+
+    pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut ::c_uchar {
+        (cmsg as *mut ::c_uchar)
+            .offset(CMSG_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
+    }
+
+    pub fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
+        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(::mem::size_of::<cmsghdr>()))
+            as ::c_uint
+    }
+
+    pub fn CMSG_LEN(length: ::c_uint) -> ::c_uint {
+        CMSG_ALIGN(::mem::size_of::<cmsghdr>()) as ::c_uint + length
+    }
+}
+
+extern {
     pub fn isalnum(c: c_int) -> c_int;
     pub fn isalpha(c: c_int) -> c_int;
     pub fn iscntrl(c: c_int) -> c_int;
@@ -1095,8 +1069,7 @@ extern "C" {
     pub fn free(p: *mut c_void);
     pub fn abort() -> !;
     pub fn exit(status: c_int) -> !;
-    //    pub fn _exit(status: c_int) -> !;
-    pub fn atexit(cb: extern "C" fn()) -> c_int;
+    pub fn atexit(cb: extern fn()) -> c_int;
     pub fn system(s: *const c_char) -> c_int;
     pub fn getenv(s: *const c_char) -> *mut c_char;
 
@@ -1129,7 +1102,6 @@ extern "C" {
         n: size_t,
     ) -> c_int;
     pub fn strlen(cs: *const c_char) -> size_t;
-    pub fn strnlen(cs: *const c_char, maxlen: size_t) -> size_t;
     pub fn strerror(n: c_int) -> *mut c_char;
     pub fn strtok(s: *mut c_char, t: *const c_char) -> *mut c_char;
     pub fn strxfrm(s: *mut c_char, ct: *const c_char, n: size_t) -> size_t;
@@ -1155,7 +1127,7 @@ extern "C" {
     pub fn memset(dest: *mut c_void, c: c_int, n: size_t) -> *mut c_void;
 }
 
-extern "C" {
+extern {
     pub fn getpwnam(name: *const ::c_char) -> *mut passwd;
     pub fn getpwuid(uid: ::uid_t) -> *mut passwd;
 
@@ -1372,7 +1344,7 @@ extern "C" {
     ) -> ::c_int;
     pub fn gethostname(name: *mut ::c_char, len: ::size_t) -> ::c_int;
     pub fn chroot(name: *const ::c_char) -> ::c_int;
-    pub fn usleep(secs: ::c_uint) -> ::c_int;
+    pub fn usleep(secs: ::useconds_t) -> ::c_int;
     pub fn putenv(string: *mut c_char) -> ::c_int;
     pub fn setlocale(
         category: ::c_int,
@@ -1427,11 +1399,8 @@ extern "C" {
     pub fn _rtld_dladdr(addr: *const ::c_void, info: *mut Dl_info) -> ::c_int;
 }
 
-extern "C" {
-    // this is gonna be a big one
-
+extern {
     // stdlib.h
-    // This function may not be defined for armv7
     pub fn memalign(block_size: ::size_t, size_arg: ::size_t)
         -> *mut ::c_void;
 
@@ -1443,7 +1412,6 @@ extern "C" {
 
     // pthread.h
     pub fn pthread_mutexattr_init(
-        /* PTHREAD STUFF */
         attr: *mut pthread_mutexattr_t,
     ) -> ::c_int;
 
@@ -1507,7 +1475,7 @@ extern "C" {
     pub fn pthread_create(
         pThread: *mut ::pthread_t,
         pAttr: *const ::pthread_attr_t,
-        start_routine: extern "C" fn(*mut ::c_void) -> *mut ::c_void,
+        start_routine: extern fn(*mut ::c_void) -> *mut ::c_void,
         value: *mut ::c_void,
     ) -> ::c_int;
 
@@ -1519,9 +1487,9 @@ extern "C" {
 
     // int pthread_atfork (void (*)(void), void (*)(void), void (*)(void));
     pub fn pthread_atfork(
-        prepare: ::Option<unsafe extern "C" fn()>,
-        parent: ::Option<unsafe extern "C" fn()>,
-        child: ::Option<unsafe extern "C" fn()>,
+        prepare: ::Option<unsafe extern fn()>,
+        parent: ::Option<unsafe extern fn()>,
+        child: ::Option<unsafe extern fn()>,
     ) -> ::c_int;
     // stat.h
     pub fn fstat(fildes: ::c_int, buf: *mut stat) -> ::c_int;
@@ -1650,7 +1618,7 @@ extern "C" {
     // pthread.h
     pub fn pthread_key_create(
         key: *mut ::pthread_key_t,
-        dtor: ::Option<unsafe extern "C" fn(*mut ::c_void)>,
+        dtor: ::Option<unsafe extern fn(*mut ::c_void)>,
     ) -> ::c_int;
 
     // pthread.h
@@ -1786,7 +1754,7 @@ extern "C" {
         mp: *mut ::msghdr,
         flags: ::c_int,
     ) -> ::ssize_t;
-    
+
     // socket.h
     pub fn send(
         socket: ::c_int,
@@ -1800,7 +1768,7 @@ extern "C" {
         mp: *const ::msghdr,
         flags: ::c_int,
     ) -> ::ssize_t;
-    
+
     // socket.h
     pub fn sendto(
         socket: ::c_int,
@@ -2104,30 +2072,6 @@ extern "C" {
         iovcnt: ::c_int,
     ) -> ::ssize_t;
 
-    // epoll.h
-    pub fn epoll_create(size: ::c_int) -> ::c_int;
-    pub fn epoll_create1(flags: ::c_int) -> ::c_int;
-
-    pub fn epoll_ctl(
-        epfd: ::c_int,
-        op: ::c_int,
-        fd: ::c_int,
-        event: *mut ::epoll_event
-    ) -> ::c_int;
-
-    pub fn epoll_create_and_ctl(
-        num: ::c_int,
-        fds: *mut ::c_int,
-        event: *mut ::epoll_event
-    ) -> ::c_int;
-    
-    pub fn epoll_wait(
-        epfd: ::c_int,
-        events: *mut ::epoll_event,
-        maxevents: ::c_int,
-        timeout: ::c_int
-    ) -> ::c_int;
-    
     // randomNumGen.h
     pub fn randBytes(buf: *mut c_uchar, length: c_int) -> c_int;
     pub fn randABytes(buf: *mut c_uchar, length: c_int) -> c_int;
@@ -2205,6 +2149,39 @@ pub fn posix_memalign(
     }
 }
 
+// epoll.h
+// Unfortunately epoll is currently only supported in the VxWorks kernel
+#[allow(unused_variables)]
+pub fn epoll_create(size: ::c_int) -> ::c_int { -1 }
+#[allow(unused_variables)]
+pub fn epoll_create1(flags: ::c_int) -> ::c_int { -1 }
+#[allow(unused_variables)]
+pub fn epoll_ctl(
+    epfd: ::c_int,
+    op: ::c_int,
+    fd: ::c_int,
+    event: *mut ::epoll_event
+    ) -> ::c_int {
+    -1
+}
+#[allow(unused_variables)]
+pub fn epoll_create_and_ctl(
+    num: ::c_int,
+    fds: *mut ::c_int,
+        event: *mut ::epoll_event
+) -> ::c_int {
+    -1
+}
+#[allow(unused_variables)]
+pub fn epoll_wait(
+    epfd: ::c_int,
+    events: *mut ::epoll_event,
+    maxevents: ::c_int,
+    timeout: ::c_int
+) -> ::c_int {
+        -1
+}
+
 // From sysconf.c -> doesn't seem to be supported?
 pub fn getpwuid_r(
     _uid: ::uid_t,
@@ -2264,9 +2241,6 @@ cfg_if! {
     } else if #[cfg(any(target_arch = "arm"))] {
         mod arm;
         pub use self::arm::*;
-    } else if #[cfg(any(target_arch = "armv7"))] {
-        mod armv7;
-        pub use self::armv7::*;
     }  else if #[cfg(any(target_arch = "x86"))] {
         mod x86;
         pub use self::x86::*;

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -187,6 +187,22 @@ s! {
         pub iov_len: ::size_t,
     }
 
+    pub struct msghdr {
+        pub msg_name: *mut c_void,
+        pub msg_namelen: socklen_t,
+        pub msg_iov: *mut iovec,
+        pub msg_iovlen: ::c_int,
+        pub msg_control: *mut c_void,
+        pub msg_controllen: socklen_t,
+        pub msg_flags: ::c_int,
+    }
+
+    pub struct cmsghdr {
+        pub cmsg_len: socklen_t,
+        pub cmsg_level: ::c_int,
+        pub cmsg_type: ::c_int,
+    }
+    
     // poll.h
     pub struct pollfd {
         pub fd      : ::c_int,
@@ -438,6 +454,13 @@ s! {
         pub pw_shell: *mut ::c_char,
     }
 
+    // epoll.h
+
+    pub struct epoll_event {
+        pub events: u32,
+        pub u64: u64,
+    }
+    
     // rtpLibCommon.h
     pub struct RTP_DESC {
         pub status    : ::c_int,
@@ -804,6 +827,21 @@ pub const FIOCANCEL: ::c_int = 14;
 pub const FIOSQUEEZE: ::c_int = 15;
 pub const FIONBIO: ::c_int = 16;
 pub const _POSIX_PATH_MAX: ::c_int = 256;
+
+// epoll.h
+pub const EPOLLIN: ::c_int = 0x1;
+pub const EPOLLPRI: ::c_int = 0x2;
+pub const EPOLLOUT: ::c_int = 0x4;
+pub const EPOLLERR: ::c_int = 0x8;
+pub const EPOLLHUP: ::c_int = 0x10;
+pub const EPOLLRDHUP: ::c_int = 0x2000;
+pub const EPOLLONESHOT: ::c_int = 1 << 30;
+pub const EPOLLET: ::c_int = 1 << 31;
+
+
+pub const EPOLL_CTL_ADD: ::c_int = 1;
+pub const EPOLL_CTL_DEL: ::c_int = 2;
+pub const EPOLL_CTL_MOD: ::c_int = 3;
 
 // Some poll stuff
 pub const POLLIN: ::c_short = 0x0001;
@@ -1743,6 +1781,12 @@ extern "C" {
         pFromLen: *mut ::socklen_t,
     ) -> ::ssize_t;
 
+    pub fn recvmsg(
+        socket: ::c_int,
+        mp: *mut ::msghdr,
+        flags: ::c_int,
+    ) -> ::ssize_t;
+    
     // socket.h
     pub fn send(
         socket: ::c_int,
@@ -1751,6 +1795,12 @@ extern "C" {
         flags: ::c_int,
     ) -> ::ssize_t;
 
+    pub fn sendmsg(
+        socket: ::c_int,
+        mp: *const ::msghdr,
+        flags: ::c_int,
+    ) -> ::ssize_t;
+    
     // socket.h
     pub fn sendto(
         socket: ::c_int,
@@ -2054,6 +2104,30 @@ extern "C" {
         iovcnt: ::c_int,
     ) -> ::ssize_t;
 
+    // epoll.h
+    pub fn epoll_create(size: ::c_int) -> ::c_int;
+    pub fn epoll_create1(flags: ::c_int) -> ::c_int;
+
+    pub fn epoll_ctl(
+        epfd: ::c_int,
+        op: ::c_int,
+        fd: ::c_int,
+        event: *mut ::epoll_event
+    ) -> ::c_int;
+
+    pub fn epoll_create_and_ctl(
+        num: ::c_int,
+        fds: *mut ::c_int,
+        event: *mut ::epoll_event
+    ) -> ::c_int;
+    
+    pub fn epoll_wait(
+        epfd: ::c_int,
+        events: *mut ::epoll_event,
+        maxevents: ::c_int,
+        timeout: ::c_int
+    ) -> ::c_int;
+    
     // randomNumGen.h
     pub fn randBytes(buf: *mut c_uchar, length: c_int) -> c_int;
     pub fn randABytes(buf: *mut c_uchar, length: c_int) -> c_int;

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -104,8 +104,8 @@ pub type SD_ID = ::OBJ_HANDLE;
 pub type CONDVAR_ID = ::OBJ_HANDLE;
 
 // From vxTypes.h
-pub type _Vx_usr_arg_t = ::isize;
-pub type _Vx_exit_code_t = ::isize;
+pub type _Vx_usr_arg_t = isize;
+pub type _Vx_exit_code_t = isize;
 pub type _Vx_ticks_t = ::c_uint;
 pub type _Vx_ticks64_t = ::c_ulonglong;
 

--- a/src/vxworks/powerpc.rs
+++ b/src/vxworks/powerpc.rs
@@ -1,3 +1,4 @@
 pub type c_char = u8;
+pub type wchar_t = u32;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/vxworks/powerpc64.rs
+++ b/src/vxworks/powerpc64.rs
@@ -1,3 +1,4 @@
 pub type c_char = u8;
+pub type wchar_t = u32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/vxworks/x86.rs
+++ b/src/vxworks/x86.rs
@@ -1,3 +1,4 @@
 pub type c_char = i8;
+pub type wchar_t = i32;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/vxworks/x86_64.rs
+++ b/src/vxworks/x86_64.rs
@@ -1,3 +1,4 @@
+pub type c_char = i8;
+pub type wchar_t = i32;
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = i8;


### PR DESCRIPTION
fix problems found in testing
VxWorks socket and epoll definitions needed by mio and related crates; epoll only supported in VxWorks kernel; just provide stub definitions for user mode for now
Fixed usage of isize
libc VxWorks cleanups and additions
remove copyright notice


