### PR TITLE
Add DevkitPPC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ newer Rust features are only available on newer Rust toolchains:
 | `extra_traits`       |  1.25.0 |
 | `core::ffi::c_void`  |  1.30.0 |
 | `repr(packed(N))`    |  1.33.0 |
+| `cfg(target_vendor)` |  1.33.0 |
 
 ## Platform support
 

--- a/build.rs
+++ b/build.rs
@@ -65,9 +65,10 @@ fn main() {
         println!("cargo:rustc-cfg=libc_core_cvoid");
     }
 
-    // Rust >= 1.33 supports repr(packed(N))
+    // Rust >= 1.33 supports repr(packed(N)) and cfg(target_vendor).
     if rustc_minor_ver >= 33 || rustc_dep_of_std {
         println!("cargo:rustc-cfg=libc_packedN");
+        println!("cargo:rustc-cfg=libc_cfg_target_vendor");
     }
 
     // #[thread_local] is currently unstable

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -596,9 +596,13 @@ extern "C" {
     pub fn getchar_unlocked() -> ::c_int;
     pub fn putchar_unlocked(c: ::c_int) -> ::c_int;
 
+    #[cfg(not(all(libc_cfg_target_vendor, target_arch = "powerpc",
+          target_vendor = "nintendo")))]
     #[cfg_attr(target_os = "netbsd", link_name = "__socket30")]
     #[cfg_attr(target_os = "illumos", link_name = "__xnet_socket")]
     pub fn socket(domain: ::c_int, ty: ::c_int, protocol: ::c_int) -> ::c_int;
+    #[cfg(not(all(libc_cfg_target_vendor, target_arch = "powerpc",
+          target_vendor = "nintendo")))]
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "connect$UNIX2003"
@@ -614,6 +618,8 @@ extern "C" {
         link_name = "listen$UNIX2003"
     )]
     pub fn listen(socket: ::c_int, backlog: ::c_int) -> ::c_int;
+    #[cfg(not(all(libc_cfg_target_vendor, target_arch = "powerpc",
+          target_vendor = "nintendo")))]
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "accept$UNIX2003"
@@ -623,6 +629,8 @@ extern "C" {
         address: *mut sockaddr,
         address_len: *mut socklen_t,
     ) -> ::c_int;
+    #[cfg(not(all(libc_cfg_target_vendor, target_arch = "powerpc",
+          target_vendor = "nintendo")))]
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "getpeername$UNIX2003"
@@ -632,6 +640,8 @@ extern "C" {
         address: *mut sockaddr,
         address_len: *mut socklen_t,
     ) -> ::c_int;
+    #[cfg(not(all(libc_cfg_target_vendor, target_arch = "powerpc",
+          target_vendor = "nintendo")))]
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "getsockname$UNIX2003"
@@ -659,6 +669,8 @@ extern "C" {
         protocol: ::c_int,
         socket_vector: *mut ::c_int,
     ) -> ::c_int;
+    #[cfg(not(all(libc_cfg_target_vendor, target_arch = "powerpc",
+          target_vendor = "nintendo")))]
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "sendto$UNIX2003"
@@ -1234,6 +1246,8 @@ extern "C" {
     pub fn dlclose(handle: *mut ::c_void) -> ::c_int;
     pub fn dladdr(addr: *const ::c_void, info: *mut Dl_info) -> ::c_int;
 
+    #[cfg(not(all(libc_cfg_target_vendor, target_arch = "powerpc",
+          target_vendor = "nintendo")))]
     #[cfg_attr(target_os = "illumos", link_name = "__xnet_getaddrinfo")]
     pub fn getaddrinfo(
         node: *const c_char,
@@ -1241,6 +1255,8 @@ extern "C" {
         hints: *const addrinfo,
         res: *mut *mut addrinfo,
     ) -> ::c_int;
+    #[cfg(not(all(libc_cfg_target_vendor, target_arch = "powerpc",
+          target_vendor = "nintendo")))]
     pub fn freeaddrinfo(res: *mut addrinfo);
     pub fn gai_strerror(errcode: ::c_int) -> *const ::c_char;
     #[cfg_attr(

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -33,11 +33,15 @@ s! {
         pub ai_protocol: ::c_int,
         pub ai_addrlen: socklen_t,
 
+        #[cfg(not(all(libc_cfg_target_vendor, target_arch = "powerpc",
+              target_vendor = "nintendo")))]
         #[cfg(target_arch = "xtensa")]
         pub ai_addr: *mut sockaddr,
 
         pub ai_canonname: *mut ::c_char,
 
