### PR TITLE
Declare `O_RSYNC` for Android

### DIFF
--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -1101,6 +1101,7 @@ pub const O_SYNC: ::c_int = 0x101000;
 pub const O_ASYNC: ::c_int = 0x2000;
 pub const O_NDELAY: ::c_int = 0x800;
 pub const O_DSYNC: ::c_int = 4096;
+pub const O_RSYNC: ::c_int = O_SYNC;
 
 pub const NI_MAXHOST: ::size_t = 1025;
 pub const NI_MAXSERV: ::size_t = 32;


### PR DESCRIPTION
Bionic [defines](https://github.com/aosp-mirror/platform_bionic/blob/35bb46188ce8dbbb8bde0702e6cc6bf1d0795980/libc/include/fcntl.h#L57) it to be `O_SYNC`.

For context, [this](https://github.com/bytecodealliance/wasmtime/pull/2502#pullrequestreview-550837614) is where this option was necessary.