### PR TITLE
fix type of __priority_which_t/__rlimit_resource_t

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1,6 +1,6 @@
 pub type pthread_t = c_ulong;
-pub type __priority_which_t = ::c_uint;
-pub type __rlimit_resource_t = ::c_uint;
+pub type __priority_which_t = ::c_int;
+pub type __rlimit_resource_t = ::c_int;
 pub type Lmid_t = ::c_long;
 pub type regoff_t = ::c_int;
 


### PR DESCRIPTION
This has the incorrect type as shown here:
https://github.com/bminor/glibc/blob/be9b0b9a012780a403a266c90878efffb9a5f3ca/resource/sys/resource.h#L44

According to posix this is also defined as int.
This is causing compatibility problems when compiling against glibc vs musl.