### PR TITLE
Add missing SYS_clone3 for linux musl targets

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2638,7 +2638,8 @@ fn test_linux(target: &str) {
 
             // FIXME: Not currently available in headers on MIPS
             // Not yet implemented on sparc64
-            "SYS_clone3" if mips | sparc64 => true,
+            // FIXME: available in musl headers since musl 1.2.0 
+            "SYS_clone3" if mips | sparc64 | musl => true,
 
             // Missing from musl's kernel headers
             | "IFLA_GSO_MAX_SEGS"

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -834,6 +834,7 @@ pub const SYS_pkey_mprotect: ::c_long = 394;
 pub const SYS_pkey_alloc: ::c_long = 395;
 pub const SYS_pkey_free: ::c_long = 396;
 pub const SYS_statx: ::c_long = 397;
+pub const SYS_clone3: ::c_long = 435;
 
 extern "C" {
     pub fn getrandom(

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -845,6 +845,7 @@ pub const SYS_pkey_mprotect: ::c_long = 4000 + 363;
 pub const SYS_pkey_alloc: ::c_long = 4000 + 364;
 pub const SYS_pkey_free: ::c_long = 4000 + 365;
 pub const SYS_statx: ::c_long = 4000 + 366;
+pub const SYS_clone3: ::c_long = 4000 + 435;
 
 cfg_if! {
     if #[cfg(libc_align)] {

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -858,6 +858,7 @@ pub const SYS_statx: ::c_long = 383;
 pub const SYS_pkey_alloc: ::c_long = 384;
 pub const SYS_pkey_free: ::c_long = 385;
 pub const SYS_pkey_mprotect: ::c_long = 386;
+pub const SYS_clone3: ::c_long = 435;
 
 extern "C" {
     pub fn getrandom(

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -924,6 +924,7 @@ pub const SYS_pkey_mprotect: ::c_long = 380;
 pub const SYS_pkey_alloc: ::c_long = 381;
 pub const SYS_pkey_free: ::c_long = 382;
 pub const SYS_statx: ::c_long = 383;
+pub const SYS_clone3: ::c_long = 435;
 
 // offsets in user_regs_structs, from sys/reg.h
 pub const EBX: ::c_int = 0;

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -515,6 +515,7 @@ pub const SYS_pkey_mprotect: ::c_long = 288;
 pub const SYS_pkey_alloc: ::c_long = 289;
 pub const SYS_pkey_free: ::c_long = 290;
 pub const SYS_statx: ::c_long = 291;
+pub const SYS_clone3: ::c_long = 435;
 
 pub const RLIMIT_NLIMITS: ::c_int = 15;
 pub const TIOCINQ: ::c_int = ::FIONREAD;

--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -425,6 +425,7 @@ pub const SYS_pkey_mprotect: ::c_long = 5000 + 323;
 pub const SYS_pkey_alloc: ::c_long = 5000 + 324;
 pub const SYS_pkey_free: ::c_long = 5000 + 325;
 pub const SYS_statx: ::c_long = 5000 + 326;
+pub const SYS_clone3: ::c_long = 5000 + 435;
 
 pub const O_DIRECT: ::c_int = 0x8000;
 pub const O_DIRECTORY: ::c_int = 0x10000;

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -601,6 +601,7 @@ pub const SYS_preadv2: ::c_long = 380;
 pub const SYS_pwritev2: ::c_long = 381;
 pub const SYS_kexec_file_load: ::c_long = 382;
 pub const SYS_statx: ::c_long = 383;
+pub const SYS_clone3: ::c_long = 435;
 
 pub const FIOCLEX: ::c_int = 0x20006601;
 pub const FIONCLEX: ::c_int = 0x20006602;

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -580,6 +580,7 @@ pub const SYS_pkey_mprotect: ::c_long = 329;
 pub const SYS_pkey_alloc: ::c_long = 330;
 pub const SYS_pkey_free: ::c_long = 331;
 pub const SYS_statx: ::c_long = 332;
+pub const SYS_clone3: ::c_long = 435;
 
 // offsets in user_regs_structs, from sys/reg.h
 pub const R15: ::c_int = 0;


### PR DESCRIPTION
In #1897 `SYS_clone3` was added for linux gnu targets. This PR adds the constant for musl targets.
https://github.com/rust-lang/rust/pull/81825 is currently blocked on this.

`SYS_clone3` is added to the following architectures:
- [arm](https://github.com/torvalds/linux/blob/7d6beb71da3cc033649d641e1e608713b8220290/arch/arm/tools/syscall.tbl#L451)
- [mips](https://github.com/torvalds/linux/blob/7d6beb71da3cc033649d641e1e608713b8220290/arch/mips/kernel/syscalls/syscall_n32.tbl#L376)
- [powerpc](https://github.com/torvalds/linux/blob/7d6beb71da3cc033649d641e1e608713b8220290/arch/powerpc/kernel/syscalls/syscall.tbl#L517)
- [x86](https://github.com/torvalds/linux/blob/7d6beb71da3cc033649d641e1e608713b8220290/arch/x86/entry/syscalls/syscall_32.tbl#L442)
- aarch64
- [mips64](https://github.com/torvalds/linux/blob/7d6beb71da3cc033649d641e1e608713b8220290/arch/mips/kernel/syscalls/syscall_n64.tbl#L352)
- powerpc64
- [x86_64](https://github.com/torvalds/linux/blob/7d6beb71da3cc033649d641e1e608713b8220290/arch/x86/entry/syscalls/syscall_64.tbl#L359)

It was already added for s390x in https://github.com/rust-lang/libc/commit/88de3880fbc3e72358023c68ecced285a830a8ca.

cc @joshtriplett 