### PR TITLE
Bump version ready to import into Android tree.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.71"
+version = "0.2.72"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
I need to bump the version number so that I can get the changes from https://github.com/rust-lang/libc/pull/1795 into the version of the libc crate vendored into the Android tree at https://android.googlesource.com/platform/external/rust/crates/libc/.