### PR TITLE
openbsd: Fix `WIFSTOPPED` following upstream

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1385,7 +1385,7 @@ f! {
     }
 
     pub fn WIFSTOPPED(status: ::c_int) -> bool {
-        (status & 0o177) == 0o177
+        (status & 0xff) == 0o177
     }
 }
 


### PR DESCRIPTION
ref: https://github.com/openbsd/src/blob/b66614995ab119f75167daaa7755b34001836821/sys/sys/wait.h#L52

Fixes #1784