### PR TITLE
Upgrade to musl 1.1.24 in CI

### DIFF
--- a/ci/docker/mips-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mips-unknown-linux-musl/Dockerfile
@@ -2,16 +2,23 @@ FROM ubuntu:19.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates qemu-system-mips curl \
-        bzip2
+        xz-utils patch
 
 RUN mkdir /toolchain
 
-# Note that this originally came from:
-# https://downloads.openwrt.org/snapshots/trunk/ar71xx/generic/OpenWrt-SDK-ar71xx-generic_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2
-RUN curl --retry 5 -L https://ci-mirrors.rust-lang.org/libc/OpenWrt-SDK-ar71xx-generic_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2 | \
-    tar xjf - -C /toolchain --strip-components=1
+# Linux kernel version: 4.14.151
+# See build_dir/target-mips_24kc_musl/linux-ar71xx_generic/linux-4.14.151
+# Musl version: 1.1.24
+# See staging_dir/toolchain-mips_24kc_gcc-7.4.0_musl/info.mk
+RUN curl --retry 5 -L https://downloads.openwrt.org/releases/19.07.0-rc1/targets/ar71xx/generic/openwrt-sdk-19.07.0-rc1-ar71xx-generic_gcc-7.4.0_musl.Linux-x86_64.tar.xz | \
+    tar xJf - -C /toolchain --strip-components=1
 
-ENV PATH=$PATH:/rust/bin:/toolchain/staging_dir/toolchain-mips_34kc_gcc-5.3.0_musl-1.1.15/bin \
-    CC_mips_unknown_linux_musl=mips-openwrt-linux-gcc \
-    CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_LINKER=mips-openwrt-linux-gcc \
-    CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_RUNNER="qemu-mips -L /toolchain/staging_dir/toolchain-mips_34kc_gcc-5.3.0_musl-1.1.15"
+# See https://lkml.org/lkml/2014/3/14/269
+COPY sysinfo_guard.patch /toolchain
+RUN patch /toolchain/staging_dir/toolchain-mips_24kc_gcc-7.4.0_musl/include/linux/kernel.h </toolchain/sysinfo_guard.patch
+
+ENV PATH=$PATH:/rust/bin:/toolchain/staging_dir/toolchain-mips_24kc_gcc-7.4.0_musl/bin \
+    STAGING_DIR=/toolchain/staging_dir \
+    CC_mips_unknown_linux_musl=mips-openwrt-linux-musl-gcc \
+    CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_LINKER=mips-openwrt-linux-musl-gcc \
+    CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_RUNNER="qemu-mips -L /toolchain/staging_dir/toolchain-mips_24kc_gcc-7.4.0_musl"

--- a/ci/docker/mipsel-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mipsel-unknown-linux-musl/Dockerfile
@@ -1,17 +1,24 @@
 FROM ubuntu:19.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        gcc libc6-dev qemu-user ca-certificates qemu-system-mips curl \
-        bzip2
+        gcc libc6-dev qemu-user ca-certificates qemu-system-mipsel curl \
+        xz-utils patch
 
 RUN mkdir /toolchain
 
-# Note that this originally came from:
-# https://downloads.openwrt.org/snapshots/trunk/malta/generic/OpenWrt-Toolchain-malta-le_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2
-RUN curl --retry 5 -L https://ci-mirrors.rust-lang.org/libc/OpenWrt-Toolchain-malta-le_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2 | \
-      tar xjf - -C /toolchain --strip-components=2
+# Linux kernel version: 4.14.151
+# See build_dir/target-mipsel_mips32_musl/linux-brcm47xx_generic/linux-4.14.151
+# Musl version: 1.1.24
+# See staging_dir/toolchain-mipsel_mips32_gcc-7.4.0_musl/info.mk
+RUN curl --retry 5 -L https://downloads.openwrt.org/releases/19.07.0-rc1/targets/brcm47xx/generic/openwrt-sdk-19.07.0-rc1-brcm47xx-generic_gcc-7.4.0_musl.Linux-x86_64.tar.xz | \
+    tar xJf - -C /toolchain --strip-components=1
 
-ENV PATH=$PATH:/rust/bin:/toolchain/bin \
-    CC_mipsel_unknown_linux_musl=mipsel-openwrt-linux-gcc \
-    CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_LINKER=mipsel-openwrt-linux-gcc \
-    CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_RUNNER="qemu-mipsel -L /toolchain"
+# See https://lkml.org/lkml/2014/3/14/269
+COPY sysinfo_guard.patch /toolchain
+RUN patch /toolchain/staging_dir/toolchain-mipsel_mips32_gcc-7.4.0_musl/include/linux/kernel.h </toolchain/sysinfo_guard.patch
+
+ENV PATH=$PATH:/rust/bin:/toolchain/staging_dir/toolchain-mipsel_mips32_gcc-7.4.0_musl/bin \
+    STAGING_DIR=/toolchain/staging_dir \
+    CC_mipsel_unknown_linux_musl=mipsel-openwrt-linux-musl-gcc \
+    CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_LINKER=mipsel-openwrt-linux-musl-gcc \
+    CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_RUNNER="qemu-mipsel -L /toolchain/staging_dir/toolchain-mipsel_mips32_gcc-7.4.0_musl"

--- a/ci/install-musl.sh
+++ b/ci/install-musl.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-MUSL_VERSION=1.1.22
+MUSL_VERSION=1.1.24
 MUSL="musl-${MUSL_VERSION}"
 
 # Download, configure, build, and install musl:

