### PR TITLE
Revert the solaris target renaming for semver check

### DIFF
--- a/ci/semver.sh
+++ b/ci/semver.sh
@@ -18,6 +18,8 @@ rustup component add rustc-dev llvm-tools-preview
 # Should update the nightly version in bors CI config if we touch this.
 cargo install --locked --git https://github.com/rust-lang/rust-semverver --rev 71c340ff867d2f79613cfe02c6714f1d2ef00bc4
 
+# FIXME: Replace `x86_64-sun-solaris` with `x86_64-pc-solaris`
+# when we update the nightly date for semverver to nightly-2021-03-02 or later.
 TARGETS=
 case "${OS}" in
     *linux*)
@@ -39,7 +41,7 @@ x86_64-unknown-freebsd \
 x86_64-unknown-linux-gnu \
 x86_64-unknown-linux-musl \
 x86_64-unknown-netbsd \
-x86_64-pc-solaris \
+x86_64-sun-solaris \
 x86_64-fuchsia \
 x86_64-pc-windows-gnu \
 x86_64-unknown-linux-gnux32 \


### PR DESCRIPTION
The semver check uses an old nightly and it doesn't have the renamed target yet, I completely forgot it.
r? @ghost