### PR TITLE
Define SO_INCOMING_CPU for i686-unknown-linux-musl

### DIFF
--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -443,6 +443,7 @@ pub const SO_RCVBUFFORCE: ::c_int = 33;
 pub const SO_PASSSEC: ::c_int = 34;
 pub const SO_PROTOCOL: ::c_int = 38;
 pub const SO_DOMAIN: ::c_int = 39;
+pub const SO_INCOMING_CPU: ::c_int = 49;
 
 pub const SA_ONSTACK: ::c_int = 0x08000000;
 pub const SA_SIGINFO: ::c_int = 0x00000004;


### PR DESCRIPTION
Following the examples from https://github.com/rust-lang/libc/pull/2119 and https://github.com/rust-lang/libc/pull/2123, to fix the same issue with `socket2`: https://github.com/rust-lang/socket2/issues/213