### PR TITLE
FreeBSDLike: Remove obsolete constants in version 1.0.0

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2328,12 +2328,6 @@ fn test_freebsd(target: &str) {
             // still be accepted and ignored at runtime.
             "MAP_RENAME" | "MAP_NORESERVE" => true,
 
-            // FIXME: These are deprecated - remove in a couple of releases.
-            // These constants were removed in FreeBSD 11 (svn r262489),
-            // and they've never had any legitimate use outside of the
-            // base system anyway.
-            "CTL_MAXID" | "KERN_MAXID" | "HW_MAXID" | "USER_MAXID" => true,
-
             // FIXME: This is deprecated - remove in a couple of releases.
             // This was removed in FreeBSD 14 (git 1b4701fe1e8) and never
             // should've been used anywhere anyway.

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -3857,26 +3857,6 @@ pub const SHM_STAT: ::c_int = 13;
 pub const SHM_INFO: ::c_int = 14;
 pub const SHM_ANON: *mut ::c_char = 1 as *mut ::c_char;
 
-// The *_MAXID constants never should've been used outside of the
-// FreeBSD base system.  And with the exception of CTL_P1003_1B_MAXID,
-// they were all removed in svn r262489.  They remain here for backwards
-// compatibility only, and are scheduled to be removed in libc 1.0.0.
-#[doc(hidden)]
-#[deprecated(since = "0.2.54", note = "Removed in FreeBSD 11")]
-pub const CTL_MAXID: ::c_int = 10;
-#[doc(hidden)]
-#[deprecated(since = "0.2.54", note = "Removed in FreeBSD 11")]
-pub const KERN_MAXID: ::c_int = 38;
-#[doc(hidden)]
-#[deprecated(since = "0.2.54", note = "Removed in FreeBSD 11")]
-pub const HW_MAXID: ::c_int = 13;
-#[doc(hidden)]
-#[deprecated(since = "0.2.54", note = "Removed in FreeBSD 11")]
-pub const USER_MAXID: ::c_int = 21;
-#[doc(hidden)]
-#[deprecated(since = "0.2.74", note = "Removed in FreeBSD 13")]
-pub const CTL_P1003_1B_MAXID: ::c_int = 26;
-
 pub const MSG_NOTIFICATION: ::c_int = 0x00002000;
 pub const MSG_NBIO: ::c_int = 0x00004000;
 pub const MSG_COMPAT: ::c_int = 0x00008000;


### PR DESCRIPTION
Fixes #454 