### PR TITLE
Add reenterant shadow.h functions

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1090,6 +1090,26 @@ cfg_if! {
 pub const PTHREAD_MUTEX_ADAPTIVE_NP: ::c_int = 3;
 
 extern "C" {
+    pub fn fgetspent_r(
+        fp: *mut ::FILE,
+        spbuf: *mut ::spwd,
+        buf: *mut ::c_char,
+        buflen: ::size_t,
+        spbufp: *mut *mut ::spwd,
+    ) -> ::c_int;
+    pub fn sgetspent_r(
+        s: *const ::c_char,
+        spbuf: *mut ::spwd,
+        buf: *mut ::c_char,
+        buflen: ::size_t,
+        spbufp: *mut *mut ::spwd,
+    ) -> ::c_int;
+    pub fn getspent_r(
+        spbuf: *mut ::spwd,
+        buf: *mut ::c_char,
+        buflen: ::size_t,
+        spbufp: *mut *mut ::spwd,
+    ) -> ::c_int;
     pub fn qsort_r(
         base: *mut ::c_void,
         num: ::size_t,

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -2579,7 +2579,17 @@ extern "C" {
     pub fn endspent();
     pub fn getspent() -> *mut spwd;
 
-    pub fn getspnam(__name: *const ::c_char) -> *mut spwd;
+    pub fn getspnam(name: *const ::c_char) -> *mut spwd;
+    // Only `getspnam_r` is implemented for musl, out of all of the reenterant
+    // functions from `shadow.h`.
+    // https://git.musl-libc.org/cgit/musl/tree/include/shadow.h
+    pub fn getspnam_r(
+        name: *const ::c_char,
+        spbuf: *mut spwd,
+        buf: *mut ::c_char,
+        buflen: ::size_t,
+        spbufp: *mut *mut spwd,
+    ) -> ::c_int;
 
     pub fn shm_open(
         name: *const c_char,


### PR DESCRIPTION
This PR adds:
* `getspent_r`
* `getspnam_r`
* `fgetspent_r`
* `sgetspent_r`