### PR TITLE
add getlogin_r, re-entrant getlogin

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -837,6 +837,7 @@ extern "C" {
     pub fn getgid() -> gid_t;
     pub fn getgroups(ngroups_max: ::c_int, groups: *mut gid_t) -> ::c_int;
     pub fn getlogin() -> *mut c_char;
+    pub fn getlogin_r(name: *mut ::c_char, len: ::size_t) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "getopt$UNIX2003"


### PR DESCRIPTION
`getlogin_r()`: `_POSIX_C_SOURCE >= 199506L`, according to `glibc`, so I believe it will be widely deployed. Let's see what CI says!

Prototype copied from `gethostname`, which appears identical; see (closed/abandoned) https://github.com/nix-rust/nix/pull/789