### PR TITLE
Add ioctl generation macros for linux

### DIFF
--- a/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
@@ -868,6 +868,16 @@ pub const SYS_pkey_alloc: ::c_long = 395;
 pub const SYS_pkey_free: ::c_long = 396;
 pub const SYS_statx: ::c_long = 397;
 
+// from uapi/asm-generic
+pub const _IOC_NRBITS: u32 = 8;
+pub const _IOC_TYPEBITS: u32 = 8;
+pub const _IOC_SIZEBITS: u32 = 14;
+pub const _IOC_DIRBITS: u32 = 2;
+
+pub const _IOC_NONE: ::c_ulong = 0;
+pub const _IOC_READ: ::c_ulong = 1;
+pub const _IOC_WRITE: ::c_ulong = 2;
+
 cfg_if! {
     if #[cfg(libc_align)] {
         mod align;

--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -893,6 +893,17 @@ pub const TIOCM_DSR: ::c_int = 0x400;
 
 pub const EHWPOISON: ::c_int = 168;
 
+// from uapi/asm-generic
+pub const _IOC_NRBITS: u32 = 8;
+pub const _IOC_TYPEBITS: u32 = 8;
+// from arch/mips/include/uapi/asm
+pub const _IOC_SIZEBITS: u32 = 13;
+pub const _IOC_DIRBITS: u32 = 3;
+
+pub const _IOC_NONE: ::c_ulong = 1;
+pub const _IOC_READ: ::c_ulong = 2;
+pub const _IOC_WRITE: ::c_ulong = 4;
+
 cfg_if! {
     if #[cfg(libc_align)] {
         mod align;

--- a/src/unix/linux_like/linux/gnu/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/gnu/b32/powerpc.rs
@@ -871,3 +871,14 @@ pub const SYS_preadv2: ::c_long = 380;
 pub const SYS_pwritev2: ::c_long = 381;
 pub const SYS_kexec_file_load: ::c_long = 382;
 pub const SYS_statx: ::c_long = 383;
+
+// from uapi/asm-generic
+pub const _IOC_NRBITS: u32 = 8;
+pub const _IOC_TYPEBITS: u32 = 8;
+// from arch/powerpc/include/uapi/asm
+pub const _IOC_SIZEBITS: u32 = 13;
+pub const _IOC_DIRBITS: u32 = 3;
+
+pub const _IOC_NONE: ::c_ulong = 1;
+pub const _IOC_READ: ::c_ulong = 2;
+pub const _IOC_WRITE: ::c_ulong = 4;

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -958,6 +958,17 @@ pub const SYS_preadv2: ::c_long = 358;
 pub const SYS_pwritev2: ::c_long = 359;
 pub const SYS_statx: ::c_long = 360;
 
+// from uapi/asm-generic
+pub const _IOC_NRBITS: u32 = 8;
+pub const _IOC_TYPEBITS: u32 = 8;
+// from arch/sparc/include/uapi/asm
+pub const _IOC_SIZEBITS: u32 = 13;
+pub const _IOC_DIRBITS: u32 = 3;
+
+pub const _IOC_NONE: ::c_ulong = 1;
+pub const _IOC_READ: ::c_ulong = 2;
+pub const _IOC_WRITE: ::c_ulong = 4;
+
 #[link(name = "util")]
 extern "C" {
     pub fn sysctl(

--- a/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
@@ -1101,6 +1101,16 @@ pub const SYS_pkey_alloc: ::c_long = 381;
 pub const SYS_pkey_free: ::c_long = 382;
 pub const SYS_statx: ::c_long = 383;
 
+// from uapi/asm-generic
+pub const _IOC_NRBITS: u32 = 8;
+pub const _IOC_TYPEBITS: u32 = 8;
+pub const _IOC_SIZEBITS: u32 = 14;
+pub const _IOC_DIRBITS: u32 = 2;
+
+pub const _IOC_NONE: ::c_ulong = 0;
+pub const _IOC_READ: ::c_ulong = 1;
+pub const _IOC_WRITE: ::c_ulong = 2;
+
 // offsets in user_regs_structs, from sys/reg.h
 pub const EBX: ::c_int = 0;
 pub const ECX: ::c_int = 1;

--- a/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
@@ -946,6 +946,16 @@ extern "C" {
     ) -> ::c_int;
 }
 
+// from uapi/asm-generic
+pub const _IOC_NRBITS: u32 = 8;
+pub const _IOC_TYPEBITS: u32 = 8;
+pub const _IOC_SIZEBITS: u32 = 14;
+pub const _IOC_DIRBITS: u32 = 2;
+
+pub const _IOC_NONE: ::c_ulong = 0;
+pub const _IOC_READ: ::c_ulong = 1;
+pub const _IOC_WRITE: ::c_ulong = 2;
+
 cfg_if! {
     if #[cfg(libc_align)] {
         mod align;

--- a/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
@@ -997,6 +997,17 @@ pub const TIOCM_DSR: ::c_int = 0x400;
 
 pub const EHWPOISON: ::c_int = 168;
 
+// from uapi/asm-generic
+pub const _IOC_NRBITS: u32 = 8;
+pub const _IOC_TYPEBITS: u32 = 8;
+// from arch/mips/include/uapi/asm
+pub const _IOC_SIZEBITS: u32 = 13;
+pub const _IOC_DIRBITS: u32 = 3;
+
+pub const _IOC_NONE: ::c_ulong = 1;
+pub const _IOC_READ: ::c_ulong = 2;
+pub const _IOC_WRITE: ::c_ulong = 4;
+
 #[link(name = "util")]
 extern "C" {
     pub fn sysctl(

--- a/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
@@ -1032,6 +1032,17 @@ pub const SYS_pwritev2: ::c_long = 381;
 pub const SYS_kexec_file_load: ::c_long = 382;
 pub const SYS_statx: ::c_long = 383;
 
+// from uapi/asm-generic
+pub const _IOC_NRBITS: u32 = 8;
+pub const _IOC_TYPEBITS: u32 = 8;
+// from arch/powerpc/include/uapi/asm
+pub const _IOC_SIZEBITS: u32 = 13;
+pub const _IOC_DIRBITS: u32 = 3;
+
+pub const _IOC_NONE: ::c_ulong = 1;
+pub const _IOC_READ: ::c_ulong = 2;
+pub const _IOC_WRITE: ::c_ulong = 4;
+
 #[link(name = "util")]
 extern "C" {
     pub fn sysctl(

--- a/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
@@ -859,3 +859,13 @@ pub const SYS_pkey_mprotect: ::c_long = 288;
 pub const SYS_pkey_alloc: ::c_long = 289;
 pub const SYS_pkey_free: ::c_long = 290;
 pub const SYS_statx: ::c_long = 291;
+
+// from uapi/asm-generic
+pub const _IOC_NRBITS: u32 = 8;
+pub const _IOC_TYPEBITS: u32 = 8;
+pub const _IOC_SIZEBITS: u32 = 14;
+pub const _IOC_DIRBITS: u32 = 2;
+
+pub const _IOC_NONE: ::c_ulong = 0;
+pub const _IOC_READ: ::c_ulong = 1;
+pub const _IOC_WRITE: ::c_ulong = 2;

--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -1003,6 +1003,16 @@ pub const SYS_setfsgid: ::c_long = 216;
 pub const SYS_newfstatat: ::c_long = 293;
 pub const SYS_statx: ::c_long = 379;
 
+// from uapi/asm-generic
+pub const _IOC_NRBITS: u32 = 8;
+pub const _IOC_TYPEBITS: u32 = 8;
+pub const _IOC_SIZEBITS: u32 = 14;
+pub const _IOC_DIRBITS: u32 = 2;
+
+pub const _IOC_NONE: ::c_ulong = 0;
+pub const _IOC_READ: ::c_ulong = 1;
+pub const _IOC_WRITE: ::c_ulong = 2;
+
 #[link(name = "util")]
 extern "C" {
 

--- a/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
@@ -968,6 +968,17 @@ pub const SYS_preadv2: ::c_long = 358;
 pub const SYS_pwritev2: ::c_long = 359;
 pub const SYS_statx: ::c_long = 360;
 
+// from uapi/asm-generic
+pub const _IOC_NRBITS: u32 = 8;
+pub const _IOC_TYPEBITS: u32 = 8;
+// from arch/sparc/include/uapi/asm
+pub const _IOC_SIZEBITS: u32 = 13;
+pub const _IOC_DIRBITS: u32 = 3;
+
+pub const _IOC_NONE: ::c_ulong = 1;
+pub const _IOC_READ: ::c_ulong = 2;
+pub const _IOC_WRITE: ::c_ulong = 4;
+
 #[link(name = "util")]
 extern "C" {
     pub fn sysctl(

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -890,6 +890,16 @@ pub const REG_TRAPNO: ::c_int = 20;
 pub const REG_OLDMASK: ::c_int = 21;
 pub const REG_CR2: ::c_int = 22;
 
+// from uapi/asm-generic
+pub const _IOC_NRBITS: u32 = 8;
+pub const _IOC_TYPEBITS: u32 = 8;
+pub const _IOC_SIZEBITS: u32 = 14;
+pub const _IOC_DIRBITS: u32 = 2;
+
+pub const _IOC_NONE: ::c_ulong = 0;
+pub const _IOC_READ: ::c_ulong = 1;
+pub const _IOC_WRITE: ::c_ulong = 2;
+
 extern "C" {
     pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;
     pub fn setcontext(ucp: *const ucontext_t) -> ::c_int;

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -962,35 +962,35 @@ extern "C" {
 }
 
 // glibc uses the definitions from the kernel header files.
-pub fn _IOC(dir: ::c_ulong, typ: ::c_ulong, nr: ::c_ulong, size: ::c_ulong) -> ::c_ulong {
+pub fn _IOC(dir: ::c_ulong, typ: u8, nr: u8, size: ::c_ulong) -> ::c_ulong {
     const _IOC_NRSHIFT: u32 = 0;
     const _IOC_TYPESHIFT: u32 = _IOC_NRSHIFT+_IOC_NRBITS;
     const _IOC_SIZESHIFT: u32 = _IOC_TYPESHIFT+_IOC_TYPEBITS;
     const _IOC_DIRSHIFT: u32 = _IOC_SIZESHIFT+_IOC_SIZEBITS;
 
-    (((dir)  << _IOC_DIRSHIFT) |
-     ((typ) << _IOC_TYPESHIFT) |
-     ((nr)   << _IOC_NRSHIFT) |
-     ((size) << _IOC_SIZESHIFT))
+    (((dir)              << _IOC_DIRSHIFT) |
+     ((typ as ::c_ulong) << _IOC_TYPESHIFT) |
+     ((nr as ::c_ulong)  << _IOC_NRSHIFT) |
+     ((size)             << _IOC_SIZESHIFT))
 }
 
 pub fn _IO(a:u8,b:u8) -> ::c_ulong {
-    _IOC(_IOC_NONE,(a as ::c_ulong),(b as ::c_ulong),0)
+    _IOC(_IOC_NONE,a,b,0)
 }
 
 pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_ulong {
     let size = ::core::mem::size_of::<T>() as ::c_ulong;
-    _IOC(_IOC_WRITE,(a as ::c_ulong),(b as ::c_ulong),size)
+    _IOC(_IOC_WRITE,a,b,size)
 }
 
 pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_ulong {
     let size = ::core::mem::size_of::<T>() as ::c_ulong;
-    _IOC(_IOC_READ,(a as ::c_ulong),(b as ::c_ulong),size)
+    _IOC(_IOC_READ,a,b,size)
 }
 
 pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_ulong {
     let size = ::core::mem::size_of::<T>() as ::c_ulong;
-    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_ulong),(b as ::c_ulong),size)
+    _IOC(_IOC_READ|_IOC_WRITE,a,b,size)
 }
 
 #[link(name = "util")]

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -961,6 +961,38 @@ extern "C" {
     ) -> ::ssize_t;
 }
 
+// glibc uses the definitions from the kernel header files.
+pub fn _IOC(dir: ::c_ulong, typ: ::c_ulong, nr: ::c_ulong, size: ::c_ulong) -> ::c_ulong {
+    const _IOC_NRSHIFT: u32 = 0;
+    const _IOC_TYPESHIFT: u32 = _IOC_NRSHIFT+_IOC_NRBITS;
+    const _IOC_SIZESHIFT: u32 = _IOC_TYPESHIFT+_IOC_TYPEBITS;
+    const _IOC_DIRSHIFT: u32 = _IOC_SIZESHIFT+_IOC_SIZEBITS;
+
+    (((dir)  << _IOC_DIRSHIFT) |
+     ((typ) << _IOC_TYPESHIFT) |
+     ((nr)   << _IOC_NRSHIFT) |
+     ((size) << _IOC_SIZESHIFT))
+}
+
+pub fn _IO(a:u8,b:u8) -> ::c_ulong {
+    _IOC(_IOC_NONE,(a as ::c_ulong),(b as ::c_ulong),0)
+}
+
+pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_ulong {
+    let size = ::core::mem::size_of::<T>() as ::c_ulong;
+    _IOC(_IOC_WRITE,(a as ::c_ulong),(b as ::c_ulong),size)
+}
+
+pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_ulong {
+    let size = ::core::mem::size_of::<T>() as ::c_ulong;
+    _IOC(_IOC_READ,(a as ::c_ulong),(b as ::c_ulong),size)
+}
+
+pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_ulong {
+    let size = ::core::mem::size_of::<T>() as ::c_ulong;
+    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_ulong),(b as ::c_ulong),size)
+}
+
 #[link(name = "util")]
 extern "C" {
     pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -968,10 +968,10 @@ pub fn _IOC(dir: ::c_ulong, typ: u8, nr: u8, size: ::c_ulong) -> ::c_ulong {
     const _IOC_SIZESHIFT: u32 = _IOC_TYPESHIFT+_IOC_TYPEBITS;
     const _IOC_DIRSHIFT: u32 = _IOC_SIZESHIFT+_IOC_SIZEBITS;
 
-    (((dir)              << _IOC_DIRSHIFT) |
-     ((typ as ::c_ulong) << _IOC_TYPESHIFT) |
-     ((nr as ::c_ulong)  << _IOC_NRSHIFT) |
-     ((size)             << _IOC_SIZESHIFT))
+    ((dir)              << _IOC_DIRSHIFT) |
+    ((typ as ::c_ulong) << _IOC_TYPESHIFT) |
+    ((nr as ::c_ulong)  << _IOC_NRSHIFT) |
+    ((size)             << _IOC_SIZESHIFT)
 }
 
 pub fn _IO(a:u8,b:u8) -> ::c_ulong {

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -152,31 +152,31 @@ s! {
     }
 }
 
-pub fn _IOC(a: ::c_int, b: ::c_int,c: ::c_int, d: ::c_int) -> ::c_int {
-    ( (a<<30) | (b<<8) | c | (d<<16) )
+pub fn _IOC(a: ::c_uint, b: u8, c: u8, d: ::c_int) -> ::c_int {
+    (a<<30) as ::c_int | (b as ::c_int)<<8 | c as ::c_int | d<<16
 }
 
-pub const _IOC_NONE: ::c_int = 0;
-pub const _IOC_WRITE: ::c_int = 1;
-pub const _IOC_READ: ::c_int = 2;
+pub const _IOC_NONE: ::c_uint = 0;
+pub const _IOC_WRITE: ::c_uint = 1;
+pub const _IOC_READ: ::c_uint = 2;
 
 pub fn _IO(a:u8,b:u8) -> ::c_int {
-    _IOC(_IOC_NONE,(a as ::c_int),(b as ::c_int),0)
+    _IOC(_IOC_NONE,a,b,0)
 }
 
 pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_WRITE,a,b,size)
 }
 
 pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_READ,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_READ,a,b,size)
 }
 
 pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_READ|_IOC_WRITE,a,b,size)
 }
 
 pub const SIGSTKSZ: ::size_t = 8192;

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -152,6 +152,33 @@ s! {
     }
 }
 
+pub fn _IOC(a: ::c_int, b: ::c_int,c: ::c_int, d: ::c_int) -> ::c_int {
+    ( (a<<30) | (b<<8) | c | (d<<16) )
+}
+
+pub const _IOC_NONE: ::c_int = 0;
+pub const _IOC_WRITE: ::c_int = 1;
+pub const _IOC_READ: ::c_int = 2;
+
+pub fn _IO(a:u8,b:u8) -> ::c_int {
+    _IOC(_IOC_NONE,(a as ::c_int),(b as ::c_int),0)
+}
+
+pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+}
+
+pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_READ,(a as ::c_int),(b as ::c_int),size)
+}
+
+pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+}
+
 pub const SIGSTKSZ: ::size_t = 8192;
 pub const MINSIGSTKSZ: ::size_t = 2048;
 

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -163,6 +163,33 @@ s! {
     }
 }
 
