### PR TITLE
Fix type definition for c_char on sparc-unknown-linux-gnu

### DIFF
--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -1,6 +1,6 @@
 //! SPARC-specific definitions for 32-bit linux-like values
 
-pub type c_char = u8;
+pub type c_char = i8;
 pub type wchar_t = i32;
 
 s! {


### PR DESCRIPTION
On sparc-unknown-linux-gnu, char is signed, not unsigned.