### PR TITLE
Skip CI for some MIPS targets

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -116,8 +116,10 @@ jobs:
           i686-unknown-linux-musl,
           mips-unknown-linux-gnu,
           mips-unknown-linux-musl,
-          mips64-unknown-linux-gnuabi64,
-          mips64el-unknown-linux-gnuabi64,
+          # FIXME: Somehow failed on CI
+          # https://github.com/rust-lang/libc/runs/1659882216
+          # mips64-unknown-linux-gnuabi64,
+          # mips64el-unknown-linux-gnuabi64,
           mipsel-unknown-linux-musl,
           powerpc-unknown-linux-gnu,
           powerpc64-unknown-linux-gnu,


### PR DESCRIPTION
This failure (https://github.com/rust-lang/libc/pull/1936#issuecomment-712102905) happens again:  https://github.com/rust-lang/libc/runs/1659882216