### PR TITLE
CI: Consolidate and blanket-ignore kernel definitions on non-glibc

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2573,6 +2573,7 @@ fn test_linux(target: &str) {
             // of prefixes of all those that have appeared here or that get
             // updated regularly and seem likely to cause breakage.
             if name.starts_with("AF_")
+                || name.starts_with("ARPHRD_")
                 || name.starts_with("EPOLL")
                 || name.starts_with("F_")
                 || name.starts_with("FALLOC_FL_")


### PR DESCRIPTION
Skip definitions from the kernel on non-glibc Linux targets.
They're libc-independent, so we only need to check them on one
libc. We don't want to break CI if musl or another libc doesn't
have the definitions yet. (We do still want to check them on
every glibc target, though, as some of them can vary by
architecture.)