### PR TITLE
Add strsignal(3) to unix

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -538,6 +538,7 @@ extern "C" {
     pub fn strerror(n: c_int) -> *mut c_char;
     pub fn strtok(s: *mut c_char, t: *const c_char) -> *mut c_char;
     pub fn strxfrm(s: *mut c_char, ct: *const c_char, n: size_t) -> size_t;
+    pub fn strsignal(sig: c_int) -> *mut c_char;
     pub fn wcslen(buf: *const wchar_t) -> size_t;
     pub fn wcstombs(
         dest: *mut c_char,


### PR DESCRIPTION
This does not add sys_siglist because the docs specify that the function
should be used instead, whenever possible.

Note: Draft PR until the CI is finished.