### PR TITLE
Declare `seekdir` and `telldir` for Android

### DIFF
--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -2465,6 +2465,8 @@ extern "C" {
     pub fn setutent();
     pub fn getutent() -> *mut utmp;
 
+    pub fn seekdir(dirp: *mut ::DIR, loc: ::c_long);
+    pub fn telldir(dirp: *mut ::DIR) -> ::c_long;
     pub fn fallocate(
         fd: ::c_int,
         mode: ::c_int,


### PR DESCRIPTION
These declarations are the same as those for other platforms.

They are available [since API level 23](https://github.com/aosp-mirror/platform_bionic/blob/29cff99e08746f8060f32eba03df3b95acf1163d/libc/include/dirent.h#L145-L163).