### PR TITLE
Removed repr(packed) from some NetBSD structures

### DIFF
--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -445,7 +445,6 @@ s_no_extra_traits! {
         pub ipi_ifindex: ::c_uint,
     }
 
-    #[repr(packed)]
     pub struct arphdr {
         pub ar_hrd: u16,
         pub ar_pro: u16,
@@ -454,7 +453,6 @@ s_no_extra_traits! {
         pub ar_op: u16,
     }
 
-    #[repr(packed)]
     pub struct in_addr {
         pub s_addr: ::in_addr_t,
     }


### PR DESCRIPTION
The structures in question have always been properly aligned, so the
packed attribute only serves to generate annoying compiler warnings.  It
will be removed in the next release of NetBSD.

https://github.com/NetBSD/src/commit/415c686e207c29e0b6329b5045273224c091a434