### PR TITLE
NetBSD pthread_attr_get_np

### DIFF
--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1669,6 +1669,10 @@ extern "C" {
         name: *const ::c_char,
         arg: *mut ::c_void,
     ) -> ::c_int;
+    pub fn pthread_attr_get_np(
+        thread: ::pthread_t,
+        attr: *mut ::pthread_attr_t,
+    ) -> ::c_int;
     pub fn pthread_getattr_np(
         native: ::pthread_t,
         attr: *mut ::pthread_attr_t,


### PR DESCRIPTION
This patch adds a signature for the [`pthread_attr_get_np`](https://netbsd.gw.com/cgi-bin/man-cgi?pthread_attr_get_np+3+NetBSD-current) function for all architectures on NetBSD.

Closes #1538 