### PR TITLE
Re-add accept4 for Android on 32 bit ARM.

### DIFF
--- a/src/unix/linux_like/android/b32/arm.rs
+++ b/src/unix/linux_like/android/b32/arm.rs
@@ -521,3 +521,19 @@ pub const REG_R14: ::c_int = 14;
 pub const REG_R15: ::c_int = 15;
 
 pub const NGREG: ::c_int = 18;
+
+f! {
+    // Sadly, Android before 5.0 (API level 21), the accept4 syscall is not
+    // exposed by the libc. As work-around, we implement it through `syscall`
+    // directly. This workaround can be removed if the minimum version of
+    // Android is bumped. When the workaround is removed, `accept4` can be
+    // moved back to `linux_like/mod.rs`
+    pub fn accept4(
+        fd: ::c_int,
+        addr: *mut ::sockaddr,
+        len: *mut ::socklen_t,
+        flg: ::c_int
+    ) -> ::c_int {
+        ::syscall(SYS_accept4, fd, addr, len, flg) as ::c_int
+    }
+}


### PR DESCRIPTION
`accept4` was accidentally removed from 32 bit Android targets except for x86 in https://github.com/rust-lang/libc/pull/2079. This PR adds it back using the same definition as other non-x86 platforms.

Fixes #2101