### PR TITLE
Solarish: Fix utmx Debug impl and re-add support for extra traits

### DIFF
--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -536,7 +536,7 @@ cfg_if! {
                     .field("ut_session", &self.ut_session)
                     .field("ut_pad", &self.ut_pad)
                     .field("ut_syslen", &self.ut_syslen)
-                    .field("ut_host", &self.ut_host)
+                // .field("ut_host", &self.ut_host)
                     .finish()
             }
         }

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -561,8 +561,8 @@ cfg_if! {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
                     match self {
-                        Self { d_desc } => f.debug_struct("door_desc_t__d_data").field("d_desc", &self.d_desc),
-                        Self { d_resv } => f.debug_struct("door_desc_t__d_data").field("d_resv", &self.d_resv),
+                        Self { d_desc } => f.debug_struct("door_desc_t__d_data").field("d_desc", &self.d_desc).finish(),
+                        Self { d_resv } => f.debug_struct("door_desc_t__d_data").field("d_resv", &self.d_resv).finish(),
                     }
                 }
             }

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -557,6 +557,17 @@ cfg_if! {
             }
         }
 
+        impl ::fmt::Debug for door_desc_t__d_data {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                unsafe {
+                    match self {
+                        Self { d_desc } => f.debug_struct("door_desc_t__d_data").field("d_desc", &self.d_desc),
+                        Self { d_resv } => f.debug_struct("door_desc_t__d_data").field("d_resv", &self.d_resv),
+                    }
+                }
+            }
+        }
+
         impl PartialEq for epoll_event {
             fn eq(&self, other: &epoll_event) -> bool {
                 self.events == other.events

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -479,18 +479,19 @@ s_no_extra_traits! {
         __sigev_pad2: ::c_int,
     }
 
+    #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
     pub union door_desc_t__d_data {
         pub d_desc: door_desc_t__d_data__d_desc,
         d_resv: [::c_int; 5], /* Check out /usr/include/sys/door.h */
     }
 
-    #[derive(Debug)]
+    #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
     pub struct door_desc_t {
         pub d_attributes: door_attr_t,
         pub d_data: door_desc_t__d_data,
     }
 
-    #[derive(Debug)]
+    #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
     pub struct door_arg_t {
         pub data_ptr: *const ::c_char,
         pub data_size: ::size_t,
@@ -556,21 +557,6 @@ cfg_if! {
                 self.ut_tv.hash(state);
                 self.ut_syslen.hash(state);
                 self.ut_pad.hash(state);
-            }
-        }
-
-        impl ::fmt::Debug for door_desc_t__d_data {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                unsafe {
-                    match self {
-                        Self { d_desc } => f.debug_struct("door_desc_t__d_data")
-                            .field("d_desc", &self.d_desc)
-                            .finish(),
-                        Self { d_resv } => f.debug_struct("door_desc_t__d_data")
-                            .field("d_resv", &self.d_resv)
-                            .finish(),
-                    }
-                }
             }
         }
 

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -484,11 +484,13 @@ s_no_extra_traits! {
         d_resv: [::c_int; 5], /* Check out /usr/include/sys/door.h */
     }
 
+    #[derive(Debug)]
     pub struct door_desc_t {
         pub d_attributes: door_attr_t,
         pub d_data: door_desc_t__d_data,
     }
 
+    #[derive(Debug)]
     pub struct door_arg_t {
         pub data_ptr: *const ::c_char,
         pub data_size: ::size_t,
@@ -561,8 +563,12 @@ cfg_if! {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
                     match self {
-                        Self { d_desc } => f.debug_struct("door_desc_t__d_data").field("d_desc", &self.d_desc).finish(),
-                        Self { d_resv } => f.debug_struct("door_desc_t__d_data").field("d_resv", &self.d_resv).finish(),
+                        Self { d_desc } => f.debug_struct("door_desc_t__d_data")
+                            .field("d_desc", &self.d_desc)
+                            .finish(),
+                        Self { d_resv } => f.debug_struct("door_desc_t__d_data")
+                            .field("d_resv", &self.d_resv)
+                            .finish(),
                     }
                 }
             }

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -536,7 +536,7 @@ cfg_if! {
                     .field("ut_session", &self.ut_session)
                     .field("ut_pad", &self.ut_pad)
                     .field("ut_syslen", &self.ut_syslen)
-                // .field("ut_host", &self.ut_host)
+                    .field("ut_host", &&self.ut_host[..])
                     .finish()
             }
         }


### PR DESCRIPTION
Fix a bug where the compilation failed cause `utmpx.host` is bigger than 32 so we cannot print it.

Due to a break of compilation (only with extra trait enabled) on a Tier 2 platform, I do think it would be better to do another release as soon as proven fixing compilation