### PR TITLE
Add definitions for cgroupfs and cgroup2fs MAGIC

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -634,6 +634,8 @@ pub const REISERFS_SUPER_MAGIC: ::c_long = 0x52654973;
 pub const SMB_SUPER_MAGIC: ::c_long = 0x0000517b;
 pub const TMPFS_MAGIC: ::c_long = 0x01021994;
 pub const USBDEVICE_SUPER_MAGIC: ::c_long = 0x00009fa2;
+pub const CGROUP_SUPER_MAGIC: ::c_long = 0x27e0eb;
+pub const CGROUP2_SUPER_MAGIC: ::c_long = 0x63677270;
 
 pub const CPU_SETSIZE: ::c_int = 0x400;
 


### PR DESCRIPTION
Here is man page I have taken numbers from: http://man7.org/linux/man-pages/man2/statfs.2.html