### PR TITLE
Bump version to 0.2.70

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.69"
+version = "0.2.70"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
https://github.com/rust-lang/libc/pull/1745 is needed to fix the compilation of [effective-limits](https://crates.io/crates/effective-limits) on riscv64gc-unknown-linux-gnu. This will pave the way for [RISC-V support in rustup](https://github.com/rust-lang/rustup/pull/2313).

The version bump will allow effective-limits to depend upon the fix.