### PR TITLE
Enable `s390x-unknown-linux-gnu` on CI

### DIFF
--- a/ci/azure.yml
+++ b/ci/azure.yml
@@ -70,8 +70,8 @@ jobs:
           TARGET: powerpc64-unknown-linux-gnu
         powerpc64le-unknown-linux-gnu:
           TARGET: powerpc64le-unknown-linux-gnu
-        #s390x-unknown-linux-gnu:
-        #  TARGET: s390x-unknown-linux-gnu
+        s390x-unknown-linux-gnu:
+          TARGET: s390x-unknown-linux-gnu
         #wasm32-wasi
         #  TARGET: wasm32-wasi
         sparc64-unknown-linux-gnu:

--- a/ci/linux-s390x.sh
+++ b/ci/linux-s390x.sh
@@ -6,8 +6,8 @@ mkdir -m 777 /qemu
 cd /qemu
 
 curl --retry 5 -LO https://github.com/qemu/qemu/raw/master/pc-bios/s390-ccw.img
-curl --retry 5 -LO http://ftp.debian.org/debian/dists/testing/main/installer-s390x/20190410/images/generic/kernel.debian
-curl --retry 5 -LO http://ftp.debian.org/debian/dists/testing/main/installer-s390x/20190410/images/generic/initrd.debian
+curl --retry 5 -LO http://ftp.debian.org/debian/dists/testing/main/installer-s390x/20191129/images/generic/kernel.debian
+curl --retry 5 -LO http://ftp.debian.org/debian/dists/testing/main/installer-s390x/20191129/images/generic/initrd.debian
 
 mv kernel.debian kernel
 mv initrd.debian initrd.gz

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2531,6 +2531,8 @@ fn test_linux(target: &str) {
         "utsname" if mips32 || mips64 => true,
         // FIXME:
         "mcontext_t" if s390x => true,
+        // FIXME: This is actually a union.
+        "fpreg_t" if s390x => true,
 
         "sockaddr_un" | "sembuf" | "ff_constant_effect"
             if mips32 && (gnu || musl) =>


### PR DESCRIPTION
Let's check if this target works well, we should add FIXME comment at least if it doesn't.
r? @ghost