### PR TITLE
expose futimens() for illumos systems

### DIFF
--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2157,6 +2157,10 @@ extern "C" {
         path: *const ::c_char,
         times: *const ::timeval,
     ) -> ::c_int;
+    pub fn futimens(
+        dirfd: ::c_int,
+        times: *const ::timespec,
+    ) -> ::c_int;
     pub fn utimensat(
         dirfd: ::c_int,
         path: *const ::c_char,

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2157,10 +2157,7 @@ extern "C" {
         path: *const ::c_char,
         times: *const ::timeval,
     ) -> ::c_int;
-    pub fn futimens(
-        dirfd: ::c_int,
-        times: *const ::timespec,
-    ) -> ::c_int;
+    pub fn futimens(dirfd: ::c_int, times: *const ::timespec) -> ::c_int;
     pub fn utimensat(
         dirfd: ::c_int,
         path: *const ::c_char,


### PR DESCRIPTION
illumos has an implementation of `futimens()` which we should expose.  I'm working on a broader set of [fixes for illumos](https://github.com/rust-lang/libc/compare/master...jclulow:illumos_fixes) in general, but that's going to take a lot more work to be ready so the test suite doesn't currently seem to function.