### PR TITLE
Expose si_pid and si_uid from siginfo_t as functions

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -680,6 +680,14 @@ impl siginfo_t {
 
         (*(self as *const siginfo_t as *const siginfo_timer)).si_value
     }
+
+    pub unsafe fn si_pid(&self) -> ::pid_t {
+        self.si_pid
+    }
+
+    pub unsafe fn si_uid(&self) -> ::uid_t {
+        self.si_uid
+    }
 }
 
 cfg_if! {

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -31,6 +31,14 @@ impl siginfo_t {
     pub unsafe fn si_value(&self) -> ::sigval {
         self.si_value
     }
+
+    pub unsafe fn si_pid(&self) -> ::pid_t {
+        self.si_pid
+    }
+
+    pub unsafe fn si_uid(&self) -> ::uid_t {
+        self.si_uid
+    }
 }
 
 s! {

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -38,6 +38,20 @@ impl ::Clone for timezone {
     }
 }
 
+impl siginfo_t {
+    pub unsafe fn si_addr(&self) -> *mut ::c_void {
+        self.si_addr
+    }
+
+    pub unsafe fn si_pid(&self) -> ::pid_t {
+        self.si_pid
+    }
+
+    pub unsafe fn si_uid(&self) -> ::uid_t {
+        self.si_uid
+    }
+}
+
 s! {
     pub struct in_addr {
         pub s_addr: ::in_addr_t,

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -322,6 +322,8 @@ cfg_if! {
             si_pid: ::pid_t,
             si_uid: ::uid_t,
             si_status: ::c_int,
+            si_utime: ::c_long,
+            si_stime: ::c_long,
         }
 
         // Internal, for casts to access union fields
@@ -355,6 +357,14 @@ cfg_if! {
 
             pub unsafe fn si_status(&self) -> ::c_int {
                 self.sifields().sigchld.si_status
+            }
+
+            pub unsafe fn si_utime(&self) -> ::c_long {
+                self.sifields().sigchld.si_utime
+            }
+
+            pub unsafe fn si_stime(&self) -> ::c_long {
+                self.sifields().sigchld.si_stime
             }
         }
     }

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -336,9 +336,7 @@ cfg_if! {
         // sifields vary on 32-bit and 64-bit architectures.
         #[repr(C)]
         struct siginfo_f {
-            _si_signo: ::c_int,
-            _si_errno: ::c_int,
-            _si_code: ::c_int,
+            _siginfo_base: [::c_int; 3],
             sifields: sifields,
         }
 

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -112,6 +112,24 @@ impl ::Clone for _Vx_semaphore {
     }
 }
 
+impl siginfo_t {
+    pub unsafe fn si_addr(&self) -> *mut ::c_void {
+        self.si_addr
+    }
+
+    pub unsafe fn si_value(&self) -> ::sigval {
+        self.si_value
+    }
+
+    pub unsafe fn si_pid(&self) -> ::pid_t {
+        self.si_pid
+    }
+
+    pub unsafe fn si_uid(&self) -> ::uid_t {
+        self.si_uid
+    }
+}
+
 s! {
     // b_pthread_condattr_t.h
     pub struct pthread_condattr_t {


### PR DESCRIPTION
On Linux, siginfo_t cannot expose these fields directly due to
https://github.com/rust-lang/libc/issues/716 , so expose them as
functions, just like si_addr and si_value.

Provide the same functions on other platforms that have these fields
declared, for consistency.