### PR TITLE
Unify mmap flags

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -481,9 +481,7 @@ pub const LC_ALL_MASK: ::c_int = ::LC_CTYPE_MASK
     | LC_MEASUREMENT_MASK
     | LC_IDENTIFICATION_MASK;
 
-pub const MAP_SHARED_VALIDATE: ::c_int = 0x3;
 pub const MAP_FIXED_NOREPLACE: ::c_int = 0x100000;
-
 pub const ENOTSUP: ::c_int = EOPNOTSUPP;
 
 pub const SOCK_SEQPACKET: ::c_int = 5;

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -481,7 +481,6 @@ pub const LC_ALL_MASK: ::c_int = ::LC_CTYPE_MASK
     | LC_MEASUREMENT_MASK
     | LC_IDENTIFICATION_MASK;
 
-pub const MAP_FIXED_NOREPLACE: ::c_int = 0x100000;
 pub const ENOTSUP: ::c_int = EOPNOTSUPP;
 
 pub const SOCK_SEQPACKET: ::c_int = 5;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -2310,6 +2310,7 @@ pub const MAP_SHARED_VALIDATE: ::c_int = 0x3;
 // include/uapi/asm-generic/mman-common.h
 #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
 pub const MAP_SYNC : ::c_int = 0x080000;
+pub const MAP_FIXED_NOREPLACE: ::c_int = 0x100000;
 
 // uapi/linux/vm_sockets.h
 pub const VMADDR_CID_ANY: ::c_uint = 0xFFFFFFFF;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -2307,6 +2307,10 @@ pub const ALG_OP_ENCRYPT: ::c_int = 1;
 // include/uapi/linux/mman.h
 pub const MAP_SHARED_VALIDATE: ::c_int = 0x3;
 
+// include/uapi/asm-generic/mman-common.h
+#[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
+pub const MAP_SYNC : ::c_int = 0x080000;
+
 // uapi/linux/vm_sockets.h
 pub const VMADDR_CID_ANY: ::c_uint = 0xFFFFFFFF;
 pub const VMADDR_CID_HYPERVISOR: ::c_uint = 0;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -2304,6 +2304,9 @@ pub const ALG_SET_AEAD_AUTHSIZE: ::c_int = 5;
 pub const ALG_OP_DECRYPT: ::c_int = 0;
 pub const ALG_OP_ENCRYPT: ::c_int = 1;
 
+// include/uapi/linux/mman.h
+pub const MAP_SHARED_VALIDATE: ::c_int = 0x3;
+
 // uapi/linux/vm_sockets.h
 pub const VMADDR_CID_ANY: ::c_uint = 0xFFFFFFFF;
 pub const VMADDR_CID_HYPERVISOR: ::c_uint = 0;


### PR DESCRIPTION
`MAP_SHARED_VALIDATE` and `MAP_FIXED_NOREPLACE` can be exported for both gnu and musl.

Add `MAP_SYNC`.

I checked these values for both gnu and musl and they are the same.