### PR TITLE
Add memfd_create to linux and android

### DIFF
--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -3914,6 +3914,8 @@ extern "C" {
         needlelen: ::size_t,
     ) -> *mut ::c_void;
     pub fn sched_getcpu() -> ::c_int;
+
+    pub fn memfd_create(name: *const ::c_char, flags: ::c_uint) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
Android only added the wrapper in API level 30, i.e. Android 11. Should this have libc::syscall implementation for android ?