### PR TITLE
Make si_status method more compatible

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -690,6 +690,10 @@ impl siginfo_t {
     pub unsafe fn si_uid(&self) -> ::uid_t {
         self.si_uid
     }
+
+    pub unsafe fn si_status(&self) -> ::c_int {
+        self.si_status
+    }
 }
 
 cfg_if! {

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -71,6 +71,10 @@ impl siginfo_t {
     pub unsafe fn si_uid(&self) -> ::uid_t {
         self.si_uid
     }
+
+    pub unsafe fn si_status(&self) -> ::c_int {
+        self.si_status
+    }
 }
 
 s! {

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -50,6 +50,10 @@ impl siginfo_t {
     pub unsafe fn si_uid(&self) -> ::uid_t {
         self.si_uid
     }
+
+    pub unsafe fn si_status(&self) -> ::c_int {
+        self.si_status
+    }
 }
 
 s! {

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -128,6 +128,10 @@ impl siginfo_t {
     pub unsafe fn si_uid(&self) -> ::uid_t {
         self.si_uid
     }
+
+    pub unsafe fn si_status(&self) -> ::c_int {
+        self.si_status
+    }
 }
 
 s! {


### PR DESCRIPTION
Now that [this PR](https://github.com/rust-lang/libc/pull/1858/files) has been merged, `siginfo_t::si_status` is a method for some targets and a field on others. This PR adds the method on targets that already expose the field, which lets the method be used without target detection.

I think this change is backward compatible, but it would be better if someone else could confirm that. The struct would now have a method and a field with the same name on some targets. If that's incompatible, another method could be added that accesses the field or calls the method depending on the target, but this is cleaner.