### PR TITLE
add fmemopen, open_memstream, and open_wmemstream for POSIX.1-2008

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1592,7 +1592,8 @@ fn test_android(target: &str) {
             // https://github.com/rust-lang/libc/issues/1765
             "lockf" | "preadv64" | "pwritev64" | "openpty" | "forkpty"
             | "login_tty" | "getifaddrs" | "freeifaddrs" | "sethostname"
-            | "getgrgid_r" | "getgrnam_r" | "sigtimedwait"
+            | "getgrgid_r" | "getgrnam_r" | "sigtimedwait" | "fmemopen"
+            | "open_memstream" | "open_wmemstream"
                 if aarch64 =>
             {
                 true

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -419,6 +419,19 @@ extern "C" {
         mode: *const c_char,
         file: *mut FILE,
     ) -> *mut FILE;
+    pub fn fmemopen(
+        buf: *mut c_void,
+        size: size_t,
+        mode: *const c_char,
+    ) -> *mut FILE;
+    pub fn open_memstream(
+        ptr: *mut *mut c_char,
+        sizeloc: *mut size_t,
+    ) -> *mut FILE;
+    pub fn open_wmemstream(
+        ptr: *mut *mut wchar_t,
+        sizeloc: *mut size_t,
+    ) -> *mut FILE;
     pub fn fflush(file: *mut FILE) -> c_int;
     pub fn fclose(file: *mut FILE) -> c_int;
     pub fn remove(filename: *const c_char) -> c_int;


### PR DESCRIPTION
This is useful for interfacing with C libraries that can write output to `FILE` objects, for example.