### PR TITLE
Bump version to 0.2.74

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.73"
+version = "0.2.74"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Fuchsia developers are porting the nix crate to Fuchsia. nix on Fuchsia
depends upon libc defining the CMSG_* macros for Fuchsia. This version
bump will include the recent addition of CMSG_* macros for Fuchsia in
commit 59749267fa458952b33d259f51e7f195b6434fc1, allowing work on the
Fuchsia port of nix to continue.