--- a/ci/sysinfo_guard.patch
+++ b/ci/sysinfo_guard.patch
@@ -1,0 +1,10 @@
+@@ -2,7 +2,9 @@
+ #ifndef _LINUX_KERNEL_H
+ #define _LINUX_KERNEL_H
+ 
++#ifdef __GLIBC__
+ #include <linux/sysinfo.h>
++#endif
+ 
+ /*
+  * 'kernel.h' contains some often-used function prototypes etc

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2061,7 +2061,6 @@ fn test_linux(target: &str) {
     let i686 = target.contains("i686");
     let mips = target.contains("mips");
     let mips32 = mips && !target.contains("64");
-    let mips32_musl = mips32 && musl;
     let mips64 = mips && target.contains("64");
     let ppc64 = target.contains("powerpc64");
     let s390x = target.contains("s390x");
@@ -2069,6 +2068,7 @@ fn test_linux(target: &str) {
     let x32 = target.contains("x32");
     let x86_32 = target.contains("i686");
     let x86_64 = target.contains("x86_64");
+    let aarch64_musl = target.contains("aarch64") && musl;
 
     let mut cfg = ctest_cfg();
     cfg.define("_GNU_SOURCE", None);
@@ -2132,8 +2132,7 @@ fn test_linux(target: &str) {
                "sys/prctl.h",
                "sys/ptrace.h",
                "sys/quota.h",
-               // FIXME: the mips-musl CI build jobs use ancient musl 1.0.15:
-               [!mips32_musl]: "sys/random.h",
+               "sys/random.h",
                "sys/reboot.h",
                "sys/resource.h",
                "sys/sem.h",
@@ -2187,8 +2186,7 @@ fn test_linux(target: &str) {
         "linux/fs.h",
         "linux/futex.h",
         "linux/genetlink.h",
-        // FIXME: musl version 1.0.15 used by mips build jobs is ancient
-        [!mips32_musl]: "linux/if.h",
+        "linux/if.h",
         "linux/if_addr.h",
         "linux/if_alg.h",
         "linux/if_ether.h",
@@ -2303,9 +2301,6 @@ fn test_linux(target: &str) {
             // structs.
             "termios2" => true,
 
-            // FIXME: musl version using by mips build jobs 1.0.15 is ancient:
-            "ifmap" | "ifreq" | "ifconf" if mips32_musl => true,
-
             // FIXME: remove once Ubuntu 20.04 LTS is released, somewhere in 2020.
             // ucontext_t added a new field as of glibc 2.28; our struct definition is
             // conservative and omits the field, but that means the size doesn't match for newer
@@ -2349,7 +2344,7 @@ fn test_linux(target: &str) {
             // Require Linux kernel 5.1:
             "F_SEAL_FUTURE_WRITE" => true,
 
-            // The musl version 1.0.22 used in CI does not
+            // The musl version 1.1.24 used in CI does not
             // contain these glibc constants yet:
             | "RLIMIT_RTTIME" // should be in `resource.h`
             | "TCP_COOKIE_TRANSACTIONS"  // should be in the `netinet/tcp.h` header
@@ -2370,10 +2365,6 @@ fn test_linux(target: &str) {
             // FIXME: on musl the pthread types are defined a little differently
             // - these constants are used by the glibc implementation.
             n if musl && n.contains("__SIZEOF_PTHREAD") => true,
-
-            // FIXME: musl version 1.0.15 used by mips build jobs is ancient
-            t if mips32_musl && t.starts_with("IFF") => true,
-            "MFD_HUGETLB" | "AF_XDP" | "PF_XDP" if mips32_musl => true,
 
             _ => false,
         }
@@ -2458,7 +2449,17 @@ fn test_linux(target: &str) {
                                            field == "_pad2" ||
                                            field == "ssi_syscall" ||
                                            field == "ssi_call_addr" ||
-                                           field == "ssi_arch"))
+                                           field == "ssi_arch")) ||
+        // FIXME: After musl 1.1.24, it have only one field `sched_priority`,
+        // while other fields become reserved.
+        (struct_ == "sched_param" && [
+            "sched_ss_low_priority",
+            "sched_ss_repl_period",
+            "sched_ss_init_budget",
+            "sched_ss_max_repl",
+        ].contains(&field) && musl) ||
+        // FIXME: After musl 1.1.24, the type becomes `int` instead of `unsigned short`.
+        (struct_ == "ipc_perm" && field == "__seq" && aarch64_musl)
     });
 
     cfg.skip_roundtrip(move |s| match s {


### PR DESCRIPTION
Required by #1577 

Note that in musl 1.1.24, `struct sched_param` from `sched.h` has changed and some fields became reserved. So [these fields](https://github.com/rust-lang/libc/blob/13d4a5da2eafd82d3ebb2acb729d8b8c9148fb1f/src/unix/linux_like/mod.rs#L97) are outdated. I'm not sure if we should rename them, since they are in public API.

I simply skip `struct sched_param` from the test now.

Here's the diff between musl 1.1.23 and 1.1.24
```
diff --git a/include/sched.h b/include/sched.h
index 05d40b1e..7e470d3a 100644
--- a/include/sched.h
+++ b/include/sched.h
@@ -18,10 +18,12 @@ extern "C" {
 
 struct sched_param {
        int sched_priority;
-       int sched_ss_low_priority;
-       struct timespec sched_ss_repl_period;
-       struct timespec sched_ss_init_budget;
-       int sched_ss_max_repl;
+       int __reserved1;
+       struct {
+               time_t __reserved1;
+               long __reserved2;
+       } __reserved2[2];
+       int __reserved3;
 };
```
