### PR TITLE
Add a declaration for `posix_fadvise64` on Linux.

### DIFF
--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1316,6 +1316,12 @@ extern "C" {
         len: ::off_t,
         advise: ::c_int,
     ) -> ::c_int;
+    pub fn posix_fadvise64(
+        fd: ::c_int,
+        offset: ::off64_t,
+        len: ::off64_t,
+        advise: ::c_int,
+    ) -> ::c_int;
     pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
     pub fn utimensat(
         dirfd: ::c_int,


### PR DESCRIPTION
As with the other *64 functions in Linux, `posix_fadvise64` is like
`posix_fadvise` but uses `off64_t` instead of `off_t`.