### PR TITLE
Add `RLIM_INFINITY` definition for Android

### DIFF
--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -1099,6 +1099,8 @@ pub const RLIMIT_MSGQUEUE: ::c_int = 12;
 pub const RLIMIT_NICE: ::c_int = 13;
 pub const RLIMIT_RTPRIO: ::c_int = 14;
 
+pub const RLIM_INFINITY: ::rlim_t = !0;
+
 pub const TCGETS: ::c_int = 0x5401;
 pub const TCSETS: ::c_int = 0x5402;
 pub const TCSETSW: ::c_int = 0x5403;


### PR DESCRIPTION
This adds the definition for `RLIM_INFINITY` to Android, mirroring the Linux definition. Ran into this while trying to build `sccache` natively in Termux on Android, and is the only thing preventing `sccache` from building on libc master.