### PR TITLE
Bump version to 0.2.65

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.64"
+version = "0.2.65"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Requesting to bump the patch version, as I'd like to get https://github.com/rust-lang/libc/pull/1541 into sccache!