### PR TITLE
Remove license headers

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2014 The Rust Project Developers
+Copyright (c) 2014-2020 The Rust Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/ci/android-install-ndk.sh
+++ b/ci/android-install-ndk.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env sh
+
 set -ex
 
 NDK=android-ndk-r19c

--- a/ci/android-install-ndk.sh
+++ b/ci/android-install-ndk.sh
@@ -1,14 +1,3 @@
-#!/usr/bin/env sh
-# Copyright 2016 The Rust Project Developers. See the COPYRIGHT
-# file at the top-level directory of this distribution and at
-# http://rust-lang.org/COPYRIGHT.
-#
-# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-# option. This file may not be copied, modified, or distributed
-# except according to those terms.
-
 set -ex
 
 NDK=android-ndk-r19c

--- a/ci/android-install-sdk.sh
+++ b/ci/android-install-sdk.sh
@@ -1,14 +1,3 @@
-#!/usr/bin/env sh
-# Copyright 2016 The Rust Project Developers. See the COPYRIGHT
-# file at the top-level directory of this distribution and at
-# http://rust-lang.org/COPYRIGHT.
-#
-# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-# option. This file may not be copied, modified, or distributed
-# except according to those terms.
-
 set -ex
 
 # Prep the SDK and emulator

--- a/ci/android-install-sdk.sh
+++ b/ci/android-install-sdk.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env sh
+
 set -ex
 
 # Prep the SDK and emulator

--- a/ci/android-sysimage.sh
+++ b/ci/android-sysimage.sh
@@ -1,15 +1,3 @@
-#!/usr/bin/env bash
-
-# Copyright 2017 The Rust Project Developers. See the COPYRIGHT
-# file at the top-level directory of this distribution and at
-# http://rust-lang.org/COPYRIGHT.
-#
-# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-# option. This file may not be copied, modified, or distributed
-# except according to those terms.
-
 set -ex
 
 URL=https://dl.google.com/android/repository/sys-img/android

--- a/ci/android-sysimage.sh
+++ b/ci/android-sysimage.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -ex
 
 URL=https://dl.google.com/android/repository/sys-img/android

--- a/ci/emscripten-entry.sh
+++ b/ci/emscripten-entry.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -ex
 
 # shellcheck disable=SC1091

--- a/ci/emscripten-entry.sh
+++ b/ci/emscripten-entry.sh
@@ -1,14 +1,3 @@
-#!/usr/bin/env bash
-# Copyright 2017 The Rust Project Developers. See the COPYRIGHT
-# file at the top-level directory of this distribution and at
-# http://rust-lang.org/COPYRIGHT.
-#
-# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-# option. This file may not be copied, modified, or distributed
-# except according to those terms.
-
 set -ex
 
 # shellcheck disable=SC1091

--- a/ci/emscripten.sh
+++ b/ci/emscripten.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -ex
 
 hide_output() {

--- a/ci/emscripten.sh
+++ b/ci/emscripten.sh
@@ -1,14 +1,3 @@
-#!/usr/bin/env bash
-# Copyright 2017 The Rust Project Developers. See the COPYRIGHT
-# file at the top-level directory of this distribution and at
-# http://rust-lang.org/COPYRIGHT.
-#
-# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-# option. This file may not be copied, modified, or distributed
-# except according to those terms.
-
 set -ex
 
 hide_output() {

--- a/ci/ios/deploy_and_run_on_ios_simulator.rs
+++ b/ci/ios/deploy_and_run_on_ios_simulator.rs
@@ -1,13 +1,3 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 // This is a script to deploy and execute a binary on an iOS simulator.
 // The primary use of this is to be able to run unit tests on the simulator and
 // retrieve the results.

--- a/src/hermit/mod.rs
+++ b/src/hermit/mod.rs
@@ -1,13 +1,3 @@
-// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 // libc port for HermitCore (https://hermitcore.org)
 //
 // Ported by Colin Fink <colin.finck@rwth-aachen.de>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,3 @@
-// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
 //! libc - Raw FFI bindings to platforms' system libraries
 //!
 //! [Documentation for other platforms][pd].

--- a/src/unix/hermit/mod.rs
+++ b/src/unix/hermit/mod.rs
@@ -1,13 +1,3 @@
-// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 // liblibc port for HermitCore (https://hermitcore.org)
 // HermitCore is a unikernel based on lwIP, newlib, and
 // pthread-embedded.


### PR DESCRIPTION
Some projects on the rust-lang org removed the license headers, I think we can do so here.
r? @alexcrichton 