### PR TITLE
process_vm_readv, process_vm_writev should be available on android

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1610,6 +1610,8 @@ fn test_android(target: &str) {
             | "open_memstream"
             | "open_wmemstream"
             | "clock_getcpuclockid"
+            | "process_vm_readv"
+            | "process_vm_writev"
                 if aarch64 =>
             {
                 true

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -2394,7 +2394,7 @@ extern "C" {
         remote_iov: *const ::iovec,
         riovcnt: ::c_ulong,
         flags: ::c_ulong,
-    ) -> isize;
+    ) -> ::ssize_t;
     pub fn process_vm_writev(
         pid: ::pid_t,
         local_iov: *const ::iovec,
@@ -2402,7 +2402,7 @@ extern "C" {
         remote_iov: *const ::iovec,
         riovcnt: ::c_ulong,
         flags: ::c_ulong,
-    ) -> isize;
+    ) -> ::ssize_t;
     pub fn ptrace(request: ::c_int, ...) -> ::c_long;
     pub fn getpriority(which: ::c_int, who: ::id_t) -> ::c_int;
     pub fn setpriority(which: ::c_int, who: ::id_t, prio: ::c_int) -> ::c_int;

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -2387,6 +2387,22 @@ extern "C" {
         sevlen: ::size_t,
         flags: ::c_int,
     ) -> ::c_int;
+    pub fn process_vm_readv(
+        pid: ::pid_t,
+        local_iov: *const ::iovec,
+        liovcnt: ::c_ulong,
+        remote_iov: *const ::iovec,
+        riovcnt: ::c_ulong,
+        flags: ::c_ulong,
+    ) -> isize;
+    pub fn process_vm_writev(
+        pid: ::pid_t,
+        local_iov: *const ::iovec,
+        liovcnt: ::c_ulong,
+        remote_iov: *const ::iovec,
+        riovcnt: ::c_ulong,
+        flags: ::c_ulong,
+    ) -> isize;
     pub fn ptrace(request: ::c_int, ...) -> ::c_long;
     pub fn getpriority(which: ::c_int, who: ::id_t) -> ::c_int;
     pub fn setpriority(which: ::c_int, who: ::id_t, prio: ::c_int) -> ::c_int;


### PR DESCRIPTION
process_vm_readv and process_vm_writev generally return -EPERM(-1) when used in android, however the syscalls work fine when running under privileged shell.
The following was tested(with modified nix) on Android 9/10 running Linux Kernel 4.9 on a SDM 845 phone:

```
fn read_mem_real(pid: i32, addr: usize, vsize: usize) -> Result<Vec<u8>, String> {
    let mut res = vec![0; vsize];
    let riovec: [RemoteIoVec; 1] = [RemoteIoVec {base: addr, len: vsize}];

    match process_vm_readv(Pid::from_raw(pid), &[IoVec::from_mut_slice(&mut res)], &riovec) {
        Err(e) => {
            log::info!("ERR {}", e);
            return Err(e.to_string());
        },
        Ok(_) => {
            return Ok(res);
        }
    }
}
```

This will work fine when run under su shell.