### PR TITLE
Remove redundant definitions and add some constants on RISC-V.

### DIFF
--- a/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
@@ -4,23 +4,10 @@ pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type wchar_t = ::c_int;
-pub type time_t = ::c_long;
 
-pub type dev_t = ::c_ulong;
-pub type uid_t = ::c_uint;
-pub type gid_t = ::c_uint;
-pub type ino_t = ::c_ulong;
-pub type ino64_t = ::c_ulong;
-pub type mode_t = ::c_uint;
 pub type nlink_t = ::c_uint;
-pub type off_t = ::c_long;
-pub type off64_t = ::c_long;
-pub type pid_t = ::c_int;
 pub type blksize_t = ::c_int;
-pub type blkcnt_t = ::c_long;
-pub type fsblkcnt_t = ::c_ulong;
 pub type fsblkcnt64_t = ::c_ulong;
-pub type fsfilcnt_t = ::c_ulong;
 pub type fsfilcnt64_t = ::c_ulong;
 pub type suseconds_t = i64;
 pub type __u64 = ::c_ulonglong;
@@ -31,50 +18,50 @@ s! {
     }
 
     pub struct timespec {
-        pub tv_sec: time_t,
+        pub tv_sec: ::time_t,
         pub tv_nsec: ::c_long,
     }
 
     pub struct stat {
-        pub st_dev: dev_t,
-        pub st_ino: ino_t,
-        pub st_mode: mode_t,
-        pub st_nlink: nlink_t,
-        pub st_uid: uid_t,
-        pub st_gid: gid_t,
-        pub st_rdev: dev_t,
-        pub __pad1: dev_t,
-        pub st_size: off_t,
-        pub st_blksize: blksize_t,
+        pub st_dev: ::dev_t,
+        pub st_ino: ::ino_t,
+        pub st_mode: ::mode_t,
+        pub st_nlink: ::nlink_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        pub __pad1: ::dev_t,
+        pub st_size: ::off_t,
+        pub st_blksize: ::blksize_t,
         pub __pad2: ::c_int,
-        pub st_blocks: blkcnt_t,
-        pub st_atime: time_t,
+        pub st_blocks: ::blkcnt_t,
+        pub st_atime: ::time_t,
         pub st_atime_nsec: ::c_long,
-        pub st_mtime: time_t,
+        pub st_mtime: ::time_t,
         pub st_mtime_nsec: ::c_long,
-        pub st_ctime: time_t,
+        pub st_ctime: ::time_t,
         pub st_ctime_nsec: ::c_long,
         pub __unused: [::c_int; 2usize],
     }
 
     pub struct stat64 {
-        pub st_dev: dev_t,
-        pub st_ino: ino64_t,
-        pub st_mode: mode_t,
-        pub st_nlink: nlink_t,
-        pub st_uid: uid_t,
-        pub st_gid: gid_t,
-        pub st_rdev: dev_t,
-        pub __pad1: dev_t,
-        pub st_size: off64_t,
-        pub st_blksize: blksize_t,
+        pub st_dev: ::dev_t,
+        pub st_ino: ::ino64_t,
+        pub st_mode: ::mode_t,
+        pub st_nlink: ::nlink_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        pub __pad1: ::dev_t,
+        pub st_size: ::off64_t,
+        pub st_blksize: ::blksize_t,
         pub __pad2: ::c_int,
-        pub st_blocks: blkcnt_t,
-        pub st_atime: time_t,
+        pub st_blocks: ::blkcnt_t,
+        pub st_atime: ::time_t,
         pub st_atime_nsec: ::c_long,
-        pub st_mtime: time_t,
+        pub st_mtime: ::time_t,
         pub st_mtime_nsec: ::c_long,
-        pub st_ctime: time_t,
+        pub st_ctime: ::time_t,
         pub st_ctime_nsec: ::c_long,
         pub __unused: [::c_int; 2],
     }
