### PR TITLE
Add UIO_MAXIOV constant to uclibc

### DIFF
--- a/src/unix/uclibc/mod.rs
+++ b/src/unix/uclibc/mod.rs
@@ -932,6 +932,8 @@ pub const SS_DISABLE: ::c_int = 2;
 
 pub const PATH_MAX: ::c_int = 4096;
 
+pub const UIO_MAXIOV: ::c_int = 1024;
+
 pub const FD_SETSIZE: usize = 1024;
 
 pub const EPOLLIN: ::c_int = 0x1;


### PR DESCRIPTION
#1880 added UIO_MAXIOV to linux-like libc, but did not add it
to uclibc. This causes build breaks for std against uclibc.