### PR TITLE
Bump version to 0.2.69

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.68"
+version = "0.2.69"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
I'd like to use lockf (#1708) and POSIX regexes (#1719) in my project, so I'd appreciate a new libc release. It's been 27 days and 46 commits since 0.2.68, so I think I won't be the only one benefiting.