### PR TITLE
Expose EPOLLEXCLUSIVE on illumos platform

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -794,6 +794,11 @@ fn test_solarish(target: &str) {
         // This evaluates to a sysconf() call rather than a constant
         "PTHREAD_STACK_MIN" => true,
 
+        // EPOLLEXCLUSIVE is a relatively recent addition to the epoll interface and may not be
+        // defined on older systems.  It is, however, safe to use on systems which do not
+        // explicitly support it. (A no-op is an acceptable implementation of EPOLLEXCLUSIVE.)
+        "EPOLLEXCLUSIVE" => true,
+
         _ => false,
     });
 

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1838,6 +1838,7 @@ pub const EPOLLET: ::c_int = 0x80000000;
 pub const EPOLLRDHUP: ::c_int = 0x2000;
 pub const EPOLLONESHOT: ::c_int = 0x40000000;
 pub const EPOLLWAKEUP: ::c_int = 0x20000000;
+pub const EPOLLEXCLUSIVE: ::c_int = 0x10000000;
 pub const EPOLL_CLOEXEC: ::c_int = 0x80000;
 pub const EPOLL_CTL_ADD: ::c_int = 1;
 pub const EPOLL_CTL_MOD: ::c_int = 3;

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -29,8 +29,6 @@ s! {
 pub const PORT_SOURCE_POSTWAIT: ::c_int = 8;
 pub const PORT_SOURCE_SIGNAL: ::c_int = 9;
 
-pub const EPOLLEXCLUSIVE: ::c_int = 0x10000000;
-
 pub const AF_LOCAL: ::c_int = 0;
 pub const AF_FILE: ::c_int = 0;
 


### PR DESCRIPTION
Initially the `EPOLLEXCLUSIVE` definition was hidden on the illumos platform as it lacked explicit support.  After further review, it was concluded that `EPOLLEXCLUSIVE` can safely be considered a no-op, when not fully implemented by the OS, making it safe for use on illumos.

I've confirmed that the `ci/style` check is clean, and the `libc-test` suite runs successfully on an illumos system.