### PR TITLE
linux: replace VMADDR_CID_RESERVED with VMADDR_CID_LOCAL

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2614,6 +2614,12 @@ fn test_linux(target: &str) {
             // We should do so after a while.
             "SOMAXCONN" if gnu => true,
 
+            // deprecated: not available from Linux kernel 5.6:
+            "VMADDR_CID_RESERVED" => true,
+
+            // Require Linux kernel 5.6:
+            "VMADDR_CID_LOCAL" => true,
+
             _ => false,
         }
     });

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -2355,7 +2355,13 @@ pub const MAP_FIXED_NOREPLACE: ::c_int = 0x100000;
 // uapi/linux/vm_sockets.h
 pub const VMADDR_CID_ANY: ::c_uint = 0xFFFFFFFF;
 pub const VMADDR_CID_HYPERVISOR: ::c_uint = 0;
+#[deprecated(
+    since = "0.2.74",
+    note = "VMADDR_CID_RESERVED is removed since Linux v5.6 and \
+            replaced with VMADDR_CID_LOCAL"
+)]
 pub const VMADDR_CID_RESERVED: ::c_uint = 1;
+pub const VMADDR_CID_LOCAL: ::c_uint = 1;
 pub const VMADDR_CID_HOST: ::c_uint = 2;
 pub const VMADDR_PORT_ANY: ::c_uint = 0xFFFFFFFF;
 


### PR DESCRIPTION
In Linux we replaced VMADDR_CID_RESERVED with VMADDR_CID_LOCAL
in commit ef343b35d46667668a099655fca4a5b2e43a5dfe.
It is available since Linux v5.6, and it can be used to do
local communication if supported.

Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>