### PR TITLE
Reduce checks for demoted apple 32-bit targets

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -137,13 +137,6 @@ x86_64-apple-darwin \
 x86_64-apple-ios \
 "
 
-RUST_LT_1_42_OSX_TARGETS="\
-armv7-apple-ios \
-armv7s-apple-ios \
-i386-apple-ios \
-i686-apple-darwin \
-"
-
 # The targets are listed here alphabetically
 TARGETS=""
 case "${OS}" in
@@ -167,12 +160,6 @@ case "${OS}" in
         ;;
     osx*)
         TARGETS="${RUST_OSX_TARGETS}"
-
-        if [ "${RUST}" != "nightly" ]; then
-            if [ "${RUST}" != "beta" ]; then
-                TARGETS="${TARGETS} ${RUST_LT_1_42_OSX_TARGETS}"
-            fi
-        fi
         ;;
     *)
         ;;


### PR DESCRIPTION
Apple 32-bit targets are demoted in latest stable, we should reduce support level also here.

r? @ghost