### PR TITLE
Add ENOTSUP constant for uclibc

### DIFF
--- a/src/unix/uclibc/mod.rs
+++ b/src/unix/uclibc/mod.rs
@@ -716,6 +716,7 @@ pub const EPIPE: ::c_int = 32;
 pub const EDOM: ::c_int = 33;
 pub const ERANGE: ::c_int = 34;
 pub const EWOULDBLOCK: ::c_int = EAGAIN;
+pub const ENOTSUP: ::c_int = EOPNOTSUPP;
 
 pub const SCM_RIGHTS: ::c_int = 0x01;
 pub const SCM_CREDENTIALS: ::c_int = 0x02;


### PR DESCRIPTION
In the vein of other linux-like c libs, just define `ENOTSUP` as equal to `EOPNOTSUPP`.