### PR TITLE
Define SO_INCOMING_CPU for i686-unknown-linux-gnu

### DIFF
--- a/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
@@ -528,6 +528,7 @@ pub const SO_RCVTIMEO: ::c_int = 20;
 pub const SO_SNDTIMEO: ::c_int = 21;
 pub const SO_PEERSEC: ::c_int = 31;
 pub const SO_PASSSEC: ::c_int = 34;
+pub const SO_INCOMING_CPU: ::c_int = 49;
 
 pub const SA_SIGINFO: ::c_int = 0x00000004;
 pub const SA_NOCLDWAIT: ::c_int = 0x00000002;


### PR DESCRIPTION
Hi! Following the example from #2119, I've tried adding the constant to i686-unknown-linux-gnu as well to fix a similar issue.