+pub fn _IOC(a: ::c_int, b: ::c_int,c: ::c_int, d: ::c_int) -> ::c_int {
+    ( (a<<29) | (b<<8) | c | (d<<16) )
+}
+
+pub const _IOC_NONE: ::c_int = 1;
+pub const _IOC_READ: ::c_int = 2;
+pub const _IOC_WRITE: ::c_int = 4;
+
+pub fn _IO(a:u8,b:u8) -> ::c_int {
+    _IOC(_IOC_NONE,(a as ::c_int),(b as ::c_int),0)
+}
+
+pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+}
+
+pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_READ,(a as ::c_int),(b as ::c_int),size)
+}
+
+pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+}
+
 pub const SIGSTKSZ: ::size_t = 8192;
 pub const MINSIGSTKSZ: ::size_t = 2048;
 

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -163,31 +163,31 @@ s! {
     }
 }
 
-pub fn _IOC(a: ::c_int, b: ::c_int,c: ::c_int, d: ::c_int) -> ::c_int {
-    ( (a<<29) | (b<<8) | c | (d<<16) )
+pub fn _IOC(a: ::c_uint, b: u8, c: u8, d: ::c_int) -> ::c_int {
+    (a<<29) as ::c_int | (b as ::c_int)<<8 | c as ::c_int | d<<16
 }
 
-pub const _IOC_NONE: ::c_int = 1;
-pub const _IOC_READ: ::c_int = 2;
-pub const _IOC_WRITE: ::c_int = 4;
+pub const _IOC_NONE: ::c_uint = 1;
+pub const _IOC_READ: ::c_uint = 2;
+pub const _IOC_WRITE: ::c_uint = 4;
 
 pub fn _IO(a:u8,b:u8) -> ::c_int {
-    _IOC(_IOC_NONE,(a as ::c_int),(b as ::c_int),0)
+    _IOC(_IOC_NONE,a,b,0)
 }
 
 pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_WRITE,a,b,size)
 }
 
 pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_READ,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_READ,a,b,size)
 }
 
 pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_READ|_IOC_WRITE,a,b,size)
 }
 
 pub const SIGSTKSZ: ::size_t = 8192;

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -155,6 +155,33 @@ s! {
     }
 }
 
