### PR TITLE
Add more TCP options for solaris systems.

### DIFF
--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -22,6 +22,10 @@ pub const EFD_SEMAPHORE: ::c_int = 0x1;
 pub const EFD_NONBLOCK: ::c_int = 0x800;
 pub const EFD_CLOEXEC: ::c_int = 0x80000;
 
+pub const TCP_KEEPIDLE: ::c_int = 34;
+pub const TCP_KEEPCNT: ::c_int = 35;
+pub const TCP_KEEPINTVL: ::c_int = 36;
+
 extern "C" {
     pub fn eventfd(init: ::c_uint, flags: ::c_int) -> ::c_int;
 

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1387,6 +1387,9 @@ pub const IPV6_LEAVE_GROUP: ::c_int = 10;
 
 pub const TCP_NODELAY: ::c_int = 1;
 pub const TCP_KEEPIDLE: ::c_int = 34;
+pub const TCP_KEEPCNT: ::c_int = 35;
+pub const TCP_KEEPINTVL: ::c_int = 36;
+
 pub const SOL_SOCKET: ::c_int = 0xffff;
 pub const SO_DEBUG: ::c_int = 0x01;
 pub const SO_ACCEPTCONN: ::c_int = 0x0002;

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1386,9 +1386,6 @@ pub const IPV6_JOIN_GROUP: ::c_int = 9;
 pub const IPV6_LEAVE_GROUP: ::c_int = 10;
 
 pub const TCP_NODELAY: ::c_int = 1;
-pub const TCP_KEEPIDLE: ::c_int = 34;
-pub const TCP_KEEPCNT: ::c_int = 35;
-pub const TCP_KEEPINTVL: ::c_int = 36;
 
 pub const SOL_SOCKET: ::c_int = 0xffff;
 pub const SO_DEBUG: ::c_int = 0x01;

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -32,6 +32,10 @@ pub const PORT_SOURCE_SIGNAL: ::c_int = 9;
 pub const AF_LOCAL: ::c_int = 0;
 pub const AF_FILE: ::c_int = 0;
 
+pub const TCP_KEEPIDLE: ::c_int = 0x1d;
+pub const TCP_KEEPCNT: ::c_int = 0x1e;
+pub const TCP_KEEPINTVL: ::c_int = 0x1f;
+
 extern "C" {
     pub fn fexecve(
         fd: ::c_int,


### PR DESCRIPTION
This adds the `TCP_KEEPCNT` and `TCP_KEEPINTVL` tcp values to the libc crate. It also corrects the value of `TCP_KEEPIDLE` for Solaris systems. As seen in the diff, the value is different between illumos and Solaris (as the feature was added after the two code bases forked, and each ended up choosing a different value).

Adding these to libc will allow the nix crate to utilize them when used on solarish systems.