### PR TITLE
Add support for Apple's O_SYMLINK flag

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1406,6 +1406,7 @@ pub const O_DSYNC: ::c_int = 0x400000;
 pub const O_NOCTTY: ::c_int = 0x20000;
 pub const O_CLOEXEC: ::c_int = 0x1000000;
 pub const O_DIRECTORY: ::c_int = 0x100000;
+pub const O_SYMLINK: ::c_int = 0x200000;
 pub const S_IFIFO: mode_t = 4096;
 pub const S_IFCHR: mode_t = 8192;
 pub const S_IFBLK: mode_t = 24576;


### PR DESCRIPTION
Adds support for macOS/iOS's `O_SYMLINK` flag, which allows opening symlinks themselves (instead of their targets).