### PR TITLE
fix glob symbol name on macOS aarch64

### DIFF
--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -632,7 +632,10 @@ extern "C" {
         egid: *mut ::gid_t,
     ) -> ::c_int;
 
-    #[cfg_attr(target_os = "macos", link_name = "glob$INODE64")]
+    #[cfg_attr(
+        all(target_os = "macos", not(target_arch = "aarch64")),
+        link_name = "glob$INODE64")
+    ]
     #[cfg_attr(target_os = "netbsd", link_name = "__glob30")]
     #[cfg_attr(
         all(target_os = "freebsd", any(freebsd11, freebsd10)),


### PR DESCRIPTION
This is another symbol like the ones #2007. Missed this one earlier, because the test suite did not get this far, because of #2008 .