+pub fn _IOC(a: ::c_int, b: ::c_int,c: ::c_int, d: ::c_int) -> ::c_int {
+    ( (a<<29) | (b<<8) | c | (d<<16) )
+}
+
+pub const _IOC_NONE: ::c_int = 1;
+pub const _IOC_WRITE: ::c_int = 4;
+pub const _IOC_READ: ::c_int = 2;
+
+pub fn _IO(a:u8,b:u8) -> ::c_int {
+    _IOC(_IOC_NONE,(a as ::c_int),(b as ::c_int),0)
+}
+
+pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+}
+
+pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_READ,(a as ::c_int),(b as ::c_int),size)
+}
+
+pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+}
+
 pub const MADV_SOFT_OFFLINE: ::c_int = 101;
 pub const SIGSTKSZ: ::size_t = 10240;
 pub const MINSIGSTKSZ: ::size_t = 4096;

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -155,31 +155,31 @@ s! {
     }
 }
 
-pub fn _IOC(a: ::c_int, b: ::c_int,c: ::c_int, d: ::c_int) -> ::c_int {
-    ( (a<<29) | (b<<8) | c | (d<<16) )
+pub fn _IOC(a: ::c_uint, b: u8, c: u8, d: ::c_int) -> ::c_int {
+    (a<<29) as ::c_int | (b as as ::c_int)<<8 | c as as ::c_int | d<<16
 }
 
-pub const _IOC_NONE: ::c_int = 1;
-pub const _IOC_WRITE: ::c_int = 4;
-pub const _IOC_READ: ::c_int = 2;
+pub const _IOC_NONE: ::c_uint = 1;
+pub const _IOC_WRITE: ::c_uint = 4;
+pub const _IOC_READ: ::c_uint = 2;
 
 pub fn _IO(a:u8,b:u8) -> ::c_int {
-    _IOC(_IOC_NONE,(a as ::c_int),(b as ::c_int),0)
+    _IOC(_IOC_NONE,a,b,0)
 }
 
 pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_WRITE,a,b,size)
 }
 
 pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_READ,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_READ,a,b,size)
 }
 
 pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_READ|_IOC_WRITE,a,b,size)
 }
 
 pub const MADV_SOFT_OFFLINE: ::c_int = 101;

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -156,7 +156,7 @@ s! {
 }
 
 pub fn _IOC(a: ::c_uint, b: u8, c: u8, d: ::c_int) -> ::c_int {
-    (a<<29) as ::c_int | (b as as ::c_int)<<8 | c as as ::c_int | d<<16
+    (a<<29) as ::c_int | (b as ::c_int)<<8 | c as ::c_int | d<<16
 }
 
 pub const _IOC_NONE: ::c_uint = 1;

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -213,7 +213,7 @@ cfg_if! {
 }
 
 pub fn _IOC(a: ::c_uint, b: u8, c: u8, d: ::c_int) -> ::c_int {
-    ( (a<<30) as ::c_int | (b as ::c_int)<<8 | c as ::c_int | (d<<16) )
+    (a<<30) as ::c_int | (b as ::c_int)<<8 | c as ::c_int | (d<<16)
 }
 
 pub const _IOC_NONE: ::c_uint = 0;

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -212,6 +212,33 @@ cfg_if! {
     }
 }
 
