### PR TITLE
Haiku: add definitions for the Haiku's native sytem API.

### DIFF
--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -11,7 +11,7 @@ default-features = false
 [build-dependencies]
 cc = "1.0.61"
 # FIXME: Use fork ctest until the maintainer gets back.
-ctest2 = "0.3"
+ctest2 = "0.4"
 
 [features]
 default = [ "std" ]

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -1553,3 +1553,6 @@ cfg_if! {
         pub use self::b32::*;
     }
 }
+
+mod native;
+pub use self::native::*;

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -1,9 +1,9 @@
 pub type rlim_t = ::uintptr_t;
 pub type sa_family_t = u8;
 pub type pthread_key_t = ::c_int;
-pub type nfds_t = ::c_long;
+pub type nfds_t = ::c_ulong;
 pub type tcflag_t = ::c_uint;
-pub type speed_t = ::c_uint;
+pub type speed_t = ::c_uchar;
 pub type c_char = i8;
 pub type clock_t = i32;
 pub type clockid_t = i32;
@@ -19,6 +19,7 @@ pub type nlink_t = i32;
 pub type useconds_t = u32;
 pub type socklen_t = u32;
 pub type pthread_t = ::uintptr_t;
+pub type pthread_condattr_t = ::uintptr_t;
 pub type pthread_mutexattr_t = ::uintptr_t;
 pub type pthread_rwlockattr_t = ::uintptr_t;
 pub type sigset_t = u64;
@@ -28,6 +29,7 @@ pub type pthread_attr_t = *mut ::c_void;
 pub type nl_item = ::c_int;
 pub type id_t = i32;
 pub type idtype_t = ::c_uint;
