### PR TITLE
linux: Add definitions for Multipath TCP

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2649,6 +2649,10 @@ fn test_linux(target: &str) {
             // Require Linux kernel 5.6:
             "VMADDR_CID_LOCAL" => true,
 
+            // IPPROTO_MAX was increased in 5.6 for IPPROTO_MPTCP:
+            | "IPPROTO_MAX"
+            | "IPPROTO_MPTCP" => true,
+
             // Defined in kernel headers but musl removes it; need musl 1.2 for definition in musl
             // headers.
             "P_PIDFD" => true,

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -1008,6 +1008,8 @@ pub const SOCK_SEQPACKET: ::c_int = 5;
 pub const SOCK_DCCP: ::c_int = 6;
 pub const SOCK_PACKET: ::c_int = 10;
 
+pub const IPPROTO_MAX: ::c_int = 256;
+
 pub const SOL_SOCKET: ::c_int = 1;
 pub const SOL_SCTP: ::c_int = 132;
 pub const SOL_IPX: ::c_int = 256;
@@ -1067,6 +1069,8 @@ pub const SO_DOMAIN: ::c_int = 39;
 pub const SO_RXQ_OVFL: ::c_int = 40;
 pub const SO_PEEK_OFF: ::c_int = 42;
 pub const SO_BUSY_POLL: ::c_int = 46;
+
+pub const TCP_ULP: ::c_int = 31;
 
 pub const IPTOS_ECN_NOTECT: u8 = 0x00;
 

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1557,6 +1557,8 @@ pub const SOCK_STREAM: ::c_int = 1;
 pub const SOCK_DGRAM: ::c_int = 2;
 pub const SOCK_SEQPACKET: ::c_int = 5;
 
+pub const IPPROTO_MAX: ::c_int = 256;
+
 pub const SOL_SOCKET: ::c_int = 1;
 
 pub const SO_REUSEADDR: ::c_int = 2;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1267,10 +1267,12 @@ pub const SCHED_RESET_ON_FORK: ::c_int = 0x40000000;
 /// Multipath TCP
 pub const IPPROTO_MPTCP: ::c_int = 262;
 #[deprecated(
-    since = "0.2.79",
-    note = "IPPROTO_MAX depends on the kernel version on the target system"
+    since = "0.2.80",
+    note = "This value was increased in the newer kernel \
+            and we'll change this following upstream in the future release. \
+            See #1896 for more info."
 )]
-pub const IPPROTO_MAX: ::c_int = 263;
+pub const IPPROTO_MAX: ::c_int = 256;
 
 pub const AF_IB: ::c_int = 27;
 pub const AF_MPLS: ::c_int = 28;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1228,6 +1228,7 @@ pub const RTLD_NOW: ::c_int = 0x2;
 pub const AT_EACCESS: ::c_int = 0x200;
 
 pub const TCP_MD5SIG: ::c_int = 14;
+pub const TCP_ULP: ::c_int = 31;
 
 align_const! {
     pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
@@ -1262,6 +1263,15 @@ pub const SCHED_RESET_ON_FORK: ::c_int = 0x40000000;
 
 // netinet/in.h
 // NOTE: These are in addition to the constants defined in src/unix/mod.rs
+
+/// Multipath TCP
+pub const IPPROTO_MPTCP: ::c_int = 262;
+#[deprecated(
+    since = "0.2.79",
+    note = "IPPROTO_MAX depends on the kernel version on the target system"
+)]
+pub const IPPROTO_MAX: ::c_int = 263;
+
 pub const AF_IB: ::c_int = 27;
 pub const AF_MPLS: ::c_int = 28;
 pub const AF_NFC: ::c_int = 39;

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -869,7 +869,6 @@ pub const IPPROTO_UDPLITE: ::c_int = 136;
 pub const IPPROTO_MPLS: ::c_int = 137;
 /// raw IP packet
 pub const IPPROTO_RAW: ::c_int = 255;
-pub const IPPROTO_MAX: ::c_int = 256;
 
 pub const MCAST_EXCLUDE: ::c_int = 0;
 pub const MCAST_INCLUDE: ::c_int = 1;


### PR DESCRIPTION
The Linux kernel recently gained support for [Multipath TCP](https://en.wikipedia.org/wiki/Multipath_TCP), a protocol which builds upon TCP. This patch adds `IPPROTO_MPTCP` to open new sockets and `TCP_ULP` to query the upper layer protocol of traditional TCP sockets (which is set to `mptcp` for all underlying connections)

Source: [tcp: Define IPPROTO_MPTCP](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=faf391c3826cd29feae02078ca2022d2f912f7cc)

cc #1896 