### PR TITLE
Add timer interface for illumos and Solaris

### DIFF
--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -20,6 +20,7 @@ pub type rlim_t = ::c_ulong;
 pub type speed_t = ::c_uint;
 pub type tcflag_t = ::c_uint;
 pub type time_t = ::c_long;
+pub type timer_t = ::c_int;
 pub type wchar_t = ::c_int;
 pub type nfds_t = ::c_ulong;
 pub type projid_t = ::c_int;
@@ -118,6 +119,11 @@ s! {
         pub ifa_netmask: *mut ::sockaddr,
         pub ifa_dstaddr: *mut ::sockaddr,
         pub ifa_data: *mut ::c_void
+    }
+
+    pub struct itimerspec {
+        pub it_interval: ::timespec,
+        pub it_value: ::timespec,
     }
 
     pub struct tm {
@@ -2655,6 +2661,21 @@ extern "C" {
 
     pub fn ntp_adjtime(buf: *mut timex) -> ::c_int;
     pub fn ntp_gettime(buf: *mut ntptimeval) -> ::c_int;
+
+    pub fn timer_create(
+        clock_id: clockid_t,
+        evp: *mut sigevent,
+        timerid: *mut timer_t,
+    ) -> ::c_int;
+    pub fn timer_delete(timerid: timer_t) -> ::c_int;
+    pub fn timer_getoverrun(timerid: timer_t) -> ::c_int;
+    pub fn timer_gettime(timerid: timer_t, value: *mut itimerspec) -> ::c_int;
+    pub fn timer_settime(
+        timerid: timer_t,
+        flags: ::c_int,
+        value: *const itimerspec,
+        ovalue: *mut itimerspec,
+    ) -> ::c_int;
 
     pub fn ucred_get(pid: ::pid_t) -> *mut ucred_t;
     pub fn getpeerucred(fd: ::c_int, ucred: *mut *mut ucred_t) -> ::c_int;


### PR DESCRIPTION
This adds the `timer_*` family of functions present in illumos (and Solaris), along with the associated types.  The `libc-test` suite passes on an illumos (OmniOSCE) machine.  While I do not have resources available to test on Solaris, these interfaces have been stable since Oracle forked.