### PR TITLE
Refine definition of mcontext_t on x86_64-unknown-linux-musl

### DIFF
--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -100,7 +100,9 @@ s! {
         pub u_debugreg: [::c_ulong; 8],
     }
 
-    // https://github.com/ifduyue/musl/blob/b4b1e10364c8737a632be61582e05a8d3acf5690/arch/x86_64/bits/signal.h#L80-L84
+    // GitHub repo: ifduyue/musl/
+    // commit: b4b1e10364c8737a632be61582e05a8d3acf5690
+    // file: arch/x86_64/bits/signal.h#L80-L84
     pub struct mcontext_t {
         pub gregs: [greg_t; 23],
         __private: [u64; 9],
@@ -607,7 +609,9 @@ pub const FS: ::c_int = 25;
 pub const GS: ::c_int = 26;
 
 // offsets in mcontext_t.gregs from bits/signal.h
-// https://github.com/ifduyue/musl/blob/b4b1e10364c8737a632be61582e05a8d3acf5690/arch/x86_64/bits/signal.h#L9-L56
+// GitHub repo: ifduyue/musl/
+// commit: b4b1e10364c8737a632be61582e05a8d3acf5690
+// file: arch/x86_64/bits/signal.h#L9-L56
 pub const REG_R8: ::c_int = 0;
 pub const REG_R9: ::c_int = 1;
 pub const REG_R10: ::c_int = 2;

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -3,6 +3,7 @@ pub type wchar_t = i32;
 pub type nlink_t = u64;
 pub type blksize_t = ::c_long;
 pub type __u64 = ::c_ulonglong;
+pub type greg_t = i64;
 
 s! {
     pub struct stat {
@@ -99,8 +100,10 @@ s! {
         pub u_debugreg: [::c_ulong; 8],
     }
 
+    // https://github.com/ifduyue/musl/blob/b4b1e10364c8737a632be61582e05a8d3acf5690/arch/x86_64/bits/signal.h#L80-L84
     pub struct mcontext_t {
-        __private: [u64; 32],
+        pub gregs: [greg_t; 23],
+        __private: [u64; 9],
     }
 
     pub struct ipc_perm {
@@ -602,6 +605,32 @@ pub const DS: ::c_int = 23;
 pub const ES: ::c_int = 24;
 pub const FS: ::c_int = 25;
 pub const GS: ::c_int = 26;
+
+// offsets in mcontext_t.gregs from bits/signal.h
+// https://github.com/ifduyue/musl/blob/b4b1e10364c8737a632be61582e05a8d3acf5690/arch/x86_64/bits/signal.h#L9-L56
+pub const REG_R8: ::c_int = 0;
+pub const REG_R9: ::c_int = 1;
+pub const REG_R10: ::c_int = 2;
+pub const REG_R11: ::c_int = 3;
+pub const REG_R12: ::c_int = 4;
+pub const REG_R13: ::c_int = 5;
+pub const REG_R14: ::c_int = 6;
+pub const REG_R15: ::c_int = 7;
+pub const REG_RDI: ::c_int = 8;
+pub const REG_RSI: ::c_int = 9;
+pub const REG_RBP: ::c_int = 10;
+pub const REG_RBX: ::c_int = 11;
+pub const REG_RDX: ::c_int = 12;
+pub const REG_RAX: ::c_int = 13;
+pub const REG_RCX: ::c_int = 14;
+pub const REG_RSP: ::c_int = 15;
+pub const REG_RIP: ::c_int = 16;
+pub const REG_EFL: ::c_int = 17;
+pub const REG_CSGSFS: ::c_int = 18;
+pub const REG_ERR: ::c_int = 19;
+pub const REG_TRAPNO: ::c_int = 20;
+pub const REG_OLDMASK: ::c_int = 21;
+pub const REG_CR2: ::c_int = 22;
 
 pub const MADV_SOFT_OFFLINE: ::c_int = 101;
 pub const MAP_32BIT: ::c_int = 0x0040;


### PR DESCRIPTION
Fixes #1553 

I've inlined the links I used for defining constants and fields, although they pretty much map to the changes introduced in ac7f0fac2f34d4eed1f05e9d20f236149711ff87 and ae06c2b2ae6938c9162b9deadae442194a816ad2.