### PR TITLE
add shm support for NetBSD and OpenBSD

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -322,6 +322,7 @@ fn test_openbsd(target: &str) {
         "ufs/ufs/quota.h",
         "pthread_np.h",
         "sys/syscall.h",
+        "sys/shm.h",
     }
 
     cfg.skip_struct(move |ty| {
@@ -818,6 +819,7 @@ fn test_netbsd(target: &str) {
         "netinet/dccp.h",
         "sys/event.h",
         "sys/quota.h",
+        "sys/shm.h",
     }
 
     cfg.type_name(move |ty, is_struct, is_union| {

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -10,6 +10,7 @@ pub type nl_item = c_long;
 pub type clockid_t = ::c_int;
 pub type id_t = u32;
 pub type sem_t = *mut sem;
+pub type key_t = c_long;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum timezone {}
@@ -62,6 +63,16 @@ s! {
         pub l_pid: ::pid_t,
         pub l_type: ::c_short,
         pub l_whence: ::c_short,
+    }
+
+    pub struct ipc_perm {
+        pub cuid: ::uid_t,
+        pub cgid: ::gid_t,
+        pub uid: ::uid_t,
+        pub gid: ::gid_t,
+        pub mode: ::mode_t,
+        pub seq: ::c_ushort,
+        pub key: ::key_t,
     }
 }
 
@@ -199,8 +210,19 @@ pub const MAP_SHARED: ::c_int = 0x0001;
 pub const MAP_PRIVATE: ::c_int = 0x0002;
 pub const MAP_FIXED: ::c_int = 0x0010;
 pub const MAP_ANON: ::c_int = 0x1000;
+pub const MAP_ANONYMOUS: ::c_int = MAP_ANON;
 
 pub const MAP_FAILED: *mut ::c_void = !0 as *mut ::c_void;
+
+pub const IPC_CREAT: ::c_int = 0o001000;
+pub const IPC_EXCL: ::c_int = 0o002000;
+pub const IPC_NOWAIT: ::c_int = 0o004000;
+
+pub const IPC_PRIVATE: ::key_t = 0;
+
+pub const IPC_RMID: ::c_int = 0;
+pub const IPC_SET: ::c_int = 1;
+pub const IPC_STAT: ::c_int = 2;
 
 pub const MCL_CURRENT: ::c_int = 0x0001;
 pub const MCL_FUTURE: ::c_int = 0x0002;
@@ -715,6 +737,19 @@ extern "C" {
     pub fn getdomainname(name: *mut ::c_char, len: ::size_t) -> ::c_int;
     pub fn setdomainname(name: *const ::c_char, len: ::size_t) -> ::c_int;
     pub fn uname(buf: *mut ::utsname) -> ::c_int;
+
+    pub fn shmget(key: ::key_t, size: ::size_t, shmflg: ::c_int) -> ::c_int;
+    pub fn shmat(
+        shmid: ::c_int,
+        shmaddr: *const ::c_void,
+        shmflg: ::c_int,
+    ) -> *mut ::c_void;
+    pub fn shmdt(shmaddr: *const ::c_void) -> ::c_int;
+    pub fn shmctl(
+        shmid: ::c_int,
+        cmd: ::c_int,
+        buf: *mut ::shmid_ds,
+    ) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -9,6 +9,7 @@ pub type mqd_t = ::c_int;
 type __pthread_spin_t = __cpu_simple_lock_nv_t;
 pub type vm_size_t = ::uintptr_t;
 pub type lwpid_t = ::c_uint;
+pub type shmatt_t = ::c_uint;
 
 impl siginfo_t {
     pub unsafe fn si_value(&self) -> ::sigval {
@@ -280,6 +281,18 @@ s! {
     pub struct mmsghdr {
         pub msg_hdr: ::msghdr,
         pub msg_len: ::c_uint,
+    }
+
+    pub struct shmid_ds {
+        pub shm_perm: ::ipc_perm,
+        pub shm_segsz: ::size_t,
+        pub shm_lpid: ::pid_t,
+        pub shm_cpid: ::pid_t,
+        pub shm_nattch: ::shmatt_t,
+        pub shm_atime: ::time_t,
+        pub shm_dtime: ::time_t,
+        pub shm_ctime: ::time_t,
+        _shm_internal: *mut ::c_void,
     }
 }
 

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -306,6 +306,21 @@ s! {
         pub ar_pln: u8,
         pub ar_op: u16,
     }
+
+    pub struct shmid_ds {
+        pub shm_perm: ::ipc_perm,
+        pub shm_segsz: ::c_int,
+        pub shm_lpid: ::pid_t,
+        pub shm_cpid: ::pid_t,
+        pub shm_nattch: ::c_short,
+        pub shm_atime: ::time_t,
+        __shm_atimensec: c_long,
+        pub shm_dtime: ::time_t,
+        __shm_dtimensec: c_long,
+        pub shm_ctime: ::time_t,
+        __shm_ctimensec: c_long,
+        pub shm_internal: *mut ::c_void,
+    }
 }
 
 impl siginfo_t {


### PR DESCRIPTION
initial work from @landryb for OpenBSD, various fixes and NetBSD support from me.

Fixes #1585

shm support is need for firefox building (for slice-deque)

cc @jakllsch @ryoon for NetBSD