### PR TITLE
Add mount ID to statx

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2656,6 +2656,9 @@ fn test_linux(target: &str) {
             | "CAN_RAW_FILTER_MAX"
             | "CAN_NPROTO" => true,
 
+            // FIXME: Requires recent kernel headers (5.8):
+            "STATX_MNT_ID" => true,
+
             _ => false,
         }
     });

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -13,7 +13,7 @@ s! {
         pub stx_uid: u32,
         pub stx_gid: u32,
         pub stx_mode: u16,
-        pub __statx_pad1: [u16; 1],
+        __statx_pad1: [u16; 1],
         pub stx_ino: u64,
         pub stx_size: u64,
         pub stx_blocks: u64,
@@ -26,7 +26,7 @@ s! {
         pub stx_rdev_minor: u32,
         pub stx_dev_major: u32,
         pub stx_dev_minor: u32,
-        pub __statx_pad2: [u64; 14],
+        __statx_pad2: [u64; 14],
     }
 
     pub struct statx_timestamp {

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -26,7 +26,9 @@ s! {
         pub stx_rdev_minor: u32,
         pub stx_dev_major: u32,
         pub stx_dev_minor: u32,
-        __statx_pad2: [u64; 14],
+        pub stx_mnt_id: u64,
+        __statx_pad2: u64,
+        __statx_pad3: [u64; 12],
     }
 
     pub struct statx_timestamp {
@@ -1171,6 +1173,7 @@ pub const STATX_SIZE: ::c_uint = 0x0200;
 pub const STATX_BLOCKS: ::c_uint = 0x0400;
 pub const STATX_BASIC_STATS: ::c_uint = 0x07ff;
 pub const STATX_BTIME: ::c_uint = 0x0800;
+pub const STATX_MNT_ID: ::c_uint = 0x1000;
 pub const STATX_ALL: ::c_uint = 0x0fff;
 pub const STATX__RESERVED: ::c_int = 0x80000000;
 pub const STATX_ATTR_COMPRESSED: ::c_int = 0x0004;


### PR DESCRIPTION
This mirrors the modifications to `include/uapi/linux/stat.h` by [Linux commit fa2fcf4f1df1559a0a4ee0f46915b496cc2ebf60 (“statx: add mount ID”)](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=fa2fcf4f1df1559a0a4ee0f46915b496cc2ebf60).

What changed in v2 (v1: #2023):
* Skip testing the new `STATX_MNT_ID` constant, because it’s only part of Linux as of 5.8. That’s too new e.g. for Ubuntu 20.04.1 (with a kernel derived from 5.4), which is what’s used by the CI.