### PR TITLE
Fix ordering of allowed lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,14 +6,14 @@
 #![crate_name = "libc"]
 #![crate_type = "rlib"]
 #![allow(
+    renamed_and_removed_lints, // Keep this order.
+    unknown_lints, // Keep this order.
     bad_style,
     overflowing_literals,
     improper_ctypes,
     // This lint is renamed but we run CI for old stable rustc so should be here.
     redundant_semicolon,
-    redundant_semicolons,
-    renamed_and_removed_lints,
-    unknown_lints
+    redundant_semicolons
 )]
 #![cfg_attr(libc_deny_warnings, deny(warnings))]
 // Attributes needed when building as part of the standard library


### PR DESCRIPTION
The current list causes this:
```
   Updating crates.io index
   Compiling libc v0.2.71 (/home/vsts/work/1/s)
warning: lint `redundant_semicolon` has been renamed to `redundant_semicolons`
  --> src/lib.rs:13:5
   |
13 |     redundant_semicolon,
   |     ^^^^^^^^^^^^^^^^^^^ help: use the new name: `redundant_semicolons`
   |
   = note: `#[warn(renamed_and_removed_lints)]` on by default
```

So, `renamed_and_removed_lints` and `unknown_lints` should be placed at the top of the list.