### PR TITLE
Switch macOS images to 10.14

### DIFF
--- a/ci/azure.yml
+++ b/ci/azure.yml
@@ -189,7 +189,7 @@ jobs:
   - job: BuildChannelsOSX
     dependsOn: StyleAndDocs
     pool:
-      vmImage: macos-10.13
+      vmImage: macos-10.14
     steps:
       - template: azure-install-rust.yml
       - script: LIBC_CI=1 sh ./ci/build.sh


### PR DESCRIPTION
[Pipelines will remove macOS-10.13 builder](https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/), let's switch to 10.14.