### PR TITLE
Bump to 0.2.77

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.76"
+version = "0.2.77"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Bumping version to `0.2.77`, for using the syscall numbers added in #1882 