### PR TITLE
Provide SYS_statx for more target_arch/target_env

### DIFF
--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -526,6 +526,7 @@ pub const SYS_pwritev2: ::c_long = 4000 + 362;
 pub const SYS_pkey_mprotect: ::c_long = 4000 + 363;
 pub const SYS_pkey_alloc: ::c_long = 4000 + 364;
 pub const SYS_pkey_free: ::c_long = 4000 + 365;
+pub const SYS_statx: ::c_long = 4000 + 366;
 
 pub const O_DIRECT: ::c_int = 0x8000;
 pub const O_DIRECTORY: ::c_int = 0x10000;

--- a/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
@@ -924,6 +924,7 @@ pub const SYS_pwritev2: ::c_long = 287;
 pub const SYS_pkey_mprotect: ::c_long = 288;
 pub const SYS_pkey_alloc: ::c_long = 289;
 pub const SYS_pkey_free: ::c_long = 290;
+pub const SYS_statx: ::c_long = 291;
 
 #[link(name = "util")]
 extern "C" {

--- a/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
@@ -568,6 +568,7 @@ pub const SYS_pwritev2: ::c_long = 5000 + 322;
 pub const SYS_pkey_mprotect: ::c_long = 5000 + 323;
 pub const SYS_pkey_alloc: ::c_long = 5000 + 324;
 pub const SYS_pkey_free: ::c_long = 5000 + 325;
+pub const SYS_statx: ::c_long = 5000 + 326;
 
 pub const SFD_CLOEXEC: ::c_int = 0x080000;
 

--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -993,6 +993,7 @@ pub const SYS_chown: ::c_long = 212;
 pub const SYS_setfsuid: ::c_long = 215;
 pub const SYS_setfsgid: ::c_long = 216;
 pub const SYS_newfstatat: ::c_long = 293;
+pub const SYS_statx: ::c_long = 379;
 
 #[link(name = "util")]
 extern "C" {

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -827,6 +827,7 @@ pub const SYS_pwritev2: ::c_long = 393;
 pub const SYS_pkey_mprotect: ::c_long = 394;
 pub const SYS_pkey_alloc: ::c_long = 395;
 pub const SYS_pkey_free: ::c_long = 396;
+pub const SYS_statx: ::c_long = 397;
 
 extern "C" {
     pub fn getrandom(

--- a/src/unix/linux_like/linux/musl/b32/hexagon.rs
+++ b/src/unix/linux_like/linux/musl/b32/hexagon.rs
@@ -710,6 +710,7 @@ pub const SYS_wait4: ::c_int = 260;
 pub const SYS_waitid: ::c_int = 95;
 pub const SYS_write: ::c_int = 64;
 pub const SYS_writev: ::c_int = 66;
+pub const SYS_statx: ::c_int = 291;
 pub const TCFLSH: ::c_int = 21515;
 pub const TCGETA: ::c_int = 21509;
 pub const TCGETS: ::c_int = 21505;

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -836,6 +836,10 @@ pub const SYS_mlock2: ::c_long = 4000 + 359;
 pub const SYS_copy_file_range: ::c_long = 4000 + 360;
 pub const SYS_preadv2: ::c_long = 4000 + 361;
 pub const SYS_pwritev2: ::c_long = 4000 + 362;
+pub const SYS_pkey_mprotect: ::c_long = 4000 + 363;
+pub const SYS_pkey_alloc: ::c_long = 4000 + 364;
+pub const SYS_pkey_free: ::c_long = 4000 + 365;
+pub const SYS_statx: ::c_long = 4000 + 366;
 
 cfg_if! {
     if #[cfg(libc_align)] {

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -916,6 +916,7 @@ pub const SYS_preadv2: ::c_long = 378;
 pub const SYS_pwritev2: ::c_long = 379;
 // FIXME syscalls 380-382 have been added in musl 1.16
 // See discussion https://github.com/rust-lang/libc/pull/699
+pub const SYS_statx: ::c_long = 383;
 
 // offsets in user_regs_structs, from sys/reg.h
 pub const EBX: ::c_int = 0;

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -914,8 +914,9 @@ pub const SYS_mlock2: ::c_long = 376;
 pub const SYS_copy_file_range: ::c_long = 377;
 pub const SYS_preadv2: ::c_long = 378;
 pub const SYS_pwritev2: ::c_long = 379;
-// FIXME syscalls 380-382 have been added in musl 1.16
-// See discussion https://github.com/rust-lang/libc/pull/699
+pub const SYS_pkey_mprotect: ::c_long = 380;
+pub const SYS_pkey_alloc: ::c_long = 381;
+pub const SYS_pkey_free: ::c_long = 382;
 pub const SYS_statx: ::c_long = 383;
 
 // offsets in user_regs_structs, from sys/reg.h

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -506,6 +506,7 @@ pub const SYS_pwritev2: ::c_long = 287;
 pub const SYS_pkey_mprotect: ::c_long = 288;
 pub const SYS_pkey_alloc: ::c_long = 289;
 pub const SYS_pkey_free: ::c_long = 290;
+pub const SYS_statx: ::c_long = 291;
 
 pub const RLIMIT_NLIMITS: ::c_int = 15;
 pub const TIOCINQ: ::c_int = ::FIONREAD;

--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -424,6 +424,7 @@ pub const SYS_pwritev2: ::c_long = 5000 + 322;
 pub const SYS_pkey_mprotect: ::c_long = 5000 + 323;
 pub const SYS_pkey_alloc: ::c_long = 5000 + 324;
 pub const SYS_pkey_free: ::c_long = 5000 + 325;
+pub const SYS_statx: ::c_long = 5000 + 326;
 
 pub const O_DIRECT: ::c_int = 0x8000;
 pub const O_DIRECTORY: ::c_int = 0x10000;

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -596,6 +596,7 @@ pub const SYS_copy_file_range: ::c_long = 379;
 pub const SYS_preadv2: ::c_long = 380;
 pub const SYS_pwritev2: ::c_long = 381;
 pub const SYS_kexec_file_load: ::c_long = 382;
+pub const SYS_statx: ::c_long = 383;
 
 pub const FIOCLEX: ::c_int = 0x20006601;
 pub const FIONCLEX: ::c_int = 0x20006602;

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -578,6 +578,7 @@ pub const SYS_preadv2: ::c_long = 327;
 pub const SYS_pwritev2: ::c_long = 328;
 // FIXME syscalls 329-331 have been added in musl 1.16
 // See discussion https://github.com/rust-lang/libc/pull/699
+pub const SYS_statx: ::c_long = 332;
 
 // offsets in user_regs_structs, from sys/reg.h
 pub const R15: ::c_int = 0;

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -576,8 +576,9 @@ pub const SYS_mlock2: ::c_long = 325;
 pub const SYS_copy_file_range: ::c_long = 326;
 pub const SYS_preadv2: ::c_long = 327;
 pub const SYS_pwritev2: ::c_long = 328;
-// FIXME syscalls 329-331 have been added in musl 1.16
-// See discussion https://github.com/rust-lang/libc/pull/699
+pub const SYS_pkey_mprotect: ::c_long = 329;
+pub const SYS_pkey_alloc: ::c_long = 330;
+pub const SYS_pkey_free: ::c_long = 331;
 pub const SYS_statx: ::c_long = 332;
 
 // offsets in user_regs_structs, from sys/reg.h


### PR DESCRIPTION
Fixes #1545 

The syscall `statx` is provided by Linux Kernel, so it should be available on any `target_env`/`target_arch`, not only some arch on `gnu`.

Syscall ids are got from [this commit of musl](http://git.etalabs.net/cgit/musl/commit/?id=9864f60e929100e253fc813bd4105d6dd7652787), except for hexagon, which is got from Linux Kernel (`make O=build ARCH=hexagon headers`).

**Not tested yet**
