### PR TITLE
add pthread_getname_np for mac os

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -3237,6 +3237,11 @@ extern "C" {
     #[allow(deprecated)]
     pub fn mach_timebase_info(info: *mut ::mach_timebase_info) -> ::c_int;
     pub fn pthread_setname_np(name: *const ::c_char) -> ::c_int;
+    pub fn pthread_getname_np(
+        thread: ::pthread_t,
+        name: *mut ::c_char,
+        len: ::size_t,
+    ) -> ::c_int;
     pub fn pthread_get_stackaddr_np(thread: ::pthread_t) -> *mut ::c_void;
     pub fn pthread_get_stacksize_np(thread: ::pthread_t) -> ::size_t;
     pub fn pthread_condattr_setpshared(


### PR DESCRIPTION
In macos's `pthread.h`

```c
/*SPI to set and get pthread name*/
__API_AVAILABLE(macos(10.6), ios(3.2))
int	pthread_getname_np(pthread_t,char*,size_t);

__API_AVAILABLE(macos(10.6), ios(3.2))
int	pthread_setname_np(const char*);
```

I believe `pthread_getname_np` is usable in macos after 10.6.

Signed-off-by: Yang Keao <keao.yang@yahoo.com>