### PR TITLE
Import `core::ops` to use `Range` syntax

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,8 @@ cfg_if! {
         #[allow(unused_imports)]
         use core::iter;
         #[allow(unused_imports)]
+        use core::ops;
+        #[allow(unused_imports)]
         use core::option;
     }
 }


### PR DESCRIPTION
This is required on rust-lang/rust. Should _fix_ rust-lang/rust#72263.