### PR TITLE
Fix bug in `CMSG_NXTHDR` for android.

### DIFF
--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -2289,6 +2289,9 @@ pub const PF_VSOCK: ::c_int = AF_VSOCK;
 f! {
     pub fn CMSG_NXTHDR(mhdr: *const msghdr,
                        cmsg: *const cmsghdr) -> *mut cmsghdr {
+        if ((*cmsg).cmsg_len as usize) < ::mem::size_of::<cmsghdr>() {
+            return 0 as *mut cmsghdr;
+        };
         let next = (cmsg as usize
                     + super::CMSG_ALIGN((*cmsg).cmsg_len as usize))
             as *mut cmsghdr;


### PR DESCRIPTION
`CMSG_NXTHDR` should return NULL if it is the last control message in the chain.