### PR TITLE
Implement accept4 on Android as raw syscall.

### DIFF
--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -2349,6 +2349,20 @@ f! {
     pub fn SO_EE_OFFENDER(ee: *const ::sock_extended_err) -> *mut ::sockaddr {
         ee.offset(1) as *mut ::sockaddr
     }
+
+    // Sadly, Android before 5.0 (API level 21), the accept4 syscall is not
+    // exposed by the libc. As work-around, we implement it through `syscall`
+    // directly. This workaround can be removed if the minimum version of
+    // Android is bumped. When the workaround is removed, `accept4` can be
+    // moved back to `linux_like/mod.rs`
+    pub fn accept4(
+        fd: ::c_int,
+        addr: *mut ::sockaddr,
+        len: *mut ::socklen_t,
+        flg: ::c_int
+    ) -> ::c_int {
+        syscall(SYS_accept4, fd, addr, len, flg) as ::c_int
+    }
 }
 
 extern "C" {

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1851,6 +1851,12 @@ extern "C" {
     ) -> ::c_int;
     pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t)
         -> *mut ::c_char;
+    pub fn accept4(
+        fd: ::c_int,
+        addr: *mut ::sockaddr,
+        len: *mut ::socklen_t,
+        flg: ::c_int,
+    ) -> ::c_int;
     pub fn getnameinfo(
         sa: *const ::sockaddr,
         salen: ::socklen_t,

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -2997,6 +2997,12 @@ extern "C" {
     pub fn sigwaitinfo(set: *const sigset_t, info: *mut siginfo_t) -> ::c_int;
     pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t)
         -> *mut ::c_char;
+    pub fn accept4(
+        fd: ::c_int,
+        addr: *mut ::sockaddr,
+        len: *mut ::socklen_t,
+        flg: ::c_int,
+    ) -> ::c_int;
     pub fn getnameinfo(
         sa: *const ::sockaddr,
         salen: ::socklen_t,

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1581,12 +1581,6 @@ extern "C" {
         attr: *mut pthread_condattr_t,
         pshared: ::c_int,
     ) -> ::c_int;
-    pub fn accept4(
-        fd: ::c_int,
-        addr: *mut ::sockaddr,
-        len: *mut ::socklen_t,
-        flg: ::c_int,
-    ) -> ::c_int;
     pub fn pthread_mutexattr_setpshared(
         attr: *mut pthread_mutexattr_t,
         pshared: ::c_int,


### PR DESCRIPTION
This PR implements `accept4()` on Android using `syscall()` instead of the `accept4()` wrapper.

This is done because the `accept4()` wrapper wasn't added to Androids `libc` until version 5.0 (API level 21). By using `syscall` directly, `accept4` will also work on older  Android versions.

The kernel itself has supported it since Linux 2.6.28, which was shipped with stock Android since version 1.6 already: https://en.wikipedia.org/wiki/Android_version_history#Android_1.6_Donut_(API_4)

At the moment, the CI for the rust repo still uses API level 14. Although I also opened a PR to bump that too: https://github.com/rust-lang/rust/pull/78601. However, it might make sense to keep the old API level in CI if this is merged.