### PR TITLE
Adding nmount call to support FreeBSD disk mounting

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1499,6 +1499,12 @@ extern "C" {
         needle: *const ::c_void,
         needlelen: ::size_t,
     ) -> *mut ::c_void;
+
+    pub fn nmount(
+	iov: *const ::iovec,
+	niov: ::c_uint,
+	flags: ::c_int
+    ) -> ::c_int;
 }
 
 #[link(name = "util")]


### PR DESCRIPTION
Adding disk mounting support for FreeBSD, which prefers nmount over mount.