+pub fn _IOC(a: ::c_int, b: ::c_int,c: ::c_int, d: ::c_int) -> ::c_int {
+    ( (a<<30) | (b<<8) | c | (d<<16) )
+}
+
+pub const _IOC_NONE: ::c_int = 0;
+pub const _IOC_WRITE: ::c_int = 1;
+pub const _IOC_READ: ::c_int = 2;
+
+pub fn _IO(a:u8,b:u8) -> ::c_int {
+    _IOC(_IOC_NONE,(a as ::c_int),(b as ::c_int),0)
+}
+
+pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+}
+
+pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_READ,(a as ::c_int),(b as ::c_int),size)
+}
+
+pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+}
+
 pub const SIGSTKSZ: ::size_t = 8192;
 pub const MINSIGSTKSZ: ::size_t = 2048;
 

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -212,31 +212,31 @@ cfg_if! {
     }
 }
 
-pub fn _IOC(a: ::c_int, b: ::c_int,c: ::c_int, d: ::c_int) -> ::c_int {
-    ( (a<<30) | (b<<8) | c | (d<<16) )
+pub fn _IOC(a: ::c_uint, b: u8, c: u8, d: ::c_int) -> ::c_int {
+    ( (a<<30) as ::c_int | (b as ::c_int)<<8 | c as ::c_int | (d<<16) )
 }
 
-pub const _IOC_NONE: ::c_int = 0;
-pub const _IOC_WRITE: ::c_int = 1;
-pub const _IOC_READ: ::c_int = 2;
+pub const _IOC_NONE: ::c_uint = 0;
+pub const _IOC_WRITE: ::c_uint = 1;
+pub const _IOC_READ: ::c_uint = 2;
 
 pub fn _IO(a:u8,b:u8) -> ::c_int {
-    _IOC(_IOC_NONE,(a as ::c_int),(b as ::c_int),0)
+    _IOC(_IOC_NONE,a,b,0)
 }
 
 pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_WRITE,a,b,size)
 }
 
 pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_READ,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_READ,a,b,size)
 }
 
 pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_READ|_IOC_WRITE,a,b,size)
 }
 
 pub const SIGSTKSZ: ::size_t = 8192;

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -62,31 +62,31 @@ s! {
     }
 }
 
