### PR TITLE
Bump up libc version to 0.2.87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.86"
+version = "0.2.87"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 name = "libc-test"
-version = "0.1.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
+version = "0.2.87"
+authors = ["The Rust Project Developers"]
+license = "MIT OR Apache-2.0"
 build = "build.rs"
+repository = "https://github.com/rust-lang/libc"
+homepage = "https://github.com/rust-lang/libc"
 
 [dependencies.libc]
 path = ".."
+version = "0.2.87"
 default-features = false
 
 [build-dependencies]


### PR DESCRIPTION
r? @ghost
In order to unblock https://github.com/rust-lang/rust/issues/82400.
This also closes #2065.
