### PR TITLE
Retry N times on s390x CI to avoid timeout failure

### DIFF
--- a/ci/linux-s390x.sh
+++ b/ci/linux-s390x.sh
@@ -6,8 +6,8 @@ mkdir -m 777 /qemu
 cd /qemu
 
 curl --retry 5 -LO https://github.com/qemu/qemu/raw/master/pc-bios/s390-ccw.img
-curl --retry 5 -LO http://ftp.debian.org/debian/dists/testing/main/installer-s390x/20191129/images/generic/kernel.debian
-curl --retry 5 -LO http://ftp.debian.org/debian/dists/testing/main/installer-s390x/20191129/images/generic/initrd.debian
+curl --retry 5 -LO http://ftp.debian.org/debian/dists/testing/main/installer-s390x/20200314/images/generic/kernel.debian
+curl --retry 5 -LO http://ftp.debian.org/debian/dists/testing/main/installer-s390x/20200314/images/generic/initrd.debian
 
 mv kernel.debian kernel
 mv initrd.debian initrd.gz


### PR DESCRIPTION
This target often fails to test due to timeout so let's retry N times like rustup installing.