### PR TITLE
illumos fixups

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -866,6 +866,11 @@ fn test_solarish(target: &str) {
             "madvise" | "mprotect" if is_illumos => true,
             "door_call" | "door_return" | "door_create" if is_illumos => true,
 
+            // These functions may return int or void depending on the exact
+            // configuration of the compilation environment, but the return
+            // value is not useful (always 0) so we can ignore it:
+            "setservent" | "endservent" if is_illumos => true,
+
             _ => false,
         }
     });

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -25,6 +25,7 @@ pub const EFD_CLOEXEC: ::c_int = 0x80000;
 pub const TCP_KEEPIDLE: ::c_int = 34;
 pub const TCP_KEEPCNT: ::c_int = 35;
 pub const TCP_KEEPINTVL: ::c_int = 36;
+pub const TCP_CONGESTION: ::c_int = 37;
 
 extern "C" {
     pub fn eventfd(init: ::c_uint, flags: ::c_int) -> ::c_int;

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1385,7 +1385,24 @@ pub const IP_DROP_MEMBERSHIP: ::c_int = 20;
 pub const IPV6_JOIN_GROUP: ::c_int = 9;
 pub const IPV6_LEAVE_GROUP: ::c_int = 10;
 
-pub const TCP_NODELAY: ::c_int = 1;
+// These TCP socket options are common between illumos and Solaris, while higher
+// numbers have generally diverged:
+pub const TCP_NODELAY: ::c_int = 0x1;
+pub const TCP_MAXSEG: ::c_int = 0x2;
+pub const TCP_KEEPALIVE: ::c_int = 0x8;
+pub const TCP_NOTIFY_THRESHOLD: ::c_int = 0x10;
+pub const TCP_ABORT_THRESHOLD: ::c_int = 0x11;
+pub const TCP_CONN_NOTIFY_THRESHOLD: ::c_int = 0x12;
+pub const TCP_CONN_ABORT_THRESHOLD: ::c_int = 0x13;
+pub const TCP_RECVDSTADDR: ::c_int = 0x14;
+pub const TCP_INIT_CWND: ::c_int = 0x15;
+pub const TCP_KEEPALIVE_THRESHOLD: ::c_int = 0x16;
+pub const TCP_KEEPALIVE_ABORT_THRESHOLD: ::c_int = 0x17;
+pub const TCP_CORK: ::c_int = 0x18;
+pub const TCP_RTO_INITIAL: ::c_int = 0x19;
+pub const TCP_RTO_MIN: ::c_int = 0x1a;
+pub const TCP_RTO_MAX: ::c_int = 0x1b;
+pub const TCP_LINGER2: ::c_int = 0x1c;
 
 pub const SOL_SOCKET: ::c_int = 0xffff;
 pub const SO_DEBUG: ::c_int = 0x01;


### PR DESCRIPTION
I needed `TCP_MAXSEG` for use with 0.3.x of [socket2](https://github.com/alexchrichton/socket2-rs), and while I was there I figured I would add the rest of the TCP socket options we have on illumos.  Many of these are common with Solaris, but some are not; I have attempted to put them in the correct place so that they will only be active where they are valid.

The other commit in this PR gags the test for `setservent()` and `endservent()`, which on illumos have some complexity with respect to return types under different compilation conditions.

I don't have an Oracle Solaris system on which to test, but on my relatively current illumos system the tests pass:

```
$ (cd libc-test && CC_x86_64_unknown_illumos=clang AR_x86_64_unknown_illumos=gar cargo test)
   Compiling libc v0.2.80 (/ws/safari/libc)
   Compiling libc-test v0.1.0 (/ws/safari/libc/libc-test)
    Finished test [unoptimized + debuginfo] target(s) in 12.45s
     Running /ws/safari/libc/target/debug/deps/cmsg-9ceed5ee937b4c5f

running 5 tests
test t::test_cmsg_data ... ok
test t::test_cmsg_firsthdr ... ok
test t::test_cmsg_len ... ok
test t::test_cmsg_space ... ok
test t::test_cmsg_nxthdr ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running /ws/safari/libc/target/debug/deps/errqueue-70aa763a9ed1f681

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running /ws/safari/libc/target/debug/deps/linux_elf-534b101b72339f59
PASSED 0 tests
     Running /ws/safari/libc/target/debug/deps/linux_fcntl-4dca948e65c4e2bb
PASSED 0 tests
     Running /ws/safari/libc/target/debug/deps/linux_ipv6-74ce6ee23c41bad1
PASSED 0 tests
     Running /ws/safari/libc/target/debug/deps/linux_strerror_r-c7705986f4a1d214
PASSED 0 tests
     Running /ws/safari/libc/target/debug/deps/linux_termios-690bf406ed77f8a9
PASSED 0 tests
     Running /ws/safari/libc/target/debug/deps/main-0b8735d9db2c09ba
RUNNING ALL TESTS
PASSED 6543 tests
```