@@ -82,11 +69,11 @@ s! {
     pub struct statfs {
         pub f_type: ::c_long,
         pub f_bsize: ::c_long,
-        pub f_blocks: fsblkcnt_t,
-        pub f_bfree: fsblkcnt_t,
-        pub f_bavail: fsblkcnt_t,
-        pub f_files: fsfilcnt_t,
-        pub f_ffree: fsfilcnt_t,
+        pub f_blocks: ::fsblkcnt_t,
+        pub f_bfree: ::fsblkcnt_t,
+        pub f_bavail: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
         pub f_fsid: ::fsid_t,
         pub f_namelen: ::c_long,
         pub f_frsize: ::c_long,
@@ -97,11 +84,11 @@ s! {
     pub struct statfs64 {
         pub f_type: ::c_long,
         pub f_bsize: ::c_long,
-        pub f_blocks: fsblkcnt64_t,
-        pub f_bfree: fsblkcnt64_t,
-        pub f_bavail: fsblkcnt64_t,
-        pub f_files: fsfilcnt64_t,
-        pub f_ffree: fsfilcnt64_t,
+        pub f_blocks: ::fsblkcnt64_t,
+        pub f_bfree: ::fsblkcnt64_t,
+        pub f_bavail: ::fsblkcnt64_t,
+        pub f_files: ::fsfilcnt64_t,
+        pub f_ffree: ::fsfilcnt64_t,
         pub f_fsid: ::fsid_t,
         pub f_namelen: ::c_long,
         pub f_frsize: ::c_long,
@@ -112,12 +99,12 @@ s! {
     pub struct statvfs {
         pub f_bsize: ::c_ulong,
         pub f_frsize: ::c_ulong,
-        pub f_blocks: fsblkcnt_t,
-        pub f_bfree: fsblkcnt_t,
-        pub f_bavail: fsblkcnt_t,
-        pub f_files: fsfilcnt_t,
-        pub f_ffree: fsfilcnt_t,
-        pub f_favail: fsfilcnt_t,
+        pub f_blocks: ::fsblkcnt_t,
+        pub f_bfree: ::fsblkcnt_t,
+        pub f_bavail: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
+        pub f_favail: ::fsfilcnt_t,
         pub f_fsid: ::c_ulong,
         pub f_flag: ::c_ulong,
         pub f_namemax: ::c_ulong,
@@ -127,12 +114,12 @@ s! {
     pub struct statvfs64 {
         pub f_bsize: ::c_ulong,
         pub f_frsize: ::c_ulong,
-        pub f_blocks: fsblkcnt64_t,
-        pub f_bfree: fsblkcnt64_t,
-        pub f_bavail: fsblkcnt64_t,
-        pub f_files: fsfilcnt64_t,
-        pub f_ffree: fsfilcnt64_t,
-        pub f_favail: fsfilcnt64_t,
+        pub f_blocks: ::fsblkcnt64_t,
+        pub f_bfree: ::fsblkcnt64_t,
+        pub f_bavail: ::fsblkcnt64_t,
+        pub f_files: ::fsfilcnt64_t,
+        pub f_ffree: ::fsfilcnt64_t,
+        pub f_favail: ::fsfilcnt64_t,
         pub f_fsid: ::c_ulong,
         pub f_flag: ::c_ulong,
         pub f_namemax: ::c_ulong,
@@ -167,16 +154,12 @@ s! {
         pub sa_restorer: ::Option<unsafe extern "C" fn()>,
     }
 
-    pub struct sigset_t {
-        pub __val: [::c_ulong; 16],
-    }
-
     pub struct ipc_perm {
         pub __key: ::key_t,
-        pub uid: uid_t,
-        pub gid: gid_t,
-        pub cuid: uid_t,
-        pub cgid: gid_t,
+        pub uid: ::uid_t,
+        pub gid: ::gid_t,
+        pub cuid: ::uid_t,
+        pub cgid: ::gid_t,
         pub mode: ::c_ushort,
         pub __pad1: ::c_ushort,
         pub __seq: ::c_ushort,
@@ -186,13 +169,13 @@ s! {
     }
 
     pub struct shmid_ds {
-        pub shm_perm: ipc_perm,
+        pub shm_perm: ::ipc_perm,
         pub shm_segsz: ::size_t,
-        pub shm_atime: time_t,
-        pub shm_dtime: time_t,
-        pub shm_ctime: time_t,
-        pub shm_cpid: pid_t,
-        pub shm_lpid: pid_t,
+        pub shm_atime: ::time_t,
+        pub shm_dtime: ::time_t,
+        pub shm_ctime: ::time_t,
+        pub shm_cpid: ::pid_t,
+        pub shm_lpid: ::pid_t,
         pub shm_nattch: ::shmatt_t,
         pub __unused5: ::c_ulong,
         pub __unused6: ::c_ulong,
@@ -210,10 +193,18 @@ s! {
 pub const POSIX_FADV_DONTNEED: ::c_int = 4;
 pub const POSIX_FADV_NOREUSE: ::c_int = 5;
 pub const VEOF: usize = 4;
+pub const RTLD_DEEPBIND: ::c_int = 8;
+pub const RTLD_GLOBAL: ::c_int = 256;
+pub const RTLD_NOLOAD: ::c_int = 4;
 pub const TIOCGSOFTCAR: ::c_ulong = 21529;
 pub const TIOCSSOFTCAR: ::c_ulong = 21530;
 pub const TIOCGRS485: ::c_int = 21550;
 pub const TIOCSRS485: ::c_int = 21551;
+pub const RLIMIT_RSS: ::__rlimit_resource_t = 5;
+pub const RLIMIT_AS: ::__rlimit_resource_t = 9;
+pub const RLIMIT_MEMLOCK: ::__rlimit_resource_t = 8;
+pub const RLIMIT_NOFILE: ::__rlimit_resource_t = 7;
+pub const RLIMIT_NPROC: ::__rlimit_resource_t = 6;
 pub const O_APPEND: ::c_int = 1024;
 pub const O_CREAT: ::c_int = 64;
 pub const O_EXCL: ::c_int = 128;
@@ -469,6 +460,13 @@ pub const EREMOTEIO: ::c_int = 121;
 pub const FIOCLEX: ::c_ulong = 21585;
 pub const FIONCLEX: ::c_ulong = 21584;
 pub const FIONBIO: ::c_ulong = 21537;
+pub const PTRACE_GETFPREGS: ::c_uint = 14;
+pub const PTRACE_SETFPREGS: ::c_uint = 15;
+pub const PTRACE_GETFPXREGS: ::c_uint = 18;
+pub const PTRACE_SETFPXREGS: ::c_uint = 19;
+pub const PTRACE_GETREGS: ::c_uint = 12;
+pub const PTRACE_SETREGS: ::c_uint = 13;
+pub const PTRACE_PEEKSIGINFO_SHARED: ::c_uint = 1;
 pub const MCL_CURRENT: ::c_int = 1;
 pub const MCL_FUTURE: ::c_int = 2;
 pub const SIGSTKSZ: ::size_t = 8192;


### PR DESCRIPTION
Some of the type definitions are already defined in the common `mod.rs` for 64-bit GNU/Linux.
This also refactor the type definitions to use types from crate root.