### PR TITLE
Add accept4() for NetBSD, Illumos and Solaris

### DIFF
--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -632,6 +632,12 @@ extern "C" {
     ) -> ::c_int;
 
     pub fn daemon(nochdir: ::c_int, noclose: ::c_int) -> ::c_int;
+    pub fn accept4(
+        s: ::c_int,
+        addr: *mut ::sockaddr,
+        addrlen: *mut ::socklen_t,
+        flags: ::c_int,
+    ) -> ::c_int;
     pub fn mincore(
         addr: *mut ::c_void,
         len: ::size_t,

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1393,12 +1393,6 @@ extern "C" {
         tp: *const ::timeval,
         tz: *const ::timezone,
     ) -> ::c_int;
-    pub fn accept4(
-        s: ::c_int,
-        addr: *mut ::sockaddr,
-        addrlen: *mut ::socklen_t,
-        flags: ::c_int,
-    ) -> ::c_int;
     pub fn execvpe(
         file: *const ::c_char,
         argv: *const *const ::c_char,

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2347,6 +2347,12 @@ extern "C" {
         msg: *mut ::msghdr,
         flags: ::c_int,
     ) -> ::ssize_t;
+    pub fn accept4(
+        fd: ::c_int,
+        address: *mut sockaddr,
+        address_len: *mut socklen_t,
+        flags: ::c_int
+    ) -> ::c_int;
 
     pub fn mq_open(name: *const ::c_char, oflag: ::c_int, ...) -> ::mqd_t;
     pub fn mq_close(mqd: ::mqd_t) -> ::c_int;


### PR DESCRIPTION
NetBSD (became available with 8.0): [header](http://cvsweb.netbsd.org/bsdweb.cgi/src/sys/sys/socket.h?annotate=1.129&only_with_tag=MAIN), [implementation](http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/sys/accept4.c?annotate=1.2&only_with_tag=MAIN)
Illumos: [manpage](https://illumos.org/man/3socket/accept), [header](https://github.com/illumos/illumos-gate/blob/master/usr/src/uts/common/sys/socket.h), [definition](https://github.com/illumos/illumos-gate/blob/master/usr/src/lib/libsocket/socket/weaks.c)
Solaris: [manpage](https://docs.oracle.com/cd/E88353_01/html/E37843/accept-3c.html)

I've tested it on NetBSD 8.0 and OmniOSce 5.11.

Fixes #1636