+pub type fd_mask = u32;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum timezone {}
@@ -69,7 +71,7 @@ s! {
     pub struct sockaddr {
         pub sa_len: u8,
         pub sa_family: sa_family_t,
-        pub sa_data: [::c_char; 30],
+        pub sa_data: [u8; 30],
     }
 
     pub struct sockaddr_in {
@@ -77,13 +79,13 @@ s! {
         pub sin_family: sa_family_t,
         pub sin_port: ::in_port_t,
         pub sin_addr: ::in_addr,
-        pub sin_zero: [u8; 24],
+        pub sin_zero: [i8; 24],
     }
 
     pub struct sockaddr_in6 {
         pub sin6_len: u8,
-        pub sin6_family: sa_family_t,
-        pub sin6_port: ::in_port_t,
+        pub sin6_family: u8,
+        pub sin6_port: u16,
         pub sin6_flowinfo: u32,
         pub sin6_addr: ::in6_addr,
         pub sin6_scope_id: u32,
@@ -101,7 +103,8 @@ s! {
     }
 
     pub struct fd_set {
-        fds_bits: [c_ulong; FD_SETSIZE / ULONG_SIZE],
+        // size for 1024 bits, and a fd_mask with size u32
+        fds_bits: [fd_mask; 32],
     }
 
     pub struct tm {
@@ -114,8 +117,8 @@ s! {
         pub tm_wday: ::c_int,
         pub tm_yday: ::c_int,
         pub tm_isdst: ::c_int,
-        pub tm_gmtoff: ::c_long,
-        pub tm_zone: *const ::c_char,
+        pub tm_gmtoff: ::c_int,
+        pub tm_zone: *mut ::c_char,
     }
 
     pub struct utsname {
@@ -155,16 +158,16 @@ s! {
 
     pub struct msghdr {
         pub msg_name: *mut ::c_void,
-        pub msg_namelen: ::socklen_t,
+        pub msg_namelen: socklen_t,
         pub msg_iov: *mut ::iovec,
         pub msg_iovlen: ::c_int,
         pub msg_control: *mut ::c_void,
-        pub msg_controllen: ::socklen_t,
+        pub msg_controllen: socklen_t,
         pub msg_flags: ::c_int,
     }
 
     pub struct cmsghdr {
-        pub cmsg_len: ::size_t,
+        pub cmsg_len: ::socklen_t,
         pub cmsg_level: ::c_int,
         pub cmsg_type: ::c_int,
     }
@@ -301,22 +304,16 @@ s! {
     }
 
     pub struct sigaction {
-        pub sa_sigaction: ::sighandler_t,
+        pub sa_sigaction: ::sighandler_t, //actually a union with sa_handler
         pub sa_mask: ::sigset_t,
         pub sa_flags: ::c_int,
         sa_userdata: *mut ::c_void,
     }
 
     pub struct sem_t {
-        pub se_type: i32,
-        pub se_named_id: i32, // this is actually a union
-        pub se_unnamed: i32,
-        pub se_padding: [i32; 4],
-    }
-
-    pub struct pthread_condattr_t {
-        pub process_shared: bool,
-        pub clock_id: i32,
+        pub type_: i32,
+        pub named_sem_id: i32, // actually a union with unnamed_sem (i32)
+        pub padding: [i32; 2],
     }
 }
 
@@ -491,17 +488,6 @@ cfg_if! {
     }
 }
 
-// intentionally not public, only used for fd_set
-cfg_if! {
-    if #[cfg(target_pointer_width = "32")] {
-        const ULONG_SIZE: usize = 32;
-    } else if #[cfg(target_pointer_width = "64")] {
-        const ULONG_SIZE: usize = 64;
-    } else {
-        // Unknown target_pointer_width
-    }
-}
-
 pub const EXIT_FAILURE: ::c_int = 1;
 pub const EXIT_SUCCESS: ::c_int = 0;
 pub const RAND_MAX: ::c_int = 2147483647;
@@ -559,7 +545,7 @@ pub const RLIMIT_STACK: ::c_int = 5;
 pub const RLIMIT_AS: ::c_int = 6;
 // Haiku specific
 pub const RLIMIT_NOVMON: ::c_int = 7;
-pub const RLIMIT_NLIMITS: ::c_int = 8;
+pub const RLIM_NLIMITS: ::c_int = 8;
 
 pub const RUSAGE_SELF: ::c_int = 0;
 
@@ -596,18 +582,20 @@ pub const S_IFREG: ::mode_t = 32768;
 pub const S_IFLNK: ::mode_t = 40960;
 pub const S_IFSOCK: ::mode_t = 49152;
 pub const S_IFMT: ::mode_t = 61440;
-pub const S_IRWXU: ::mode_t = 448;
-pub const S_IXUSR: ::mode_t = 64;
-pub const S_IWUSR: ::mode_t = 128;
-pub const S_IRUSR: ::mode_t = 256;
-pub const S_IRWXG: ::mode_t = 70;
-pub const S_IXGRP: ::mode_t = 10;
-pub const S_IWGRP: ::mode_t = 20;
-pub const S_IRGRP: ::mode_t = 40;
-pub const S_IRWXO: ::mode_t = 7;
-pub const S_IXOTH: ::mode_t = 1;
-pub const S_IWOTH: ::mode_t = 2;
-pub const S_IROTH: ::mode_t = 4;
+
+pub const S_IRWXU: ::mode_t = 0o00700;
+pub const S_IRUSR: ::mode_t = 0o00400;
+pub const S_IWUSR: ::mode_t = 0o00200;
+pub const S_IXUSR: ::mode_t = 0o00100;
+pub const S_IRWXG: ::mode_t = 0o00070;
+pub const S_IRGRP: ::mode_t = 0o00040;
+pub const S_IWGRP: ::mode_t = 0o00020;
+pub const S_IXGRP: ::mode_t = 0o00010;
+pub const S_IRWXO: ::mode_t = 0o00007;
+pub const S_IROTH: ::mode_t = 0o00004;
+pub const S_IWOTH: ::mode_t = 0o00002;
+pub const S_IXOTH: ::mode_t = 0o00001;
+
 pub const F_OK: ::c_int = 0;
 pub const R_OK: ::c_int = 4;
 pub const W_OK: ::c_int = 2;
@@ -707,8 +695,8 @@ pub const ENOTTY: ::c_int = -2147454966;
 pub const ENXIO: ::c_int = -2147454965;
 pub const ESPIPE: ::c_int = -2147454964;
 pub const ESRCH: ::c_int = -2147454963;
-pub const EFPOS: ::c_int = -2147457962;
-pub const ESIGPARM: ::c_int = -2147457961;
+pub const EFPOS: ::c_int = -2147454962;
+pub const ESIGPARM: ::c_int = -2147454961;
 pub const EDOM: ::c_int = -2147454960;
 pub const ERANGE: ::c_int = -2147454959;
 pub const EPROTOTYPE: ::c_int = -2147454958;
@@ -756,7 +744,7 @@ pub const ETXTBSY: ::c_int = -2147454917;
 pub const ENOATTR: ::c_int = -2147454916;
 
 // INT_MIN
-pub const ENOMEM: ::c_int = -2147454976;
+pub const ENOMEM: ::c_int = -2147483648;
 
 // POSIX errors that can be mapped to BeOS error codes
 pub const EACCES: ::c_int = -2147483646;
@@ -844,6 +832,9 @@ pub const TCP_MAXSEG: ::c_int = 0x02;
 pub const TCP_NOPUSH: ::c_int = 0x04;
 pub const TCP_NOOPT: ::c_int = 0x08;
 
+pub const IF_NAMESIZE: ::size_t = 32;
+pub const IFNAMSIZ: ::size_t = IF_NAMESIZE;
+
 pub const IPV6_MULTICAST_IF: ::c_int = 24;
 pub const IPV6_MULTICAST_HOPS: ::c_int = 25;
 pub const IPV6_MULTICAST_LOOP: ::c_int = 26;
@@ -854,7 +845,7 @@ pub const IPV6_V6ONLY: ::c_int = 30;
 pub const IPV6_PKTINFO: ::c_int = 31;
 pub const IPV6_RECVPKTINFO: ::c_int = 32;
 pub const IPV6_HOPLIMIT: ::c_int = 33;
-pub const IPV6_REVCHOPLIMIT: ::c_int = 34;
+pub const IPV6_RECVHOPLIMIT: ::c_int = 34;
 pub const IPV6_HOPOPTS: ::c_int = 35;
 pub const IPV6_DSTOPTS: ::c_int = 36;
 pub const IPV6_RTHDR: ::c_int = 37;
@@ -1239,7 +1230,60 @@ pub const PRIO_PROCESS: ::c_int = 0;
 pub const PRIO_PGRP: ::c_int = 1;
 pub const PRIO_USER: ::c_int = 2;
 
+pub const LOG_PID: ::c_int = 1 << 12;
+pub const LOG_CONS: ::c_int = 2 << 12;
+pub const LOG_ODELAY: ::c_int = 4 << 12;
+pub const LOG_NDELAY: ::c_int = 8 << 12;
+pub const LOG_SERIAL: ::c_int = 16 << 12;
+pub const LOG_PERROR: ::c_int = 32 << 12;
+pub const LOG_NOWAIT: ::c_int = 64 << 12;
+
+const_fn! {
+    {const} fn CMSG_ALIGN(len: usize) -> usize {
+        len + ::mem::size_of::<usize>() - 1 & !(::mem::size_of::<usize>() - 1)
+    }
+}
+
 f! {
+    pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
+        if (*mhdr).msg_controllen as usize >= ::mem::size_of::<cmsghdr>() {
+            (*mhdr).msg_control as *mut cmsghdr
+        } else {
+            0 as *mut cmsghdr
+        }
+    }
+
+    pub fn CMSG_DATA(cmsg: *const ::cmsghdr) -> *mut ::c_uchar {
+        (cmsg as *mut ::c_uchar)
+            .offset(CMSG_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
+    }
+
+    pub {const} fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
+        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(::mem::size_of::<cmsghdr>()))
+            as ::c_uint
+    }
+
+    pub fn CMSG_LEN(length: ::c_uint) -> ::c_uint {
+        CMSG_ALIGN(::mem::size_of::<cmsghdr>()) as ::c_uint + length
+    }
+
+    pub fn CMSG_NXTHDR(mhdr: *const msghdr,
+                       cmsg: *const cmsghdr) -> *mut cmsghdr {
+        if cmsg.is_null() {
+            return ::CMSG_FIRSTHDR(mhdr);
+        };
+        let next = cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize)
+            + CMSG_ALIGN(::mem::size_of::<::cmsghdr>());
+        let max = (*mhdr).msg_control as usize
+            + (*mhdr).msg_controllen as usize;
+        if next > max {
+            0 as *mut ::cmsghdr
+        } else {
+            (cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize))
+                as *mut ::cmsghdr
+        }
+    }
+
     pub fn FD_CLR(fd: ::c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
@@ -1368,10 +1412,10 @@ extern "C" {
         clock_id: ::clockid_t,
     ) -> ::c_int;
     pub fn memalign(align: ::size_t, size: ::size_t) -> *mut ::c_void;
-    pub fn setgroups(ngroups: ::size_t, ptr: *const ::gid_t) -> ::c_int;
-    pub fn ioctl(fd: ::c_int, request: ::c_int, ...) -> ::c_int;
+    pub fn setgroups(ngroups: ::c_int, ptr: *const ::gid_t) -> ::c_int;
+    pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
     pub fn mprotect(
-        addr: *const ::c_void,
+        addr: *mut ::c_void,
         len: ::size_t,
         prot: ::c_int,
     ) -> ::c_int;
@@ -1380,9 +1424,9 @@ extern "C" {
         sa: *const ::sockaddr,
         salen: ::socklen_t,
         host: *mut ::c_char,
-        hostlen: ::size_t,
+        hostlen: ::socklen_t,
         serv: *mut ::c_char,
-        sevlen: ::size_t,
+        sevlen: ::socklen_t,
         flags: ::c_int,
     ) -> ::c_int;
     pub fn pthread_mutex_timedlock(
@@ -1455,12 +1499,12 @@ extern "C" {
     pub fn writev(
         fd: ::c_int,
         iov: *const ::iovec,
-        iovcnt: ::c_int,
+        count: ::size_t,
     ) -> ::ssize_t;
     pub fn readv(
         fd: ::c_int,
         iov: *const ::iovec,
-        iovcnt: ::c_int,
+        count: ::size_t,
     ) -> ::ssize_t;
 
     pub fn sendmsg(

--- a/src/unix/haiku/native.rs
+++ b/src/unix/haiku/native.rs
@@ -1,0 +1,1146 @@
+// This module contains bindings to the native Haiku API. The Haiku API
+// originates from BeOS, and it was the original way to perform low level
+// system and IO operations. The POSIX API was in that era was like a
+// compatibility layer. In current Haiku development, both the POSIX API and
+// the Haiku API are considered to be co-equal status. However, they are not
+// integrated like they are on other UNIX platforms, which means that for many
+// low level concepts there are two versions, like processes (POSIX) and
+// teams (Haiku), or pthreads and native threads.
+//
+// Both the POSIX API and the Haiku API live in libroot.so, the library that is
+// linked to any binary by default.
+//
+// This file follows the Haiku API for Haiku R1 beta 2. It is organized by the
+// C/C++ header files in which the concepts can be found, while adhering to the
+// style guide for this crate.
+
+// Helper macro to generate u32 constants. The Haiku API uses (non-standard)
+// multi-character constants (like 'UPDA' or 'MSGM') to represent 32 bit
+// integer constants.
+
+macro_rules! haiku_constant {
+    ($a:tt, $b:tt, $c:tt, $d:tt) => {
+        (($a as u32) << 24)
+            + (($b as u32) << 16)
+            + (($c as u32) << 8)
+            + ($d as u32)
+    };
+}
+
+// support/SupportDefs.h
+pub type status_t = i32;
+pub type bigtime_t = i64;
+pub type nanotime_t = i64;
+pub type type_code = u32;
+pub type perform_code = u32;
+
+// kernel/OS.h
+pub type area_id = i32;
+pub type port_id = i32;
+pub type sem_id = i32;
+pub type team_id = i32;
+pub type thread_id = i32;
+
+pub type thread_func = extern "C" fn(*mut ::c_void) -> status_t;
+
+// kernel/image.h
+pub type image_id = i32;
+
+e! {
+    // kernel/OS.h
+    pub enum thread_state {
+        B_THREAD_RUNNING = 1,
+        B_THREAD_READY,
+        B_THREAD_RECEIVING,
+        B_THREAD_ASLEEP,
+        B_THREAD_SUSPENDED,
+        B_THREAD_WAITING
+    }
+
+    // kernel/image.h
+    pub enum image_type {
+        B_APP_IMAGE = 1,
+        B_LIBRARY_IMAGE,
+        B_ADD_ON_IMAGE,
+        B_SYSTEM_IMAGE
+    }
+}
+
+s! {
+    // kernel/OS.h
+    pub struct area_info {
+        pub area: area_id,
+        pub name: [::c_char; B_OS_NAME_LENGTH],
+        pub size: usize,
+        pub lock: u32,
+        pub protection: u32,
+        pub team: team_id,
+        pub ram_size: u32,
+        pub copy_count: u32,
+        pub in_count: u32,
+        pub out_count: u32,
+        pub address: *mut ::c_void
+    }
+
+    pub struct port_info {
+        pub port: port_id,
+        pub team: team_id,
+        pub name: [::c_char; B_OS_NAME_LENGTH],
+        pub capacity: i32,
+        pub queue_count: i32,
+        pub total_count: i32,
+    }
+
+    pub struct port_message_info {
+        pub size: ::size_t,
+        pub sender: ::uid_t,
+        pub sender_group: ::gid_t,
+        pub sender_team: ::team_id
+    }
+
+    pub struct team_info {
+        team: team_id,
+        thread_count: i32,
+        image_count: i32,
+        area_count: i32,
+        debugger_nub_thread: thread_id,
+        debugger_nub_port: port_id,
+        argc: i32,
+        args: [::c_char; 64],
+        uid: ::uid_t,
+        gid: ::gid_t
+    }
+
+    pub struct sem_info {
+        sem: sem_id,
+        team: team_id,
+        name: [::c_char; B_OS_NAME_LENGTH],
+        count: i32,
+        latest_holder: thread_id
+    }
+
+    pub struct team_usage_info {
+        user_time: bigtime_t,
+        kernel_time: bigtime_t
+    }
+
+    pub struct thread_info {
+        pub thread: thread_id,
+        pub team: team_id,
+        pub name: [::c_char; B_OS_NAME_LENGTH],
+        pub state: thread_state,
+        pub priority: i32,
+        pub sem: sem_id,
+        pub user_time: bigtime_t,
+        pub kernel_time: bigtime_t,
+        pub stack_base: *mut ::c_void,
+        pub stack_end: *mut ::c_void
+    }
+
+    pub struct cpu_info {
+        pub active_time: bigtime_t,
+        pub enabled: bool
+    }
+
+    pub struct system_info {
+        pub boot_time: bigtime_t,
+        pub cpu_count: u32,
+        pub max_pages: u64,
+        pub used_pages: u64,
+        pub cached_pages: u64,
+        pub block_cache_pages: u64,
+        pub ignored_pages: u64,
+        pub needed_memory: u64,
+        pub free_memory: u64,
+        pub max_swap_pages: u64,
+        pub free_swap_pages: u64,
+        pub page_faults: u32,
+        pub max_sems: u32,
+        pub used_sems: u32,
+        pub max_ports: u32,
+        pub used_ports: u32,
+        pub max_threads: u32,
+        pub used_threads: u32,
+        pub max_teams: u32,
+        pub used_teams: u32,
+        pub kernel_name: [::c_char; B_FILE_NAME_LENGTH],
+        pub kernel_build_date: [::c_char; B_OS_NAME_LENGTH],
+        pub kernel_build_time: [::c_char; B_OS_NAME_LENGTH],
+        pub kernel_version: i64,
+        pub abi: u32
+    }
+
+    pub struct object_wait_info {
+        pub object: i32,
+        pub type_: u16,
+        pub events: u16
+    }
+
+    // kernel/fs_attr.h
+    pub struct attr_info {
+        type_: u32,
+        size: ::off_t
+    }
+
+    // kernel/fs_index.h
+    pub struct index_info {
+        type_: u32,
+        size: ::off_t,
+        modification_time: ::time_t,
+        creation_time: ::time_t,
+        uid: ::uid_t,
+        gid: ::gid_t
+    }
+
+    //kernel/fs_info.h
+    pub struct fs_info {
+        dev: ::dev_t,
+        root: ::ino_t,
+        flags: u32,
+        block_size: ::off_t,
+        io_size: ::off_t,
+        total_blocks: ::off_t,
+        free_blocks: ::off_t,
+        total_nodes: ::off_t,
+        free_nodes: ::off_t,
+        device_name: [::c_char; 128],
+        volume_name: [::c_char; B_FILE_NAME_LENGTH],
+        fsh_name: [::c_char; B_OS_NAME_LENGTH]
+    }
+
+    // kernel/image.h
+    pub struct image_info {
+        pub id: image_id,
+        pub image_type: ::c_int,
+        pub sequence: i32,
+        pub init_order: i32,
+        pub init_routine: extern "C" fn(),
+        pub term_routine: extern "C" fn(),
+        pub device: ::dev_t,
+        pub node: ::ino_t,
+        pub name: [::c_char; ::PATH_MAX as usize],
+        pub text: *mut ::c_void,
+        pub data: *mut ::c_void,
+        pub text_size: i32,
+        pub data_size: i32,
+        pub api_version: i32,
+        pub abi: i32
+    }
+}
+
+// kernel/OS.h
+pub const B_OS_NAME_LENGTH: usize = 32;
+pub const B_PAGE_SIZE: usize = 4096;
+pub const B_INFINITE_TIMEOUT: usize = 9223372036854775807;
+
+pub const B_RELATIVE_TIMEOUT: u32 = 0x8;
+pub const B_ABSOLUTE_TIMEOUT: u32 = 0x10;
+pub const B_TIMEOUT_REAL_TIME_BASE: u32 = 0x40;
+pub const B_ABSOLUTE_REAL_TIME_TIMEOUT: u32 =
+    B_ABSOLUTE_TIMEOUT | B_TIMEOUT_REAL_TIME_BASE;
+
+pub const B_NO_LOCK: u32 = 0;
+pub const B_LAZY_LOCK: u32 = 1;
+pub const B_FULL_LOCK: u32 = 2;
+pub const B_CONTIGUOUS: u32 = 3;
+pub const B_LOMEM: u32 = 4;
+pub const B_32_BIT_FULL_LOCK: u32 = 5;
+pub const B_32_BIT_CONTIGUOUS: u32 = 6;
+
+pub const B_ANY_ADDRESS: u32 = 0;
+pub const B_EXACT_ADDRESS: u32 = 1;
+pub const B_BASE_ADDRESS: u32 = 2;
+pub const B_CLONE_ADDRESS: u32 = 3;
+pub const B_ANY_KERNEL_ADDRESS: u32 = 4;
+pub const B_RANDOMIZED_ANY_ADDRESS: u32 = 6;
+pub const B_RANDOMIZED_BASE_ADDRESS: u32 = 7;
+
+pub const B_READ_AREA: u32 = 1 << 0;
+pub const B_WRITE_AREA: u32 = 1 << 1;
+pub const B_EXECUTE_AREA: u32 = 1 << 2;
+pub const B_STACK_AREA: u32 = 1 << 3;
+pub const B_CLONEABLE_AREA: u32 = 1 << 8;
+
+pub const B_CAN_INTERRUPT: u32 = 0x01;
+pub const B_CHECK_PERMISSION: u32 = 0x04;
+pub const B_KILL_CAN_INTERRUPT: u32 = 0x20;
+pub const B_DO_NOT_RESCHEDULE: u32 = 0x02;
+pub const B_RELEASE_ALL: u32 = 0x08;
+pub const B_RELEASE_IF_WAITING_ONLY: u32 = 0x10;
+
+pub const B_CURRENT_TEAM: team_id = 0;
+pub const B_SYSTEM_TEAM: team_id = 1;
+
+pub const B_TEAM_USAGE_SELF: i32 = 0;
+pub const B_TEAM_USAGE_CHILDREN: i32 = -1;
+
+pub const B_IDLE_PRIORITY: i32 = 0;
+pub const B_LOWEST_ACTIVE_PRIORITY: i32 = 1;
+pub const B_LOW_PRIORITY: i32 = 5;
+pub const B_NORMAL_PRIORITY: i32 = 10;
+pub const B_DISPLAY_PRIORITY: i32 = 15;
+pub const B_URGENT_DISPLAY_PRIORITY: i32 = 20;
+pub const B_REAL_TIME_DISPLAY_PRIORITY: i32 = 100;
+pub const B_URGENT_PRIORITY: i32 = 110;
+pub const B_REAL_TIME_PRIORITY: i32 = 120;
+
+pub const B_SYSTEM_TIMEBASE: i32 = 0;
+pub const B_FIRST_REAL_TIME_PRIORITY: i32 = B_REAL_TIME_DISPLAY_PRIORITY;
+
+pub const B_ONE_SHOT_ABSOLUTE_ALARM: u32 = 1;
+pub const B_ONE_SHOT_RELATIVE_ALARM: u32 = 2;
+pub const B_PERIODIC_ALARM: u32 = 3;
+
+pub const B_OBJECT_TYPE_FD: u16 = 0;
+pub const B_OBJECT_TYPE_SEMAPHORE: u16 = 1;
+pub const B_OBJECT_TYPE_PORT: u16 = 2;
+pub const B_OBJECT_TYPE_THREAD: u16 = 3;
+
+pub const B_EVENT_READ: u16 = 0x0001;
+pub const B_EVENT_WRITE: u16 = 0x0002;
+pub const B_EVENT_ERROR: u16 = 0x0004;
+pub const B_EVENT_PRIORITY_READ: u16 = 0x0008;
+pub const B_EVENT_PRIORITY_WRITE: u16 = 0x0010;
+pub const B_EVENT_HIGH_PRIORITY_READ: u16 = 0x0020;
+pub const B_EVENT_HIGH_PRIORITY_WRITE: u16 = 0x0040;
+pub const B_EVENT_DISCONNECTED: u16 = 0x0080;
+pub const B_EVENT_ACQUIRE_SEMAPHORE: u16 = 0x0001;
+pub const B_EVENT_INVALID: u16 = 0x1000;
+
+// kernel/fs_info.h
+pub const B_FS_IS_READONLY: u32 = 0x00000001;
+pub const B_FS_IS_REMOVABLE: u32 = 0x00000002;
+pub const B_FS_IS_PERSISTENT: u32 = 0x00000004;
+pub const B_FS_IS_SHARED: u32 = 0x00000008;
+pub const B_FS_HAS_MIME: u32 = 0x00010000;
+pub const B_FS_HAS_ATTR: u32 = 0x00020000;
+pub const B_FS_HAS_QUERY: u32 = 0x00040000;
+pub const B_FS_HAS_SELF_HEALING_LINKS: u32 = 0x00080000;
+pub const B_FS_HAS_ALIASES: u32 = 0x00100000;
+pub const B_FS_SUPPORTS_NODE_MONITORING: u32 = 0x00200000;
+pub const B_FS_SUPPORTS_MONITOR_CHILDREN: u32 = 0x00400000;
+
+// kernel/fs_query.h
+pub const B_LIVE_QUERY: u32 = 0x00000001;
+pub const B_QUERY_NON_INDEXED: u32 = 0x00000002;
+
+// kernel/fs_volume.h
+pub const B_MOUNT_READ_ONLY: u32 = 1;
+pub const B_MOUNT_VIRTUAL_DEVICE: u32 = 2;
+pub const B_FORCE_UNMOUNT: u32 = 1;
+
+// kernel/image.h
+pub const B_FLUSH_DCACHE: u32 = 0x0001;
+pub const B_FLUSH_ICACHE: u32 = 0x0004;
+pub const B_INVALIDATE_DCACHE: u32 = 0x0002;
+pub const B_INVALIDATE_ICACHE: u32 = 0x0008;
+
+pub const B_SYMBOL_TYPE_DATA: i32 = 0x1;
+pub const B_SYMBOL_TYPE_TEXT: i32 = 0x2;
+pub const B_SYMBOL_TYPE_ANY: i32 = 0x5;
+
+// storage/StorageDefs.h
+pub const B_DEV_NAME_LENGTH: usize = 128;
+pub const B_FILE_NAME_LENGTH: usize = ::FILENAME_MAX as usize;
+pub const B_PATH_NAME_LENGTH: usize = ::PATH_MAX as usize;
+pub const B_ATTR_NAME_LENGTH: usize = B_FILE_NAME_LENGTH - 1;
+pub const B_MIME_TYPE_LENGTH: usize = B_ATTR_NAME_LENGTH - 15;
+pub const B_MAX_SYMLINKS: usize = 16;
+
+// Haiku open modes in BFile are passed as u32
+pub const B_READ_ONLY: u32 = ::O_RDONLY as u32;
+pub const B_WRITE_ONLY: u32 = ::O_WRONLY as u32;
+pub const B_READ_WRITE: u32 = ::O_RDWR as u32;
+
+pub const B_FAIL_IF_EXISTS: u32 = ::O_EXCL as u32;
+pub const B_CREATE_FILE: u32 = ::O_CREAT as u32;
+pub const B_ERASE_FILE: u32 = ::O_TRUNC as u32;
+pub const B_OPEN_AT_END: u32 = ::O_APPEND as u32;
+
+pub const B_FILE_NODE: u32 = 0x01;
+pub const B_SYMLINK_NODE: u32 = 0x02;
+pub const B_DIRECTORY_NODE: u32 = 0x04;
+pub const B_ANY_NODE: u32 = 0x07;
+
+// support/Errors.h
+pub const B_GENERAL_ERROR_BASE: status_t = core::i32::MIN;
+pub const B_OS_ERROR_BASE: status_t = B_GENERAL_ERROR_BASE + 0x1000;
+pub const B_APP_ERROR_BASE: status_t = B_GENERAL_ERROR_BASE + 0x2000;
+pub const B_INTERFACE_ERROR_BASE: status_t = B_GENERAL_ERROR_BASE + 0x3000;
+pub const B_MEDIA_ERROR_BASE: status_t = B_GENERAL_ERROR_BASE + 0x4000;
+pub const B_TRANSLATION_ERROR_BASE: status_t = B_GENERAL_ERROR_BASE + 0x4800;
+pub const B_MIDI_ERROR_BASE: status_t = B_GENERAL_ERROR_BASE + 0x5000;
+pub const B_STORAGE_ERROR_BASE: status_t = B_GENERAL_ERROR_BASE + 0x6000;
+pub const B_POSIX_ERROR_BASE: status_t = B_GENERAL_ERROR_BASE + 0x7000;
+pub const B_MAIL_ERROR_BASE: status_t = B_GENERAL_ERROR_BASE + 0x8000;
+pub const B_PRINT_ERROR_BASE: status_t = B_GENERAL_ERROR_BASE + 0x9000;
+pub const B_DEVICE_ERROR_BASE: status_t = B_GENERAL_ERROR_BASE + 0xa000;
+pub const B_ERRORS_END: status_t = B_GENERAL_ERROR_BASE + 0xffff;
+
+// General errors
+pub const B_NO_MEMORY: status_t = B_GENERAL_ERROR_BASE + 0;
+pub const B_IO_ERROR: status_t = B_GENERAL_ERROR_BASE + 1;
+pub const B_PERMISSION_DENIED: status_t = B_GENERAL_ERROR_BASE + 2;
+pub const B_BAD_INDEX: status_t = B_GENERAL_ERROR_BASE + 3;
+pub const B_BAD_TYPE: status_t = B_GENERAL_ERROR_BASE + 4;
+pub const B_BAD_VALUE: status_t = B_GENERAL_ERROR_BASE + 5;
+pub const B_MISMATCHED_VALUES: status_t = B_GENERAL_ERROR_BASE + 6;
+pub const B_NAME_NOT_FOUND: status_t = B_GENERAL_ERROR_BASE + 7;
+pub const B_NAME_IN_USE: status_t = B_GENERAL_ERROR_BASE + 8;
+pub const B_TIMED_OUT: status_t = B_GENERAL_ERROR_BASE + 9;
+pub const B_INTERRUPTED: status_t = B_GENERAL_ERROR_BASE + 10;
+pub const B_WOULD_BLOCK: status_t = B_GENERAL_ERROR_BASE + 11;
+pub const B_CANCELED: status_t = B_GENERAL_ERROR_BASE + 12;
+pub const B_NO_INIT: status_t = B_GENERAL_ERROR_BASE + 13;
+pub const B_NOT_INITIALIZED: status_t = B_GENERAL_ERROR_BASE + 13;
+pub const B_BUSY: status_t = B_GENERAL_ERROR_BASE + 14;
+pub const B_NOT_ALLOWED: status_t = B_GENERAL_ERROR_BASE + 15;
+pub const B_BAD_DATA: status_t = B_GENERAL_ERROR_BASE + 16;
+pub const B_DONT_DO_THAT: status_t = B_GENERAL_ERROR_BASE + 17;
+
+pub const B_ERROR: status_t = -1;
+pub const B_OK: status_t = 0;
+pub const B_NO_ERROR: status_t = 0;
+
+// Kernel kit errors
+pub const B_BAD_SEM_ID: status_t = B_OS_ERROR_BASE + 0;
+pub const B_NO_MORE_SEMS: status_t = B_OS_ERROR_BASE + 1;
+
+pub const B_BAD_THREAD_ID: status_t = B_OS_ERROR_BASE + 0x100;
+pub const B_NO_MORE_THREADS: status_t = B_OS_ERROR_BASE + 0x101;
+pub const B_BAD_THREAD_STATE: status_t = B_OS_ERROR_BASE + 0x102;
+pub const B_BAD_TEAM_ID: status_t = B_OS_ERROR_BASE + 0x103;
+pub const B_NO_MORE_TEAMS: status_t = B_OS_ERROR_BASE + 0x104;
+
+pub const B_BAD_PORT_ID: status_t = B_OS_ERROR_BASE + 0x200;
+pub const B_NO_MORE_PORTS: status_t = B_OS_ERROR_BASE + 0x201;
+
+pub const B_BAD_IMAGE_ID: status_t = B_OS_ERROR_BASE + 0x300;
+pub const B_BAD_ADDRESS: status_t = B_OS_ERROR_BASE + 0x301;
+pub const B_NOT_AN_EXECUTABLE: status_t = B_OS_ERROR_BASE + 0x302;
+pub const B_MISSING_LIBRARY: status_t = B_OS_ERROR_BASE + 0x303;
+pub const B_MISSING_SYMBOL: status_t = B_OS_ERROR_BASE + 0x304;
+pub const B_UNKNOWN_EXECUTABLE: status_t = B_OS_ERROR_BASE + 0x305;
+pub const B_LEGACY_EXECUTABLE: status_t = B_OS_ERROR_BASE + 0x306;
+
+pub const B_DEBUGGER_ALREADY_INSTALLED: status_t = B_OS_ERROR_BASE + 0x400;
+
+// Application kit errors
+pub const B_BAD_REPLY: status_t = B_APP_ERROR_BASE + 0;
+pub const B_DUPLICATE_REPLY: status_t = B_APP_ERROR_BASE + 1;
+pub const B_MESSAGE_TO_SELF: status_t = B_APP_ERROR_BASE + 2;
+pub const B_BAD_HANDLER: status_t = B_APP_ERROR_BASE + 3;
+pub const B_ALREADY_RUNNING: status_t = B_APP_ERROR_BASE + 4;
+pub const B_LAUNCH_FAILED: status_t = B_APP_ERROR_BASE + 5;
+pub const B_AMBIGUOUS_APP_LAUNCH: status_t = B_APP_ERROR_BASE + 6;
+pub const B_UNKNOWN_MIME_TYPE: status_t = B_APP_ERROR_BASE + 7;
+pub const B_BAD_SCRIPT_SYNTAX: status_t = B_APP_ERROR_BASE + 8;
+pub const B_LAUNCH_FAILED_NO_RESOLVE_LINK: status_t = B_APP_ERROR_BASE + 9;
+pub const B_LAUNCH_FAILED_EXECUTABLE: status_t = B_APP_ERROR_BASE + 10;
+pub const B_LAUNCH_FAILED_APP_NOT_FOUND: status_t = B_APP_ERROR_BASE + 11;
+pub const B_LAUNCH_FAILED_APP_IN_TRASH: status_t = B_APP_ERROR_BASE + 12;
+pub const B_LAUNCH_FAILED_NO_PREFERRED_APP: status_t = B_APP_ERROR_BASE + 13;
+pub const B_LAUNCH_FAILED_FILES_APP_NOT_FOUND: status_t =
+    B_APP_ERROR_BASE + 14;
+pub const B_BAD_MIME_SNIFFER_RULE: status_t = B_APP_ERROR_BASE + 15;
+pub const B_NOT_A_MESSAGE: status_t = B_APP_ERROR_BASE + 16;
+pub const B_SHUTDOWN_CANCELLED: status_t = B_APP_ERROR_BASE + 17;
+pub const B_SHUTTING_DOWN: status_t = B_APP_ERROR_BASE + 18;
+
+// Storage kit errors
+pub const B_FILE_ERROR: status_t = B_STORAGE_ERROR_BASE + 0;
+pub const B_FILE_NOT_FOUND: status_t = B_STORAGE_ERROR_BASE + 1;
+pub const B_FILE_EXISTS: status_t = B_STORAGE_ERROR_BASE + 2;
+pub const B_ENTRY_NOT_FOUND: status_t = B_STORAGE_ERROR_BASE + 3;
+pub const B_NAME_TOO_LONG: status_t = B_STORAGE_ERROR_BASE + 4;
+pub const B_NOT_A_DIRECTORY: status_t = B_STORAGE_ERROR_BASE + 5;
+pub const B_DIRECTORY_NOT_EMPTY: status_t = B_STORAGE_ERROR_BASE + 6;
+pub const B_DEVICE_FULL: status_t = B_STORAGE_ERROR_BASE + 7;
+pub const B_READ_ONLY_DEVICE: status_t = B_STORAGE_ERROR_BASE + 8;
+pub const B_IS_A_DIRECTORY: status_t = B_STORAGE_ERROR_BASE + 9;
+pub const B_NO_MORE_FDS: status_t = B_STORAGE_ERROR_BASE + 10;
+pub const B_CROSS_DEVICE_LINK: status_t = B_STORAGE_ERROR_BASE + 11;
+pub const B_LINK_LIMIT: status_t = B_STORAGE_ERROR_BASE + 12;
+pub const B_BUSTED_PIPE: status_t = B_STORAGE_ERROR_BASE + 13;
+pub const B_UNSUPPORTED: status_t = B_STORAGE_ERROR_BASE + 14;
+pub const B_PARTITION_TOO_SMALL: status_t = B_STORAGE_ERROR_BASE + 15;
+pub const B_PARTIAL_READ: status_t = B_STORAGE_ERROR_BASE + 16;
+pub const B_PARTIAL_WRITE: status_t = B_STORAGE_ERROR_BASE + 17;
+
+// Mapped posix errors
+pub const B_BUFFER_OVERFLOW: status_t = ::EOVERFLOW;
+pub const B_TOO_MANY_ARGS: status_t = ::E2BIG;
+pub const B_FILE_TOO_LARGE: status_t = ::EFBIG;
+pub const B_RESULT_NOT_REPRESENTABLE: status_t = ::ERANGE;
+pub const B_DEVICE_NOT_FOUND: status_t = ::ENODEV;
+pub const B_NOT_SUPPORTED: status_t = ::EOPNOTSUPP;
+
+// Media kit errors
+pub const B_STREAM_NOT_FOUND: status_t = B_MEDIA_ERROR_BASE + 0;
+pub const B_SERVER_NOT_FOUND: status_t = B_MEDIA_ERROR_BASE + 1;
+pub const B_RESOURCE_NOT_FOUND: status_t = B_MEDIA_ERROR_BASE + 2;
+pub const B_RESOURCE_UNAVAILABLE: status_t = B_MEDIA_ERROR_BASE + 3;
+pub const B_BAD_SUBSCRIBER: status_t = B_MEDIA_ERROR_BASE + 4;
+pub const B_SUBSCRIBER_NOT_ENTERED: status_t = B_MEDIA_ERROR_BASE + 5;
+pub const B_BUFFER_NOT_AVAILABLE: status_t = B_MEDIA_ERROR_BASE + 6;
+pub const B_LAST_BUFFER_ERROR: status_t = B_MEDIA_ERROR_BASE + 7;
+
+pub const B_MEDIA_SYSTEM_FAILURE: status_t = B_MEDIA_ERROR_BASE + 100;
+pub const B_MEDIA_BAD_NODE: status_t = B_MEDIA_ERROR_BASE + 101;
+pub const B_MEDIA_NODE_BUSY: status_t = B_MEDIA_ERROR_BASE + 102;
+pub const B_MEDIA_BAD_FORMAT: status_t = B_MEDIA_ERROR_BASE + 103;
+pub const B_MEDIA_BAD_BUFFER: status_t = B_MEDIA_ERROR_BASE + 104;
+pub const B_MEDIA_TOO_MANY_NODES: status_t = B_MEDIA_ERROR_BASE + 105;
+pub const B_MEDIA_TOO_MANY_BUFFERS: status_t = B_MEDIA_ERROR_BASE + 106;
+pub const B_MEDIA_NODE_ALREADY_EXISTS: status_t = B_MEDIA_ERROR_BASE + 107;
+pub const B_MEDIA_BUFFER_ALREADY_EXISTS: status_t = B_MEDIA_ERROR_BASE + 108;
+pub const B_MEDIA_CANNOT_SEEK: status_t = B_MEDIA_ERROR_BASE + 109;
+pub const B_MEDIA_CANNOT_CHANGE_RUN_MODE: status_t = B_MEDIA_ERROR_BASE + 110;
+pub const B_MEDIA_APP_ALREADY_REGISTERED: status_t = B_MEDIA_ERROR_BASE + 111;
+pub const B_MEDIA_APP_NOT_REGISTERED: status_t = B_MEDIA_ERROR_BASE + 112;
+pub const B_MEDIA_CANNOT_RECLAIM_BUFFERS: status_t = B_MEDIA_ERROR_BASE + 113;
+pub const B_MEDIA_BUFFERS_NOT_RECLAIMED: status_t = B_MEDIA_ERROR_BASE + 114;
+pub const B_MEDIA_TIME_SOURCE_STOPPED: status_t = B_MEDIA_ERROR_BASE + 115;
+pub const B_MEDIA_TIME_SOURCE_BUSY: status_t = B_MEDIA_ERROR_BASE + 116;
+pub const B_MEDIA_BAD_SOURCE: status_t = B_MEDIA_ERROR_BASE + 117;
+pub const B_MEDIA_BAD_DESTINATION: status_t = B_MEDIA_ERROR_BASE + 118;
+pub const B_MEDIA_ALREADY_CONNECTED: status_t = B_MEDIA_ERROR_BASE + 119;
+pub const B_MEDIA_NOT_CONNECTED: status_t = B_MEDIA_ERROR_BASE + 120;
+pub const B_MEDIA_BAD_CLIP_FORMAT: status_t = B_MEDIA_ERROR_BASE + 121;
+pub const B_MEDIA_ADDON_FAILED: status_t = B_MEDIA_ERROR_BASE + 122;
+pub const B_MEDIA_ADDON_DISABLED: status_t = B_MEDIA_ERROR_BASE + 123;
+pub const B_MEDIA_CHANGE_IN_PROGRESS: status_t = B_MEDIA_ERROR_BASE + 124;
+pub const B_MEDIA_STALE_CHANGE_COUNT: status_t = B_MEDIA_ERROR_BASE + 125;
+pub const B_MEDIA_ADDON_RESTRICTED: status_t = B_MEDIA_ERROR_BASE + 126;
+pub const B_MEDIA_NO_HANDLER: status_t = B_MEDIA_ERROR_BASE + 127;
+pub const B_MEDIA_DUPLICATE_FORMAT: status_t = B_MEDIA_ERROR_BASE + 128;
+pub const B_MEDIA_REALTIME_DISABLED: status_t = B_MEDIA_ERROR_BASE + 129;
+pub const B_MEDIA_REALTIME_UNAVAILABLE: status_t = B_MEDIA_ERROR_BASE + 130;
+
+// Mail kit errors
+pub const B_MAIL_NO_DAEMON: status_t = B_MAIL_ERROR_BASE + 0;
+pub const B_MAIL_UNKNOWN_USER: status_t = B_MAIL_ERROR_BASE + 1;
+pub const B_MAIL_WRONG_PASSWORD: status_t = B_MAIL_ERROR_BASE + 2;
+pub const B_MAIL_UNKNOWN_HOST: status_t = B_MAIL_ERROR_BASE + 3;
+pub const B_MAIL_ACCESS_ERROR: status_t = B_MAIL_ERROR_BASE + 4;
+pub const B_MAIL_UNKNOWN_FIELD: status_t = B_MAIL_ERROR_BASE + 5;
+pub const B_MAIL_NO_RECIPIENT: status_t = B_MAIL_ERROR_BASE + 6;
+pub const B_MAIL_INVALID_MAIL: status_t = B_MAIL_ERROR_BASE + 7;
+
+// Print kit errors
+pub const B_NO_PRINT_SERVER: status_t = B_PRINT_ERROR_BASE + 0;
+
+// Device kit errors
+pub const B_DEV_INVALID_IOCTL: status_t = B_DEVICE_ERROR_BASE + 0;
+pub const B_DEV_NO_MEMORY: status_t = B_DEVICE_ERROR_BASE + 1;
+pub const B_DEV_BAD_DRIVE_NUM: status_t = B_DEVICE_ERROR_BASE + 2;
+pub const B_DEV_NO_MEDIA: status_t = B_DEVICE_ERROR_BASE + 3;
+pub const B_DEV_UNREADABLE: status_t = B_DEVICE_ERROR_BASE + 4;
+pub const B_DEV_FORMAT_ERROR: status_t = B_DEVICE_ERROR_BASE + 5;
+pub const B_DEV_TIMEOUT: status_t = B_DEVICE_ERROR_BASE + 6;
+pub const B_DEV_RECALIBRATE_ERROR: status_t = B_DEVICE_ERROR_BASE + 7;
+pub const B_DEV_SEEK_ERROR: status_t = B_DEVICE_ERROR_BASE + 8;
+pub const B_DEV_ID_ERROR: status_t = B_DEVICE_ERROR_BASE + 9;
+pub const B_DEV_READ_ERROR: status_t = B_DEVICE_ERROR_BASE + 10;
+pub const B_DEV_WRITE_ERROR: status_t = B_DEVICE_ERROR_BASE + 11;
+pub const B_DEV_NOT_READY: status_t = B_DEVICE_ERROR_BASE + 12;
+pub const B_DEV_MEDIA_CHANGED: status_t = B_DEVICE_ERROR_BASE + 13;
+pub const B_DEV_MEDIA_CHANGE_REQUESTED: status_t = B_DEVICE_ERROR_BASE + 14;
+pub const B_DEV_RESOURCE_CONFLICT: status_t = B_DEVICE_ERROR_BASE + 15;
+pub const B_DEV_CONFIGURATION_ERROR: status_t = B_DEVICE_ERROR_BASE + 16;
+pub const B_DEV_DISABLED_BY_USER: status_t = B_DEVICE_ERROR_BASE + 17;
+pub const B_DEV_DOOR_OPEN: status_t = B_DEVICE_ERROR_BASE + 18;
+
+pub const B_DEV_INVALID_PIPE: status_t = B_DEVICE_ERROR_BASE + 19;
+pub const B_DEV_CRC_ERROR: status_t = B_DEVICE_ERROR_BASE + 20;
+pub const B_DEV_STALLED: status_t = B_DEVICE_ERROR_BASE + 21;
+pub const B_DEV_BAD_PID: status_t = B_DEVICE_ERROR_BASE + 22;
+pub const B_DEV_UNEXPECTED_PID: status_t = B_DEVICE_ERROR_BASE + 23;
+pub const B_DEV_DATA_OVERRUN: status_t = B_DEVICE_ERROR_BASE + 24;
+pub const B_DEV_DATA_UNDERRUN: status_t = B_DEVICE_ERROR_BASE + 25;
+pub const B_DEV_FIFO_OVERRUN: status_t = B_DEVICE_ERROR_BASE + 26;
+pub const B_DEV_FIFO_UNDERRUN: status_t = B_DEVICE_ERROR_BASE + 27;
+pub const B_DEV_PENDING: status_t = B_DEVICE_ERROR_BASE + 28;
+pub const B_DEV_MULTIPLE_ERRORS: status_t = B_DEVICE_ERROR_BASE + 29;
+pub const B_DEV_TOO_LATE: status_t = B_DEVICE_ERROR_BASE + 30;
+
+// translation kit errors
+pub const B_TRANSLATION_BASE_ERROR: status_t = B_TRANSLATION_ERROR_BASE + 0;
+pub const B_NO_TRANSLATOR: status_t = B_TRANSLATION_ERROR_BASE + 1;
+pub const B_ILLEGAL_DATA: status_t = B_TRANSLATION_ERROR_BASE + 2;
+
+// support/TypeConstants.h
+pub const B_AFFINE_TRANSFORM_TYPE: u32 = haiku_constant!('A', 'M', 'T', 'X');
+pub const B_ALIGNMENT_TYPE: u32 = haiku_constant!('A', 'L', 'G', 'N');
+pub const B_ANY_TYPE: u32 = haiku_constant!('A', 'N', 'Y', 'T');
+pub const B_ATOM_TYPE: u32 = haiku_constant!('A', 'T', 'O', 'M');
+pub const B_ATOMREF_TYPE: u32 = haiku_constant!('A', 'T', 'M', 'R');
+pub const B_BOOL_TYPE: u32 = haiku_constant!('B', 'O', 'O', 'L');
+pub const B_CHAR_TYPE: u32 = haiku_constant!('C', 'H', 'A', 'R');
+pub const B_COLOR_8_BIT_TYPE: u32 = haiku_constant!('C', 'L', 'R', 'B');
+pub const B_DOUBLE_TYPE: u32 = haiku_constant!('D', 'B', 'L', 'E');
+pub const B_FLOAT_TYPE: u32 = haiku_constant!('F', 'L', 'O', 'T');
+pub const B_GRAYSCALE_8_BIT_TYPE: u32 = haiku_constant!('G', 'R', 'Y', 'B');
+pub const B_INT16_TYPE: u32 = haiku_constant!('S', 'H', 'R', 'T');
+pub const B_INT32_TYPE: u32 = haiku_constant!('L', 'O', 'N', 'G');
+pub const B_INT64_TYPE: u32 = haiku_constant!('L', 'L', 'N', 'G');
+pub const B_INT8_TYPE: u32 = haiku_constant!('B', 'Y', 'T', 'E');
+pub const B_LARGE_ICON_TYPE: u32 = haiku_constant!('I', 'C', 'O', 'N');
+pub const B_MEDIA_PARAMETER_GROUP_TYPE: u32 =
+    haiku_constant!('B', 'M', 'C', 'G');
+pub const B_MEDIA_PARAMETER_TYPE: u32 = haiku_constant!('B', 'M', 'C', 'T');
+pub const B_MEDIA_PARAMETER_WEB_TYPE: u32 =
+    haiku_constant!('B', 'M', 'C', 'W');
+pub const B_MESSAGE_TYPE: u32 = haiku_constant!('M', 'S', 'G', 'G');
+pub const B_MESSENGER_TYPE: u32 = haiku_constant!('M', 'S', 'N', 'G');
+pub const B_MIME_TYPE: u32 = haiku_constant!('M', 'I', 'M', 'E');
+pub const B_MINI_ICON_TYPE: u32 = haiku_constant!('M', 'I', 'C', 'N');
+pub const B_MONOCHROME_1_BIT_TYPE: u32 = haiku_constant!('M', 'N', 'O', 'B');
+pub const B_OBJECT_TYPE: u32 = haiku_constant!('O', 'P', 'T', 'R');
+pub const B_OFF_T_TYPE: u32 = haiku_constant!('O', 'F', 'F', 'T');
+pub const B_PATTERN_TYPE: u32 = haiku_constant!('P', 'A', 'T', 'N');
+pub const B_POINTER_TYPE: u32 = haiku_constant!('P', 'N', 'T', 'R');
+pub const B_POINT_TYPE: u32 = haiku_constant!('B', 'P', 'N', 'T');
+pub const B_PROPERTY_INFO_TYPE: u32 = haiku_constant!('S', 'C', 'T', 'D');
+pub const B_RAW_TYPE: u32 = haiku_constant!('R', 'A', 'W', 'T');
+pub const B_RECT_TYPE: u32 = haiku_constant!('R', 'E', 'C', 'T');
+pub const B_REF_TYPE: u32 = haiku_constant!('R', 'R', 'E', 'F');
+pub const B_RGB_32_BIT_TYPE: u32 = haiku_constant!('R', 'G', 'B', 'B');
+pub const B_RGB_COLOR_TYPE: u32 = haiku_constant!('R', 'G', 'B', 'C');
+pub const B_SIZE_TYPE: u32 = haiku_constant!('S', 'I', 'Z', 'E');
+pub const B_SIZE_T_TYPE: u32 = haiku_constant!('S', 'I', 'Z', 'T');
+pub const B_SSIZE_T_TYPE: u32 = haiku_constant!('S', 'S', 'Z', 'T');
+pub const B_STRING_TYPE: u32 = haiku_constant!('C', 'S', 'T', 'R');
+pub const B_STRING_LIST_TYPE: u32 = haiku_constant!('S', 'T', 'R', 'L');
+pub const B_TIME_TYPE: u32 = haiku_constant!('T', 'I', 'M', 'E');
+pub const B_UINT16_TYPE: u32 = haiku_constant!('U', 'S', 'H', 'T');
+pub const B_UINT32_TYPE: u32 = haiku_constant!('U', 'L', 'N', 'G');
+pub const B_UINT64_TYPE: u32 = haiku_constant!('U', 'L', 'L', 'G');
+pub const B_UINT8_TYPE: u32 = haiku_constant!('U', 'B', 'Y', 'T');
+pub const B_VECTOR_ICON_TYPE: u32 = haiku_constant!('V', 'I', 'C', 'N');
+pub const B_XATTR_TYPE: u32 = haiku_constant!('X', 'A', 'T', 'R');
+pub const B_NETWORK_ADDRESS_TYPE: u32 = haiku_constant!('N', 'W', 'A', 'D');
+pub const B_MIME_STRING_TYPE: u32 = haiku_constant!('M', 'I', 'M', 'S');
+pub const B_ASCII_TYPE: u32 = haiku_constant!('T', 'E', 'X', 'T');
+
+extern "C" {
+    // kernel/OS.h
+    pub fn create_area(
+        name: *const ::c_char,
+        startAddress: *mut *mut ::c_void,
+        addressSpec: u32,
+        size: usize,
+        lock: u32,
+        protection: u32,
+    ) -> area_id;
+    pub fn clone_area(
+        name: *const ::c_char,
+        destAddress: *mut *mut ::c_void,
+        addressSpec: u32,
+        protection: u32,
+        source: area_id,
+    ) -> area_id;
+    pub fn find_area(name: *const ::c_char) -> area_id;
+    pub fn area_for(address: *mut ::c_void) -> area_id;
+    pub fn delete_area(id: area_id) -> status_t;
+    pub fn resize_area(id: area_id, newSize: usize) -> status_t;
+    pub fn set_area_protection(id: area_id, newProtection: u32) -> status_t;
+    pub fn _get_area_info(
+        id: area_id,
+        areaInfo: *mut area_info,
+        size: usize,
+    ) -> status_t;
+    pub fn _get_next_area_info(
+        team: team_id,
+        cookie: *mut isize,
+        areaInfo: *mut area_info,
+        size: usize,
+    ) -> status_t;
+
+    pub fn create_port(capacity: i32, name: *const ::c_char) -> port_id;
+    pub fn find_port(name: *const ::c_char) -> port_id;
+    pub fn read_port(
+        port: port_id,
+        code: *mut i32,
+        buffer: *mut ::c_void,
+        bufferSize: ::size_t,
+    ) -> ::ssize_t;
+    pub fn read_port_etc(
+        port: port_id,
+        code: *mut i32,
+        buffer: *mut ::c_void,
+        bufferSize: ::size_t,
+        flags: u32,
+        timeout: bigtime_t,
+    ) -> ::ssize_t;
+    pub fn write_port(
+        port: port_id,
+        code: i32,
+        buffer: *const ::c_void,
+        bufferSize: ::size_t,
+    ) -> status_t;
+    pub fn write_port_etc(
+        port: port_id,
+        code: i32,
+        buffer: *const ::c_void,
+        bufferSize: ::size_t,
+        flags: u32,
+        timeout: bigtime_t,
+    ) -> status_t;
+    pub fn close_port(port: port_id) -> status_t;
+    pub fn delete_port(port: port_id) -> status_t;
+    pub fn port_buffer_size(port: port_id) -> ::ssize_t;
+    pub fn port_buffer_size_etc(
+        port: port_id,
+        flags: u32,
+        timeout: bigtime_t,
+    ) -> ::ssize_t;
+    pub fn port_count(port: port_id) -> ::ssize_t;
+    pub fn set_port_owner(port: port_id, team: team_id) -> status_t;
+
+    pub fn _get_port_info(
+        port: port_id,
+        buf: *mut port_info,
+        portInfoSize: ::size_t,
+    ) -> status_t;
+    pub fn _get_next_port_info(
+        port: port_id,
+        cookie: *mut i32,
+        portInfo: *mut port_info,
+        portInfoSize: ::size_t,
+    ) -> status_t;
+    pub fn _get_port_message_info_etc(
+        port: port_id,
+        info: *mut port_message_info,
+        infoSize: ::size_t,
+        flags: u32,
+        timeout: bigtime_t,
+    ) -> status_t;
+
+    pub fn create_sem(count: i32, name: *const ::c_char) -> sem_id;
+    pub fn delete_sem(id: sem_id) -> status_t;
+    pub fn acquire_sem(id: sem_id) -> status_t;
+    pub fn acquire_sem_etc(
+        id: sem_id,
+        count: i32,
+        flags: u32,
+        timeout: bigtime_t,
+    ) -> status_t;
+    pub fn release_sem(id: sem_id) -> status_t;
+    pub fn release_sem_etc(id: sem_id, count: i32, flags: u32) -> status_t;
+    pub fn switch_sem(semToBeReleased: sem_id, id: sem_id) -> status_t;
+    pub fn switch_sem_etc(
+        semToBeReleased: sem_id,
+        id: sem_id,
+        count: i32,
+        flags: u32,
+        timeout: bigtime_t,
+    ) -> status_t;
+    pub fn get_sem_count(id: sem_id, threadCount: *mut i32) -> status_t;
+    pub fn set_sem_owner(id: sem_id, team: team_id) -> status_t;
+    pub fn _get_sem_info(
+        id: sem_id,
+        info: *mut sem_info,
+        infoSize: ::size_t,
+    ) -> status_t;
+    pub fn _get_next_sem_info(
+        team: team_id,
+        cookie: *mut i32,
+        info: *mut sem_info,
+        infoSize: ::size_t,
+    ) -> status_t;
+
+    pub fn kill_team(team: team_id) -> status_t;
+    pub fn _get_team_info(
+        team: team_id,
+        info: *mut team_info,
+        size: ::size_t,
+    ) -> status_t;
+    pub fn _get_next_team_info(
+        cookie: *mut i32,
+        info: *mut team_info,
+        size: ::size_t,
+    ) -> status_t;
+
+    pub fn spawn_thread(
+        func: thread_func,
+        name: *const ::c_char,
+        priority: i32,
+        data: *mut ::c_void,
+    ) -> thread_id;
+    pub fn kill_thread(thread: thread_id) -> status_t;
+    pub fn resume_thread(thread: thread_id) -> status_t;
+    pub fn suspend_thread(thread: thread_id) -> status_t;
+
+    pub fn rename_thread(
+        thread: thread_id,
+        newName: *const ::c_char,
+    ) -> status_t;
+    pub fn set_thread_priority(
+        thread: thread_id,
+        newPriority: i32,
+    ) -> status_t;
+    pub fn exit_thread(status: status_t);
+    pub fn wait_for_thread(
+        thread: thread_id,
+        returnValue: *mut status_t,
+    ) -> status_t;
+    pub fn on_exit_thread(
+        callback: extern "C" fn(*mut ::c_void),
+        data: *mut ::c_void,
+    ) -> status_t;
+
+    pub fn find_thread(name: *const ::c_char) -> thread_id;
+
+    pub fn send_data(
+        thread: thread_id,
+        code: i32,
+        buffer: *const ::c_void,
+        bufferSize: ::size_t,
+    ) -> status_t;
+    pub fn receive_data(
+        sender: *mut thread_id,
+        buffer: *mut ::c_void,
+        bufferSize: ::size_t,
+    ) -> i32;
+    pub fn has_data(thread: thread_id) -> bool;
+
+    pub fn snooze(amount: bigtime_t) -> status_t;
+    pub fn snooze_etc(
+        amount: bigtime_t,
+        timeBase: ::c_int,
+        flags: u32,
+    ) -> status_t;
+    pub fn snooze_until(time: bigtime_t, timeBase: ::c_int) -> status_t;
+
+    pub fn _get_thread_info(
+        id: thread_id,
+        info: *mut thread_info,
+        size: ::size_t,
+    ) -> status_t;
+    pub fn _get_next_thread_info(
+        team: team_id,
+        cookie: *mut i32,
+        info: *mut thread_info,
+        size: ::size_t,
+    ) -> status_t;
+
+    pub fn get_pthread_thread_id(thread: ::pthread_t) -> thread_id;
+
+    pub fn _get_team_usage_info(
+        team: team_id,
+        who: i32,
+        info: *mut team_usage_info,
+        size: ::size_t,
+    ) -> status_t;
+
+    pub fn real_time_clock() -> ::c_ulong;
+    pub fn set_real_time_clock(secsSinceJan1st1970: ::c_ulong);
+    pub fn real_time_clock_usecs() -> bigtime_t;
+    pub fn system_time() -> bigtime_t;
+    pub fn system_time_nsecs() -> nanotime_t;
+    // set_timezone() is deprecated and a no-op
+
+    pub fn set_alarm(when: bigtime_t, flags: u32) -> bigtime_t;
+    pub fn debugger(message: *const ::c_char);
+    pub fn disable_debugger(state: ::c_int) -> ::c_int;
+
+    // TODO: cpuid_info struct and the get_cpuid() function
+
+    pub fn get_system_info(info: *mut system_info) -> status_t;
+    pub fn get_cpu_info(
+        firstCPU: u32,
+        cpuCount: u32,
+        info: *mut cpu_info,
+    ) -> status_t;
+    pub fn is_computer_on() -> i32;
+    pub fn is_computer_on_fire() -> ::c_double;
+    pub fn send_signal(threadID: thread_id, signal: ::c_uint) -> ::c_int;
+    pub fn set_signal_stack(base: *mut ::c_void, size: ::size_t);
+
+    pub fn wait_for_objects(
+        infos: *mut object_wait_info,
+        numInfos: ::c_int,
+    ) -> ::ssize_t;
+    pub fn wait_for_objects_etc(
+        infos: *mut object_wait_info,
+        numInfos: ::c_int,
+        flags: u32,
+        timeout: bigtime_t,
+    ) -> ::ssize_t;
+
+    // kernel/fs_attr.h
+    pub fn fs_read_attr(
+        fd: ::c_int,
+        attribute: *const ::c_char,
+        type_: u32,
+        pos: ::off_t,
+        buffer: *mut ::c_void,
+        readBytes: ::size_t,
+    ) -> ::ssize_t;
+    pub fn fs_write_attr(
+        fd: ::c_int,
+        attribute: *const ::c_char,
+        type_: u32,
+        pos: ::off_t,
+        buffer: *const ::c_void,
+        writeBytes: ::size_t,
+    ) -> ::ssize_t;
+    pub fn fs_remove_attr(fd: ::c_int, attribute: *const ::c_char) -> ::c_int;
+    pub fn fs_stat_attr(
+        fd: ::c_int,
+        attribute: *const ::c_char,
+        attrInfo: *mut attr_info,
+    ) -> ::c_int;
+
+    pub fn fs_open_attr(
+        path: *const ::c_char,
+        attribute: *const ::c_char,
+        type_: u32,
+        openMode: ::c_int,
+    ) -> ::c_int;
+    pub fn fs_fopen_attr(
+        fd: ::c_int,
+        attribute: *const ::c_char,
+        type_: u32,
+        openMode: ::c_int,
+    ) -> ::c_int;
+    pub fn fs_close_attr(fd: ::c_int) -> ::c_int;
+
+    pub fn fs_open_attr_dir(path: *const ::c_char) -> *mut ::DIR;
+    pub fn fs_lopen_attr_dir(path: *const ::c_char) -> *mut ::DIR;
+    pub fn fs_fopen_attr_dir(fd: ::c_int) -> *mut ::DIR;
+    pub fn fs_close_attr_dir(dir: *mut ::DIR) -> ::c_int;
+    pub fn fs_read_attr_dir(dir: *mut ::DIR) -> *mut ::dirent;
+    pub fn fs_rewind_attr_dir(dir: *mut ::DIR);
+
+    // kernel/fs_image.h
+    pub fn fs_create_index(
+        device: ::dev_t,
+        name: *const ::c_char,
+        type_: u32,
+        flags: u32,
+    ) -> ::c_int;
+    pub fn fs_remove_index(device: ::dev_t, name: *const ::c_char) -> ::c_int;
+    pub fn fs_stat_index(
+        device: ::dev_t,
+        name: *const ::c_char,
+        indexInfo: *mut index_info,
+    ) -> ::c_int;
+
+    pub fn fs_open_index_dir(device: ::dev_t) -> *mut ::DIR;
+    pub fn fs_close_index_dir(indexDirectory: *mut ::DIR) -> ::c_int;
+    pub fn fs_read_index_dir(indexDirectory: *mut ::DIR) -> *mut ::dirent;
+    pub fn fs_rewind_index_dir(indexDirectory: *mut ::DIR);
+
+    // kernel/fs_info.h
+    pub fn dev_for_path(path: *const ::c_char) -> ::dev_t;
+    pub fn next_dev(pos: *mut i32) -> ::dev_t;
+    pub fn fs_stat_dev(dev: ::dev_t, info: *mut fs_info) -> ::c_int;
+
+    // kernel/fs_query.h
+    pub fn fs_open_query(
+        device: ::dev_t,
+        query: *const ::c_char,
+        flags: u32,
+    ) -> *mut ::DIR;
+    pub fn fs_open_live_query(
+        device: ::dev_t,
+        query: *const ::c_char,
+        flags: u32,
+        port: port_id,
+        token: i32,
+    ) -> *mut ::DIR;
+    pub fn fs_close_query(d: *mut ::DIR) -> ::c_int;
+    pub fn fs_read_query(d: *mut ::DIR) -> *mut ::dirent;
+    pub fn get_path_for_dirent(
+        dent: *mut ::dirent,
+        buf: *mut ::c_char,
+        len: ::size_t,
+    ) -> status_t;
+
+    // kernel/fs_volume.h
+    pub fn fs_mount_volume(
+        where_: *const ::c_char,
+        device: *const ::c_char,
+        filesystem: *const ::c_char,
+        flags: u32,
+        parameters: *const ::c_char,
+    ) -> ::dev_t;
+    pub fn fs_unmount_volume(path: *const ::c_char, flags: u32) -> status_t;
+
+    // kernel/image.h
+    pub fn load_image(
+        argc: i32,
+        argv: *mut *const ::c_char,
+        environ: *mut *const ::c_char,
+    ) -> thread_id;
+    pub fn load_add_on(path: *const ::c_char) -> image_id;
+    pub fn unload_add_on(image: image_id) -> status_t;
+    pub fn get_image_symbol(
+        image: image_id,
+        name: *const ::c_char,
+        symbolType: i32,
+        symbolLocation: *mut *mut ::c_void,
+    ) -> status_t;
+    pub fn get_nth_image_symbol(
+        image: image_id,
+        n: i32,
+        nameBuffer: *mut ::c_char,
+        nameLength: *mut i32,
+        symbolType: *mut i32,
+        symbolLocation: *mut *mut ::c_void,
+    ) -> status_t;
+    pub fn clear_caches(address: *mut ::c_void, length: ::size_t, flags: u32);
+    pub fn _get_image_info(
+        image: image_id,
+        info: *mut image_info,
+        size: ::size_t,
+    ) -> status_t;
+    pub fn _get_next_image_info(
+        team: team_id,
+        cookie: *mut i32,
+        info: *mut image_info,
+        size: ::size_t,
+    ) -> status_t;
+}
+
+// The following functions are defined as macros in C/C++
+pub unsafe fn get_area_info(id: area_id, info: *mut area_info) -> status_t {
+    _get_area_info(id, info, core::mem::size_of::<area_info>() as usize)
+}
+
+pub unsafe fn get_next_area_info(
+    team: team_id,
+    cookie: *mut isize,
+    info: *mut area_info,
+) -> status_t {
+    _get_next_area_info(
+        team,
+        cookie,
+        info,
+        core::mem::size_of::<area_info>() as usize,
+    )
+}
+
+pub unsafe fn get_port_info(port: port_id, buf: &mut port_info) -> status_t {
+    _get_port_info(port, buf, core::mem::size_of::<port_info>() as ::size_t)
+}
+
+pub unsafe fn get_next_port_info(
+    port: port_id,
+    cookie: &mut i32,
+    portInfo: &mut port_info,
+) -> status_t {
+    _get_next_port_info(
+        port,
+        cookie,
+        portInfo,
+        core::mem::size_of::<port_info>() as ::size_t,
+    )
+}
+
+pub unsafe fn get_port_message_info_etc(
+    port: port_id,
+    info: &mut port_message_info,
+    flags: u32,
+    timeout: bigtime_t,
+) -> status_t {
+    _get_port_message_info_etc(
+        port,
+        info,
+        core::mem::size_of::<port_message_info>() as ::size_t,
+        flags,
+        timeout,
+    )
+}
+
+pub unsafe fn get_sem_info(id: sem_id, info: &mut sem_info) -> status_t {
+    _get_sem_info(id, info, core::mem::size_of::<sem_info>() as ::size_t)
+}
+
+pub unsafe fn get_next_sem_info(
+    team: team_id,
+    cookie: &mut i32,
+    info: &mut sem_info,
+) -> status_t {
+    _get_next_sem_info(
+        team,
+        cookie,
+        info,
+        core::mem::size_of::<sem_info>() as ::size_t,
+    )
+}
+
+pub unsafe fn get_team_info(team: team_id, info: &mut team_info) -> status_t {
+    _get_team_info(team, info, core::mem::size_of::<team_info>() as ::size_t)
+}
+
+pub unsafe fn get_next_team_info(
+    cookie: &mut i32,
+    info: &mut team_info,
+) -> status_t {
+    _get_next_team_info(
+        cookie,
+        info,
+        core::mem::size_of::<team_info>() as ::size_t,
+    )
+}
+
+pub unsafe fn get_team_usage_info(
+    team: team_id,
+    who: i32,
+    info: &mut team_usage_info,
+) -> status_t {
+    _get_team_usage_info(
+        team,
+        who,
+        info,
+        core::mem::size_of::<team_usage_info>() as ::size_t,
+    )
+}
+
+pub unsafe fn get_thread_info(
+    id: thread_id,
+    info: &mut thread_info,
+) -> status_t {
+    _get_thread_info(id, info, core::mem::size_of::<thread_info>() as ::size_t)
+}
+
+pub unsafe fn get_next_thread_info(
+    team: team_id,
+    cookie: &mut i32,
+    info: &mut thread_info,
+) -> status_t {
+    _get_next_thread_info(
+        team,
+        cookie,
+        info,
+        core::mem::size_of::<thread_info>() as ::size_t,
+    )
+}
+
+// kernel/image.h
+pub unsafe fn get_image_info(
+    image: image_id,
+    info: &mut image_info,
+) -> status_t {
+    _get_image_info(
+        image,
+        info,
+        core::mem::size_of::<image_info>() as ::size_t,
+    )
+}
+
+pub unsafe fn get_next_image_info(
+    team: team_id,
+    cookie: &mut i32,
+    info: &mut image_info,
+) -> status_t {
+    _get_next_image_info(
+        team,
+        cookie,
+        info,
+        core::mem::size_of::<image_info>() as ::size_t,
+    )
+}

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -227,7 +227,8 @@ pub const S_ISGID: ::mode_t = 0x400;
 pub const S_ISVTX: ::mode_t = 0x200;
 
 cfg_if! {
-    if #[cfg(not(any(target_os = "illumos", target_os = "solaris")))] {
+    if #[cfg(not(any(target_os = "haiku", target_os = "illumos",
+                     target_os = "solaris")))] {
         pub const IF_NAMESIZE: ::size_t = 16;
         pub const IFNAMSIZ: ::size_t = IF_NAMESIZE;
     }
@@ -260,12 +261,15 @@ pub const LOG_LOCAL5: ::c_int = 21 << 3;
 pub const LOG_LOCAL6: ::c_int = 22 << 3;
 pub const LOG_LOCAL7: ::c_int = 23 << 3;
 
-pub const LOG_PID: ::c_int = 0x01;
-pub const LOG_CONS: ::c_int = 0x02;
-pub const LOG_ODELAY: ::c_int = 0x04;
-pub const LOG_NDELAY: ::c_int = 0x08;
-pub const LOG_NOWAIT: ::c_int = 0x10;
-
+cfg_if! {
+    if #[cfg(not(target_os = "haiku"))] {
+        pub const LOG_PID: ::c_int = 0x01;
+        pub const LOG_CONS: ::c_int = 0x02;
+        pub const LOG_ODELAY: ::c_int = 0x04;
+        pub const LOG_NDELAY: ::c_int = 0x08;
+        pub const LOG_NOWAIT: ::c_int = 0x10;
+    }
+}
 pub const LOG_PRIMASK: ::c_int = 7;
 pub const LOG_FACMASK: ::c_int = 0x3f8;
 


### PR DESCRIPTION
On the Haiku platform, the POSIX (and BSD) API coexists with the native API,
that has its origins on the BeOS platform. Unlike other UNIX-like platforms,
the native API is not an extension of the POSIX API, but instead exists sui
generis, and many of the POSIX concepts have their own native variety, with
relatively limited interoperability.

Nonetheless, the native API coexists in the same library as the standard C and
POSIX functions, namely libroot.so, and therefore this crate is a good place
to add bindings to it.

This commit implements most of Haiku's support kit, the most important parts
of the kernel kit, and a part of the storage kit.