### PR TITLE
Add preadv and pwritev for macOS

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -213,6 +213,9 @@ fn test_apple(target: &str) {
             // close calls the close_nocancel system call
             "close" => true,
 
+            // these calls require macOS 11.0 or higher
+            "preadv" | "pwritev" => true,
+
             _ => false,
         }
     });

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -3538,6 +3538,18 @@ extern "C" {
     pub fn setpriority(which: ::c_int, who: ::id_t, prio: ::c_int) -> ::c_int;
     pub fn getdomainname(name: *mut ::c_char, len: ::c_int) -> ::c_int;
     pub fn setdomainname(name: *const ::c_char, len: ::c_int) -> ::c_int;
+    pub fn preadv(
+        fd: ::c_int,
+        iov: *const ::iovec,
+        iovcnt: ::c_int,
+        offset: ::off_t,
+    ) -> ::ssize_t;
+    pub fn pwritev(
+        fd: ::c_int,
+        iov: *const ::iovec,
+        iovcnt: ::c_int,
+        offset: ::off_t,
+    ) -> ::ssize_t;
     pub fn getxattr(
         path: *const ::c_char,
         name: *const ::c_char,


### PR DESCRIPTION
Add declarations for the preadv and pwritev system calls, introduced
in macOS 11.0 (Big Sur).

Signed-off-by: Sergio Lopez <slp@redhat.com>