### PR TITLE
Use Rust union types

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2680,8 +2680,6 @@ fn test_linux(target: &str) {
         "utsname" if mips32 || mips64 => true,
         // FIXME:
         "mcontext_t" if s390x => true,
-        // FIXME: This is actually a union.
-        "fpreg_t" if s390x => true,
 
         "sockaddr_un" | "sembuf" | "ff_constant_effect"
             if mips32 && (gnu || musl) =>

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -668,8 +668,6 @@ fn test_solarish(target: &str) {
 
     cfg.field_name(move |struct_, field| {
         match struct_ {
-            // rust struct uses raw u64, rather than union
-            "epoll_event" if field == "u64" => "data.u64".to_string(),
             // rust struct was committed with typo for Solaris
             "door_arg_t" if field == "dec_num" => "desc_num".to_string(),
             "stat" if field.ends_with("_nsec") => {
@@ -893,7 +891,6 @@ fn test_netbsd(target: &str) {
             s if s.ends_with("_nsec") && struct_.starts_with("stat") => {
                 s.replace("e_nsec", ".tv_nsec")
             }
-            "u64" if struct_ == "epoll_event" => "data.u64".to_string(),
             s => s.to_string(),
         }
     });
@@ -1094,7 +1091,6 @@ fn test_dragonflybsd(target: &str) {
             s if s.ends_with("_nsec") && struct_.starts_with("stat") => {
                 s.replace("e_nsec", ".tv_nsec")
             }
-            "u64" if struct_ == "epoll_event" => "data.u64".to_string(),
             // Field is named `type` in C but that is a Rust keyword,
             // so these fields are translated to `type_` in the bindings.
             "type_" if struct_ == "rtprio" => "type".to_string(),
@@ -1424,8 +1420,6 @@ fn test_android(target: &str) {
             s if s.ends_with("_nsec") && struct_.starts_with("stat") => {
                 s.to_string()
             }
-            // FIXME: appears that `epoll_event.data` is an union
-            "u64" if struct_ == "epoll_event" => "data.u64".to_string(),
             s => s.to_string(),
         }
     });
@@ -1960,8 +1954,6 @@ fn test_emscripten(target: &str) {
             s if s.ends_with("_nsec") && struct_.starts_with("stat") => {
                 s.replace("e_nsec", ".tv_nsec")
             }
-            // FIXME: appears that `epoll_event.data` is an union
-            "u64" if struct_ == "epoll_event" => "data.u64".to_string(),
             s => s.to_string(),
         }
     });
@@ -2389,10 +2381,6 @@ fn test_linux(target: &str) {
             s if s.ends_with("_nsec") && struct_.starts_with("stat") => {
                 s.replace("e_nsec", ".tv_nsec")
             }
-            // FIXME: epoll_event.data is actuall a union in C, but in Rust
-            // it is only a u64 because we only expose one field
-            // http://man7.org/linux/man-pages/man2/epoll_wait.2.html
-            "u64" if struct_ == "epoll_event" => "data.u64".to_string(),
             // The following structs have a field called `type` in C,
             // but `type` is a Rust keyword, so these fields are translated
             // to `type_` in Rust.

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -973,8 +973,6 @@ fn test_netbsd(target: &str) {
     });
 
     cfg.skip_field_type(move |struct_, field| {
-        // This is a weird union, don't check the type.
-        (struct_ == "ifaddrs" && field == "ifa_ifu") ||
         // sighandler_t type is super weird
         (struct_ == "sigaction" && field == "sa_sigaction") ||
         // aio_buf is "volatile void*" and Rust doesn't understand volatile
@@ -1174,8 +1172,6 @@ fn test_dragonflybsd(target: &str) {
     });
 
     cfg.skip_field_type(move |struct_, field| {
-        // This is a weird union, don't check the type.
-        (struct_ == "ifaddrs" && field == "ifa_ifu") ||
         // sighandler_t type is super weird
         (struct_ == "sigaction" && field == "sa_sigaction") ||
         // aio_buf is "volatile void*" and Rust doesn't understand volatile
@@ -1504,11 +1500,6 @@ fn test_android(target: &str) {
 
             _ => false,
         }
-    });
-
-    cfg.skip_field_type(move |struct_, field| {
-        // This is a weird union, don't check the type.
-        struct_ == "ifaddrs" && field == "ifa_ifu"
     });
 
     cfg.skip_field(move |struct_, field| {
@@ -1986,6 +1977,9 @@ fn test_emscripten(target: &str) {
     });
 
     cfg.skip_struct(move |ty| {
+        if ty.starts_with("__c_anonymous_") {
+            return true;
+        }
         match ty {
             // FIXME: It was removed in
             // emscripten-core/emscripten@953e414
@@ -2029,9 +2023,6 @@ fn test_emscripten(target: &str) {
     });
 
     cfg.skip_field_type(move |struct_, field| {
-        // This is a weird union, don't check the type.
-        // FIXME: is this necessary?
-        (struct_ == "ifaddrs" && field == "ifa_ifu") ||
         // sighandler_t type is super weird
         // FIXME: is this necessary?
         (struct_ == "sigaction" && field == "sa_sigaction") ||

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -180,15 +180,6 @@ fn test_apple(target: &str) {
         [x86_64]: "crt_externs.h",
     }
 
-    cfg.skip_struct(move |ty| {
-        match ty {
-            // FIXME: actually a union
-            "sigval" => true,
-
-            _ => false,
-        }
-    });
-
     cfg.skip_const(move |name| {
         match name {
             // These OSX constants are removed in Sierra.
@@ -225,14 +216,6 @@ fn test_apple(target: &str) {
             // FIXME: the array size has been changed since macOS 10.15 ([8] -> [7]).
             ("statfs", "f_reserved") => true,
             ("__darwin_arm_neon_state64", "__v") => true,
-            _ => false,
-        }
-    });
-
-    cfg.skip_field_type(move |struct_, field| {
-        match (struct_, field) {
-            // FIXME: actually a union
-            ("sigevent", "sigev_value") => true,
             _ => false,
         }
     });
@@ -360,15 +343,6 @@ fn test_openbsd(target: &str) {
         "sys/syscall.h",
         "sys/shm.h",
     }
-
-    cfg.skip_struct(move |ty| {
-        match ty {
-            // FIXME: actually a union
-            "sigval" => true,
-
-            _ => false,
-        }
-    });
 
     cfg.skip_const(move |name| {
         match name {
@@ -739,8 +713,6 @@ fn test_solarish(target: &str) {
             return true;
         }
         match ty {
-            // union, not a struct
-            "sigval" => true,
             // a bunch of solaris-only fields
             "utmpx" if is_illumos => true,
             _ => false,
@@ -755,8 +727,6 @@ fn test_solarish(target: &str) {
             "sigaction" if field == "sa_sigaction" => true,
             // Missing in illumos
             "sigevent" if field == "ss_sp" => true,
-            // Avoid sigval union issues
-            "sigevent" if field == "sigev_value" => true,
             // const issues
             "sigevent" if field == "sigev_notify_attributes" => true,
 
@@ -938,8 +908,6 @@ fn test_netbsd(target: &str) {
 
     cfg.skip_struct(move |ty| {
         match ty {
-            // This is actually a union, not a struct
-            "sigval" => true,
             // These are tested as part of the linux_fcntl tests since there are
             // header conflicts when including them with all the other structs.
             "termios2" => true,
@@ -1009,8 +977,6 @@ fn test_netbsd(target: &str) {
         (struct_ == "ifaddrs" && field == "ifa_ifu") ||
         // sighandler_t type is super weird
         (struct_ == "sigaction" && field == "sa_sigaction") ||
-        // sigval is actually a union, but we pretend it's a struct
-        (struct_ == "sigevent" && field == "sigev_value") ||
         // aio_buf is "volatile void*" and Rust doesn't understand volatile
         (struct_ == "aiocb" && field == "aio_buf")
     });
@@ -1149,9 +1115,6 @@ fn test_dragonflybsd(target: &str) {
 
     cfg.skip_struct(move |ty| {
         match ty {
-            // This is actually a union, not a struct
-            "sigval" => true,
-
             // FIXME: These are tested as part of the linux_fcntl tests since
             // there are header conflicts when including them with all the other
             // structs.
@@ -1215,8 +1178,6 @@ fn test_dragonflybsd(target: &str) {
         (struct_ == "ifaddrs" && field == "ifa_ifu") ||
         // sighandler_t type is super weird
         (struct_ == "sigaction" && field == "sa_sigaction") ||
-        // sigval is actually a union, but we pretend it's a struct
-        (struct_ == "sigevent" && field == "sigev_value") ||
         // aio_buf is "volatile void*" and Rust doesn't understand volatile
         (struct_ == "aiocb" && field == "aio_buf")
     });
@@ -1453,9 +1414,6 @@ fn test_android(target: &str) {
 
             t if t.ends_with("_t") => t.to_string(),
 
-            // sigval is a struct in Rust, but a union in C:
-            "sigval" => format!("union sigval"),
-
             // put `struct` in front of all structs:.
             t if is_struct => format!("struct {}", t),
 
@@ -1550,9 +1508,7 @@ fn test_android(target: &str) {
 
     cfg.skip_field_type(move |struct_, field| {
         // This is a weird union, don't check the type.
-        (struct_ == "ifaddrs" && field == "ifa_ifu") ||
-        // sigval is actually a union, but we pretend it's a struct
-        (struct_ == "sigevent" && field == "sigev_value")
+        struct_ == "ifaddrs" && field == "ifa_ifu"
     });
 
     cfg.skip_field(move |struct_, field| {
@@ -1691,9 +1647,6 @@ fn test_freebsd(target: &str) {
             t if is_union => format!("union {}", t),
 
             t if t.ends_with("_t") => t.to_string(),
-
-            // sigval is a struct in Rust, but a union in C:
-            "sigval" => format!("union sigval"),
 
             // put `struct` in front of all structs:.
             t if is_struct => format!("struct {}", t),
@@ -2034,10 +1987,6 @@ fn test_emscripten(target: &str) {
 
     cfg.skip_struct(move |ty| {
         match ty {
-            // This is actually a union, not a struct
-            // FIXME: is this necessary?
-            "sigval" => true,
-
             // FIXME: It was removed in
             // emscripten-core/emscripten@953e414
             "pthread_mutexattr_t" => true,
@@ -2086,9 +2035,6 @@ fn test_emscripten(target: &str) {
         // sighandler_t type is super weird
         // FIXME: is this necessary?
         (struct_ == "sigaction" && field == "sa_sigaction") ||
-        // sigval is actually a union, but we pretend it's a struct
-        // FIXME: is this necessary?
-        (struct_ == "sigevent" && field == "sigev_value") ||
         // aio_buf is "volatile void*" and Rust doesn't understand volatile
         // FIXME: is this necessary?
         (struct_ == "aiocb" && field == "aio_buf")
@@ -2217,10 +2163,8 @@ fn test_vxworks(target: &str) {
 
     // FIXME
     cfg.skip_fn(move |name| match name {
-        // sigval
-        "sigqueue" | "_sigqueue"
         // sighandler_t
-        | "signal"
+        "signal"
         // not used in static linking by default
         | "dlerror" => true,
         _ => false,
@@ -2506,9 +2450,6 @@ fn test_linux(target: &str) {
             // which is absent in glibc, has to be defined.
             "__timeval" => true,
 
-            // FIXME: This is actually a union, not a struct
-            "sigval" => true,
-
             // This type is tested in the `linux_termios.rs` file since there
             // are header conflicts when including them with all the other
             // structs.
@@ -2700,8 +2641,6 @@ fn test_linux(target: &str) {
         (struct_ == "sigaction" && field == "sa_sigaction") ||
         // __timeval type is a patch which doesn't exist in glibc
         (struct_ == "utmpx" && field == "ut_tv") ||
-        // sigval is actually a union, but we pretend it's a struct
-        (struct_ == "sigevent" && field == "sigev_value") ||
         // this one is an anonymous union
         (struct_ == "ff_effect" && field == "u") ||
         // `__exit_status` type is a patch which is absent in musl

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -409,6 +409,13 @@ s! {
 
     pub struct epoll_event {
         pub events: u32,
+        pub data: epoll_data,
+    }
+
+    pub union epoll_data {
+        pub ptr: *mut ::c_void,
+        pub fd: ::c_int,
+        pub u32: u32,
         pub u64: u64,
     }
 

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -251,11 +251,6 @@ s! {
         pub l_linger: ::c_int,
     }
 
-    pub struct sigval {
-        // Actually a union of an int and a void*
-        pub sival_ptr: *mut ::c_void
-    }
-
     // <sys/time.h>
     pub struct itimerval {
         pub it_interval: ::timeval,
@@ -974,6 +969,11 @@ s_no_extra_traits! {
         pub sigev_notify_attributes: *mut pthread_attr_t,
         pub __pad: [::c_char; 56 - 3 * 8 /* 8 == sizeof(long) */],
     }
+
+    pub union sigval {
+        pub sival_int: ::int,
+        pub sival_ptr: *mut ::c_void,
+    }
 }
 
 cfg_if! {
@@ -1299,6 +1299,25 @@ cfg_if! {
                 self.sigev_notify.hash(state);
                 self.sigev_notify_function.hash(state);
                 self.sigev_notify_attributes.hash(state);
+            }
+        }
+
+        impl PartialEq for sigval {
+            fn eq(&self, other: &sigval) -> bool {
+                unsafe { self.sival_ptr as usize == other.sival_ptr as usize }
+            }
+        }
+        impl Eq for sigval {}
+        impl ::fmt::Debug for sigval {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("sigval")
+                    .field("sival_ptr", unsafe { &(self.sival_ptr as usize) })
+                    .finish()
+            }
+        }
+        impl ::hash::Hash for sigval {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                unsafe { (self.sival_ptr as usize).hash(state) };
             }
         }
     }

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -463,8 +463,8 @@ s! {
         pub ifa_flags: ::c_uint,
         pub ifa_addr: *mut ::sockaddr,
         pub ifa_netmask: *mut ::sockaddr,
-        pub ifa_ifu: *mut ::sockaddr, // FIXME This should be a union
-        pub ifa_data: *mut ::c_void
+        pub ifa_ifu: __c_anonymous_ifa_ifu,
+        pub ifa_data: *mut ::c_void,
     }
 
     pub struct passwd {
@@ -974,6 +974,11 @@ s_no_extra_traits! {
         pub sival_int: ::int,
         pub sival_ptr: *mut ::c_void,
     }
+
+    pub union __c_anonymous_ifa_ifu {
+        ifu_broadaddr: *mut sockaddr,
+        ifu_dstaddr: *mut sockaddr,
+    }
 }
 
 cfg_if! {
@@ -1318,6 +1323,25 @@ cfg_if! {
         impl ::hash::Hash for sigval {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe { (self.sival_ptr as usize).hash(state) };
+            }
+        }
+
+        impl PartialEq for __c_anonymous_ifa_ifu {
+            fn eq(&self, other: &__c_anonymous_ifa_ifu) -> bool {
+                unsafe { self.ifu_dstaddr == other.ifu_dstaddr }
+            }
+        }
+        impl Eq for __c_anonymous_ifa_ifu {}
+        impl ::fmt::Debug for __c_anonymous_ifa_ifu {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("ifa_ifu")
+                    .field("ifu_dstaddr", unsafe { &self.ifu_dstaddr } )
+                    .finish()
+            }
+        }
+        impl ::hash::Hash for __c_anonymous_ifa_ifu {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                unsafe { self.ifu_dstaddr.hash(state) };
             }
         }
     }

--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -222,10 +222,9 @@ s! {
 }
 
 s_no_extra_traits! {
-    // FIXME: This is actually a union.
-    pub struct fpreg_t {
+    pub union fpreg_t {
         pub d: ::c_double,
-        // f: ::c_float,
+        pub f: ::c_float,
     }
 }
 
@@ -233,7 +232,7 @@ cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         impl PartialEq for fpreg_t {
             fn eq(&self, other: &fpreg_t) -> bool {
-                self.d == other.d
+                unsafe { self.d == other.d }
             }
         }
 
@@ -242,7 +241,7 @@ cfg_if! {
         impl ::fmt::Debug for fpreg_t {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("fpreg_t")
-                    .field("d", &self.d)
+                    .field("d", unsafe { &self.d })
                     .finish()
             }
         }

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -157,8 +157,8 @@ s! {
         pub ifa_flags: ::c_uint,
         pub ifa_addr: *mut ::sockaddr,
         pub ifa_netmask: *mut ::sockaddr,
-        pub ifa_ifu: *mut ::sockaddr, // FIXME This should be a union
-        pub ifa_data: *mut ::c_void
+        pub ifa_ifu: __c_anonymous_ifa_ifu,
+        pub ifa_data: *mut ::c_void,
     }
 
     pub struct in6_rtmsg {
@@ -251,6 +251,11 @@ s_no_extra_traits! {
         __unused1: [::c_int; 11],
         #[cfg(target_pointer_width = "32")]
         __unused1: [::c_int; 12]
+    }
+
+    pub union __c_anonymous_ifa_ifu {
+        ifu_broadaddr: *mut sockaddr,
+        ifu_dstaddr: *mut sockaddr,
     }
 }
 
@@ -425,6 +430,25 @@ cfg_if! {
                 self.sigev_signo.hash(state);
                 self.sigev_notify.hash(state);
                 self.sigev_notify_thread_id.hash(state);
+            }
+        }
+
+        impl PartialEq for __c_anonymous_ifa_ifu {
+            fn eq(&self, other: &__c_anonymous_ifa_ifu) -> bool {
+                unsafe { self.ifu_dstaddr == other.ifu_dstaddr }
+            }
+        }
+        impl Eq for __c_anonymous_ifa_ifu {}
+        impl ::fmt::Debug for __c_anonymous_ifa_ifu {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("ifa_ifu")
+                    .field("ifu_dstaddr", unsafe { &self.ifu_dstaddr } )
+                    .finish()
+            }
+        }
+        impl ::hash::Hash for __c_anonymous_ifa_ifu {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                unsafe { self.ifu_dstaddr.hash(state) };
             }
         }
     }

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -214,6 +214,13 @@ s_no_extra_traits! {
         repr(packed))]
     pub struct epoll_event {
         pub events: u32,
+        pub data: epoll_data,
+    }
+
+    pub union epoll_data {
+        pub ptr: *mut ::c_void,
+        pub fd: ::c_int,
+        pub u32: u32,
         pub u64: u64,
     }
 
@@ -264,25 +271,46 @@ cfg_if! {
         impl PartialEq for epoll_event {
             fn eq(&self, other: &epoll_event) -> bool {
                 self.events == other.events
-                    && self.u64 == other.u64
+                    && unsafe { self.data.u64 == other.data.u64 }
             }
         }
         impl Eq for epoll_event {}
         impl ::fmt::Debug for epoll_event {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 let events = self.events;
-                let u64 = self.u64;
+                let data = self.data;
                 f.debug_struct("epoll_event")
                     .field("events", &events)
-                    .field("u64", &u64)
+                    .field("data", &data)
                     .finish()
             }
         }
         impl ::hash::Hash for epoll_event {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 let events = self.events;
-                let u64 = self.u64;
+                let data = self.data;
                 events.hash(state);
+                data.hash(state);
+            }
+        }
+
+        impl PartialEq for epoll_data {
+            fn eq(&self, other: &epoll_data) -> bool {
+                unsafe { self.u64 == other.u64 }
+            }
+        }
+        impl Eq for epoll_data {}
+        impl ::fmt::Debug for epoll_data {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                let u64 = unsafe { self.u64 };
+                f.debug_struct("epoll_data")
+                    .field("data", &u64)
+                    .finish()
+            }
+        }
+        impl ::hash::Hash for epoll_data {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                let u64 = unsafe { self.u64 };
                 u64.hash(state);
             }
         }

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -162,11 +162,6 @@ s! {
         pub l_linger: ::c_int,
     }
 
-    pub struct sigval {
-        // Actually a union of an int and a void*
-        pub sival_ptr: *mut ::c_void
-    }
-
     // <sys/time.h>
     pub struct itimerval {
         pub it_interval: ::timeval,
@@ -192,6 +187,36 @@ s! {
         pub p_name: *mut ::c_char,
         pub p_aliases: *mut *mut ::c_char,
         pub p_proto: ::c_int,
+    }
+}
+
+s_no_extra_traits! {
+    pub union sigval {
+        pub sival_int: ::c_int,
+        pub sival_ptr: *mut ::c_void,
+    }
+}
+
+cfg_if! {
+    if #[cfg(feature = "extra_traits")] {
+        impl PartialEq for sigval {
+            fn eq(&self, other: &sigval) -> bool {
+                unsafe { self.sival_ptr as usize == other.sival_ptr as usize }
+            }
+        }
+        impl Eq for sigval {}
+        impl ::fmt::Debug for sigval {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("sigval")
+                    .field("sival_ptr", unsafe { &(self.sival_ptr as usize) })
+                    .finish()
+            }
+        }
+        impl ::hash::Hash for sigval {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                unsafe { (self.sival_ptr as usize).hash(state) };
+            }
+        }
     }
 }
 

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -429,6 +429,13 @@ s_no_extra_traits! {
         ), repr(packed))]
     pub struct epoll_event {
         pub events: u32,
+        pub data: epoll_data,
+    }
+
+    pub union epoll_data {
+        pub ptr: *mut ::c_void,
+        pub fd: ::c_int,
+        pub u32: u32,
         pub u64: u64,
     }
 
@@ -563,25 +570,46 @@ cfg_if! {
         impl PartialEq for epoll_event {
             fn eq(&self, other: &epoll_event) -> bool {
                 self.events == other.events
-                    && self.u64 == other.u64
+                    && unsafe { self.data.u64 == other.data.u64 }
             }
         }
         impl Eq for epoll_event {}
         impl ::fmt::Debug for epoll_event {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 let events = self.events;
-                let u64 = self.u64;
+                let data = self.data;
                 f.debug_struct("epoll_event")
                     .field("events", &events)
-                    .field("u64", &u64)
+                    .field("data", &data)
                     .finish()
             }
         }
         impl ::hash::Hash for epoll_event {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 let events = self.events;
-                let u64 = self.u64;
+                let data = self.data;
                 events.hash(state);
+                data.hash(state);
+            }
+        }
+
+        impl PartialEq for epoll_data {
+            fn eq(&self, other: &epoll_data) -> bool {
+                unsafe { self.u64 == other.u64 }
+            }
+        }
+        impl Eq for epoll_data {}
+        impl ::fmt::Debug for epoll_data {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                let u64 = unsafe { self.u64 };
+                f.debug_struct("epoll_data")
+                    .field("data", &u64)
+                    .finish()
+            }
+        }
+        impl ::hash::Hash for epoll_data {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                let u64 = unsafe { self.u64 };
                 u64.hash(state);
             }
         }

--- a/src/unix/uclibc/mod.rs
+++ b/src/unix/uclibc/mod.rs
@@ -184,8 +184,8 @@ s! {
         pub ifa_flags: ::c_uint,
         pub ifa_addr: *mut ::sockaddr,
         pub ifa_netmask: *mut ::sockaddr,
-        pub ifa_ifu: *mut ::sockaddr, // FIXME This should be a union
-        pub ifa_data: *mut ::c_void
+        pub ifa_ifu: __c_anonymous_ifa_ifu,
+        pub ifa_data: *mut ::c_void,
     }
 
     pub struct pthread_rwlockattr_t {
@@ -436,6 +436,11 @@ s_no_extra_traits! {
         #[cfg(target_pointer_width = "32")]
         __unused1: [::c_int; 12]
     }
+
+    pub union __c_anonymous_ifa_ifu {
+        ifu_broadaddr: *mut sockaddr,
+        ifu_dstaddr: *mut sockaddr,
+    }
 }
 
 cfg_if! {
@@ -520,6 +525,25 @@ cfg_if! {
                 self.sigev_signo.hash(state);
                 self.sigev_notify.hash(state);
                 self.sigev_notify_thread_id.hash(state);
+            }
+        }
+
+        impl PartialEq for __c_anonymous_ifa_ifu {
+            fn eq(&self, other: &__c_anonymous_ifa_ifu) -> bool {
+                unsafe { self.ifu_dstaddr == other.ifu_dstaddr }
+            }
+        }
+        impl Eq for __c_anonymous_ifa_ifu {}
+        impl ::fmt::Debug for __c_anonymous_ifa_ifu {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("ifa_ifu")
+                    .field("ifu_dstaddr", unsafe { &self.ifu_dstaddr } )
+                    .finish()
+            }
+        }
+        impl ::hash::Hash for __c_anonymous_ifa_ifu {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                unsafe { self.ifu_dstaddr.hash(state) };
             }
         }
     }

--- a/src/unix/uclibc/mod.rs
+++ b/src/unix/uclibc/mod.rs
@@ -362,6 +362,14 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     pub struct epoll_event {
         pub events: u32,
+        pub data: epoll_data,
+    }
+
+    #[allow(missing_debug_implementations)]
+    pub union epoll_data {
+        pub ptr: *mut ::c_void,
+        pub fd: ::c_int,
+        pub u32: u32,
         pub u64: u64,
     }
 


### PR DESCRIPTION
For #1020 

Replace some types with unions now that rustc supports them.

I also found `sigevent.sigev_notify_thread_id`, `siginfo_t.__data` and `sigaction.sa_sigaction` that I think should be unions, but I wasn't sure.