### PR TITLE
Add sys/personality.h constants for Linux

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -771,6 +771,10 @@ pub const NDA_MASTER: ::c_ushort = 9;
 pub const NDA_LINK_NETNSID: ::c_ushort = 10;
 pub const NDA_SRC_VNI: ::c_ushort = 11;
 
+// linux/personality.h
+pub const UNAME26: ::c_int = 0x0020000;
+pub const FDPIC_FUNCPTRS: ::c_int = 0x0080000;
+
 // linux/if_addr.h
 pub const IFA_FLAGS: ::c_ushort = 8;
 

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -961,6 +961,17 @@ pub const WEXITED: ::c_int = 0x00000004;
 pub const WCONTINUED: ::c_int = 0x00000008;
 pub const WNOWAIT: ::c_int = 0x01000000;
 
+// Options for personality(2).
+pub const ADDR_NO_RANDOMIZE: ::c_int = 0x0040000;
+pub const MMAP_PAGE_ZERO: ::c_int = 0x0100000;
+pub const ADDR_COMPAT_LAYOUT: ::c_int = 0x0200000;
+pub const READ_IMPLIES_EXEC: ::c_int = 0x0400000;
+pub const ADDR_LIMIT_32BIT: ::c_int = 0x0800000;
+pub const SHORT_INODE: ::c_int = 0x1000000;
+pub const WHOLE_SECONDS: ::c_int = 0x2000000;
+pub const STICKY_TIMEOUTS: ::c_int = 0x4000000;
+pub const ADDR_LIMIT_3GB: ::c_int = 0x8000000;
+
 // Options set using PTRACE_SETOPTIONS.
 pub const PTRACE_O_TRACESYSGOOD: ::c_int = 0x00000001;
 pub const PTRACE_O_TRACEFORK: ::c_int = 0x00000002;


### PR DESCRIPTION
These consts are used for the `personality(2)` syscall and can be found in `/usr/include/sys/personality.h`