### PR TITLE
Update bindings for the wasm32-wasi target

### DIFF
--- a/ci/docker/wasm32-wasi/Dockerfile
+++ b/ci/docker/wasm32-wasi/Dockerfile
@@ -1,93 +1,39 @@
-# In the first container we want to assemble the `wasi-sysroot` by compiling it
-# from source. This requires a clang 8.0+ compiler with enough wasm support and
-# then we're just running a standard `make` inside of what we clone.
-FROM ubuntu:18.04 as wasi-sysroot
+FROM ubuntu:19.10
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
     clang \
-    cmake \
     curl \
-    g++ \
     git \
     libc6-dev \
-    libclang-dev \
     make \
-    ssh \
     xz-utils
-
-# Fetch clang 8.0+ which is used to compile the wasi target and link our
-# programs together.
-RUN curl http://releases.llvm.org/8.0.0/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz | tar xJf -
-RUN mv /clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04 /wasmcc
 
 # Note that we're using `git reset --hard` to pin to a specific commit for
 # verification for now. The sysroot is currently in somewhat of a state of flux
 # and is expected to have breaking changes, so this is an attempt to mitigate
 # those breaking changes on `libc`'s own CI
-RUN git clone https://github.com/CraneStation/wasi-sysroot && \
-  cd wasi-sysroot && \
-  git reset --hard eee6ee7566e26f2535eb6088c8494a112ff423b9
-RUN make -C wasi-sysroot install -j $(nproc) WASM_CC=/wasmcc/bin/clang INSTALL_DIR=/wasi-sysroot
+RUN git clone https://github.com/CraneStation/wasi-libc && \
+  cd wasi-libc && \
+  git reset --hard f645f498dfbbbc00a7a97874d33082d3605c3f21
+RUN apt-get install -y --no-install-recommends llvm
+RUN make -C wasi-libc install -j $(nproc) INSTALL_DIR=/wasi-libc
 
-# This is a small wrapper script which executes the actual clang binary in
-# `/wasmcc` and then is sure to pass the right `--sysroot` argument which we
-# just built above.
-COPY docker/wasm32-wasi/clang.sh /wasi-sysroot/bin/clang
+RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/dev/wasmtime-dev-x86_64-linux.tar.xz | \
+  tar xJf -
+ENV PATH=$PATH:/wasmtime-dev-x86_64-linux
+COPY docker/wasm32-wasi/clang.sh /wasi-libc/bin/clang
 
-# In the second container we're going to build the `wasmtime` binary which is
-# used to execute wasi executables. This is a standard Rust project so we're
-# just checking out a known revision (which pairs with the sysroot one we
-# downlaoded above) and then we're building it with Cargo
-FROM ubuntu:18.04 as wasmtime
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    ca-certificates \
-    clang \
-    cmake \
-    curl \
-    g++ \
-    git \
-    libclang-dev \
-    make \
-    ssh
-
-RUN curl -sSf https://sh.rustup.rs |  sh -s -- -y
-ENV PATH=/root/.cargo/bin:$PATH
-
-RUN apt-get install -y --no-install-recommends python
-RUN git clone --recursive https://github.com/CraneStation/wasmtime wasmtime && \
-  cd wasmtime && \
-  git reset --hard a2647878977726935c3d04c05cabad9607ec7606
-RUN cargo build --release --manifest-path wasmtime/Cargo.toml
-
-# And finally in the last image we're going to assemble everything together.
-# We'll install things needed at runtime for now and then copy over the
-# sysroot/wasmtime artifacts into their final location.
-FROM ubuntu:18.04
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    gcc \
-    libc6-dev \
-    libxml2 \
-    ca-certificates
-
-# Copy over clang we downloaded to link executables ...
-COPY --from=wasi-sysroot /wasmcc /wasmcc/
-# ... and the sysroot we built to link executables against ...
-COPY --from=wasi-sysroot /wasi-sysroot/ /wasi-sysroot/
-# ... and finally wasmtime to actually execute binaries
-COPY --from=wasmtime /wasmtime/target/release/wasmtime /usr/bin/
+RUN apt-get install -y --no-install-recommends lld
+ENV PATH=$PATH:/usr/lib/llvm-9/bin
 
 # Of note here is our clang wrapper which just executes a normal clang
 # executable with the right sysroot, and then we're sure to turn off the
 # crt-static feature to ensure that the CRT that we're specifying with `clang`
 # is used.
 ENV CARGO_TARGET_WASM32_WASI_RUNNER=wasmtime \
