### PR TITLE
[FreeBSD] Add missing getnameinfo() flag values.

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1740,6 +1740,7 @@ fn test_freebsd(target: &str) {
             | "IP_RECVORIGDSTADDR"
             | "IPV6_ORIGDSTADDR"
             | "IPV6_RECVORIGDSTADDR"
+            | "NI_NUMERICSCOPE"
                 if Some(11) == freebsd_ver =>
             {
                 true
@@ -1765,6 +1766,7 @@ fn test_freebsd(target: &str) {
             | "PD_CLOEXEC"
             | "PD_ALLOWED_AT_FORK"
             | "IP_RSS_LISTEN_BUCKET"
+            | "NI_NUMERICSCOPE"
                 if Some(10) == freebsd_ver =>
             {
                 true

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -349,6 +349,13 @@ pub const RLIMIT_UMTXP: ::c_int = 14;
 #[deprecated(since = "0.2.64", note = "Not stable across OS versions")]
 pub const RLIM_NLIMITS: ::rlim_t = 15;
 
+pub const NI_NOFQDN: ::c_int = 0x00000001;
+pub const NI_NUMERICHOST: ::c_int = 0x00000002;
+pub const NI_NAMEREQD: ::c_int = 0x00000004;
+pub const NI_NUMERICSERV: ::c_int = 0x00000008;
+pub const NI_DGRAM: ::c_int = 0x00000010;
+pub const NI_NUMERICSCOPE: ::c_int = 0x00000020;
+
 pub const Q_GETQUOTA: ::c_int = 0x700;
 pub const Q_SETQUOTA: ::c_int = 0x800;
 


### PR DESCRIPTION
This patchs adds missing flag values for getnameinfo()
on FreeBSD, the following flags have been added from
the FreeBSD tree.

```c
/*
 * Flag values for getnameinfo()
 */
#define	NI_NOFQDN	0x00000001
#define	NI_NUMERICHOST	0x00000002
#define	NI_NAMEREQD	0x00000004
#define	NI_NUMERICSERV	0x00000008
#define	NI_DGRAM	0x00000010
#define	NI_NUMERICSCOPE	0x00000020
```