### PR TITLE
Add types for newlib on Xtensa.

### DIFF
--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -50,6 +50,8 @@ s! {
         pub sin6_scope_id: u32,
     }
 
+    // The order of the `ai_addr` field in this struct is crucial
+    // for converting between the Rust and C types.
     pub struct addrinfo {
         pub ai_flags: ::c_int,
         pub ai_family: ::c_int,

--- a/src/unix/newlib/aarch64/mod.rs
+++ b/src/unix/newlib/aarch64/mod.rs
@@ -1,3 +1,4 @@
+pub type clock_t = ::c_long;
 pub type c_char = u8;
 pub type wchar_t = u32;
 
@@ -29,5 +30,13 @@ s! {
     }
 }
 
+pub const FIONBIO: ::c_ulong = 1;
+
+pub const POLLIN: ::c_short = 0x1;
+pub const POLLPRI: ::c_short = 0x2;
 pub const POLLOUT: ::c_short = 0x4;
+pub const POLLERR: ::c_short = 0x8;
 pub const POLLHUP: ::c_short = 0x10;
+pub const POLLNVAL: ::c_short = 0x20;
+
+pub const SOL_SOCKET: ::c_int = 65535;

--- a/src/unix/newlib/arm/mod.rs
+++ b/src/unix/newlib/arm/mod.rs
@@ -1,3 +1,4 @@
+pub type clock_t = ::c_long;
 pub type c_char = u8;
 pub type wchar_t = u32;
 
@@ -31,5 +32,13 @@ s! {
     }
 }
 
-pub const POLLOUT: ::c_short = 0x10;
+pub const FIONBIO: ::c_ulong = 1;
+
+pub const POLLIN: ::c_short = 0x1;
+pub const POLLPRI: ::c_short = 0x2;
 pub const POLLHUP: ::c_short = 0x4;