-pub fn _IOC(a: ::c_int, b: ::c_int,c: ::c_int, d: ::c_int) -> ::c_int {
-    ( (a<<30) | (b<<8) | c | (d<<16) )
+pub fn _IOC(a: ::c_uint, b: u8, c: u8, d: ::c_int) -> ::c_int {
+    (a<<30) as ::c_int | (b as ::c_int)<<8 | c | (d<<16)
 }
 
-pub const _IOC_NONE: ::c_int = 0;
-pub const _IOC_WRITE: ::c_int = 1;
-pub const _IOC_READ: ::c_int = 2;
+pub const _IOC_NONE: ::c_uint = 0;
+pub const _IOC_WRITE: ::c_uint = 1;
+pub const _IOC_READ: ::c_uint = 2;
 
 pub fn _IO(a:u8,b:u8) -> ::c_int {
-    _IOC(_IOC_NONE,(a as ::c_int),(b as ::c_int),0)
+    _IOC(_IOC_NONE,a,b,0)
 }
 
 pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_WRITE,a,b,size)
 }
 
 pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_READ,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_READ,a,b,size)
 }
 
 pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_READ|_IOC_WRITE,a,b,size)
 }
 
 pub const O_APPEND: ::c_int = 1024;

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -62,6 +62,33 @@ s! {
     }
 }
 
