### PR TITLE
Bump to 0.2.73

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.72"
+version = "0.2.73"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This incorporates the changes needed to cross-compile `rustc` for the
aarch64-apple-darwin target.