+pub const POLLERR: ::c_short = 0x8;
+pub const POLLOUT: ::c_short = 0x10;
+pub const POLLNVAL: ::c_short = 0x20;
+
+pub const SOL_SOCKET: ::c_int = 65535;

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -24,6 +24,8 @@ pub type time_t = i32;
 pub type useconds_t = u32;
 
 s! {
+    // The order of the `ai_addr` field in this struct is crucial
+    // for converting between the Rust and C types.
     pub struct addrinfo {
         pub ai_flags: ::c_int,
         pub ai_family: ::c_int,

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -1,6 +1,5 @@
 pub type blkcnt_t = i32;
 pub type blksize_t = i32;
-pub type clock_t = i32;
 pub type clockid_t = ::c_ulong;
 pub type dev_t = u32;
 pub type fsblkcnt_t = u64;
@@ -31,8 +30,15 @@ s! {
         pub ai_socktype: ::c_int,
         pub ai_protocol: ::c_int,
         pub ai_addrlen: socklen_t,
-        pub ai_canonname: *mut ::c_char,
+
+        #[cfg(target_arch = "xtensa")]
         pub ai_addr: *mut sockaddr,
+
+        pub ai_canonname: *mut ::c_char,
+
+        #[cfg(not(target_arch = "xtensa"))]
+        pub ai_addr: *mut sockaddr,
+
         pub ai_next: *mut addrinfo,
     }
 
@@ -364,11 +370,6 @@ pub const O_NONBLOCK: ::c_int = 16384;
 pub const O_ACCMODE: ::c_int = 3;
 pub const O_CLOEXEC: ::c_int = 0x80000;
 
-pub const POLLIN: ::c_short = 0x1;
-pub const POLLPRI: ::c_short = 0x2;
-pub const POLLERR: ::c_short = 0x8;
-pub const POLLNVAL: ::c_short = 0x20;
-
 pub const RTLD_LAZY: ::c_int = 0x1;
 
 pub const STDIN_FILENO: ::c_int = 0;
@@ -379,7 +380,6 @@ pub const SEEK_SET: ::c_int = 0;
 pub const SEEK_CUR: ::c_int = 1;
 pub const SEEK_END: ::c_int = 2;
 
-pub const FIONBIO: ::c_ulong = 1;
 pub const FIOCLEX: ::c_ulong = 0x20006601;
 pub const FIONCLEX: ::c_ulong = 0x20006602;
 
@@ -406,7 +406,6 @@ pub const S_IROTH: ::mode_t = 4;
 pub const S_IWOTH: ::mode_t = 2;
 pub const S_IXOTH: ::mode_t = 1;
 
-pub const SOL_SOCKET: ::c_int = 65535;
 pub const SOL_TCP: ::c_int = 6;
 
 pub const PF_UNSPEC: ::c_int = 0;
@@ -546,6 +545,9 @@ pub const EAI_FAMILY: ::c_int = -303;
 pub const EAI_MEMORY: ::c_int = -304;
 pub const EAI_NONAME: ::c_int = -305;
 pub const EAI_SOCKTYPE: ::c_int = -307;
+
+pub const EXIT_SUCCESS: ::c_int = 0;
+pub const EXIT_FAILURE: ::c_int = 1;
 
 pub const PRIO_PROCESS: ::c_int = 0;
 pub const PRIO_PGRP: ::c_int = 1;
@@ -702,6 +704,9 @@ cfg_if! {
     } else if #[cfg(target_arch = "aarch64")] {
         mod aarch64;
         pub use self::aarch64::*;
+    } else if #[cfg(target_arch = "xtensa")] {
+        mod xtensa;
+        pub use self::xtensa::*;
     } else {
         // Only tested on ARM so far. Other platforms might have different
         // definitions for types and constants.

--- a/src/unix/newlib/xtensa/mod.rs
+++ b/src/unix/newlib/xtensa/mod.rs
@@ -1,0 +1,97 @@
+pub type clock_t = ::c_ulong;
+pub type c_char = i8;
+pub type wchar_t = u32;
+
+pub type c_long = i32;
+pub type c_ulong = u32;
+
+s! {
+    pub struct cmsghdr {
+        pub cmsg_len: ::socklen_t,
+        pub cmsg_level: ::c_int,
+        pub cmsg_type: ::c_int,
+    }
+
+    pub struct msghdr {
+        pub msg_name: *mut ::c_void,
+        pub msg_namelen: ::socklen_t,
+        pub msg_iov: *mut ::iovec,
+        pub msg_iovlen: ::c_int,
+        pub msg_control: *mut ::c_void,
+        pub msg_controllen: ::socklen_t,
+        pub msg_flags: ::c_int,
+    }
+
+    pub struct sockaddr_un {
+        pub sun_family: ::sa_family_t,
+        pub sun_path: [::c_char; 108],
+    }
+
+    pub struct sockaddr {
+        pub sa_len: u8,
+        pub sa_family: ::sa_family_t,
+        pub sa_data: [::c_char; 14],
+    }
+
+    pub struct sockaddr_in6 {
+        pub sin6_len: u8,
+        pub sin6_family: ::sa_family_t,
+        pub sin6_port: ::in_port_t,
+        pub sin6_flowinfo: u32,
+        pub sin6_addr: ::in6_addr,
+        pub sin6_scope_id: u32,
+    }
+
+    pub struct sockaddr_in {
+        pub sin_len: u8,
+        pub sin_family: ::sa_family_t,
+        pub sin_port: ::in_port_t,
+        pub sin_addr: ::in_addr,
+        pub sin_zero: [::c_char; 8],
+    }
+
+    pub struct sockaddr_storage {
+        pub s2_len: u8,
+        pub ss_family: ::sa_family_t,
+        pub s2_data1: [::c_char; 2],
+        pub s2_data2: [u32; 3],
+        pub s2_data3: [u32; 3],
+    }
+}
+
+pub const AF_UNIX: ::c_int = 1;
+
+pub const FIONBIO: ::c_ulong = 2147772030;
+
+pub const POLLIN: ::c_short = 1 << 0;
+pub const POLLRDNORM: ::c_short = 1 << 1;
+pub const POLLRDBAND: ::c_short = 1 << 2;
+pub const POLLPRI: ::c_short = POLLRDBAND;
+pub const POLLOUT: ::c_short = 1 << 3;
+pub const POLLWRNORM: ::c_short = POLLOUT;
+pub const POLLWRBAND: ::c_short = 1 << 4;
+pub const POLLERR: ::c_short = 1 << 5;
+pub const POLLHUP: ::c_short = 1 << 6;
+
+pub const SOL_SOCKET: ::c_int = 0xfff;
+
+extern "C" {
+    pub fn sendmsg(
+        s: ::c_int,
+        msg: *const ::msghdr,
+        flags: ::c_int,
+    ) -> ::ssize_t;
+    pub fn recvmsg(
+        s: ::c_int,
+        msg: *mut ::msghdr,
+        flags: ::c_int,
+    ) -> ::ssize_t;
+
+    pub fn writev(s: ::c_int, iov: *const ::iovec, iovcnt: ::c_int)
+        -> ::c_int;
+    pub fn readv(
+        fd: ::c_int,
+        iov: *const ::iovec,
+        iovcnt: ::c_int,
+    ) -> ::ssize_t;
+}


### PR DESCRIPTION
These are needed for implementing `libstd` for Xtensa targets.