### PR TITLE
Split up Solaris and illumos targets

### DIFF
--- a/libc-test/test/cmsg.rs
+++ b/libc-test/test/cmsg.rs
@@ -4,6 +4,7 @@
 extern crate libc;
 
 #[cfg(unix)]
+#[cfg(not(any(target_os = "solaris", target_os = "illumos")))]
 mod t {
 
     use libc::{self, c_uchar, c_uint, c_void, cmsghdr, msghdr};

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -226,8 +226,12 @@ pub const S_ISUID: ::mode_t = 0x800;
 pub const S_ISGID: ::mode_t = 0x400;
 pub const S_ISVTX: ::mode_t = 0x200;
 
-pub const IF_NAMESIZE: ::size_t = 16;
-pub const IFNAMSIZ: ::size_t = IF_NAMESIZE;
+cfg_if! {
+    if #[cfg(not(any(target_os = "illumos", target_os = "solaris")))] {
+        pub const IF_NAMESIZE: ::size_t = 16;
+        pub const IFNAMSIZ: ::size_t = IF_NAMESIZE;
+    }
+}
 
 pub const LOG_EMERG: ::c_int = 0;
 pub const LOG_ALERT: ::c_int = 1;
@@ -611,7 +615,6 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "listen$UNIX2003"
     )]
-    #[cfg_attr(target_os = "illumos", link_name = "__xnet_listen")]
     pub fn listen(socket: ::c_int, backlog: ::c_int) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
@@ -854,6 +857,7 @@ extern "C" {
     pub fn geteuid() -> uid_t;
     pub fn getgid() -> gid_t;
     pub fn getgroups(ngroups_max: ::c_int, groups: *mut gid_t) -> ::c_int;
+    #[cfg_attr(target_os = "illumos", link_name = "getloginx")]
     pub fn getlogin() -> *mut c_char;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
@@ -910,6 +914,7 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "ttyname_r$UNIX2003"
     )]
+    #[cfg_attr(target_os = "illumos", link_name = "__posix_ttyname_r")]
     pub fn ttyname_r(
         fd: ::c_int,
         buf: *mut c_char,
@@ -1216,6 +1221,7 @@ extern "C" {
     pub fn dlclose(handle: *mut ::c_void) -> ::c_int;
     pub fn dladdr(addr: *const ::c_void, info: *mut Dl_info) -> ::c_int;
 
+    #[cfg_attr(target_os = "illumos", link_name = "__xnet_getaddrinfo")]
     pub fn getaddrinfo(
         node: *const c_char,
         service: *const c_char,

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -1,0 +1,27 @@
+s! {
+    pub struct shmid_ds {
+        pub shm_perm: ::ipc_perm,
+        pub shm_segsz: ::size_t,
+        pub shm_amp: *mut ::c_void,
+        pub shm_lkcnt: ::c_ushort,
+        pub shm_lpid: ::pid_t,
+        pub shm_cpid: ::pid_t,
+        pub shm_nattch: ::shmatt_t,
+        pub shm_cnattch: ::c_ulong,
+        pub shm_atime: ::time_t,
+        pub shm_dtime: ::time_t,
+        pub shm_ctime: ::time_t,
+        pub shm_pad4: [i64; 4],
+    }
+}
+
+pub const AF_LOCAL: ::c_int = 1; // AF_UNIX
+pub const AF_FILE: ::c_int = 1; // AF_UNIX
+
+extern "C" {
+    pub fn mincore(
+        addr: ::caddr_t,
+        len: ::size_t,
+        vec: *mut ::c_char,
+    ) -> ::c_int;
+}

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -1,0 +1,94 @@
+pub type door_attr_t = ::c_uint;
+pub type door_id_t = ::c_ulonglong;
+
+s! {
+    pub struct shmid_ds {
+        pub shm_perm: ::ipc_perm,
+        pub shm_segsz: ::size_t,
+        pub shm_flags: ::uintptr_t,
+        pub shm_lkcnt: ::c_ushort,
+        pub shm_lpid: ::pid_t,
+        pub shm_cpid: ::pid_t,
+        pub shm_nattch: ::shmatt_t,
+        pub shm_cnattch: ::c_ulong,
+        pub shm_atime: ::time_t,
+        pub shm_dtime: ::time_t,
+        pub shm_ctime: ::time_t,
+        pub shm_amp: *mut ::c_void,
+        pub shm_gransize: u64,
+        pub shm_allocated: u64,
+        pub shm_pad4: [i64; 1],
+    }
+
+    pub struct door_desc_t__d_data__d_desc {
+        pub d_descriptor: ::c_int,
+        pub d_id: ::door_id_t
+    }
+}
+
+pub const PORT_SOURCE_POSTWAIT: ::c_int = 8;
+pub const PORT_SOURCE_SIGNAL: ::c_int = 9;
+
+pub const EPOLLEXCLUSIVE: ::c_int = 0x10000000;
+
+pub const AF_LOCAL: ::c_int = 0;
+pub const AF_FILE: ::c_int = 0;
+
+extern "C" {
+    pub fn fexecve(
+        fd: ::c_int,
+        argv: *const *const ::c_char,
+        envp: *const *const ::c_char,
+    ) -> ::c_int;
+
+    pub fn mincore(
+        addr: *const ::c_void,
+        len: ::size_t,
+        vec: *mut ::c_char,
+    ) -> ::c_int;
+
+    pub fn door_call(d: ::c_int, params: *const door_arg_t) -> ::c_int;
+    pub fn door_return(
+        data_ptr: *const ::c_char,
+        data_size: ::size_t,
+        desc_ptr: *const door_desc_t,
+        num_desc: ::c_uint,
+    );
+    pub fn door_create(
+        server_procedure: extern "C" fn(
+            cookie: *const ::c_void,
+            argp: *const ::c_char,
+            arg_size: ::size_t,
+            dp: *const door_desc_t,
+            n_desc: ::c_uint,
+        ),
+        cookie: *const ::c_void,
+        attributes: door_attr_t,
+    ) -> ::c_int;
+
+    pub fn fattach(fildes: ::c_int, path: *const ::c_char) -> ::c_int;
+}
+
+s_no_extra_traits! {
+    #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
+    pub union door_desc_t__d_data {
+        pub d_desc: door_desc_t__d_data__d_desc,
+        d_resv: [::c_int; 5], /* Check out /usr/include/sys/door.h */
+    }
+
+    #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
+    pub struct door_desc_t {
+        pub d_attributes: door_attr_t,
+        pub d_data: door_desc_t__d_data,
+    }
+
+    #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
+    pub struct door_arg_t {
+        pub data_ptr: *const ::c_char,
+        pub data_size: ::size_t,
+        pub desc_ptr: *const door_desc_t,
+        pub dec_num: ::c_uint,
+        pub rbuf: *const ::c_char,
+        pub rsize: ::size_t,
+    }
+}


### PR DESCRIPTION
While they share a common lineage, Solaris and illumos are distinct (and diverging) platforms which should be handled differently in libc.  This PR splits them up and addresses some all of the `libc-test` failures which appeared on illumos.  I have a separate branch for the `libc-test` updates, but given that `ctest` does not support illumos today, and the maintainer appears to be absent, those updates only function with that dependency overridden.

This is one of the last remaining pre-req updates required for rust-lang/rust#55553