### PR TITLE
Deprecate CTL_P1003_1B_MAXID

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1824,6 +1824,10 @@ fn test_freebsd(target: &str) {
             // base system anyway.
             "CTL_MAXID" | "KERN_MAXID" | "HW_MAXID" | "USER_MAXID" => true,
 
+            // This constant was removed in FreeBSD 13 (svn r363622), and never
+            // had any legitimate use outside of the base system anyway.
+            "CTL_P1003_1B_MAXID" => true,
+
             // This was renamed in FreeBSD 12.2 and 13 (r352486).
             "CTL_UNSPEC" | "CTL_SYSCTL" => true,
 

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1056,6 +1056,7 @@ pub const HW_MAXID: ::c_int = 13;
 #[deprecated(since = "0.2.54", note = "Removed in FreeBSD 11")]
 pub const USER_MAXID: ::c_int = 21;
 #[doc(hidden)]
+#[deprecated(since = "0.2.74", note = "Removed in FreeBSD 13")]
 pub const CTL_P1003_1B_MAXID: ::c_int = 26;
 
 pub const MSG_NOTIFICATION: ::c_int = 0x00002000;


### PR DESCRIPTION
It's been removed in FreeBSD 13 (svn r363622), and never had any
legitimate use outside of the base system anyway.