### PR TITLE
Remove link directives for libutil on linux-gnu targets

### DIFF
--- a/src/unix/linux_like/linux/gnu/b32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mod.rs
@@ -321,7 +321,6 @@ pub const PTRACE_SETREGS: ::c_uint = 13;
 pub const TIOCSBRK: ::c_int = 0x5427;
 pub const TIOCCBRK: ::c_int = 0x5428;
 
-#[link(name = "util")]
 extern "C" {
     pub fn sysctl(
         name: *mut ::c_int,

--- a/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
@@ -979,7 +979,6 @@ pub const SYS_statx: ::c_long = 291;
 pub const SYS_pidfd_open: ::c_long = 434;
 pub const SYS_clone3: ::c_long = 435;
 
-#[link(name = "util")]
 extern "C" {
     pub fn sysctl(
         name: *mut ::c_int,

--- a/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
@@ -1004,7 +1004,6 @@ pub const TIOCM_DSR: ::c_int = 0x400;
 
 pub const EHWPOISON: ::c_int = 168;
 
-#[link(name = "util")]
 extern "C" {
     pub fn sysctl(
         name: *mut ::c_int,

--- a/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
@@ -1046,7 +1046,6 @@ pub const SYS_statx: ::c_long = 383;
 pub const SYS_pidfd_open: ::c_long = 434;
 pub const SYS_clone3: ::c_long = 435;
 
-#[link(name = "util")]
 extern "C" {
     pub fn sysctl(
         name: *mut ::c_int,

--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -1010,7 +1010,6 @@ pub const SYS_statx: ::c_long = 379;
 pub const SYS_pidfd_open: ::c_long = 434;
 pub const SYS_clone3: ::c_long = 435;
 
-#[link(name = "util")]
 extern "C" {
 
     pub fn sysctl(

--- a/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
@@ -977,7 +977,6 @@ pub const SYS_pidfd_open: ::c_long = 434;
 // Reserved in the kernel, but not actually implemented yet
 pub const SYS_clone3: ::c_long = 435;
 
-#[link(name = "util")]
 extern "C" {
     pub fn sysctl(
         name: *mut ::c_int,


### PR DESCRIPTION
These are all handled in src/unix/mod.rs now, which also addresses the
crt-static case; no linux-gnu target should have any link directives in
any other module.

This fixes static linking with glibc for various architectures.

Fixes #2033