### PR TITLE
Fix error when building rustc with a custom libc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 // Enable extra lints:
 #![cfg_attr(feature = "extra_traits", deny(missing_debug_implementations))]
 #![deny(missing_copy_implementations, safe_packed_borrows)]
-#![no_std]
+#![cfg_attr(not(feature = "rustc-dep-of-std"), no_std)]
 #![cfg_attr(feature = "rustc-dep-of-std", no_core)]
 #![cfg_attr(
     any(feature = "rustc-dep-of-std", target_os = "redox"),


### PR DESCRIPTION
When pulling a custom `libc` into a `rustc` build (with the `rustc-dep-of-std` feature set), the following error occurs:
```
error: unused attribute
  --> /hdd/libc/src/lib.rs:29:1
   |
29 | #![no_std]
   | ^^^^^^^^^^
   |
   = note: `-D unused-attributes` implied by `-D warnings`

error: crate-level attribute should be in the root module
  --> /hdd/libc/src/lib.rs:29:1
   |
29 | #![no_std]
   | ^^^^^^^^^^
```

I think this is because both the `no_std` and `no_core` attributes are specified, although the error message doesn't make this very clear. This PR changes this so `no_std` is only supplied when the `rustc-dep-of-std` feature is not.