### PR TITLE
android: add android_set_abort_message

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1439,6 +1439,11 @@ fn test_android(target: &str) {
 
     }
 
+    // Include Android-specific headers:
+    headers! { cfg:
+                "android/set_abort_message.h"
+    }
+
     cfg.type_name(move |ty, is_struct, is_union| {
         match ty {
             // Just pass all these through, no need for a "struct" prefix

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -2821,6 +2821,8 @@ extern "C" {
     ) -> ::size_t;
 
     pub fn regfree(preg: *mut ::regex_t);
+
+    pub fn android_set_abort_message(msg: *const ::c_char);
 }
 
 cfg_if! {


### PR DESCRIPTION
As definied in set_abort_message.h [1].

[1] https://android.googlesource.com/platform/bionic/+/master/libc/include/android/set_abort_message.h