### PR TITLE
Creating proper type for sighandler_t using anonymous union on Unix

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -43,9 +43,13 @@ pub type locale_t = *mut ::c_void;
 s_no_extra_traits! {
     pub union _c_anonymous_sigaction_handler {
         pub sa_handler: Option<extern "C" fn(c_int) -> ()>,
-        pub sa_sigaction: Option<extern "C" fn(c_int, *mut siginfo_t, *mut c_void) -> ()>,
+        pub sa_sigaction: Option<extern "C" fn(
+            c_int,
+            *mut siginfo_t,
+            *mut c_void
+        ) -> ()>,
         pub default: size_t,
-    } 
+    }
 }
 
 s! {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -43,7 +43,7 @@ pub type locale_t = *mut ::c_void;
 s_no_extra_traits! {
     pub union _c_anonymous_sigaction_handler {
         pub sa_handler: Option<extern "C" fn(c_int) -> ()>,
-        pub sa_sigaction: Option<extern "C" fn(c_int, *mut siginfo_t, *const c_void) -> ()>,
+        pub sa_sigaction: Option<extern "C" fn(c_int, *mut siginfo_t, *mut c_void) -> ()>,
         pub default: size_t,
     } 
 }

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -27,7 +27,7 @@ pub type uid_t = u32;
 pub type gid_t = u32;
 pub type in_addr_t = u32;
 pub type in_port_t = u16;
-pub type sighandler_t = ::size_t;
+pub type sighandler_t = _c_anonymous_sigaction_handler;
 pub type cc_t = ::c_uchar;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
@@ -39,6 +39,14 @@ impl ::Clone for DIR {
     }
 }
 pub type locale_t = *mut ::c_void;
+
+s_no_extra_traits! {
+    pub union _c_anonymous_sigaction_handler {
+        pub sa_handler: Option<extern "C" fn(c_int) -> ()>,
+        pub sa_sigaction: Option<extern "C" fn(c_int, *mut siginfo_t, *const c_void) -> ()>,
+        pub default: size_t,
+    } 
+}
 
 s! {
     pub struct group {
@@ -198,9 +206,9 @@ s! {
 pub const INT_MIN: c_int = -2147483648;
 pub const INT_MAX: c_int = 2147483647;
 
-pub const SIG_DFL: sighandler_t = 0 as sighandler_t;
-pub const SIG_IGN: sighandler_t = 1 as sighandler_t;
-pub const SIG_ERR: sighandler_t = !0 as sighandler_t;
+pub const SIG_DFL: sighandler_t = sighandler_t {default: 0};
+pub const SIG_IGN: sighandler_t = sighandler_t {default: 1};
+pub const SIG_ERR: sighandler_t = sighandler_t {default: !0};
 
 pub const DT_UNKNOWN: u8 = 0;
 pub const DT_FIFO: u8 = 1;


### PR DESCRIPTION
Solves #1359

This PR allows you to use the sigaction struct on Unix properly. For instance you'll be able to create a new sigaction struct passing all three types of handlers, below demonstrates both the creation of a handler of type `void (*sa_handler)(int)` and for `SIG_IGN` which is a const `size_t`:

```rust
extern "C" fn signal_handler(signal: i32) {todo!()}

let mut act = libc::sigaction {
    sa_sigaction: libc::sighandler_t {
        sa_handler: Some(signal_handler),
    },
    sa_mask: newmask,
    sa_flags: 0,
    sa_restorer: None,
};

// Demonstrating use of SIG_IGN constant 
let _ignore_action = libc::sigaction {
    sa_sigaction: libc::SIG_IGN,
    sa_mask: newmask,
    sa_flags: 0,
    sa_restorer: None,
};

unsafe {
    libc::sigaction(libc::SIGUSR1, &mut act, core::ptr::null_mut());
}
```