+        #[cfg(not(all(libc_cfg_target_vendor, target_arch = "powerpc",
+              target_vendor = "nintendo")))]
         #[cfg(not(target_arch = "xtensa"))]
         pub ai_addr: *mut sockaddr,
 
@@ -598,6 +602,8 @@ extern "C" {
     pub fn rand() -> ::c_int;
     pub fn srand(seed: ::c_uint);
 
+    #[cfg(not(all(libc_cfg_target_vendor, target_arch = "powerpc",
+          target_vendor = "nintendo")))]
     pub fn bind(fd: ::c_int, addr: *const sockaddr, len: socklen_t)
         -> ::c_int;
     pub fn clock_settime(
@@ -614,6 +620,8 @@ extern "C" {
     ) -> ::c_int;
     pub fn closesocket(sockfd: ::c_int) -> ::c_int;
     pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
+    #[cfg(not(all(libc_cfg_target_vendor, target_arch = "powerpc",
+          target_vendor = "nintendo")))]
     pub fn recvfrom(
         fd: ::c_int,
         buf: *mut ::c_void,
@@ -622,6 +630,8 @@ extern "C" {
         addr: *mut sockaddr,
         addr_len: *mut socklen_t,
     ) -> isize;
+    #[cfg(not(all(libc_cfg_target_vendor, target_arch = "powerpc",
+          target_vendor = "nintendo")))]
     pub fn getnameinfo(
         sa: *const sockaddr,
         salen: socklen_t,
@@ -700,6 +710,9 @@ cfg_if! {
     } else if #[cfg(target_arch = "xtensa")] {
         mod xtensa;
         pub use self::xtensa::*;
+    } else if #[cfg(target_arch = "powerpc")] {
+        mod powerpc;
+        pub use self::powerpc::*;
     } else {
         // Only tested on ARM so far. Other platforms might have different
         // definitions for types and constants.

--- a/src/unix/newlib/powerpc/mod.rs
+++ b/src/unix/newlib/powerpc/mod.rs
@@ -1,0 +1,14 @@
+pub type clock_t = ::c_ulong;
+pub type c_char = u8;
+pub type wchar_t = ::c_int;
+
+pub type c_long = i32;
+pub type c_ulong = u32;
+
+// the newlib shipped with devkitPPC does not support the following components:
+// - sockaddr
+// - AF_INET6
+// - FIONBIO
+// - POLL*
+// - SOL_SOCKET
+// - MSG_*


### PR DESCRIPTION
DevkitPPC is the de-facto Homebrew development kit for the Nintendo Gamecube, Wii and Wii U consoles. It is based on a gcc+binutils+newlib toolchain.

This pull request adds initial support for these 3 consoles.

DevkitPPC does not support unix-style sockets natively, meaning that bindings
to these functions was removed for powerpc targets with "nintendo" as
vendor

Suggested target json files:

Nintendo Gamecube:
```
{
  "arch": "powerpc",
  "data-layout": "E-m:e-p:32:32-i64:64-n32",
  "dynamic-linking": false,
  "env": "newlib",
  "executables": true,
  "has-elf-tls": false,
  "has-rpath": true,
  "linker-flavor": "gcc",
  "llvm-target": "powerpc-eabi",
  "max-atomic-width": 32,
  "os": "dolphin",
  "target-c-int-width": "32",
  "target-endian": "big",
  "target-family": "unix",
  "target-mcount": "_mcount",
  "target-pointer-width": "32",
  "vendor": "nintendo"
}
```

Nintendo Wii:
```
{
  "arch": "powerpc",
  "data-layout": "E-m:e-p:32:32-i64:64-n32",
  "dynamic-linking": false,
  "env": "newlib",
  "executables": true,
  "has-elf-tls": false,
  "has-rpath": true,
  "linker-flavor": "gcc",
  "llvm-target": "powerpc-eabi",
  "max-atomic-width": 32,
  "os": "revolution",
  "target-c-int-width": "32",
  "target-endian": "big",
  "target-family": "unix",
  "target-mcount": "_mcount",
  "target-pointer-width": "32",
  "vendor": "nintendo"
}
```