### PR TITLE
Sort targets in documentation. Fixes #1524.

### DIFF
--- a/ci/dox.sh
+++ b/ci/dox.sh
@@ -25,7 +25,7 @@ cargo +nightly install cargo-xbuild -Z install-upgrade
 # shellcheck disable=SC1003
 grep '[\d|\w|-]* \\' ci/build.sh > targets
 sed -i.bak 's/ \\//g' targets
-grep '^[_a-zA-Z0-9-]*$' targets > tmp && mv tmp targets
+grep '^[_a-zA-Z0-9-]*$' targets | sort > tmp && mv tmp targets
 
 # Create a markdown list of supported platforms in $PLATFORM_SUPPORT
 rm $PLATFORM_SUPPORT || true


### PR DESCRIPTION
Should be a simple but effective fix for #1524. Assume `sort` command is available.