### PR TITLE
Add missing AT_ constants

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -1966,6 +1966,7 @@ pub const POSIX_FADV_WILLNEED: ::c_int = 3;
 pub const AT_FDCWD: ::c_int = -100;
 pub const AT_SYMLINK_NOFOLLOW: ::c_int = 0x100;
 pub const AT_REMOVEDIR: ::c_int = 0x200;
+pub const AT_EACCESS: ::c_int = 0x200;
 pub const AT_SYMLINK_FOLLOW: ::c_int = 0x400;
 pub const AT_NO_AUTOMOUNT: ::c_int = 0x800;
 pub const AT_EMPTY_PATH: ::c_int = 0x1000;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1205,6 +1205,8 @@ pub const RTLD_DEFAULT: *mut ::c_void = 0i64 as *mut ::c_void;
 pub const RTLD_NODELETE: ::c_int = 0x1000;
 pub const RTLD_NOW: ::c_int = 0x2;
 
+pub const AT_EACCESS: ::c_int = 0x200;
+
 pub const TCP_MD5SIG: ::c_int = 14;
 
 align_const! {

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1102,6 +1102,10 @@ pub const WNOWAIT: ::c_int = 0x80;
 
 pub const AT_FDCWD: ::c_int = 0xffd19553;
 pub const AT_SYMLINK_NOFOLLOW: ::c_int = 0x1000;
+pub const AT_SYMLINK_FOLLOW: ::c_int = 0x2000;
+pub const AT_REMOVEDIR: ::c_int = 0x1;
+pub const _AT_TRIGGER: ::c_int = 0x2;
+pub const AT_EACCESS: ::c_int = 0x4;
 
 pub const P_PID: idtype_t = 0;
 pub const P_PPID: idtype_t = 1;

--- a/src/unix/uclibc/mod.rs
+++ b/src/unix/uclibc/mod.rs
@@ -1045,6 +1045,7 @@ pub const POSIX_FADV_WILLNEED: ::c_int = 3;
 pub const AT_FDCWD: ::c_int = -100;
 pub const AT_SYMLINK_NOFOLLOW: ::c_int = 0x100;
 pub const AT_REMOVEDIR: ::c_int = 0x200;
+pub const AT_EACCESS: ::c_int = 0x200;
 pub const AT_SYMLINK_FOLLOW: ::c_int = 0x400;
 
 pub const LOG_CRON: ::c_int = 9 << 3;


### PR DESCRIPTION
This adds `AT_EACCESS` to Linux, Fuchsia and Solaris, and also adds the other missing AT_ constants to Solaris as found in OpenSolaris and Illumos.

`AT_EACCESS` is needed for `faccessat()` to perform effective user/group checks.