+pub fn _IOC(a: ::c_int, b: ::c_int,c: ::c_int, d: ::c_int) -> ::c_int {
+    ( (a<<30) | (b<<8) | c | (d<<16) )
+}
+
+pub const _IOC_NONE: ::c_int = 0;
+pub const _IOC_WRITE: ::c_int = 1;
+pub const _IOC_READ: ::c_int = 2;
+
+pub fn _IO(a:u8,b:u8) -> ::c_int {
+    _IOC(_IOC_NONE,(a as ::c_int),(b as ::c_int),0)
+}
+
+pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+}
+
+pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_READ,(a as ::c_int),(b as ::c_int),size)
+}
+
+pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+}
+
 pub const O_APPEND: ::c_int = 1024;
 pub const O_DIRECT: ::c_int = 0x10000;
 pub const O_DIRECTORY: ::c_int = 0x4000;

--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -97,6 +97,33 @@ s! {
     }
 }
 
+pub fn _IOC(a: ::c_int, b: ::c_int,c: ::c_int, d: ::c_int) -> ::c_int {
+    ( (a<<29) | (b<<8) | c | (d<<16) )
+}
+
+pub const _IOC_NONE: ::c_int = 1;
+pub const _IOC_READ: ::c_int = 2;
+pub const _IOC_WRITE: ::c_int = 4;
+
+pub fn _IO(a:u8,b:u8) -> ::c_int {
+    _IOC(_IOC_NONE,(a as ::c_int),(b as ::c_int),0)
+}
+
+pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+}
+
+pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_READ,(a as ::c_int),(b as ::c_int),size)
+}
+
+pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+}
+
 pub const SIGSTKSZ: ::size_t = 8192;
 pub const MINSIGSTKSZ: ::size_t = 2048;
 

--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -97,31 +97,31 @@ s! {
     }
 }
 
