### PR TITLE
Add ucred and socket related types to uclibc-mips32

### DIFF
--- a/src/unix/uclibc/mod.rs
+++ b/src/unix/uclibc/mod.rs
@@ -288,6 +288,12 @@ s! {
         pub msgtql: ::c_int,
         pub msgseg: ::c_ushort,
     }
+
+    pub struct ucred {
+        pub pid: ::pid_t,
+        pub uid: ::uid_t,
+        pub gid: ::gid_t,
+    }
 }
 
 s_no_extra_traits! {


### PR DESCRIPTION
Fix compilation of the [tokio](https://github.com/tokio-rs) rust for MIPS architecture when using uClibc. Added missed types, which are defined in library headers:
https://github.com/kraj/uClibc/blob/ca1c74d67dd115d059a875150e10b8560a9c35a8/libc/sysdeps/linux/common/bits/socket.h#L320
https://github.com/kraj/uClibc/blob/ca1c74d67dd115d059a875150e10b8560a9c35a8/libc/sysdeps/linux/common/bits/in.h#L35-L36
https://github.com/kraj/uClibc/blob/ca1c74d67dd115d059a875150e10b8560a9c35a8/libc/sysdeps/linux/common/bits/in.h#L140-L143

Should also solve https://github.com/rust-lang-nursery/net2-rs/issues/88

Revisit of #1500