### PR TITLE
Add missing sysconf constants for Haiku

### DIFF
--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -962,6 +962,10 @@ pub const _SC_TIMER_MAX: ::c_int = 57;
 pub const _SC_TIMERS: ::c_int = 58;
 pub const _SC_CPUTIME: ::c_int = 59;
 pub const _SC_THREAD_CPUTIME: ::c_int = 60;
+pub const _SC_HOST_NAME_MAX: ::c_int = 61;
+pub const _SC_REGEXP: ::c_int = 62;
+pub const _SC_SYMLOOP_MAX: ::c_int = 63;
+pub const _SC_SHELL: ::c_int = 64;
 
 pub const PTHREAD_STACK_MIN: ::size_t = 8192;
 


### PR DESCRIPTION
Hi,

Could you add some missing Haiku constants (i'm guessing they were added after Haiku port was last updated)?

These are defined in `unistd.h`: https://github.com/haiku/haiku/blob/194a45c6b4183083afdc7fac7b9e85f9162cdeb2/headers/posix/unistd.h#L134-L137