### PR TITLE
Add struct ip_mreqn: ip multicast req with intf id

### DIFF
--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -261,6 +261,12 @@ s! {
         pub c_ispeed: ::speed_t,
         pub c_ospeed: ::speed_t,
     }
+
+    pub struct ip_mreqn {
+        pub imr_multiaddr: ::in_addr,
+        pub imr_address: ::in_addr,
+        pub imr_ifindex: ::c_int,
+    }
 }
 
 s_no_extra_traits! {


### PR DESCRIPTION
The ip_mreqn struct has an additional interface id parameter. This
allows programming IPv4 multicast groups using the interface id
alongside the src IPv4 address.
Linux has supported the ip_mreqn struct since Linux 2.2
ref: man ip.7