### PR TITLE
Add port_notify struct for illumos and Solaris

### DIFF
--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -364,6 +364,11 @@ s! {
         pub portev_user: *mut ::c_void,
     }
 
+    pub struct port_notify {
+        pub portnfy_port: ::c_int,
+        pub portnfy_user: *mut ::c_void,
+    }
+
     pub struct exit_status {
         e_termination: ::c_short,
         e_exit: ::c_short,


### PR DESCRIPTION
This adds a missing struct for configuring event ports notifications.  The `libc-test` suite passes on illumos (OmniOSCE) and is assumed to pass on Solaris, given that the interface has been present since Oracle forked from OpenSolaris.