### PR TITLE
ci: switch mirrors to use our CDN

### DIFF
--- a/ci/docker/mips-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mips-unknown-linux-musl/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir /toolchain
 
 # Note that this originally came from:
 # https://downloads.openwrt.org/snapshots/trunk/ar71xx/generic/OpenWrt-SDK-ar71xx-generic_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2
-RUN curl --retry 5 -L https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/libc/OpenWrt-SDK-ar71xx-generic_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2 | \
+RUN curl --retry 5 -L https://ci-mirrors.rust-lang.org/libc/OpenWrt-SDK-ar71xx-generic_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2 | \
     tar xjf - -C /toolchain --strip-components=1
 
 ENV PATH=$PATH:/rust/bin:/toolchain/staging_dir/toolchain-mips_34kc_gcc-5.3.0_musl-1.1.15/bin \

--- a/ci/docker/mipsel-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mipsel-unknown-linux-musl/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir /toolchain
 
 # Note that this originally came from:
 # https://downloads.openwrt.org/snapshots/trunk/malta/generic/OpenWrt-Toolchain-malta-le_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2
-RUN curl --retry 5 -L https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/libc/OpenWrt-Toolchain-malta-le_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2 | \
+RUN curl --retry 5 -L https://ci-mirrors.rust-lang.org/libc/OpenWrt-Toolchain-malta-le_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2 | \
       tar xjf - -C /toolchain --strip-components=2
 
 ENV PATH=$PATH:/rust/bin:/toolchain/bin \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-MIRRORS_URL="https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/libc"
+MIRRORS_URL="https://ci-mirrors.rust-lang.org/libc"
 
 TARGET="${1}"
 


### PR DESCRIPTION
We recently added a CDN in front of our CI mirrors as it's faster and
cheaper for us. This switches libc's CI to use it instead of accessing
the underlying bucket directly.

r? @gnzlbg 