### PR TITLE
Replace `x86_64-sun-solaris` with `x86_64-pc-solaris`

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -130,7 +130,6 @@ RUST_GT_1_19_LINUX_TARGETS="\
 aarch64-unknown-linux-musl \
 sparcv9-sun-solaris \
 wasm32-unknown-unknown \
-x86_64-sun-solaris \
 "
 RUST_GT_1_24_LINUX_TARGETS="\
 i586-unknown-linux-musl \
@@ -145,6 +144,7 @@ riscv64gc-unknown-linux-gnu \
 wasm32-wasi \
 x86_64-fortanix-unknown-sgx \
 x86_64-fuchsia \
+x86_64-pc-solaris \
 x86_64-pc-windows-gnu \
 x86_64-unknown-illumos \
 x86_64-unknown-linux-gnux32 \

--- a/ci/semver.sh
+++ b/ci/semver.sh
@@ -39,7 +39,7 @@ x86_64-unknown-freebsd \
 x86_64-unknown-linux-gnu \
 x86_64-unknown-linux-musl \
 x86_64-unknown-netbsd \
-x86_64-sun-solaris \
+x86_64-pc-solaris \
 x86_64-fuchsia \
 x86_64-pc-windows-gnu \
 x86_64-unknown-linux-gnux32 \

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2551,7 +2551,7 @@ extern "C" {
 
     // The epoll functions are actually only present on illumos.  However,
     // there are things using epoll on illumos (built using the
-    // x86_64-sun-solaris target) which would break until the illumos target is
+    // x86_64-pc-solaris target) which would break until the illumos target is
     // present in rustc.
     pub fn epoll_pwait(
         epfd: ::c_int,


### PR DESCRIPTION
Address the changes by https://github.com/rust-lang/rust/pull/82216. I didn't add `x86_64-sun-solaris` as it's now deprecated.
r? @ghost