### PR TITLE
Re-enable aarch64-linux-android CI

### DIFF
--- a/ci/azure.yml
+++ b/ci/azure.yml
@@ -34,9 +34,8 @@ jobs:
         displayName: Execute run-docker.sh
     strategy:
       matrix:
-        # FIXME: Disabled due to https://github.com/rust-lang/libc/issues/1765
-        # aarch64-unknown-linux-android:
-        #   TARGET: aarch64-linux-android
+        aarch64-unknown-linux-android:
+          TARGET: aarch64-linux-android
         aarch64-unknown-linux-gnu:
           TARGET: aarch64-unknown-linux-gnu
         aarch64-unknown-linux-musl:

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1355,6 +1355,7 @@ fn test_android(target: &str) {
         t => panic!("unsupported target: {}", t),
     };
     let x86 = target.contains("i686") || target.contains("x86_64");
+    let aarch64 = target.contains("aarch64");
 
     let mut cfg = ctest_cfg();
     cfg.define("_GNU_SOURCE", None);
@@ -1563,6 +1564,12 @@ fn test_android(target: &str) {
             // We skip the test here since here _GNU_SOURCE is defined, and
             // test the XSI version below.
             "strerror_r" => true,
+
+            // FIXME: Somehow we cannot find these fns on aarch64.
+            // https://github.com/rust-lang/libc/issues/1765
+            "lockf" | "preadv64" | "pwritev64" | "openpty" |
+            "forkpty" | "login_tty" | "getifaddrs" | "freeifaddrs" |
+            "sethostname" | "getgrgid_r" | "getgrnam_r" if aarch64 => true,
 
             _ => false,
         }


### PR DESCRIPTION
After investigating on #1763, we can re-enable aarch64-linux-android CI by skipping some fns. Though the cause still consists, it's worth to run CI anyway.
CC #1765