### PR TITLE
Add support for making functions `const`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ std = []
 align = []
 rustc-dep-of-std = ['align', 'rustc-std-workspace-core']
 extra_traits = []
+const-extern-fn = []
 # use_std is deprecated, use `std` instead
 use_std = [ 'std' ]
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ libc = "0.2"
 * `extra_traits`: all `struct`s implemented in `libc` are `Copy` and `Clone`.
   This feature derives `Debug`, `Eq`, `Hash`, and `PartialEq`.
 
+* `const-extern-fn`: Changes some `extern fn`s into `const extern fn`s.
+   This features requires a nightly rustc
+
 * **deprecated**: `use_std` is deprecated, and is equivalent to `std`.
 
 ## Rust version support

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ fn main() {
         rustc_minor_version().expect("Failed to get rustc version");
     let rustc_dep_of_std = env::var("CARGO_FEATURE_RUSTC_DEP_OF_STD").is_ok();
     let align_cargo_feature = env::var("CARGO_FEATURE_ALIGN").is_ok();
+    let const_extern_fn_cargo_feature = env::var("CARGO_FEATURE_CONST_EXTERN_FN").is_ok();
     let libc_ci = env::var("LIBC_CI").is_ok();
 
     if env::var("CARGO_FEATURE_USE_STD").is_ok() {
@@ -71,6 +72,10 @@ fn main() {
     // #[thread_local] is currently unstable
     if rustc_dep_of_std {
         println!("cargo:rustc-cfg=libc_thread_local");
+    }
+
+    if const_extern_fn_cargo_feature {
+        println!("cargo:rustc-cfg=libc_const_extern_fn");
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -3,8 +3,8 @@ use std::process::Command;
 use std::str;
 
 fn main() {
-    let rustc_minor_ver =
-        rustc_minor_version().expect("Failed to get rustc version");
+    let (rustc_minor_ver, is_nightly) =
+        rustc_minor_nightly().expect("Failed to get rustc version");
     let rustc_dep_of_std = env::var("CARGO_FEATURE_RUSTC_DEP_OF_STD").is_ok();
     let align_cargo_feature = env::var("CARGO_FEATURE_ALIGN").is_ok();
     let const_extern_fn_cargo_feature = env::var("CARGO_FEATURE_CONST_EXTERN_FN").is_ok();
@@ -75,11 +75,14 @@ fn main() {
     }
 
     if const_extern_fn_cargo_feature {
+        if !is_nightly || rustc_minor_ver < 40 {
+            panic!("const-extern-fn requires a nightly compiler >= 1.40")
+        }
         println!("cargo:rustc-cfg=libc_const_extern_fn");
     }
 }
 
-fn rustc_minor_version() -> Option<u32> {
+fn rustc_minor_nightly() -> Option<(u32, bool)> {
     macro_rules! otry {
         ($e:expr) => {
             match $e {
@@ -98,7 +101,12 @@ fn rustc_minor_version() -> Option<u32> {
         return None;
     }
 
-    otry!(pieces.next()).parse().ok()
+    let minor = pieces.next();
+    let nightly_raw = otry!(otry!(pieces.next()).split('-').nth(1));
+    let nightly = nightly_raw.starts_with("dev") || nightly_raw.starts_with("nightly");
+    let minor = otry!(otry!(minor).parse().ok());
+
+    Some((minor, nightly))
 }
 
 fn which_freebsd() -> Option<i32> {

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,8 @@ fn main() {
         rustc_minor_nightly().expect("Failed to get rustc version");
     let rustc_dep_of_std = env::var("CARGO_FEATURE_RUSTC_DEP_OF_STD").is_ok();
     let align_cargo_feature = env::var("CARGO_FEATURE_ALIGN").is_ok();
-    let const_extern_fn_cargo_feature = env::var("CARGO_FEATURE_CONST_EXTERN_FN").is_ok();
+    let const_extern_fn_cargo_feature =
+        env::var("CARGO_FEATURE_CONST_EXTERN_FN").is_ok();
     let libc_ci = env::var("LIBC_CI").is_ok();
 
     if env::var("CARGO_FEATURE_USE_STD").is_ok() {
@@ -103,7 +104,8 @@ fn rustc_minor_nightly() -> Option<(u32, bool)> {
 
     let minor = pieces.next();
     let nightly_raw = otry!(otry!(pieces.next()).split('-').nth(1));
-    let nightly = nightly_raw.starts_with("dev") || nightly_raw.starts_with("nightly");
+    let nightly =
+        nightly_raw.starts_with("dev") || nightly_raw.starts_with("nightly");
     let minor = otry!(otry!(minor).parse().ok());
 
     Some((minor, nightly))

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -67,6 +67,13 @@ test_target() {
     cargo "+${RUST}" "${BUILD_CMD}" -vv $opt --no-default-features --target "${TARGET}" \
           --features extra_traits
 
+    # Test the 'const-extern-fn' feature on nightly
+    if [ "${RUST}" = "nightly" ]; then
+        cargo "+${RUST}" "${BUILD_CMD}" -vv $opt --no-default-features --target "${TARGET}" \
+          --features const-extern-fn
+    fi
+
+
     # Also test that it builds with `extra_traits` and default features:
     if [ "$NO_STD" != "1" ]; then
         cargo "+${RUST}" "${BUILD_CMD}" -vv $opt --target "${TARGET}" \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 #![no_std]
 #![cfg_attr(feature = "rustc-dep-of-std", no_core)]
 #![cfg_attr(target_os = "redox", feature(static_nobundle))]
-#![cfg_attr(feature = "const-extern-fn", feature(const_extern_fn))]
+#![cfg_attr(libc_const_extern_fn, feature(const_extern_fn))]
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 #![no_std]
 #![cfg_attr(feature = "rustc-dep-of-std", no_core)]
 #![cfg_attr(target_os = "redox", feature(static_nobundle))]
+#![cfg_attr(feature = "const-extern-fn", feature(const_extern_fn))]
 
 #[macro_use]
 mod macros;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -149,7 +149,7 @@ macro_rules! s_no_extra_traits {
 // 2. Allow users of this macro to mix 'pub fn foo' and 'pub const fn bar' within the same
 // 'f!' block
 cfg_if! {
-    if #[cfg(feature = "const-extern-fn")] {
+    if #[cfg(libc_const_extern_fn)] {
         #[allow(unused_macros)]
         macro_rules! f {
             ($(pub $({$constness:ident})* fn $i:ident(

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -121,16 +121,96 @@ macro_rules! s_no_extra_traits {
     );
 }
 
-#[allow(unused_macros)]
-macro_rules! f {
-    ($(pub fn $i:ident($($arg:ident: $argty:ty),*) -> $ret:ty {
-        $($body:stmt);*
-    })*) => ($(
-        #[inline]
-        pub unsafe extern fn $i($($arg: $argty),*) -> $ret {
-            $($body);*
+// This is a pretty horrible hack to allow us to conditionally mark
+// some functions as 'const', without requiring users of this macro
+// to care about the "const-extern-fn" feature.
+//
+// When 'const-extern-fn' is enabled, we emit the captured 'const' keyword
+// in the expanded function.
+//
+// When 'const-extern-fn' is disabled, we always emit a plain 'pub unsafe extern fn'.
+// Note that the expression matched by the macro is exactly the same - this allows
+// users of this macro to work whether or not 'const-extern-fn' is enabled
+//
+// Unfortunately, we need to duplicate most of this macro between the 'cfg_if' blocks.
+// This is because 'const unsafe extern fn' won't even parse on older compilers,
+// so we need to avoid emitting it at all of 'const-extern-fn'.
+//
+// Specifically, moving the 'cfg_if' into the macro body will *not* work.
+// Doing so would cause the '#[cfg(feature = "const-extern-fn")]' to be emiited
+// into user code. The 'cfg' gate will not stop Rust from trying to parse the
+// 'pub const unsafe extern fn', so users would get a compiler error even when
+// the 'const-extern-fn' feature is disabled
+//
+// Note that users of this macro need to place 'const' in a weird position
+// (after the closing ')' for the arguments, but before the return type).
+// This was the only way I could satisfy the following two requirements:
+// 1. Avoid ambuguity errors from 'macro_rules!' (which happen when writing '$foo:ident fn'
+// 2. Allow users of this macro to mix 'pub fn foo' and 'pub const fn bar' within the same
+// 'f!' block
+cfg_if! {
+    if #[cfg(feature = "const-extern-fn")] {
+        #[allow(unused_macros)]
+        macro_rules! f {
+            ($(pub $({$constness:ident})* fn $i:ident(
+                        $($arg:ident: $argty:ty),*
+            ) -> $ret:ty {
+                $($body:stmt);*
+            })*) => ($(
+                #[inline]
+                pub $($constness)* unsafe extern fn $i($($arg: $argty),*
+                ) -> $ret {
+                    $($body);*
+                }
+            )*)
         }
-    )*)
+
+        #[allow(unused_macros)]
+        macro_rules! const_fn {
+            ($($({$constness:ident})* fn $i:ident(
+                        $($arg:ident: $argty:ty),*
+            ) -> $ret:ty {
+                $($body:stmt);*
+            })*) => ($(
+                #[inline]
+                $($constness)* fn $i($($arg: $argty),*
+                ) -> $ret {
+                    $($body);*
+                }
+            )*)
+        }
+
+    } else {
+        #[allow(unused_macros)]
+        macro_rules! f {
+            ($(pub $({$constness:ident})* fn $i:ident(
+                        $($arg:ident: $argty:ty),*
+            ) -> $ret:ty {
+                $($body:stmt);*
+            })*) => ($(
+                #[inline]
+                pub unsafe extern fn $i($($arg: $argty),*
+                ) -> $ret {
+                    $($body);*
+                }
+            )*)
+        }
+
+        #[allow(unused_macros)]
+        macro_rules! const_fn {
+            ($($({$constness:ident})* fn $i:ident(
+                        $($arg:ident: $argty:ty),*
+            ) -> $ret:ty {
+                $($body:stmt);*
+            })*) => ($(
+                #[inline]
+                fn $i($($arg: $argty),*
+                ) -> $ret {
+                    $($body);*
+                }
+            )*)
+        }
+    }
 }
 
 #[allow(unused_macros)]

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1165,8 +1165,10 @@ pub const ARPHRD_IEEE802154: u16 = 804;
 pub const ARPHRD_VOID: u16 = 0xFFFF;
 pub const ARPHRD_NONE: u16 = 0xFFFE;
 
-fn CMSG_ALIGN(len: usize) -> usize {
-    len + ::mem::size_of::<usize>() - 1 & !(::mem::size_of::<usize>() - 1)
+const_fn! {
+    {const} fn CMSG_ALIGN(len: usize) -> usize {
+        len + ::mem::size_of::<usize>() - 1 & !(::mem::size_of::<usize>() - 1)
+    }
 }
 
 f! {
@@ -1182,7 +1184,7 @@ f! {
         cmsg.offset(1) as *mut ::c_uchar
     }
 
-    pub fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
+    pub {const} fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
         (CMSG_ALIGN(length as usize) + CMSG_ALIGN(::mem::size_of::<cmsghdr>()))
             as ::c_uint
     }

--- a/tests/const_fn.rs
+++ b/tests/const_fn.rs
@@ -1,0 +1,5 @@
+#![cfg(libc_const_extern_fn)] // If this does not hold, the file is empty
+
+#[cfg(target_os = "linux")]
+const _FOO: libc::c_uint = unsafe { libc::CMSG_SPACE(1) }; 
+//^ if CMSG_SPACE is not const, this will fail to compile

--- a/tests/const_fn.rs
+++ b/tests/const_fn.rs
@@ -1,5 +1,5 @@
 #![cfg(libc_const_extern_fn)] // If this does not hold, the file is empty
 
 #[cfg(target_os = "linux")]
-const _FOO: libc::c_uint = unsafe { libc::CMSG_SPACE(1) }; 
+const _FOO: libc::c_uint = unsafe { libc::CMSG_SPACE(1) };
 //^ if CMSG_SPACE is not const, this will fail to compile


### PR DESCRIPTION
PR https://github.com/rust-lang/rust/pull/64906 adds the ability to write `const extern fn` and `const unsafe extern fn`, which will allow manys functions in `libc` to become `const`.

This is particuarly useful for functions which correspond to C macros (e.g. `CMSG_SPACE`). In C, these macros are constant expressions, allowing them to be used when declaring arrays. However, since the corresponding `libc` functions are not `const`, writing equivalent Rust code is impossible. Users must either perform an unecessary heap allocation, or pull in `bindgen` to evaluate the macro for specific values (e.g. `CMSG_SPACE(1)`).

However, the syntax `const extern fn` is not currently parsed by rust. To allow libc to use this without breaking backwards compatibility (i.e. bumping the minimum Rust version), I've taken the following approach:

1. A new off-by-default feature `extern-const-fn` is added to `libc`.
2. The internal `f!` macro has two versions, selected at compile-time by a `cfg_if`. When `extern-const-fn` is enabled, the declared `f!` macro passes through the `const` keyword from the macro user to the final definition (`pub const unsafe extern fn foo`. When  `extern-const-fn` is disabled, the `const` keyword passed by the macro user is discarded, resulting in a plain `pub extern const fn` being declared.

Unfortunately, I couldn't manage to get `macro_rules` to accept a normal `const` token in the proper place (after `pub`). I had to resort to placing it in curly brackets:

```rust
pub {const} fn foo(val: u8) -> i8 {
}
```

The `f!` macro then translates this to a function definition with `const` in the proper position.

I'd appreciate it if someone who's more familiar with `macro_rules!` could see if I missed a way to get the desired syntax.