### PR TITLE
Added timer_create and related calls

### DIFF
--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -13,6 +13,7 @@ pub type speed_t = ::c_uint;
 pub type nl_item = ::c_int;
 pub type id_t = i64;
 pub type vm_size_t = ::uintptr_t;
+pub type timer_t = *mut ::c_void;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum timezone {}
@@ -232,6 +233,11 @@ s! {
         pub piod_offs: *mut ::c_void,
         pub piod_addr: *mut ::c_void,
         pub piod_len: ::size_t,
+    }
+
+    pub struct itimerspec {
+        pub it_interval: ::timespec,
+        pub it_value: ::timespec,
     }
 }
 
@@ -1566,6 +1572,24 @@ extern "C" {
         abs_timeout: *const ::timespec,
     ) -> ::c_int;
     pub fn mq_unlink(name: *const ::c_char) -> ::c_int;
+
+    pub fn timer_create(
+        clockid: ::clockid_t,
+        sevp: *mut ::sigevent,
+        timerid: *mut ::timer_t,
+    ) -> ::c_int;
+    pub fn timer_settime(
+        timerid: ::timer_t,
+        flags: ::c_int,
+        new_value: *const ::itimerspec,
+        old_value: *mut ::itimerspec,
+    ) -> ::c_int;
+    pub fn timer_gettime(
+        timerid: ::timer_t,
+        curr_value: *mut ::itimerspec,
+    ) -> ::c_int;
+    pub fn timer_getoverrun(timerid: ::timer_t) -> ::c_int;
+    pub fn timer_delete(timerid: ::timer_t) -> ::c_int;
 }
 
 #[link(name = "util")]

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -10,6 +10,7 @@ type __pthread_spin_t = __cpu_simple_lock_nv_t;
 pub type vm_size_t = ::uintptr_t;
 pub type lwpid_t = ::c_uint;
 pub type shmatt_t = ::c_uint;
+pub type timer_t = *mut ::c_void;
 
 impl siginfo_t {
     pub unsafe fn si_value(&self) -> ::sigval {
@@ -339,6 +340,11 @@ s! {
         pub esterror: ::c_long,
         pub tai: ::c_long,
         pub time_state: ::c_int,
+    }
+
+    pub struct itimerspec {
+        pub it_interval: ::timespec,
+        pub it_value: ::timespec,
     }
 
 }
@@ -1759,6 +1765,24 @@ extern "C" {
         nitems: ::c_int,
         sevp: *mut sigevent,
     ) -> ::c_int;
+
+    pub fn timer_create(
+        clockid: ::clockid_t,
+        sevp: *mut ::sigevent,
+        timerid: *mut ::timer_t,
+    ) -> ::c_int;
+    pub fn timer_settime(
+        timerid: ::timer_t,
+        flags: ::c_int,
+        new_value: *const ::itimerspec,
+        old_value: *mut ::itimerspec,
+    ) -> ::c_int;
+    pub fn timer_gettime(
+        timerid: ::timer_t,
+        curr_value: *mut ::itimerspec,
+    ) -> ::c_int;
+    pub fn timer_getoverrun(timerid: ::timer_t) -> ::c_int;
+    pub fn timer_delete(timerid: ::timer_t) -> ::c_int;
 }
 
 extern "C" {

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -148,11 +148,6 @@ s! {
         _pad: [u8; 28],
     }
 
-    pub struct itimerspec {
-        pub it_interval: ::timespec,
-        pub it_value: ::timespec,
-    }
-
     pub struct ucred {
         pub pid: ::pid_t,
         pub uid: ::uid_t,
@@ -2465,13 +2460,13 @@ extern "C" {
     pub fn timerfd_create(clock: ::clockid_t, flags: ::c_int) -> ::c_int;
     pub fn timerfd_gettime(
         fd: ::c_int,
-        current_value: *mut itimerspec,
+        current_value: *mut ::itimerspec,
     ) -> ::c_int;
     pub fn timerfd_settime(
         fd: ::c_int,
         flags: ::c_int,
-        new_value: *const itimerspec,
-        old_value: *mut itimerspec,
+        new_value: *const ::itimerspec,
+        old_value: *mut ::itimerspec,
     ) -> ::c_int;
     pub fn syscall(num: ::c_long, ...) -> ::c_long;
     pub fn sched_getaffinity(

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -123,11 +123,6 @@ s! {
         _pad: [u8; 28],
     }
 
-    pub struct itimerspec {
-        pub it_interval: ::timespec,
-        pub it_value: ::timespec,
-    }
-
     pub struct fsid_t {
         __val: [::c_int; 2],
     }
@@ -2951,13 +2946,13 @@ extern "C" {
     pub fn timerfd_create(clockid: ::c_int, flags: ::c_int) -> ::c_int;
     pub fn timerfd_gettime(
         fd: ::c_int,
-        curr_value: *mut itimerspec,
+        curr_value: *mut ::itimerspec,
     ) -> ::c_int;
     pub fn timerfd_settime(
         fd: ::c_int,
         flags: ::c_int,
-        new_value: *const itimerspec,
-        old_value: *mut itimerspec,
+        new_value: *const ::itimerspec,
+        old_value: *mut ::itimerspec,
     ) -> ::c_int;
     pub fn pwritev(
         fd: ::c_int,

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -4,6 +4,7 @@ pub type tcflag_t = ::c_uint;
 pub type clockid_t = ::c_int;
 pub type key_t = ::c_int;
 pub type id_t = ::c_uint;
+pub type timer_t = *mut ::c_void;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum timezone {}
@@ -200,6 +201,11 @@ s! {
     pub struct mmsghdr {
         pub msg_hdr: ::msghdr,
         pub msg_len: ::c_uint,
+    }
+
+    pub struct itimerspec {
+        pub it_interval: ::timespec,
+        pub it_value: ::timespec,
     }
 }
 
@@ -1566,6 +1572,24 @@ extern "C" {
         flags: ::c_int,
     ) -> ::ssize_t;
     pub fn uname(buf: *mut ::utsname) -> ::c_int;
+
+    pub fn timer_create(
+        clockid: ::clockid_t,
+        sevp: *mut ::sigevent,
+        timerid: *mut ::timer_t,
+    ) -> ::c_int;
+    pub fn timer_settime(
+        timerid: ::timer_t,
+        flags: ::c_int,
+        new_value: *const ::itimerspec,
+        old_value: *mut ::itimerspec,
+    ) -> ::c_int;
+    pub fn timer_gettime(
+        timerid: ::timer_t,
+        curr_value: *mut ::itimerspec,
+    ) -> ::c_int;
+    pub fn timer_getoverrun(timerid: ::timer_t) -> ::c_int;
+    pub fn timer_delete(timerid: ::timer_t) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
Added:
* timer_create
* timer_getoverrun
* timer_gettime
* timer_settime
* timer_delete

https://www.freebsd.org/cgi/man.cgi?query=timer_create+&apropos=0&sektion=0&manpath=FreeBSD+9.0-RELEASE&arch=default&format=html

https://www.man7.org/linux/man-pages/man2/timer_create.2.html

https://man.netbsd.org/timer_create.2