### PR TITLE
Bump version to 0.2.74

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.73"
+version = "0.2.74"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This includes changes which will allow us to successfully build `libstd` for the PSP.