### PR TITLE
pthread_getattr_np is not present on illumos

### DIFF
--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2268,10 +2268,6 @@ extern "C" {
         f: extern "C" fn(*mut ::c_void) -> *mut ::c_void,
         value: *mut ::c_void,
     ) -> ::c_int;
-    pub fn pthread_getattr_np(
-        thread: ::pthread_t,
-        attr: *mut ::pthread_attr_t,
-    ) -> ::c_int;
     pub fn pthread_attr_getstack(
         attr: *const ::pthread_attr_t,
         stackaddr: *mut *mut ::c_void,

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -65,6 +65,11 @@ extern "C" {
     ) -> ::c_int;
 
     pub fn fattach(fildes: ::c_int, path: *const ::c_char) -> ::c_int;
+
+    pub fn pthread_getattr_np(
+        thread: ::pthread_t,
+        attr: *mut ::pthread_attr_t,
+    ) -> ::c_int;
 }
 
 s_no_extra_traits! {


### PR DESCRIPTION
In 9f6a7ceee819e847eb4e0218c4452ac1d0cffad4, the symbol for `pthread_getattr_np` was added to the file common to both Solaris and illumos.  This symbol does not yet exist on illumos and causes the `libc-test` suite to fail there.  It should be moved into the Solaris-specific file where its visibility is limited.

With this change, the `libc-test` suite passes once again on an illumos machine.