-pub fn _IOC(a: ::c_int, b: ::c_int,c: ::c_int, d: ::c_int) -> ::c_int {
-    ( (a<<29) | (b<<8) | c | (d<<16) )
+pub fn _IOC(a: ::c_uint, b: u8, c: u8, d: ::c_int) -> ::c_int {
+    (a<<29) as ::c_int | (b as ::c_int)<<8 | c as ::c_int | (d<<16)
 }
 
-pub const _IOC_NONE: ::c_int = 1;
-pub const _IOC_READ: ::c_int = 2;
-pub const _IOC_WRITE: ::c_int = 4;
+pub const _IOC_NONE: ::c_uint = 1;
+pub const _IOC_READ: ::c_uint = 2;
+pub const _IOC_WRITE: ::c_uint = 4;
 
 pub fn _IO(a:u8,b:u8) -> ::c_int {
-    _IOC(_IOC_NONE,(a as ::c_int),(b as ::c_int),0)
+    _IOC(_IOC_NONE,a,b,0)
 }
 
 pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_WRITE,a,b,size)
 }
 
 pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_READ,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_READ,a,b,size)
 }
 
 pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_READ|_IOC_WRITE,a,b,size)
 }
 
 pub const SIGSTKSZ: ::size_t = 8192;

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -61,7 +61,7 @@ s! {
 }
 
 pub fn _IOC(a: ::c_uint, b: u8, c: u8, d: ::c_int) -> ::c_int {
-    (a<<29) as ::c_int | (b as ::c_int)<<8 | c as ::c_int | (d<<16) )
+    (a<<29) as ::c_int | (b as ::c_int)<<8 | c as ::c_int | (d<<16)
 }
 
 pub const _IOC_NONE: ::c_uint = 1;

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -60,31 +60,31 @@ s! {
     }
 }
 
-pub fn _IOC(a: ::c_int, b: ::c_int,c: ::c_int, d: ::c_int) -> ::c_int {
-    ( (a<<29) | (b<<8) | c | (d<<16) )
+pub fn _IOC(a: ::c_uint, b: u8, c: u8, d: ::c_int) -> ::c_int {
+    (a<<29) as ::c_int | (b as ::c_int)<<8 | c as ::c_int | (d<<16) )
 }
 
-pub const _IOC_NONE: ::c_int = 1;
-pub const _IOC_WRITE: ::c_int = 4;
-pub const _IOC_READ: ::c_int = 2;
+pub const _IOC_NONE: ::c_uint = 1;
+pub const _IOC_WRITE: ::c_uint = 4;
+pub const _IOC_READ: ::c_uint = 2;
 
 pub fn _IO(a:u8,b:u8) -> ::c_int {
-    _IOC(_IOC_NONE,(a as ::c_int),(b as ::c_int),0)
+    _IOC(_IOC_NONE,a,b,0)
 }
 
 pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_WRITE,a,b,size)
 }
 
 pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_READ,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_READ,a,b,size)
 }
 
 pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_READ|_IOC_WRITE,a,b,size)
 }
 
 pub const MADV_SOFT_OFFLINE: ::c_int = 101;

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -60,6 +60,33 @@ s! {
     }
 }
 
+pub fn _IOC(a: ::c_int, b: ::c_int,c: ::c_int, d: ::c_int) -> ::c_int {
+    ( (a<<29) | (b<<8) | c | (d<<16) )
+}
+
+pub const _IOC_NONE: ::c_int = 1;
+pub const _IOC_WRITE: ::c_int = 4;
+pub const _IOC_READ: ::c_int = 2;
+
+pub fn _IO(a:u8,b:u8) -> ::c_int {
+    _IOC(_IOC_NONE,(a as ::c_int),(b as ::c_int),0)
+}
+
+pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+}
+
+pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_READ,(a as ::c_int),(b as ::c_int),size)
+}
+
+pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+}
+
 pub const MADV_SOFT_OFFLINE: ::c_int = 101;
 pub const MAP_32BIT: ::c_int = 0x0040;
 pub const O_APPEND: ::c_int = 1024;

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -245,6 +245,35 @@ cfg_if! {
     }
 }
 
