### PR TITLE
REG_ENOSYS is NetBSD specific

### DIFF
--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -621,8 +621,6 @@ pub const SF_APPEND: ::c_ulong = 0x00040000;
 
 pub const TIMER_ABSTIME: ::c_int = 1;
 
-pub const REG_ENOSYS: ::c_int = 17;
-
 #[link(name = "util")]
 extern "C" {
     pub fn setgrent();

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1646,6 +1646,8 @@ pub const FIBMAP: ::c_ulong = 0xc008667a;
 
 pub const SIGSTKSZ: ::size_t = 40960;
 
+pub const REG_ENOSYS: ::c_int = 17;
+
 pub const PT_DUMPCORE: ::c_int = 12;
 pub const PT_LWPINFO: ::c_int = 13;
 pub const PT_SYSCALL: ::c_int = 14;


### PR DESCRIPTION
OpenBSD doesn't define `REG_ENOSYS`

unbreak the build after #1719 