### PR TITLE
Add a deprecation note to `time_t` on musl

### DIFF
--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -1,5 +1,11 @@
 pub type pthread_t = *mut ::c_void;
 pub type clock_t = c_long;
+#[deprecated(
+    since = "0.2.80",
+    note = "This type is changed to 64-bit in musl 1.2.0, \
+            we'll follow that change in the future release. \
+            See #1848 for more info."
+)]
 pub type time_t = c_long;
 pub type suseconds_t = c_long;
 pub type ino_t = u64;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1315,23 +1315,33 @@ extern "C" {
     pub fn res_init() -> ::c_int;
 
     #[cfg_attr(target_os = "netbsd", link_name = "__gmtime_r50")]
+    #[cfg_attr(target_env = "musl", allow(deprecated))] // FIXME: for `time_t`
     pub fn gmtime_r(time_p: *const time_t, result: *mut tm) -> *mut tm;
     #[cfg_attr(target_os = "netbsd", link_name = "__localtime_r50")]
+    #[cfg_attr(target_env = "musl", allow(deprecated))] // FIXME: for `time_t`
     pub fn localtime_r(time_p: *const time_t, result: *mut tm) -> *mut tm;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "mktime$UNIX2003"
     )]
     #[cfg_attr(target_os = "netbsd", link_name = "__mktime50")]
+    #[cfg_attr(target_env = "musl", allow(deprecated))] // FIXME: for `time_t`
     pub fn mktime(tm: *mut tm) -> time_t;
     #[cfg_attr(target_os = "netbsd", link_name = "__time50")]
+    #[cfg_attr(target_env = "musl", allow(deprecated))] // FIXME: for `time_t`
     pub fn time(time: *mut time_t) -> time_t;
     #[cfg_attr(target_os = "netbsd", link_name = "__gmtime50")]
+    #[cfg_attr(target_env = "musl", allow(deprecated))] // FIXME: for `time_t`
     pub fn gmtime(time_p: *const time_t) -> *mut tm;
     #[cfg_attr(target_os = "netbsd", link_name = "__locatime50")]
+    #[cfg_attr(target_env = "musl", allow(deprecated))] // FIXME: for `time_t`
     pub fn localtime(time_p: *const time_t) -> *mut tm;
     #[cfg_attr(target_os = "netbsd", link_name = "__difftime50")]
+    #[cfg_attr(target_env = "musl", allow(deprecated))] // FIXME: for `time_t`
     pub fn difftime(time1: time_t, time0: time_t) -> ::c_double;
+    #[cfg_attr(target_os = "netbsd", link_name = "__timegm50")]
+    #[cfg_attr(target_env = "musl", allow(deprecated))] // FIXME: for `time_t`
+    pub fn timegm(tm: *mut ::tm) -> time_t;
 
     #[cfg_attr(target_os = "netbsd", link_name = "__mknod50")]
     #[cfg_attr(
@@ -1445,9 +1455,6 @@ extern "C" {
     ) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__sigpending14")]
     pub fn sigpending(set: *mut sigset_t) -> ::c_int;
-
-    #[cfg_attr(target_os = "netbsd", link_name = "__timegm50")]
-    pub fn timegm(tm: *mut ::tm) -> time_t;
 
     pub fn sysconf(name: ::c_int) -> ::c_long;
 


### PR DESCRIPTION
cc #1848