### PR TITLE
Re-add the build test for  `sparc-unknown-linux-gnu`

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -201,8 +201,6 @@ for TARGET in $TARGETS; do
     fi
 done
 
-# Disable the below because of LLVM on `compiler_builtins` 0.1.36:
-# sparc-unknown-linux-gnu
 RUST_LINUX_NO_CORE_TARGETS="\
 aarch64-pc-windows-msvc \
 aarch64-unknown-freebsd \
@@ -240,6 +238,7 @@ riscv32imc-unknown-none-elf \
 riscv32gc-unknown-linux-gnu \
 riscv64gc-unknown-none-elf \
 riscv64imac-unknown-none-elf \
+sparc-unknown-linux-gnu \
 sparc64-unknown-netbsd \
 
 thumbv6m-none-eabi \


### PR DESCRIPTION
The current nightly uses compiler_builtins 0.1.39 so the issue should be fixed.