### PR TITLE
Solarish: missing declaration of port_send and port_sendn

### DIFF
--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2404,6 +2404,18 @@ extern "C" {
         nget: *mut ::c_uint,
         timeout: *mut ::timespec,
     ) -> ::c_int;
+    pub fn port_send(
+        port: ::c_int,
+        events: ::c_int,
+        user: *mut ::c_void,
+    ) -> ::c_int;
+    pub fn port_sendn(
+        port_list: *mut ::c_int,
+        error_list: *mut ::c_int,
+        nent: ::c_uint,
+        events: ::c_int,
+        user: *mut ::c_void,
+    ) -> ::c_int;
     pub fn fexecve(
         fd: ::c_int,
         argv: *const *const ::c_char,


### PR DESCRIPTION
Two functions from Event port framework are missing in libc crate on Solaris. Main functions like port_create, port_associate, port_dissociate, port_get and port_getn are present.

Expected: libc crate on Solaris contains declaration of functions port_send and port_sendn
Actual:      libc crate on Solaris is missing declaration of functions port_send and port_sendn

From port_send(3C):

```
NAME
       port_send,  port_sendn - send a user-defined event to a port or list of ports

SYNOPSIS
       #include <port.h>

       int port_send(int port, int events, void *user);


       int port_sendn(int ports[], int errors[], uint_t nent,
            int events, void *user);
```

More info:
https://docs.oracle.com/cd/E88353_01/html/E37843/port-send-3c.html