### PR TITLE
Skip max_align_t in FreeBSD10

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1646,6 +1646,9 @@ fn test_freebsd(target: &str) {
             // `mmsghdr` is not available in FreeBSD 10
             "mmsghdr" if Some(10) == freebsd_ver => true,
 
+            // `max_align_t` is not available in FreeBSD 10
+            "max_align_t" if Some(10) == freebsd_ver => true,
+
             _ => false,
         }
     });


### PR DESCRIPTION
This error was able to land because FreeBSD10 is not checked by bors yet (see: RCS PR: https://github.com/rust-lang/rust-central-station/pull/481) .