### PR TITLE
Include sendfile64() for Linux

### DIFF
--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -3230,6 +3230,12 @@ extern "C" {
         offset: *mut off_t,
         count: ::size_t,
     ) -> ::ssize_t;
+    pub fn sendfile64(
+        out_fd: ::c_int,
+        in_fd: ::c_int,
+        offset: *mut off64_t,
+        count: ::size_t,
+    ) -> ::ssize_t;
     pub fn sigsuspend(mask: *const ::sigset_t) -> ::c_int;
     pub fn getgrgid_r(
         gid: ::gid_t,


### PR DESCRIPTION
`sendfile` uses the `off_t` type, which is platform dependent. On 64-bit architectures, I can pass an `off64_t` as the third argument to `libc::sendfile`, but on 32-bit architectures, this does not compile. `sendfile64` on the other hand uses a 64-bit wide offset even on 32-bit architectures, so that `off64_t` can be used.

Excerpt from `man 2 sendfile`:

> The original Linux sendfile() system call was not designed to handle large file offsets. Consequently, Linux 2.4 added sendfile64(), with a wider type for the offset argument.

I hope that supporting Linux versions below 2.4 is not a requirement for libc.
