### PR TITLE
Fix CI on `i686-unknown-linux-musl`

### DIFF
--- a/ci/docker/i686-unknown-linux-musl/Dockerfile
+++ b/ci/docker/i686-unknown-linux-musl/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 RUN dpkg --add-architecture i386
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
-  gcc-multilib make libc6-dev git curl ca-certificates libc6:i386
+  gcc-multilib make libc6-dev git curl ca-certificates libc6-i386
 
 COPY install-musl.sh /
 RUN sh /install-musl.sh i686


### PR DESCRIPTION
I suspect `focal-20210119` breaks the build, uses an older image to fix the `Could not configure 'libc6:i386'` failure.