### PR TITLE
Update emscripten installation and user

### DIFF
--- a/ci/emscripten.sh
+++ b/ci/emscripten.sh
@@ -30,21 +30,8 @@ exit 1
 
 git clone https://github.com/emscripten-core/emsdk.git /emsdk-portable
 cd /emsdk-portable
-# TODO: switch to an upstream install once
-# https://github.com/rust-lang/rust/pull/63649 lands
-hide_output ./emsdk install 1.38.42
-./emsdk activate 1.38.42
-
-# Compile and cache libc
-# shellcheck disable=SC1091
-source ./emsdk_env.sh
-echo "main(){}" > a.c
-HOME=/emsdk-portable/ emcc a.c
-rm -f a.*
-
-# Make emsdk usable by any user
-cp /root/.emscripten /emsdk-portable
-chmod a+rxw -R /emsdk-portable
+hide_output ./emsdk install 1.38.46-upstream
+./emsdk activate 1.38.46-upstream
 
 # node 8 is required to run wasm
 cd /

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -20,9 +20,17 @@ run() {
         kvm=""
     fi
 
+    # Emscripten targets require that the user is the same for building and
+    # running the image
+    if [[ "${1}" == *"emscripten" ]]; then
+      user="0"
+    else
+      user="$(id -u):$(id -g)"
+    fi
+
     docker run \
       --rm \
-      --user "$(id -u)":"$(id -g)" \
+      --user "$user" \
       --env LIBC_CI \
       --env CARGO_HOME=/cargo \
       --env CARGO_TARGET_DIR=/checkout/target \

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -22,7 +22,7 @@ run() {
 
     # Emscripten targets require that the user is the same for building and
     # running the image
-    if [[ "${1}" == *"emscripten" ]]; then
+    if echo "${1}" | grep emscripten > /dev/null; then
       user="0"
     else
       user="$(id -u):$(id -g)"


### PR DESCRIPTION
Updates the Emscripten installation used for CI to match the one used in rust-lang/rust. Also runs tests using the default docker user for Emscripten targets because the user should not change between installation and use of Emscripten.