### PR TITLE
Add getrandom to FreeBSD

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1706,6 +1706,7 @@ fn test_freebsd(target: &str) {
                 "sys/msg.h",
                 "sys/procdesc.h",
                 "sys/ptrace.h",
+                "sys/random.h",
                 "sys/resource.h",
                 "sys/rtprio.h",
                 "sys/shm.h",

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -197,12 +197,16 @@ pub const F_SEAL_SHRINK: ::c_int = 0x0002;
 pub const F_SEAL_GROW: ::c_int = 0x0004;
 pub const F_SEAL_WRITE: ::c_int = 0x0008;
 
+pub const GRND_NONBLOCK: ::c_uint = 0x1;
+pub const GRND_RANDOM: ::c_uint = 0x2;
+
 cfg_if! {
     if #[cfg(not(freebsd13))] {
         pub const ELAST: ::c_int = 96;
     } else {
         pub const EINTEGRITY: ::c_int = 97;
         pub const ELAST: ::c_int = 97;
+        pub const GRND_INSECURE: ::c_uint = 0x4;
     }
 }
 
@@ -229,6 +233,12 @@ extern "C" {
     ) -> ::c_int;
 
     pub fn fdatasync(fd: ::c_int) -> ::c_int;
+
+    pub fn getrandom(
+        buf: *mut ::c_void,
+        buflen: ::size_t,
+        flags: ::c_uint
+    ) -> ::ssize_t;
 }
 
 cfg_if! {


### PR DESCRIPTION
Introduced in FreeBSD 12.0.

Manual page: https://www.freebsd.org/cgi/man.cgi?query=getrandom.

Not sure if the constants should be `c_int`, just matching the `flags` argument in the function, in c they're macros.