### PR TITLE
ci/semver.sh: Pass --locked when installing semverver

### DIFF
--- a/ci/semver.sh
+++ b/ci/semver.sh
@@ -16,7 +16,7 @@ fi
 rustup component add rustc-dev llvm-tools-preview
 
 # Should update the nightly version in bors CI config if we touch this.
-cargo install --git https://github.com/rust-lang/rust-semverver --rev 71c340ff867d2f79613cfe02c6714f1d2ef00bc4
+cargo install --locked --git https://github.com/rust-lang/rust-semverver --rev 71c340ff867d2f79613cfe02c6714f1d2ef00bc4
 
 TARGETS=
 case "${OS}" in


### PR DESCRIPTION
We don't, in general, want our CI to be the testbed for building
semverver with newer versions of its dependencies. Pass --locked to use
the checked-in Cargo.lock instead.

This works around https://github.com/rust-lang/cargo/issues/9101 .