### PR TITLE
Update badges metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ Raw FFI bindings to platform libraries like libc.
 """
 
 [badges]
-travis-ci = { repository = "rust-lang/libc" }
-appveyor = { repository = "rust-lang/libc", project_name = "rust-lang-libs/libc" }
+cirrus-ci = { repository = "rust-lang/libc", branch = "master" }
+azure-devops = { project = "rust-lang2/libc", pipeline = "rust-lang.libc%20(1)" }
 
 [dependencies]
 rustc-std-workspace-core = { version = "1.0.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in `libc` by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
-[Azure Status]: https://dev.azure.com/rust-lang2/libc/_apis/build/status/rust-lang.libc?branchName=master
+[Azure Status]: https://dev.azure.com/rust-lang2/libc/_apis/build/status/rust-lang.libc%20(1)?branchName=master
 [Azure]: https://dev.azure.com/rust-lang2/libc/_build/latest?definitionId=1&branchName=master
 [Cirrus CI]: https://cirrus-ci.com/github/rust-lang/libc
 [Cirrus CI Status]: https://api.cirrus-ci.com/github/rust-lang/libc.svg


### PR DESCRIPTION
We use pipelines and cirrus as CI, we should releace badges metadata.
Also fix pipeline badge on README to point to actual pipeline.

r? @ghost