### PR TITLE
Allow contributors to label issues via rustbot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,1 +1,6 @@
+[relabel]
+allow-unauthenticated = [
+    "C-*", "O-*", "S-*"
+]
+
 [assign]


### PR DESCRIPTION
Now bors suggests contributors label PRs with the status labels, e.g.:

https://github.com/rust-lang/libc/pull/1902#issuecomment-702337160

This allows it, and for issues as well.