### PR TITLE
Use ctest2 to drop old dependencies

### DIFF
--- a/ci/emscripten.sh
+++ b/ci/emscripten.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+EMSDK_VERSION=1.39.16
+
 hide_output() {
   set +x
   on_err="
@@ -23,8 +25,8 @@ git clone https://github.com/emscripten-core/emsdk.git /emsdk-portable
 cd /emsdk-portable
 # FIXME: switch to an upstream install once
 # https://github.com/rust-lang/rust/pull/63649 lands
-hide_output ./emsdk install 1.39.12
-./emsdk activate 1.39.12
+hide_output ./emsdk install "${EMSDK_VERSION}"
+./emsdk activate "${EMSDK_VERSION}"
 
 # Compile and cache libc
 # shellcheck disable=SC1091
@@ -34,7 +36,6 @@ HOME=/emsdk-portable/ emcc a.c
 rm -f a.*
 
 # Make emsdk usable by any user
-cp /root/.emscripten /emsdk-portable
 chmod a+rxw -R /emsdk-portable
 
 # node 8 is required to run wasm

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -11,7 +11,7 @@ default-features = false
 [build-dependencies]
 cc = "1.0"
 # FIXME: Use fork ctest until the maintainer gets back.
-ctest = { git = "https://github.com/JohnTitor/ctest.git", branch = "old-ctest" }
+ctest2 = "0.3"
 
 [features]
 default = [ "std" ]

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1567,9 +1567,13 @@ fn test_android(target: &str) {
 
             // FIXME: Somehow we cannot find these fns on aarch64.
             // https://github.com/rust-lang/libc/issues/1765
-            "lockf" | "preadv64" | "pwritev64" | "openpty" |
-            "forkpty" | "login_tty" | "getifaddrs" | "freeifaddrs" |
-            "sethostname" | "getgrgid_r" | "getgrnam_r" if aarch64 => true,
+            "lockf" | "preadv64" | "pwritev64" | "openpty" | "forkpty"
+            | "login_tty" | "getifaddrs" | "freeifaddrs" | "sethostname"
+            | "getgrgid_r" | "getgrnam_r"
+                if aarch64 =>
+            {
+                true
+            }
 
             _ => false,
         }

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 
 extern crate cc;
-extern crate ctest;
+extern crate ctest2 as ctest;
 
 use std::env;
 


### PR DESCRIPTION
We now specify crates with branch/commit revision but it's quite fragile. I published some fork crates to drop old dependencies and not to break builds with the newer nightlies, so let's use it here.