### PR TITLE
Suppress `improper_ctypes_definitions` for `compiler_builtins`

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -43,14 +43,17 @@ test_target() {
     if [ "${NO_STD}" != "1" ]; then
         cargo "+${RUST}" "${BUILD_CMD}" -vv --no-default-features --target "${TARGET}"
     else
-        cargo "+${RUST}" "${BUILD_CMD}" -Z build-std=core,alloc -vv --no-default-features --target "${TARGET}"
+        # FIXME: With `build-std` feature, `compiler_builtins` emits a lof of lint warnings.
+        RUSTFLAGS="-A improper_ctypes_definitions" cargo "+${RUST}" "${BUILD_CMD}" \
+            -Z build-std=core,alloc -vv --no-default-features --target "${TARGET}"
     fi
     # Test that libc builds with default features (e.g. libstd)
     # if the target supports libstd
     if [ "$NO_STD" != "1" ]; then
         cargo "+${RUST}" "${BUILD_CMD}" -vv --target "${TARGET}"
     else
-        cargo "+${RUST}" "${BUILD_CMD}" -Z build-std=core,alloc -vv --target "${TARGET}"
+        RUSTFLAGS="-A improper_ctypes_definitions" cargo "+${RUST}" "${BUILD_CMD}" \
+            -Z build-std=core,alloc -vv --target "${TARGET}"
     fi
 
     # Test that libc builds with the `extra_traits` feature
@@ -58,7 +61,8 @@ test_target() {
         cargo "+${RUST}" "${BUILD_CMD}" -vv --no-default-features --target "${TARGET}" \
             --features extra_traits
     else
-        cargo "+${RUST}" "${BUILD_CMD}" -Z build-std=core,alloc -vv --no-default-features \
+        RUSTFLAGS="-A improper_ctypes_definitions" cargo "+${RUST}" "${BUILD_CMD}" \
+            -Z build-std=core,alloc -vv --no-default-features \
             --target "${TARGET}" --features extra_traits
     fi
 
@@ -68,7 +72,8 @@ test_target() {
             cargo "+${RUST}" "${BUILD_CMD}" -vv --no-default-features --target "${TARGET}" \
                 --features const-extern-fn
         else
-            cargo "+${RUST}" "${BUILD_CMD}" -Z build-std=core,alloc -vv --no-default-features \
+            RUSTFLAGS="-A improper_ctypes_definitions" cargo "+${RUST}" "${BUILD_CMD}" \
+                -Z build-std=core,alloc -vv --no-default-features \
                 --target "${TARGET}" --features const-extern-fn
         fi
     fi
@@ -78,7 +83,8 @@ test_target() {
         cargo "+${RUST}" "${BUILD_CMD}" -vv --target "${TARGET}" \
             --features extra_traits
     else
-        cargo "+${RUST}" "${BUILD_CMD}" -Z build-std=core,alloc -vv --target "${TARGET}" \
+        RUSTFLAGS="-A improper_ctypes_definitions" cargo "+${RUST}" "${BUILD_CMD}" \
+            -Z build-std=core,alloc -vv --target "${TARGET}" \
             --features extra_traits
     fi
 }

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1763,12 +1763,8 @@ fn test_freebsd(target: &str) {
     cfg.skip_const(move |name| {
         match name {
             // These constants are to be introduced in yet-unreleased FreeBSD 12.2.
-            "F_ADD_SEALS"
-            | "F_GET_SEALS"
-            | "F_SEAL_SEAL"
-            | "F_SEAL_SHRINK"
-            | "F_SEAL_GROW"
-            | "F_SEAL_WRITE"
+            "F_ADD_SEALS" | "F_GET_SEALS" | "F_SEAL_SEAL"
+            | "F_SEAL_SHRINK" | "F_SEAL_GROW" | "F_SEAL_WRITE"
                 if Some(12) <= freebsd_ver =>
             {
                 true


### PR DESCRIPTION
It causes a lot of lint warnings, we should suppress for now as it's an upstream crate.