### PR TITLE
Add support for building with static glibc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 // Attributes needed when building as part of the standard library
 #![cfg_attr(
     feature = "rustc-dep-of-std",
-    feature(cfg_target_vendor, link_cfg, no_core)
+    feature(cfg_target_vendor, link_cfg, no_core, static_nobundle)
 )]
 #![cfg_attr(libc_thread_local, feature(thread_local))]
 // Enable extra lints:

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/not_x32.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/not_x32.rs
@@ -410,7 +410,6 @@ pub const SYS_pkey_alloc: ::c_long = 330;
 pub const SYS_pkey_free: ::c_long = 331;
 pub const SYS_statx: ::c_long = 332;
 
-#[link(name = "util")]
 extern "C" {
     pub fn sysctl(
         name: *mut ::c_int,

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1435,7 +1435,6 @@ extern "C" {
     ) -> ::c_int;
 }
 
-#[link(name = "dl")]
 extern "C" {
     pub fn dlmopen(
         lmid: Lmid_t,

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1362,7 +1362,6 @@ extern "C" {
     ) -> ::c_int;
 }
 
-#[link(name = "util")]
 extern "C" {
     pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
     pub fn backtrace(buf: *mut *mut ::c_void, sz: ::c_int) -> ::c_int;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -309,6 +309,8 @@ cfg_if! {
             cfg(target_feature = "crt-static"))]
         #[link(name = "m", kind = "static-nobundle",
             cfg(target_feature = "crt-static"))]
+        #[link(name = "dl", kind = "static-nobundle",
+            cfg(target_feature = "crt-static"))]
         #[link(name = "c", kind = "static-nobundle",
             cfg(target_feature = "crt-static"))]
         #[link(name = "gcc_eh", kind = "static-nobundle",
@@ -319,6 +321,7 @@ cfg_if! {
         #[link(name = "rt", cfg(not(target_feature = "crt-static")))]
         #[link(name = "pthread", cfg(not(target_feature = "crt-static")))]
         #[link(name = "m", cfg(not(target_feature = "crt-static")))]
+        #[link(name = "dl", cfg(not(target_feature = "crt-static")))]
         #[link(name = "c", cfg(not(target_feature = "crt-static")))]
         extern {}
     } else if #[cfg(target_env = "musl")] {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -301,6 +301,8 @@ cfg_if! {
     } else if #[cfg(all(target_os = "linux",
                         target_env = "gnu",
                         feature = "rustc-dep-of-std"))] {
+        #[link(name = "util", kind = "static-nobundle",
+            cfg(target_feature = "crt-static"))]
         #[link(name = "rt", kind = "static-nobundle",
             cfg(target_feature = "crt-static"))]
         #[link(name = "pthread", kind = "static-nobundle",
@@ -313,6 +315,7 @@ cfg_if! {
             cfg(target_feature = "crt-static"))]
         #[link(name = "gcc", kind = "static-nobundle",
             cfg(target_feature = "crt-static"))]
+        #[link(name = "util", cfg(not(target_feature = "crt-static")))]
         #[link(name = "rt", cfg(not(target_feature = "crt-static")))]
         #[link(name = "pthread", cfg(not(target_feature = "crt-static")))]
         #[link(name = "m", cfg(not(target_feature = "crt-static")))]

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -298,6 +298,26 @@ cfg_if! {
     } else if #[cfg(feature = "std")] {
         // cargo build, don't pull in anything extra as the libstd dep
         // already pulls in all libs.
+    } else if #[cfg(all(target_os = "linux",
+                        target_env = "gnu",
+                        feature = "rustc-dep-of-std"))] {
+        #[link(name = "rt", kind = "static-nobundle",
+            cfg(target_feature = "crt-static"))]
+        #[link(name = "pthread", kind = "static-nobundle",
+            cfg(target_feature = "crt-static"))]
+        #[link(name = "m", kind = "static-nobundle",
+            cfg(target_feature = "crt-static"))]
+        #[link(name = "c", kind = "static-nobundle",
+            cfg(target_feature = "crt-static"))]
+        #[link(name = "gcc_eh", kind = "static-nobundle",
+            cfg(target_feature = "crt-static"))]
+        #[link(name = "gcc", kind = "static-nobundle",
+            cfg(target_feature = "crt-static"))]
+        #[link(name = "rt", cfg(not(target_feature = "crt-static")))]
+        #[link(name = "pthread", cfg(not(target_feature = "crt-static")))]
+        #[link(name = "m", cfg(not(target_feature = "crt-static")))]
+        #[link(name = "c", cfg(not(target_feature = "crt-static")))]
+        extern {}
     } else if #[cfg(target_env = "musl")] {
         #[cfg_attr(feature = "rustc-dep-of-std",
                    link(name = "c", kind = "static",


### PR DESCRIPTION
This will need corresponding changes in rust-lang/rust to activate, but
this will make it possible to make those changes.

Note that despite the apparent redundancy in config directives, the link
directives cannot be simplified any further. Attempting to factor out
the checks for `target_feature = "crt-static"` does not work.