### PR TITLE
Android: Add preadv and pwritev.

### DIFF
--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -2399,20 +2399,32 @@ extern "C" {
         sevlen: ::size_t,
         flags: ::c_int,
     ) -> ::c_int;
+    pub fn preadv(
+        fd: ::c_int,
+        iov: *const ::iovec,
+        count: ::c_int,
+        offset: ::off_t,
+    ) -> ::ssize_t;
+    pub fn pwritev(
+        fd: ::c_int,
+        iov: *const ::iovec,
+        count: ::c_int,
+        offset: ::off_t,
+    ) -> ::ssize_t;
     pub fn process_vm_readv(
         pid: ::pid_t,
         local_iov: *const ::iovec,
-        liovcnt: ::c_ulong,
+        local_iov_count: ::c_ulong,
         remote_iov: *const ::iovec,
-        riovcnt: ::c_ulong,
+        remote_iov_count: ::c_ulong,
         flags: ::c_ulong,
     ) -> ::ssize_t;
     pub fn process_vm_writev(
         pid: ::pid_t,
         local_iov: *const ::iovec,
-        liovcnt: ::c_ulong,
+        local_iov_count: ::c_ulong,
         remote_iov: *const ::iovec,
-        riovcnt: ::c_ulong,
+        remote_iov_count: ::c_ulong,
         flags: ::c_ulong,
     ) -> ::ssize_t;
     pub fn ptrace(request: ::c_int, ...) -> ::c_long;


### PR DESCRIPTION
From sys/uio.h. Note that preadv64/pwritev64 are already included in
src/unix/linux_like/mod.rs.