### PR TITLE
ci: allow overriding run-docker.sh CARGO_HOME.

### DIFF
--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -5,6 +5,13 @@
 
 set -ex
 
+# Default to assuming the CARGO_HOME is one directory up (to account for a `bin`
+# subdir) from where the `cargo` binary in `$PATH` lives.
+DEFAULT_CARGO_HOME="$(dirname "$(dirname "$(command -v cargo)")")"
+# If the CARGO_HOME env var is already set, use that. If it isn't set use the
+# default.
+CARGO_HOME="${CARGO_HOME:-$DEFAULT_CARGO_HOME}"
+
 echo "${HOME}"
 pwd
 
@@ -26,7 +33,7 @@ run() {
       --env LIBC_CI \
       --env CARGO_HOME=/cargo \
       --env CARGO_TARGET_DIR=/checkout/target \
-      --volume "$(dirname "$(dirname "$(command -v cargo)")")":/cargo \
+      --volume "$CARGO_HOME":/cargo \
       --volume "$(rustc --print sysroot)":/rust:ro \
       --volume "$(pwd)":/checkout:ro \
       --volume "$(pwd)"/target:/checkout/target \


### PR DESCRIPTION
The `ci/run-docker.sh` utility script adds a `--volume` argument to the `docker` command to mount the Cargo home directory of the host machine into the container at `/cargo`.

Prior to this patch the host's Cargo home directory is assumed to be the `dirname` of the `dirname` of the `cargo` command's path. That works in most cases where the host machine installed rust with vanilla `rustup`. It may fail if the host machine used a different method.

As one concrete example if the host machine used the [Archlinux rustup package](https://wiki.archlinux.org/index.php/rust#Arch_Linux_package) then `cargo` is installed to `/usr/bin/cargo` and the `run-docker.sh` script incorrectly mounts `/usr` to the `/cargo` directory of the test container.

This patch allows specifying an explicit `CARGO_HOME` to the `ci/run-docker.sh` script so that users with a non-standard cargo dir can use the utility without modification. By default if no `CARGO_HOME` is set then the legacy behaviour is used and `CARGO_HOME` defaults to the `dirname` of the `dirname` of the `cargo` command.