### PR TITLE
Add IOV_MAX and UIO_MAXIOV constants

### DIFF
--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -254,6 +254,8 @@ pub const FIOGETOWN: ::c_ulong = 0x4004667b;
 
 pub const PATH_MAX: ::c_int = 1024;
 
+pub const IOV_MAX: ::c_int = 1024;
+
 pub const SA_ONSTACK: ::c_int = 0x0001;
 pub const SA_SIGINFO: ::c_int = 0x0040;
 pub const SA_RESTART: ::c_int = 0x0002;

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -847,6 +847,8 @@ pub const SS_DISABLE: ::c_int = 2;
 
 pub const PATH_MAX: ::c_int = 4096;
 
+pub const UIO_MAXIOV: ::c_int = 1024;
+
 pub const FD_SETSIZE: usize = 1024;
 
 pub const EPOLLIN: ::c_int = 0x1;


### PR DESCRIPTION
These constant can be used to determine the maximum number of iovecs can
be passed to functions like readv/writev.

Linux like uses UIO_MAXIOV, while the BSD family uses IOV_MAX.