### PR TITLE
Expose regex.h for Android

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1401,6 +1401,7 @@ fn test_android(target: &str) {
                "pthread.h",
                "pty.h",
                "pwd.h",
+               "regex.h",
                "resolv.h",
                "sched.h",
                "semaphore.h",

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -224,6 +224,18 @@ s! {
         pub ee_info: u32,
         pub ee_data: u32,
     }
+
+    pub struct regex_t {
+        re_magic: ::c_int,
+        re_nsub: ::size_t,
+        re_endp: *const ::c_char,
+        re_guts: *mut ::c_void,
+    }
+
+    pub struct regmatch_t {
+        pub rm_so: ::ssize_t,
+        pub rm_eo: ::ssize_t,
+    }
 }
 
 s_no_extra_traits! {
@@ -1240,6 +1252,41 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: ::c_int = 0x4321FEDC;
 pub const LINUX_REBOOT_CMD_RESTART2: ::c_int = 0xA1B2C3D4;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: ::c_int = 0xD000FCE2;
 pub const LINUX_REBOOT_CMD_KEXEC: ::c_int = 0x45584543;
+
+pub const REG_BASIC: ::c_int = 0;
+pub const REG_EXTENDED: ::c_int = 1;
+pub const REG_ICASE: ::c_int = 2;
+pub const REG_NOSUB: ::c_int = 4;
+pub const REG_NEWLINE: ::c_int = 8;
+pub const REG_NOSPEC: ::c_int = 16;
+pub const REG_PEND: ::c_int = 32;
+pub const REG_DUMP: ::c_int = 128;
+
+pub const REG_NOMATCH: ::c_int = 1;
+pub const REG_BADPAT: ::c_int = 2;
+pub const REG_ECOLLATE: ::c_int = 3;
+pub const REG_ECTYPE: ::c_int = 4;
+pub const REG_EESCAPE: ::c_int = 5;
+pub const REG_ESUBREG: ::c_int = 6;
+pub const REG_EBRACK: ::c_int = 7;
+pub const REG_EPAREN: ::c_int = 8;
+pub const REG_EBRACE: ::c_int = 9;
+pub const REG_BADBR: ::c_int = 10;
+pub const REG_ERANGE: ::c_int = 11;
+pub const REG_ESPACE: ::c_int = 12;
+pub const REG_BADRPT: ::c_int = 13;
+pub const REG_EMPTY: ::c_int = 14;
+pub const REG_ASSERT: ::c_int = 15;
+pub const REG_INVARG: ::c_int = 16;
+pub const REG_ATOI: ::c_int = 255;
+pub const REG_ITOA: ::c_int = 256;
+
+pub const REG_NOTBOL: ::c_int = 1;
+pub const REG_NOTEOL: ::c_int = 2;
+pub const REG_STARTEND: ::c_int = 4;
+pub const REG_TRACE: ::c_int = 256;
+pub const REG_LARGE: ::c_int = 512;
+pub const REG_BACKR: ::c_int = 1024;
 
 pub const MCL_CURRENT: ::c_int = 0x0001;
 pub const MCL_FUTURE: ::c_int = 0x0002;
@@ -2661,6 +2708,29 @@ extern "C" {
         path: *const ::c_char,
         mask: u32,
     ) -> ::c_int;
+
+    pub fn regcomp(
+        preg: *mut ::regex_t,
+        pattern: *const ::c_char,
+        cflags: ::c_int,
+    ) -> ::c_int;
+
+    pub fn regexec(
+        preg: *const ::regex_t,
+        input: *const ::c_char,
+        nmatch: ::size_t,
+        pmatch: *mut regmatch_t,
+        eflags: ::c_int,
+    ) -> ::c_int;
+
+    pub fn regerror(
+        errcode: ::c_int,
+        preg: *const ::regex_t,
+        errbuf: *mut ::c_char,
+        errbuf_size: ::size_t,
+    ) -> ::size_t;
+
+    pub fn regfree(preg: *mut ::regex_t);
 }
 
 cfg_if! {


### PR DESCRIPTION
References:
- [regex_t](https://github.com/aosp-mirror/platform_bionic/blob/platform-tools-30.0.3/libc/include/regex.h#L49-L54)
- [regmatch_t](https://github.com/aosp-mirror/platform_bionic/blob/platform-tools-30.0.3/libc/include/regex.h#L56-L59) (with [regoff_t defined as ssize_t](https://github.com/aosp-mirror/platform_bionic/blob/platform-tools-30.0.3/libc/include/regex.h#L47) ).
- [REG_ constants](https://github.com/aosp-mirror/platform_bionic/blob/platform-tools-30.0.3/libc/include/regex.h#L62-L97)
- [The functions](https://github.com/aosp-mirror/platform_bionic/blob/platform-tools-30.0.3/libc/include/regex.h#L100-L103)

Tested by compiling the [regex-rs part of newsboat](https://github.com/newsboat/newsboat/tree/master/rust/regex-rs).