### PR TITLE
Deprecate vfork

### DIFF
--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1458,6 +1458,10 @@ extern "C" {
     pub fn acct(filename: *const ::c_char) -> ::c_int;
     pub fn brk(addr: *mut ::c_void) -> ::c_int;
     pub fn sbrk(increment: ::intptr_t) -> *mut ::c_void;
+    #[deprecated(
+        since = "0.2.66",
+        note = "causes memory corruption, see rust-lang/libc#1596"
+    )]
     pub fn vfork() -> ::pid_t;
     pub fn setresgid(rgid: ::gid_t, egid: ::gid_t, sgid: ::gid_t) -> ::c_int;
     pub fn setresuid(ruid: ::uid_t, euid: ::uid_t, suid: ::uid_t) -> ::c_int;


### PR DESCRIPTION
The compiler may generate incorrect code for `vfork` and `setjmp` because they are missing the `#[returns_twice]` attribute which is currently unstable ([tracking issue](https://github.com/rust-lang/rust/issues/58314)). Since `vfork` is impossible to use safely, I propose deprecating it until `#[returns_twice]` is stable.