### PR TITLE
Add W_EXITCODE to construct an exit code

### DIFF
--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1258,6 +1258,10 @@ f! {
         (ret << 8) | sig
     }
 
+    pub fn W_STOPCODE(sig: ::c_int) -> ::c_int {
+        (sig << 8) | 0x7f
+    }
+
     pub fn QCMD(cmd: ::c_int, type_: ::c_int) -> ::c_int {
         (cmd << 8) | (type_ & 0x00ff)
     }

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1254,6 +1254,10 @@ f! {
         (status & 0x80) != 0
     }
 
+    pub fn W_EXITCODE(ret: ::c_int, sig: ::c_int) -> ::c_int {
+        (ret << 8) | sig
+    }
+
     pub fn QCMD(cmd: ::c_int, type_: ::c_int) -> ::c_int {
         (cmd << 8) | (type_ & 0x00ff)
     }


### PR DESCRIPTION
On Linux, `sys/wait.h` defines a `W_EXITCODE` macro to construct an exit
code from a return value and a signal number. Provide an equivalent
function.