### PR TITLE
Declare `seekdir` and `telldir` for WASI.

### DIFF
--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -515,6 +515,8 @@ extern "C" {
     pub fn closedir(dirp: *mut ::DIR) -> ::c_int;
     pub fn rewinddir(dirp: *mut ::DIR);
     pub fn dirfd(dirp: *mut ::DIR) -> ::c_int;
+    pub fn seekdir(dirp: *mut ::DIR, loc: ::c_long);
+    pub fn telldir(dirp: *mut ::DIR) -> ::c_long;
 
     pub fn openat(
         dirfd: ::c_int,


### PR DESCRIPTION
These declarations are the same as those for other platforms.