### PR TITLE
Re-enable CI for `asmjs-unknown-emscripten`

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -109,9 +109,7 @@ jobs:
           arm-linux-androideabi,
           arm-unknown-linux-gnueabihf,
           arm-unknown-linux-musleabihf,
-          # FIXME: Disabled because currently broken, see:
-          # https://github.com/rust-lang/libc/issues/1591
-          # asmjs-unknown-emscripten,
+          asmjs-unknown-emscripten,
           i686-linux-android,
           i686-unknown-linux-musl,
           mips-unknown-linux-gnu,

--- a/ci/docker/asmjs-unknown-emscripten/Dockerfile
+++ b/ci/docker/asmjs-unknown-emscripten/Dockerfile
@@ -1,7 +1,12 @@
 FROM ubuntu:20.04
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+# This is a workaround to avoid the interaction with tzdata.
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/New_York
+
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends tzdata
+RUN apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     gcc \
@@ -17,6 +22,10 @@ RUN bash /emscripten.sh
 
 ENV PATH=$PATH:/rust/bin \
     CARGO_TARGET_ASMJS_UNKNOWN_EMSCRIPTEN_RUNNER=node
+
+# `-g4` is used by default which causes a linking error.
+# Using `-g3` not to generate a source map.
+ENV EMCC_CFLAGS=-g3
 
 COPY emscripten-entry.sh /
 ENTRYPOINT ["/emscripten-entry.sh"]


### PR DESCRIPTION
#1591 was closed by #1697 but it was only for `wasm32-unknown-emscripten` actually. We should make a new issue and link to it instead if it's still broken.
r? @ghost