### PR TITLE
WASI: define `AT_FDCWD` and update to latest WASI libc

### DIFF
--- a/ci/docker/wasm32-wasi/Dockerfile
+++ b/ci/docker/wasm32-wasi/Dockerfile
@@ -14,9 +14,9 @@ RUN apt-get update && \
 # verification for now. The sysroot is currently in somewhat of a state of flux
 # and is expected to have breaking changes, so this is an attempt to mitigate
 # those breaking changes on `libc`'s own CI
-RUN git clone https://github.com/CraneStation/wasi-libc && \
+RUN git clone https://github.com/WebAssembly/wasi-libc && \
   cd wasi-libc && \
-  git reset --hard f645f498dfbbbc00a7a97874d33082d3605c3f21
+  git reset --hard f2e779e5f1ba4a539937cedeeaa762c1e0c162df
 RUN apt-get install -y --no-install-recommends llvm
 RUN make -C wasi-libc install -j $(nproc) INSTALL_DIR=/wasi-libc
 

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1272,6 +1272,7 @@ fn test_wasi(target: &str) {
         "wasi/api.h",
         "wasi/libc.h",
         "wasi/libc-find-relpath.h",
+        "wasi/libc-nocwd.h",
         "wchar.h",
     }
 

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -210,6 +210,7 @@ pub const POSIX_FADV_NORMAL: c_int = 0;
 pub const POSIX_FADV_RANDOM: c_int = 2;
 pub const POSIX_FADV_SEQUENTIAL: c_int = 1;
 pub const POSIX_FADV_WILLNEED: c_int = 3;
+pub const AT_FDCWD: ::c_int = -2;
 pub const AT_EACCESS: c_int = 0x0;
 pub const AT_SYMLINK_NOFOLLOW: c_int = 0x1;
 pub const AT_SYMLINK_FOLLOW: c_int = 0x2;
@@ -775,9 +776,116 @@ extern "C" {
     pub fn __wasilibc_rmdirat(fd: c_int, path: *const c_char) -> c_int;
     pub fn __wasilibc_find_relpath(
         path: *const c_char,
-        relative_path: *mut *const c_char,
+        abs_prefix: *mut *const c_char,
+        relative_path: *mut *mut c_char,
+        relative_path_len: usize,
     ) -> c_int;
     pub fn __wasilibc_tell(fd: c_int) -> ::off_t;
+    pub fn __wasilibc_nocwd___wasilibc_unlinkat(
+        dirfd: c_int,
+        path: *const c_char,
+    ) -> c_int;
+    pub fn __wasilibc_nocwd___wasilibc_rmdirat(
+        dirfd: c_int,
+        path: *const c_char,
+    ) -> c_int;
+    pub fn __wasilibc_nocwd_linkat(
+        olddirfd: c_int,
+        oldpath: *const c_char,
+        newdirfd: c_int,
+        newpath: *const c_char,
+        flags: c_int,
+    ) -> c_int;
+    pub fn __wasilibc_nocwd_symlinkat(
+        target: *const c_char,
+        dirfd: c_int,
+        path: *const c_char,
+    ) -> c_int;
+    pub fn __wasilibc_nocwd_readlinkat(
+        dirfd: c_int,
+        path: *const c_char,
+        buf: *mut c_char,
+        bufsize: usize,
+    ) -> isize;
+    pub fn __wasilibc_nocwd_faccessat(
+        dirfd: c_int,
+        path: *const c_char,
+        mode: c_int,
+        flags: c_int,
+    ) -> c_int;
+    pub fn __wasilibc_nocwd_renameat(
+        olddirfd: c_int,
+        oldpath: *const c_char,
+        newdirfd: c_int,
+        newpath: *const c_char,
+    ) -> c_int;
+    pub fn __wasilibc_nocwd_openat_nomode(
+        dirfd: c_int,
+        path: *const c_char,
+        flags: c_int,
+    ) -> c_int;
+    pub fn __wasilibc_nocwd_fstatat(
+        dirfd: c_int,
+        path: *const c_char,
+        buf: *mut stat,
+        flags: c_int,
+    ) -> c_int;
+    pub fn __wasilibc_nocwd_mkdirat_nomode(
+        dirfd: c_int,
+        path: *const c_char,
+    ) -> c_int;
+    pub fn __wasilibc_nocwd_utimensat(
+        dirfd: c_int,
+        path: *const c_char,
+        times: *const ::timespec,
+        flags: c_int,
+    ) -> c_int;
+    pub fn __wasilibc_nocwd_opendirat(
+        dirfd: c_int,
+        path: *const c_char,
+    ) -> *mut ::DIR;
+    pub fn __wasilibc_access(
+        pathname: *const c_char,
+        mode: c_int,
+        flags: c_int,
+    ) -> c_int;
+    pub fn __wasilibc_stat(
+        pathname: *const c_char,
+        buf: *mut stat,
+        flags: c_int,
+    ) -> c_int;
+    pub fn __wasilibc_utimens(
+        pathname: *const c_char,
+        times: *const ::timespec,
+        flags: c_int,
+    ) -> c_int;
+    pub fn __wasilibc_link(
+        oldpath: *const c_char,
+        newpath: *const c_char,
+        flags: c_int,
+    ) -> c_int;
+    pub fn __wasilibc_link_oldat(
+        olddirfd: c_int,
+        oldpath: *const c_char,
+        newpath: *const c_char,
+        flags: c_int,
+    ) -> c_int;
+    pub fn __wasilibc_link_newat(
+        oldpath: *const c_char,
+        newdirfd: c_int,
+        newpath: *const c_char,
+        flags: c_int,
+    ) -> c_int;
+    pub fn __wasilibc_rename_oldat(
+        olddirfd: c_int,
+        oldpath: *const c_char,
+        newpath: *const c_char,
+    ) -> c_int;
+    pub fn __wasilibc_rename_newat(
+        oldpath: *const c_char,
+        newdirfd: c_int,
+        newpath: *const c_char,
+    ) -> c_int;
 
     pub fn arc4random() -> u32;
     pub fn arc4random_buf(a: *mut c_void, b: size_t);


### PR DESCRIPTION
Update to the latest WASI libc, define `AT_FDCWD`, update the signature
for __wasilibc_find_relpath, and add declarations for various
`__wasilibc_` utility functions.