### PR TITLE
Add freebsd nmount

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
@@ -214,6 +214,8 @@ extern "C" {
         msgtyp: ::c_long,
         msgflg: ::c_int,
     ) -> ::c_int;
+
+    pub fn fdatasync(fd: ::c_int) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -227,6 +227,8 @@ extern "C" {
         rqtp: *const ::timespec,
         rmtp: *mut ::timespec,
     ) -> ::c_int;
+
+    pub fn fdatasync(fd: ::c_int) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1299,7 +1299,6 @@ extern "C" {
         flags: ::c_int,
     ) -> ::c_int;
 
-    pub fn fdatasync(fd: ::c_int) -> ::c_int;
     pub fn posix_fallocate(
         fd: ::c_int,
         offset: ::off_t,
@@ -1499,6 +1498,12 @@ extern "C" {
         needle: *const ::c_void,
         needlelen: ::size_t,
     ) -> *mut ::c_void;
+
+    pub fn nmount(
+        iov: *mut ::iovec,
+        niov: ::c_uint,
+        flags: ::c_int
+    ) -> ::c_int;
 }
 
 #[link(name = "util")]


### PR DESCRIPTION
Adding FreeBSD's nmount call to mount devices on filesystems.  nmount is preferred over mount.