### PR TITLE
restore the type of the parameter `flags` of `getnameinfo` to `c_int`

### DIFF
--- a/src/unix/uclibc/mod.rs
+++ b/src/unix/uclibc/mod.rs
@@ -2326,7 +2326,7 @@ extern "C" {
         hostlen: ::socklen_t,
         serv: *mut ::c_char,
         sevlen: ::socklen_t,
-        flags: ::c_uint,
+        flags: ::c_int,
     ) -> ::c_int;
 }
 


### PR DESCRIPTION
Restore the type of the parameter `flags` of `getnameinfo` to `c_int`

At present, all the implementation parameters of `getnameinfo` `flags` are of type `int`, and some constants defined are also of type `int`. I have seen the implementation of uclibc. The `flags` values are basically macro definitions, so should we not do this by uclibc alone kind of special treatment.

These several places also define the `int` type.
https://github.com/rust-lang/libc/blob/master/src/unix/uclibc/mod.rs#L1375