### PR TITLE
Add FreeBSD BPF structures

### DIFF
--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -359,6 +359,14 @@ cfg_if! {
     }
 }
 
+// Non-public helper constant
+#[cfg(all(not(libc_const_size_of), target_pointer_width = "32"))]
+const SIZEOF_LONG: usize = 4;
+#[cfg(all(not(libc_const_size_of), target_pointer_width = "64"))]
+const SIZEOF_LONG: usize = 8;
+#[cfg(libc_const_size_of)]
+const SIZEOF_LONG: usize = ::mem::size_of::<::c_long>();
+
 #[deprecated(
     since = "0.2.64",
     note = "Can vary at runtime.  Use sysconf(3) instead"
@@ -1216,8 +1224,7 @@ pub const ONLRET: ::tcflag_t = 0x40;
 pub const CMGROUP_MAX: usize = 16;
 
 // https://github.com/freebsd/freebsd/blob/master/sys/net/bpf.h
-// sizeof(long)
-pub const BPF_ALIGNMENT: ::c_int = 8;
+pub const BPF_ALIGNMENT: usize = SIZEOF_LONG;
 
 // Values for rtprio struct (prio field) and syscall (function argument)
 pub const RTP_PRIO_MIN: ::c_ushort = 0;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -272,6 +272,42 @@ s! {
         pub piod_len: ::size_t,
     }
 
+    // bpf.h
+
+    pub struct bpf_program {
+        pub bf_len: ::c_uint,
+        pub bf_insns: *mut bpf_insn,
+    }
+
+    pub struct bpf_stat {
+        pub bs_recv: ::c_uint,
+        pub bs_drop: ::c_uint,
+    }
+
+    pub struct bpf_version {
+        pub bv_major: ::c_ushort,
+        pub bv_minor: ::c_ushort,
+    }
+
+    pub struct bpf_hdr {
+        pub bh_tstamp: ::timeval,
+        pub bh_caplen: u32,
+        pub bh_datalen: u32,
+        pub bh_hdrlen: ::c_ushort,
+    }
+
+    pub struct bpf_insn {
+        pub code: ::c_ushort,
+        pub jt: ::c_uchar,
+        pub jf: ::c_uchar,
+        pub k: u32,
+    }
+
+    pub struct bpf_dltlist {
+        bfl_len: ::c_uint,
+        bfl_list: *mut ::c_uint,
+    }
+
     // elf.h
 
     pub struct Elf32_Phdr {


### PR DESCRIPTION
This PR adds BPF structures that are common between [FreeBSD 11](https://github.com/freebsd/freebsd-src/blob/release/11.0.0/sys/net/bpf.h), [FreeBSD 12](https://github.com/freebsd/freebsd-src/blob/release/12.0.0/sys/net/bpf.h), [FreeBSD mainline/13](https://github.com/freebsd/freebsd-src/blob/main/sys/net/bpf.h) and [DragonFlyBSD 5.9](https://github.com/DragonFlyBSD/DragonFlyBSD/blob/v5.9.0/sys/net/bpf.h).

It also fixes the definition of `BPF_ALIGNMENT`, which should be equal to `sizeof(long)`, which is `4` on 32bit FreeBSD.

https://www.freebsd.org/cgi/man.cgi?query=arch&sektion=7
> All supported ABIs can be	divided	into two groups:
> * ILP32: `int`, `long`, `void *` types machine representations all have 4-byte size.
> * LP64: `int` type machine representation uses 4 bytes, while `long` and `void *` are 8 bytes.

I introduced the private `SIZEOF_LONG` const, since I didn't want to introduce a dependency on rust 1.24+ by depending on `libc_const_size_of`.

These changes allow my experimental crate to build on FreeBSD: https://github.com/jbit/powerline