### PR TITLE
Make semver check workable

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -239,7 +239,7 @@ if [ "${RUST}" = "nightly" ] && [ "${OS}" = "linux" ]; then
     mkdir -p target
     (
         cd target
-        wget https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman.deb
+        wget https://github.com/devkitPro/pacman/releases/download/v1.0.1/devkitpro-pacman.deb
         sudo dpkg -i devkitpro-pacman.deb
         sudo dkp-pacman -Sy
         sudo dkp-pacman -Syu

--- a/ci/semver.sh
+++ b/ci/semver.sh
@@ -13,10 +13,15 @@ if ! rustc --version | grep -E "nightly" ; then
     exit 1
 fi
 
+# FIXME: Pin nightly version to make semverver compile.
+NIGHTLY_DATE=nightly-2020-06-18
+
+rustup override set ${NIGHTLY_DATE}
+
 rustup component add rustc-dev llvm-tools-preview
 
 # FIXME: Use upstream once it gets rustup.
-cargo +nightly install semververfork
+cargo +${NIGHTLY_DATE} install semververfork
 
 TARGETS=
 case "${OS}" in
@@ -73,5 +78,5 @@ for TARGET in $TARGETS; do
     done
 
     # FIXME: Use upstream once it gets rustup.
-    cargo +nightly semverfork --api-guidelines --target="${TARGET}"
+    cargo +${NIGHTLY_DATE} semverfork --api-guidelines --target="${TARGET}"
 done


### PR DESCRIPTION
semverver fails to compile due to recent `ty::Error` change. Let's pin the nightly version until we come up with a good way.