### PR TITLE
Update Ubuntu images to 20.04

### DIFF
--- a/ci/android-install-ndk.sh
+++ b/ci/android-install-ndk.sh
@@ -33,7 +33,7 @@ case "$1" in
     ;;
 esac;
 
-${NDK}/build/tools/make_standalone_toolchain.py \
+python3 ${NDK}/build/tools/make_standalone_toolchain.py \
         --install-dir "/android/ndk-${1}" \
         --arch "${arch}" \
         --api ${api}

--- a/ci/docker/aarch64-linux-android/Dockerfile
+++ b/ci/docker/aarch64-linux-android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN dpkg --add-architecture i386 && \
     apt-get update && \

--- a/ci/docker/aarch64-linux-android/Dockerfile
+++ b/ci/docker/aarch64-linux-android/Dockerfile
@@ -6,7 +6,8 @@ RUN dpkg --add-architecture i386 && \
   file \
   curl \
   ca-certificates \
-  python \
+  python3 \
+  python3-distutils \
   unzip \
   expect \
   openjdk-8-jre \

--- a/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc libc6-dev ca-certificates \
   gcc-aarch64-linux-gnu libc6-dev-arm64-cross qemu-user

--- a/ci/docker/aarch64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc make libc6-dev git curl ca-certificates \

--- a/ci/docker/arm-linux-androideabi/Dockerfile
+++ b/ci/docker/arm-linux-androideabi/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN dpkg --add-architecture i386 && \
     apt-get update && \

--- a/ci/docker/arm-linux-androideabi/Dockerfile
+++ b/ci/docker/arm-linux-androideabi/Dockerfile
@@ -6,7 +6,8 @@ RUN dpkg --add-architecture i386 && \
   file \
   curl \
   ca-certificates \
-  python \
+  python3 \
+  python3-distutils \
   unzip \
   expect \
   openjdk-8-jre \

--- a/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc libc6-dev ca-certificates \
   gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user

--- a/ci/docker/arm-unknown-linux-musleabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-musleabihf/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc make libc6-dev git curl ca-certificates \

--- a/ci/docker/asmjs-unknown-emscripten/Dockerfile
+++ b/ci/docker/asmjs-unknown-emscripten/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/ci/docker/asmjs-unknown-emscripten/Dockerfile
+++ b/ci/docker/asmjs-unknown-emscripten/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && \
     git \
     libc6-dev \
     libxml2 \
-    python \
+    python3 \
+    python3-distutils \
     xz-utils
 
 COPY emscripten.sh /

--- a/ci/docker/i686-linux-android/Dockerfile
+++ b/ci/docker/i686-linux-android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN dpkg --add-architecture i386 && \
     apt-get update && \

--- a/ci/docker/i686-linux-android/Dockerfile
+++ b/ci/docker/i686-linux-android/Dockerfile
@@ -6,7 +6,8 @@ RUN dpkg --add-architecture i386 && \
   file \
   curl \
   ca-certificates \
-  python \
+  python3 \
+  python3-distutils \
   unzip \
   expect \
   openjdk-8-jre \

--- a/ci/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/i686-unknown-linux-gnu/Dockerfile
@@ -1,3 +1,5 @@
+# FIXME: Somehow we encounter a panic with Ubuntu 20.04.
+# Should investigate why it causes and fix.
 FROM ubuntu:19.10
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \

--- a/ci/docker/i686-unknown-linux-musl/Dockerfile
+++ b/ci/docker/i686-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN dpkg --add-architecture i386
 RUN apt-get update

--- a/ci/docker/mips-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mips-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates qemu-system-mips curl \

--- a/ci/docker/mips64-unknown-linux-muslabi64/Dockerfile
+++ b/ci/docker/mips64-unknown-linux-muslabi64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc make libc6-dev git curl ca-certificates \

--- a/ci/docker/mips64el-unknown-linux-muslabi64/Dockerfile
+++ b/ci/docker/mips64el-unknown-linux-muslabi64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc make libc6-dev git curl ca-certificates \

--- a/ci/docker/mipsel-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mipsel-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates qemu-system-mipsel curl \

--- a/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/ci/docker/s390x-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/s390x-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl ca-certificates \

--- a/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl ca-certificates \

--- a/ci/docker/wasm32-unknown-emscripten/Dockerfile
+++ b/ci/docker/wasm32-unknown-emscripten/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/ci/docker/wasm32-unknown-emscripten/Dockerfile
+++ b/ci/docker/wasm32-unknown-emscripten/Dockerfile
@@ -11,12 +11,15 @@ RUN apt-get update && \
     git \
     libc6-dev \
     libxml2 \
-    python \
+    python3 \
+    python3-distutils \
     cmake \
     sudo \
     gdb \
     xz-utils
 
+RUN ln -s /usr/bin/python3 /usr/bin/python & \
+    ln -s /usr/bin/pip3 /usr/bin/pip
 COPY emscripten.sh /
 RUN bash /emscripten.sh
 

--- a/ci/docker/wasm32-unknown-emscripten/Dockerfile
+++ b/ci/docker/wasm32-unknown-emscripten/Dockerfile
@@ -1,7 +1,12 @@
 FROM ubuntu:20.04
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+# This is a workaround to avoid the interaction with tzdata.
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/New_York
+
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends tzdata
+RUN apt-get install -y --no-install-recommends \
     ca-certificates \
     g++ \
     make \

--- a/ci/docker/wasm32-wasi/Dockerfile
+++ b/ci/docker/wasm32-wasi/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/ci/docker/x86_64-linux-android/Dockerfile
+++ b/ci/docker/x86_64-linux-android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/ci/docker/x86_64-linux-android/Dockerfile
+++ b/ci/docker/x86_64-linux-android/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update && \
   curl \
   gcc \
   libc-dev \
-  python \
+  python3 \
+  python3-distutils \
   unzip
 
 WORKDIR /android/

--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
   gcc libc6-dev ca-certificates linux-headers-generic

--- a/ci/docker/x86_64-unknown-linux-gnux32/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnux32/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
   gcc-multilib libc6-dev ca-certificates

--- a/ci/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \

--- a/ci/linux-sparc64.sh
+++ b/ci/linux-sparc64.sh
@@ -5,10 +5,10 @@ set -ex
 mkdir -m 777 /qemu
 cd /qemu
 
-curl --retry 5 -LO https://cdimage.debian.org/cdimage/ports/10.0/sparc64/iso-cd/debian-10.0-sparc64-NETINST-1.iso
-7z e debian-10.0-sparc64-NETINST-1.iso boot/initrd.gz
-7z e debian-10.0-sparc64-NETINST-1.iso boot/sparc64
-mv sparc64 kernel
+curl --retry 5 -LO https://cdimage.debian.org/cdimage/ports/2020-04-19/debian-10.0-sparc64-NETINST-1.iso
+7z e debian-10.0-sparc64-NETINST-1.iso install/initrd.gz
+7z e debian-10.0-sparc64-NETINST-1.iso install/vmlinux
+mv vmlinux kernel
 rm debian-10.0-sparc64-NETINST-1.iso
 
 mkdir init


### PR DESCRIPTION
I'd like to wait until the actual release date (Apr. 23) and the image is updated but it'd be nice to find any failures before then.