-  CARGO_TARGET_WASM32_WASI_LINKER=/wasi-sysroot/bin/clang \
-  CC_wasm32_wasi=/wasi-sysroot/bin/clang \
+  CARGO_TARGET_WASM32_WASI_LINKER=/wasi-libc/bin/clang \
+  CC_wasm32_wasi=/wasi-libc/bin/clang \
   PATH=$PATH:/rust/bin \
   RUSTFLAGS=-Ctarget-feature=-crt-static

--- a/ci/docker/wasm32-wasi/clang.sh
+++ b/ci/docker/wasm32-wasi/clang.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-exec /wasmcc/bin/clang --target=wasm32-wasi --sysroot /wasi-sysroot "$@"
+exec /usr/bin/clang --target=wasm32-wasi --sysroot /wasi-libc/sysroot "$@"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -89,10 +89,10 @@ if [ "$TARGET" = "x86_64-unknown-linux-gnux32" ]; then
   opt="--release"
 fi
 
-cargo test -vv $opt --no-default-features --manifest-path libc-test/Cargo.toml \
+cargo test $opt --no-default-features --manifest-path libc-test/Cargo.toml \
       --target "${TARGET}"
 
-cargo test -vv $opt --manifest-path libc-test/Cargo.toml --target "${TARGET}"
+cargo test $opt --manifest-path libc-test/Cargo.toml --target "${TARGET}"
 
-cargo test -vv $opt --features extra_traits --manifest-path libc-test/Cargo.toml \
+cargo test $opt --features extra_traits --manifest-path libc-test/Cargo.toml \
       --target "${TARGET}"

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1182,7 +1182,7 @@ fn test_wasi(target: &str) {
         "sys/utsname.h",
         "time.h",
         "unistd.h",
-        "wasi/core.h",
+        "wasi/api.h",
         "wasi/libc.h",
         "wasi/libc-find-relpath.h",
         "wchar.h",
@@ -1217,6 +1217,10 @@ fn test_wasi(target: &str) {
     // d_name is declared as a flexible array in WASI libc, so it
     // doesn't support sizeof.
     cfg.skip_field(|s, field| s == "dirent" && field == "d_name");
+
+    // Currently Rust/clang disagree on function argument ABI, so skip these
+    // tests. For more info see WebAssembly/tool-conventions#88
+    cfg.skip_roundtrip(|_| true);
 
     cfg.generate("../src/lib.rs", "main.rs");
 }

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -174,9 +174,9 @@ pub const EXIT_FAILURE: c_int = 1;
 pub const STDIN_FILENO: c_int = 0;
 pub const STDOUT_FILENO: c_int = 1;
 pub const STDERR_FILENO: c_int = 2;
-pub const SEEK_SET: c_int = 2;
-pub const SEEK_CUR: c_int = 0;
-pub const SEEK_END: c_int = 1;
+pub const SEEK_SET: c_int = 0;
+pub const SEEK_CUR: c_int = 1;
+pub const SEEK_END: c_int = 2;
 pub const _IOFBF: c_int = 0;
 pub const _IONBF: c_int = 2;
 pub const _IOLBF: c_int = 1;
@@ -207,8 +207,8 @@ pub const AT_EACCESS: c_int = 0x0;
 pub const AT_SYMLINK_NOFOLLOW: c_int = 0x1;
 pub const AT_SYMLINK_FOLLOW: c_int = 0x2;
 pub const AT_REMOVEDIR: c_int = 0x4;
-pub const UTIME_OMIT: c_long = 1073741822;
-pub const UTIME_NOW: c_long = 1073741823;
+pub const UTIME_OMIT: c_long = 0xfffffffe;
+pub const UTIME_NOW: c_long = 0xffffffff;
 
 pub const E2BIG: c_int = 1;
 pub const EACCES: c_int = 2;
@@ -728,11 +728,8 @@ extern "C" {
     pub fn __wasilibc_fd_renumber(fd: c_int, newfd: c_int) -> c_int;
     pub fn __wasilibc_unlinkat(fd: c_int, path: *const c_char) -> c_int;
     pub fn __wasilibc_rmdirat(fd: c_int, path: *const c_char) -> c_int;
-    pub fn __wasilibc_init_preopen();
     pub fn __wasilibc_find_relpath(
         path: *const c_char,
-        rights_base: __wasi_rights_t,
-        rights_inheriting: __wasi_rights_t,
         relative_path: *mut *const c_char,
     ) -> c_int;
     pub fn __wasilibc_tell(fd: c_int) -> ::off_t;


### PR DESCRIPTION
This commit performs a number of updates for libc with the `wasm32-wasi`
target:

* Updates the `wasi-libc` repository commit used (previously known as
  `wasi-sysroot`)
* Updates the container to Ubuntu 19.10 which has Clang 9 packaged which
  is all we need.
* Avoids building `wasmtime` and instead downloads a precompiled binary.
* Updates bindings in `src/wasi.rs` to match the current upstream state.