+// ioctl macros from bits/ioctl.h (generic)
+
+pub fn _IOC(a: ::c_int, b: ::c_int,c: ::c_int, d: ::c_int) -> ::c_int {
+    ( (a<<30) | (b<<8) | c | (d<<16) )
+}
+
+pub const _IOC_NONE: ::c_int = 0;
+pub const _IOC_WRITE: ::c_int = 1;
+pub const _IOC_READ: ::c_int = 2;
+
+pub fn _IO(a:u8,b:u8) -> ::c_int {
+    _IOC(_IOC_NONE,(a as ::c_int),(b as ::c_int),0)
+}
+
+pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+}
+
+pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_READ,(a as ::c_int),(b as ::c_int),size)
+}
+
+pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_int {
+    let size = ::core::mem::size_of::<T>() as ::c_int;
+    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+}
+
 // Syscall table
 
 pub const SYS_read: ::c_long = 0;

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -247,31 +247,31 @@ cfg_if! {
 
 // ioctl macros from bits/ioctl.h (generic)
 
-pub fn _IOC(a: ::c_int, b: ::c_int,c: ::c_int, d: ::c_int) -> ::c_int {
-    ( (a<<30) | (b<<8) | c | (d<<16) )
+pub fn _IOC(a: ::c_uint, b: u8, c: u8, d: ::c_int) -> ::c_int {
+    (a<<30) as ::c_int | (b as ::c_int)<<8 | c as ::c_int | d<<16
 }
 
-pub const _IOC_NONE: ::c_int = 0;
-pub const _IOC_WRITE: ::c_int = 1;
-pub const _IOC_READ: ::c_int = 2;
+pub const _IOC_NONE: ::c_uint = 0;
+pub const _IOC_WRITE: ::c_uint = 1;
+pub const _IOC_READ: ::c_uint = 2;
 
 pub fn _IO(a:u8,b:u8) -> ::c_int {
-    _IOC(_IOC_NONE,(a as ::c_int),(b as ::c_int),0)
+    _IOC(_IOC_NONE,a,b,0)
 }
 
 pub fn _IOW<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_WRITE,a,b,size)
 }
 
 pub fn _IOR<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_READ,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_READ,a,b,size)
 }
 
 pub fn _IOWR<T: Sized> (a:u8,b:u8) -> ::c_int {
     let size = ::core::mem::size_of::<T>() as ::c_int;
-    _IOC(_IOC_READ|_IOC_WRITE,(a as ::c_int),(b as ::c_int),size)
+    _IOC(_IOC_READ|_IOC_WRITE,a,b,size)
 }
 
 // Syscall table


### PR DESCRIPTION
The `_IOC`, `_IO`, `_IOR`, `_IOW` and `_IOWR` macros, which are exposed by both musl (which redefines them per architecture) and glibc (which includes them from the linux headers) don't currently have equivalents in Rust's libc. Given [there are a lot of ioctls out there](https://www.kernel.org/doc/Documentation/ioctl/ioctl-number.txt) and that [the format is known to be architecture-specific](https://www.kernel.org/doc/html/latest/userspace-api/ioctl/ioctl-decoding.html), not having access to those macros to generate ioctl request numbers means having to duplicate that platform-specific logic elsewhere [like the `nix` crate currently does](https://github.com/nix-rust/nix/blob/master/src/sys/ioctl/linux.rs). Moving these into the libc crate alongside all of the other musl/glibc would (as far as I can tell) be more in line with the goals of this crate.

With that said, I'm currently having trouble figuring out how those should be tested. Most of the ioctl codes currently defined in libc follow the short 16 bits format, and the few of them using the longer format are architecture-specific redefinitions, [like `TIOCGPGRP`](https://github.com/torvalds/linux/search?q=TIOCGPGRP+filename%3Aioctls.h&unscoped_q=TIOCGPGRP+filename%3Aioctls.h) which is is defined as `0x540F` in asm-generic but as `_IOR('t', 119, int)` for mips and powerpc and as `_IOR('t', 131, int)` for sparc, so testing by ensuring that the manual ioctl definitions match the macro's output most likely wouldn't work. We could always use a list of driver-specific IOCTLs with known type letters and sequence numbers and testing that those match with the kernel headers ones, but I'm not familiar enough with the way the tests are setup to get that to work.

Another thing I'm not sure how to do is declaring those as const_fn, especially since I would need `size_of` to be const_fn as well for that to work. I know there is a `libc_const_size_of` config switch for that and I have noticed that macros are available for this as well, but the macros are undocumented and thier usage is unclear, so I've left those as plain functions for now.

The reason why the definitions don't follow the same format between musl and glibc is that I was attempting to mimic how [musl defines its own macros per architecture](https://git.musl-libc.org/cgit/musl/tree/arch/generic/bits/ioctl.h) while [glibc imports them from the kernel header files](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/bits/ioctls.h) where platform-specific constants [tend to be defined in the platform-specific headers](https://github.com/torvalds/linux/blob/master/arch/powerpc/include/uapi/asm/ioctl.h) which then [re-use the generic macro](https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/ioctl.h). I'm not entirely sure whether this is preferable to sticking to one way or the other.

I'm open to suggestions on what the best way of handling this is, or if someone thinks this may not actually belong in libc.