### PR TITLE
Add FreeBSD10 support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,18 @@
 task:
+  name: nightly x86_64-unknown-freebsd-10
+  freebsd_instance:
+    image: freebsd-10-4-release-amd64 
+  setup_script:
+    - pkg install -y curl
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh --default-toolchain nightly -y
+    - . $HOME/.cargo/env
+    - rustup default nightly
+  test_script:
+    - . $HOME/.cargo/env
+    - LIBC_CI=1 sh ci/run.sh x86_64-unknown-freebsd
+ 
+task:
   name: stable x86_64-unknown-freebsd-11
   freebsd_instance:
     image: freebsd-11-3-stable-amd64-v20190801

--- a/build.rs
+++ b/build.rs
@@ -16,11 +16,15 @@ fn main() {
         );
     }
 
-    // The ABI of libc is backward compatible with FreeBSD 11.
+    // The ABI of libc used by libstd is backward compatible with FreeBSD 10.
+    // The ABI of libc from crates.io is backward compatible with FreeBSD 11.
     //
     // On CI, we detect the actual FreeBSD version and match its ABI exactly,
     // running tests to ensure that the ABI is correct.
     match which_freebsd() {
+        Some(10) if libc_ci || rustc_dep_of_std => {
+            println!("cargo:rustc-cfg=freebsd10")
+        }
         Some(11) if libc_ci => println!("cargo:rustc-cfg=freebsd11"),
         Some(12) if libc_ci => println!("cargo:rustc-cfg=freebsd12"),
         Some(13) if libc_ci => println!("cargo:rustc-cfg=freebsd13"),
@@ -109,6 +113,7 @@ fn which_freebsd() -> Option<i32> {
     let stdout = stdout.unwrap();
 
     match &stdout {
+        s if s.starts_with("10") => Some(10),
         s if s.starts_with("11") => Some(11),
         s if s.starts_with("12") => Some(12),
         s if s.starts_with("13") => Some(13),

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1456,7 +1456,7 @@ cfg_if! {
     } else if #[cfg(freebsd13)] {
         mod freebsd12;
         pub use self::freebsd12::*;
-    } else if #[cfg(freebsd11)] {
+    } else if #[cfg(any(freebsd10, freebsd11))] {
         mod freebsd11;
         pub use self::freebsd11::*;
     } else {

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1193,7 +1193,7 @@ extern "C" {
     pub fn getutxline(ut: *const utmpx) -> *mut utmpx;
     pub fn initgroups(name: *const ::c_char, basegid: ::gid_t) -> ::c_int;
     #[cfg_attr(
-        all(target_os = "freebsd", freebsd11),
+        all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "kevent@FBSD_1.0"
     )]
     pub fn kevent(
@@ -1223,7 +1223,7 @@ extern "C" {
         mode: ::mode_t,
     ) -> ::c_int;
     #[cfg_attr(
-        all(target_os = "freebsd", freebsd11),
+        all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "mknodat@FBSD_1.1"
     )]
     pub fn mknodat(

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -558,7 +558,7 @@ extern "C" {
     #[cfg_attr(target_os = "macos", link_name = "glob$INODE64")]
     #[cfg_attr(target_os = "netbsd", link_name = "__glob30")]
     #[cfg_attr(
-        all(target_os = "freebsd", freebsd11),
+        all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "glob@FBSD_1.0"
     )]
     pub fn glob(
@@ -571,7 +571,7 @@ extern "C" {
     ) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__globfree30")]
     #[cfg_attr(
-        all(target_os = "freebsd", freebsd11),
+        all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "globfree@FBSD_1.0"
     )]
     pub fn globfree(pglob: *mut ::glob_t);

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -668,7 +668,7 @@ extern "C" {
     #[cfg_attr(target_os = "macos", link_name = "fstat$INODE64")]
     #[cfg_attr(target_os = "netbsd", link_name = "__fstat50")]
     #[cfg_attr(
-        all(target_os = "freebsd", freebsd11),
+        all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "fstat@FBSD_1.0"
     )]
     pub fn fstat(fildes: ::c_int, buf: *mut stat) -> ::c_int;
@@ -678,7 +678,7 @@ extern "C" {
     #[cfg_attr(target_os = "macos", link_name = "stat$INODE64")]
     #[cfg_attr(target_os = "netbsd", link_name = "__stat50")]
     #[cfg_attr(
-        all(target_os = "freebsd", freebsd11),
+        all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "stat@FBSD_1.0"
     )]
     pub fn stat(path: *const c_char, buf: *mut stat) -> ::c_int;
@@ -721,7 +721,7 @@ extern "C" {
     #[cfg_attr(target_os = "macos", link_name = "readdir$INODE64")]
     #[cfg_attr(target_os = "netbsd", link_name = "__readdir30")]
     #[cfg_attr(
-        all(target_os = "freebsd", freebsd11),
+        all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "readdir@FBSD_1.0"
     )]
     pub fn readdir(dirp: *mut ::DIR) -> *mut ::dirent;
@@ -756,7 +756,7 @@ extern "C" {
     ) -> ::c_int;
     #[cfg_attr(target_os = "macos", link_name = "fstatat$INODE64")]
     #[cfg_attr(
-        all(target_os = "freebsd", freebsd11),
+        all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "fstatat@FBSD_1.1"
     )]
     pub fn fstatat(
@@ -988,7 +988,7 @@ extern "C" {
     #[cfg_attr(target_os = "macos", link_name = "lstat$INODE64")]
     #[cfg_attr(target_os = "netbsd", link_name = "__lstat50")]
     #[cfg_attr(
-        all(target_os = "freebsd", freebsd11),
+        all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "lstat@FBSD_1.0"
     )]
     pub fn lstat(path: *const c_char, buf: *mut stat) -> ::c_int;
@@ -1241,7 +1241,7 @@ extern "C" {
 
     #[cfg_attr(target_os = "netbsd", link_name = "__mknod50")]
     #[cfg_attr(
-        all(target_os = "freebsd", freebsd11),
+        all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "mknod@FBSD_1.0"
     )]
     pub fn mknod(
@@ -1457,7 +1457,7 @@ cfg_if! {
             #[cfg_attr(target_os = "macos", link_name = "readdir_r$INODE64")]
             #[cfg_attr(target_os = "netbsd", link_name = "__readdir_r30")]
             #[cfg_attr(
-                all(target_os = "freebsd", freebsd11),
+                all(target_os = "freebsd", any(freebsd11, freebsd10)),
                 link_name = "readdir_r@FBSD_1.0"
             )]
             /// The 64-bit libc on Solaris and illumos only has readdir_r.  If a


### PR DESCRIPTION
This adds libc-test support for Freebsd10 and a CI build job that tests
FreeBSD10 with LIBC_CI only.

cc @asomers this is a follow up to #1491 .