### PR TITLE
Fix missing dl lib on armv5te-unknown-linux-uclibceabi

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -299,7 +299,7 @@ cfg_if! {
         // cargo build, don't pull in anything extra as the libstd dep
         // already pulls in all libs.
     } else if #[cfg(all(target_os = "linux",
-                        target_env = "gnu",
+                        any(target_env = "gnu", target_env = "uclibc"),
                         feature = "rustc-dep-of-std"))] {
         #[link(name = "util", kind = "static-nobundle",
             cfg(target_feature = "crt-static"))]


### PR DESCRIPTION
I'm unable to link my executable for the Linux uClibc environment because of some missing symbols from the dl lib:
```
/home/operutka/goodcam/goodcam-server/target/armv5te-unknown-linux-uclibceabi/release/deps/goodcam_server-aefb92c403e8cd55.goodcam_server.dzc3futp-cgu.0.rcgu.o: In function `mio::sys::unix::dlsym::fetch::he5e2964820cfd29d':
      goodcam_server.dzc3futp-cgu.0:(.text._ZN3mio3sys4unix5dlsym5fetch17he5e2964820cfd29dE+0x30): undefined reference to `dlsym'
/home/operutka/goodcam/goodcam-server/target/armv5te-unknown-linux-uclibceabi/release/deps/goodcam_server-aefb92c403e8cd55.goodcam_server.dzc3futp-cgu.0.rcgu.o: In function `std::sys::unix::weak::fetch::h5ed4b0fa5792ef5c':
      goodcam_server.dzc3futp-cgu.0:(.text._ZN3std3sys4unix4weak5fetch17h5ed4b0fa5792ef5cE+0x3c): undefined reference to `dlsym'
```

The libc crate is being used at both of these points.

This change fixes the issue for me. I've tested it with two different GCC cross toolchains for armv5te and it seems to be OK.

_Note: I'm building my own std using the unstable build-std Cargo feature._