### PR TITLE
Linux: Add `preadv2` and `pwritev2` and associated constants

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -860,6 +860,15 @@ pub const EPOLLWAKEUP: ::c_int = 0x20000000;
 pub const SEEK_DATA: ::c_int = 3;
 pub const SEEK_HOLE: ::c_int = 4;
 
+// linux/fs.h
+
+// Flags for preadv2/pwritev2
+pub const RWF_HIPRI: ::c_int = 0x00000001;
+pub const RWF_DSYNC: ::c_int = 0x00000002;
+pub const RWF_SYNC: ::c_int = 0x00000004;
+pub const RWF_NOWAIT: ::c_int = 0x00000008;
+pub const RWF_APPEND: ::c_int = 0x00000010;
+
 // linux/rtnetlink.h
 pub const TCA_PAD: ::c_ushort = 9;
 pub const TCA_DUMP_INVISIBLE: ::c_ushort = 10;

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1420,6 +1420,20 @@ extern "C" {
         dirfd: ::c_int,
         path: *const ::c_char,
     ) -> ::c_int;
+    pub fn preadv2(
+        fd: ::c_int,
+        iov: *const ::iovec,
+        iovcnt: ::c_int,
+        offset: ::off_t,
+        flags: ::c_int,
+    ) -> ::ssize_t;
+    pub fn pwritev2(
+        fd: ::c_int,
+        iov: *const ::iovec,
+        iovcnt: ::c_int,
+        offset: ::off_t,
+        flags: ::c_int,
+    ) -> ::ssize_t;
 }
 
 extern "C" {

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -3033,25 +3033,11 @@ extern "C" {
         iovcnt: ::c_int,
         offset: ::off_t,
     ) -> ::ssize_t;
-    pub fn pwritev2(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-        offset: ::off_t,
-        flags: ::c_int,
-    ) -> ::ssize_t;
     pub fn preadv(
         fd: ::c_int,
         iov: *const ::iovec,
         iovcnt: ::c_int,
         offset: ::off_t,
-    ) -> ::ssize_t;
-    pub fn preadv2(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-        offset: ::off_t,
-        flags: ::c_int,
     ) -> ::ssize_t;
     pub fn quotactl(
         cmd: ::c_int,

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1440,13 +1440,6 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: ::c_uint = 1;
 pub const SYNC_FILE_RANGE_WRITE: ::c_uint = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: ::c_uint = 4;
 
-// Flags for preadv2/pwritev2
-pub const RWF_HIPRI: ::c_int = 0x00000001;
-pub const RWF_DSYNC: ::c_int = 0x00000002;
-pub const RWF_SYNC: ::c_int = 0x00000004;
-pub const RWF_NOWAIT: ::c_int = 0x00000008;
-pub const RWF_APPEND: ::c_int = 0x00000010;
-
 pub const AIO_CANCELED: ::c_int = 0;
 pub const AIO_NOTCANCELED: ::c_int = 1;
 pub const AIO_ALLDONE: ::c_int = 2;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1440,6 +1440,13 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: ::c_uint = 1;
 pub const SYNC_FILE_RANGE_WRITE: ::c_uint = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: ::c_uint = 4;
 
+// Flags for preadv2/pwritev2
+pub const RWF_HIPRI: ::c_int = 0x00000001;
+pub const RWF_DSYNC: ::c_int = 0x00000002;
+pub const RWF_SYNC: ::c_int = 0x00000004;
+pub const RWF_NOWAIT: ::c_int = 0x00000008;
+pub const RWF_APPEND: ::c_int = 0x00000010;
+
 pub const AIO_CANCELED: ::c_int = 0;
 pub const AIO_NOTCANCELED: ::c_int = 1;
 pub const AIO_ALLDONE: ::c_int = 2;
@@ -3026,11 +3033,25 @@ extern "C" {
         iovcnt: ::c_int,
         offset: ::off_t,
     ) -> ::ssize_t;
+    pub fn pwritev2(
+        fd: ::c_int,
+        iov: *const ::iovec,
+        iovcnt: ::c_int,
+        offset: ::off_t,
+        flags: ::c_int,
+    ) -> ::ssize_t;
     pub fn preadv(
         fd: ::c_int,
         iov: *const ::iovec,
         iovcnt: ::c_int,
         offset: ::off_t,
+    ) -> ::ssize_t;
+    pub fn preadv2(
+        fd: ::c_int,
+        iov: *const ::iovec,
+        iovcnt: ::c_int,
+        offset: ::off_t,
+        flags: ::c_int,
     ) -> ::ssize_t;
     pub fn quotactl(
         cmd: ::c_int,


### PR DESCRIPTION
These functions are the same as `preadv` and `pwritev` but have a flags
parameter.  `preadv2()` and `pwritev2()` first appeared in Linux 4.6.
Library support was added in glibc 2.26.

See the definition of the constants in [linux/fs.h](https://github.com/torvalds/linux/blob/fcadab740480e0e0e9fa9bd272acd409884d431a/tools/include/uapi/linux/fs.h#L288-L301).