### PR TITLE
Allow `deprecated` attribute on `f!` macros to fix dragonfly build

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -40,12 +40,12 @@ macro_rules! cfg_if {
 
     // Internal and recursive macro to emit all the items
     //
-    // Collects all the negated cfgs in a list at the beginning and after the
+    // Collects all the negated `cfg`s in a list at the beginning and after the
     // semicolon is all the remaining items
     (@__items ($($not:meta,)*) ; ) => {};
     (@__items ($($not:meta,)*) ; ( ($($m:meta),*) ($($it:item)*) ),
      $($rest:tt)*) => {
-        // Emit all items within one block, applying an approprate #[cfg]. The
+        // Emit all items within one block, applying an appropriate #[cfg]. The
         // #[cfg] will require all `$m` matchers specified and must also negate
         // all previous matchers.
         cfg_if! { @__apply cfg(all($($m,)* not(any($($not),*)))), $($it)* }
@@ -169,7 +169,7 @@ macro_rules! s_paren {
 // so we need to avoid emitting it at all of 'const-extern-fn'.
 //
 // Specifically, moving the 'cfg_if' into the macro body will *not* work.
-// Doing so would cause the '#[cfg(feature = "const-extern-fn")]' to be emiited
+// Doing so would cause the '#[cfg(feature = "const-extern-fn")]' to be emitted
 // into user code. The 'cfg' gate will not stop Rust from trying to parse the
 // 'pub const unsafe extern fn', so users would get a compiler error even when
 // the 'const-extern-fn' feature is disabled
@@ -177,19 +177,20 @@ macro_rules! s_paren {
 // Note that users of this macro need to place 'const' in a weird position
 // (after the closing ')' for the arguments, but before the return type).
 // This was the only way I could satisfy the following two requirements:
-// 1. Avoid ambuguity errors from 'macro_rules!' (which happen when writing '$foo:ident fn'
+// 1. Avoid ambiguity errors from 'macro_rules!' (which happen when writing '$foo:ident fn'
 // 2. Allow users of this macro to mix 'pub fn foo' and 'pub const fn bar' within the same
 // 'f!' block
 cfg_if! {
     if #[cfg(libc_const_extern_fn)] {
         #[allow(unused_macros)]
         macro_rules! f {
-            ($(pub $({$constness:ident})* fn $i:ident(
+            ($($(#[$attr:meta])* pub $({$constness:ident})* fn $i:ident(
                         $($arg:ident: $argty:ty),*
             ) -> $ret:ty {
                 $($body:stmt);*
             })*) => ($(
                 #[inline]
+                $(#[$attr])*
                 pub $($constness)* unsafe extern fn $i($($arg: $argty),*
                 ) -> $ret {
                     $($body);*
@@ -199,12 +200,13 @@ cfg_if! {
 
         #[allow(unused_macros)]
         macro_rules! safe_f {
-            ($(pub $({$constness:ident})* fn $i:ident(
+            ($($(#[$attr:meta])* pub $({$constness:ident})* fn $i:ident(
                         $($arg:ident: $argty:ty),*
             ) -> $ret:ty {
                 $($body:stmt);*
             })*) => ($(
                 #[inline]
+                $(#[$attr])*
                 pub $($constness)* extern fn $i($($arg: $argty),*
                 ) -> $ret {
                     $($body);*
@@ -214,12 +216,13 @@ cfg_if! {
 
         #[allow(unused_macros)]
         macro_rules! const_fn {
-            ($($({$constness:ident})* fn $i:ident(
+            ($($(#[$attr:meta])* $({$constness:ident})* fn $i:ident(
                         $($arg:ident: $argty:ty),*
             ) -> $ret:ty {
                 $($body:stmt);*
             })*) => ($(
                 #[inline]
+                $(#[$attr])*
                 $($constness)* fn $i($($arg: $argty),*
                 ) -> $ret {
                     $($body);*
@@ -230,12 +233,13 @@ cfg_if! {
     } else {
         #[allow(unused_macros)]
         macro_rules! f {
-            ($(pub $({$constness:ident})* fn $i:ident(
+            ($($(#[$attr:meta])* pub $({$constness:ident})* fn $i:ident(
                         $($arg:ident: $argty:ty),*
             ) -> $ret:ty {
                 $($body:stmt);*
             })*) => ($(
                 #[inline]
+                $(#[$attr])*
                 pub unsafe extern fn $i($($arg: $argty),*
                 ) -> $ret {
                     $($body);*
@@ -245,12 +249,13 @@ cfg_if! {
 
         #[allow(unused_macros)]
         macro_rules! safe_f {
-            ($(pub $({$constness:ident})* fn $i:ident(
+            ($($(#[$attr:meta])* pub $({$constness:ident})* fn $i:ident(
                         $($arg:ident: $argty:ty),*
             ) -> $ret:ty {
                 $($body:stmt);*
             })*) => ($(
                 #[inline]
+                $(#[$attr])*
                 pub extern fn $i($($arg: $argty),*
                 ) -> $ret {
                     $($body);*
@@ -260,12 +265,13 @@ cfg_if! {
 
         #[allow(unused_macros)]
         macro_rules! const_fn {
-            ($($({$constness:ident})* fn $i:ident(
+            ($($(#[$attr:meta])* $({$constness:ident})* fn $i:ident(
                         $($arg:ident: $argty:ty),*
             ) -> $ret:ty {
                 $($body:stmt);*
             })*) => ($(
                 #[inline]
+                $(#[$attr])*
                 fn $i($($arg: $argty),*
                 ) -> $ret {
                     $($body);*

--- a/src/unix/bsd/freebsdlike/dragonfly/errno.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/errno.rs
@@ -1,7 +1,7 @@
 // DragonFlyBSD's __error function is declared with "static inline", so it must
 // be implemented in the libc crate, as a pointer to a static thread_local.
 f! {
-    #[deprecated(since = "0.2.77", "Use `__errno_location()` instead")]
+    #[deprecated(since = "0.2.77", note = "Use `__errno_location()` instead")]
     pub fn __error() -> *mut ::c_int {
         &mut errno
     }


### PR DESCRIPTION
Fixes #1957
cc @nagisa I think this should resolve the build :)