### PR TITLE
Clean-up the style check

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,12 +6,10 @@ fn main() {
     // Avoid unnecessary re-building.
     println!("cargo:rerun-if-changed=build.rs");
 
-    let (rustc_minor_ver, is_nightly) =
-        rustc_minor_nightly().expect("Failed to get rustc version");
+    let (rustc_minor_ver, is_nightly) = rustc_minor_nightly().expect("Failed to get rustc version");
     let rustc_dep_of_std = env::var("CARGO_FEATURE_RUSTC_DEP_OF_STD").is_ok();
     let align_cargo_feature = env::var("CARGO_FEATURE_ALIGN").is_ok();
-    let const_extern_fn_cargo_feature =
-        env::var("CARGO_FEATURE_CONST_EXTERN_FN").is_ok();
+    let const_extern_fn_cargo_feature = env::var("CARGO_FEATURE_CONST_EXTERN_FN").is_ok();
     let libc_ci = env::var("LIBC_CI").is_ok();
     let target = env::var("TARGET").unwrap();
 

--- a/ci/style.rs
+++ b/ci/style.rs
@@ -16,7 +16,7 @@
 //!
 //! * No trailing whitespace
 //! * No tabs
-//! * 80-character lines
+//! * 100-character lines
 //! * Specific module layout:
 //!     1. use directives
 //!     2. typedefs
@@ -122,8 +122,8 @@ fn check_style(file: &str, path: &Path, err: &mut Errors) {
         if line.contains("\t") {
             err.error(path, i, "tab character");
         }
-        if line.len() > 80 && !(line.contains("https://") || line.contains("http://")) {
-            err.error(path, i, "line longer than 80 chars");
+        if line.len() > 100 && !(line.contains("https://") || line.contains("http://")) {
+            err.error(path, i, "line longer than 100 chars");
         }
         if line.contains("#[cfg(") && line.contains(']') && !line.contains(" if ")
             && !(line.contains("target_endian") ||

--- a/ci/style.rs
+++ b/ci/style.rs
@@ -122,7 +122,7 @@ fn check_style(file: &str, path: &Path, err: &mut Errors) {
         if line.contains("\t") {
             err.error(path, i, "tab character");
         }
-        if line.len() > 80 {
+        if line.len() > 80 && !(line.contains("https://") || line.contains("http://")) {
             err.error(path, i, "line longer than 80 chars");
         }
         if line.contains("#[cfg(") && line.contains(']') && !line.contains(" if ")

--- a/ci/style.rs
+++ b/ci/style.rs
@@ -125,8 +125,7 @@ fn check_style(file: &str, path: &Path, err: &mut Errors) {
         if line.len() > 80 {
             err.error(path, i, "line longer than 80 chars");
         }
-        // This doesn't work any more due to rustfmt changes
-        /*if line.contains("#[cfg(") && !line.contains(" if ")
+        if line.contains("#[cfg(") && line.contains(']') && !line.contains(" if ")
             && !(line.contains("target_endian") ||
                  line.contains("target_arch"))
         {
@@ -134,7 +133,7 @@ fn check_style(file: &str, path: &Path, err: &mut Errors) {
                 err.error(path, i, "use cfg_if! and submodules \
                                     instead of #[cfg]");
             }
-        }*/
+        }
         if line.contains("#[derive(") && (line.contains("Copy") || line.contains("Clone")) {
             err.error(path, i, "impl ::Copy and ::Clone manually");
         }

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -78,8 +78,7 @@ fn do_semver() {
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
 
     // `libc-test/semver` dir.
-    let mut semver_root =
-        PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let mut semver_root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     semver_root.push("semver");
 
     // NOTE: Windows has the same `family` as `os`, no point in including it
@@ -103,11 +102,7 @@ fn do_semver() {
     }
 }
 
-fn process_semver_file<W: Write, P: AsRef<Path>>(
-    output: &mut W,
-    path: &mut PathBuf,
-    file: P,
-) {
+fn process_semver_file<W: Write, P: AsRef<Path>>(output: &mut W, path: &mut PathBuf, file: P) {
     // NOTE: `path` is reused between calls, so always remove the file again.
     path.push(file);
     path.set_extension("txt");
@@ -321,9 +316,7 @@ fn test_apple(target: &str) {
     cfg.volatile_item(|i| {
         use ctest::VolatileItemKind::*;
         match i {
-            StructField(ref n, ref f) if n == "aiocb" && f == "aio_buf" => {
-                true
-            }
+            StructField(ref n, ref f) if n == "aiocb" && f == "aio_buf" => true,
             _ => false,
         }
     });
@@ -351,9 +344,7 @@ fn test_apple(target: &str) {
             // FIXME: sigaction actually contains a union with two variants:
             // a sa_sigaction with type: (*)(int, struct __siginfo *, void *)
             // a sa_handler with type sig_t
-            "sa_sigaction" if struct_ == "sigaction" => {
-                "sa_handler".to_string()
-            }
+            "sa_sigaction" if struct_ == "sigaction" => "sa_handler".to_string(),
             s => s.to_string(),
         }
     });
@@ -475,9 +466,7 @@ fn test_openbsd(target: &str) {
     cfg.type_name(move |ty, is_struct, is_union| {
         match ty {
             // Just pass all these through, no need for a "struct" prefix
-            "FILE" | "DIR" | "Dl_info" | "Elf32_Phdr" | "Elf64_Phdr" => {
-                ty.to_string()
-            }
+            "FILE" | "DIR" | "Dl_info" | "Elf32_Phdr" | "Elf64_Phdr" => ty.to_string(),
 
             // OSX calls this something else
             "sighandler_t" => "sig_t".to_string(),
@@ -490,15 +479,9 @@ fn test_openbsd(target: &str) {
     });
 
     cfg.field_name(move |struct_, field| match field {
-        "st_birthtime" if struct_.starts_with("stat") => {
-            "__st_birthtime".to_string()
-        }
-        "st_birthtime_nsec" if struct_.starts_with("stat") => {
-            "__st_birthtimensec".to_string()
-        }
-        s if s.ends_with("_nsec") && struct_.starts_with("stat") => {
-            s.replace("e_nsec", ".tv_nsec")
-        }
+        "st_birthtime" if struct_.starts_with("stat") => "__st_birthtime".to_string(),
+        "st_birthtime_nsec" if struct_.starts_with("stat") => "__st_birthtimensec".to_string(),
+        s if s.ends_with("_nsec") && struct_.starts_with("stat") => s.replace("e_nsec", ".tv_nsec"),
         "sa_sigaction" if struct_ == "sigaction" => "sa_handler".to_string(),
         s => s.to_string(),
     });
@@ -788,18 +771,17 @@ fn test_solarish(target: &str) {
     });
 
     cfg.skip_const(move |name| match name {
-        "DT_FIFO" | "DT_CHR" | "DT_DIR" | "DT_BLK" | "DT_REG" | "DT_LNK"
-        | "DT_SOCK" | "USRQUOTA" | "GRPQUOTA" | "PRIO_MIN" | "PRIO_MAX" => {
-            true
-        }
+        "DT_FIFO" | "DT_CHR" | "DT_DIR" | "DT_BLK" | "DT_REG" | "DT_LNK" | "DT_SOCK"
+        | "USRQUOTA" | "GRPQUOTA" | "PRIO_MIN" | "PRIO_MAX" => true,
 
         // skip sighandler_t assignments
         "SIG_DFL" | "SIG_ERR" | "SIG_IGN" => true,
 
         "DT_UNKNOWN" => true,
 
-        "_UTX_LINESIZE" | "_UTX_USERSIZE" | "_UTX_PADSIZE" | "_UTX_IDSIZE"
-        | "_UTX_HOSTSIZE" => true,
+        "_UTX_LINESIZE" | "_UTX_USERSIZE" | "_UTX_PADSIZE" | "_UTX_IDSIZE" | "_UTX_HOSTSIZE" => {
+            true
+        }
 
         "EADI" | "EXTPROC" | "IPC_SEAT" => true,
 
@@ -872,9 +854,7 @@ fn test_solarish(target: &str) {
             "cfmakeraw" | "cfsetspeed" => true,
 
             // const-ness issues
-            "execv" | "execve" | "execvp" | "settimeofday" | "sethostname" => {
-                true
-            }
+            "execv" | "execve" | "execvp" | "settimeofday" | "sethostname" => true,
 
             // Solaris-different
             "getpwent_r" | "getgrent_r" | "updwtmpx" if is_illumos => true,
@@ -979,10 +959,9 @@ fn test_netbsd(target: &str) {
     cfg.type_name(move |ty, is_struct, is_union| {
         match ty {
             // Just pass all these through, no need for a "struct" prefix
-            "FILE" | "fd_set" | "Dl_info" | "DIR" | "Elf32_Phdr"
-            | "Elf64_Phdr" | "Elf32_Shdr" | "Elf64_Shdr" | "Elf32_Sym"
-            | "Elf64_Sym" | "Elf32_Ehdr" | "Elf64_Ehdr" | "Elf32_Chdr"
-            | "Elf64_Chdr" => ty.to_string(),
+            "FILE" | "fd_set" | "Dl_info" | "DIR" | "Elf32_Phdr" | "Elf64_Phdr" | "Elf32_Shdr"
+            | "Elf64_Shdr" | "Elf32_Sym" | "Elf64_Sym" | "Elf32_Ehdr" | "Elf64_Ehdr"
+            | "Elf32_Chdr" | "Elf64_Chdr" => ty.to_string(),
 
             // OSX calls this something else
             "sighandler_t" => "sig_t".to_string(),
@@ -1187,10 +1166,9 @@ fn test_dragonflybsd(target: &str) {
     cfg.type_name(move |ty, is_struct, is_union| {
         match ty {
             // Just pass all these through, no need for a "struct" prefix
-            "FILE" | "fd_set" | "Dl_info" | "DIR" | "Elf32_Phdr"
-            | "Elf64_Phdr" | "Elf32_Shdr" | "Elf64_Shdr" | "Elf32_Sym"
-            | "Elf64_Sym" | "Elf32_Ehdr" | "Elf64_Ehdr" | "Elf32_Chdr"
-            | "Elf64_Chdr" => ty.to_string(),
+            "FILE" | "fd_set" | "Dl_info" | "DIR" | "Elf32_Phdr" | "Elf64_Phdr" | "Elf32_Shdr"
+            | "Elf64_Shdr" | "Elf32_Sym" | "Elf64_Sym" | "Elf32_Ehdr" | "Elf64_Ehdr"
+            | "Elf32_Chdr" | "Elf64_Chdr" => ty.to_string(),
 
             // FIXME: OSX calls this something else
             "sighandler_t" => "sig_t".to_string(),
@@ -1269,10 +1247,7 @@ fn test_dragonflybsd(target: &str) {
 
             // These are defined for Solaris 11, but the crate is tested on
             // illumos, where they are currently not defined
-            "EADI"
-            | "PORT_SOURCE_POSTWAIT"
-            | "PORT_SOURCE_SIGNAL"
-            | "PTHREAD_STACK_MIN" => true,
+            "EADI" | "PORT_SOURCE_POSTWAIT" | "PORT_SOURCE_SIGNAL" | "PTHREAD_STACK_MIN" => true,
 
             _ => false,
         }
@@ -1551,9 +1526,7 @@ fn test_android(target: &str) {
         match field {
             // Our stat *_nsec fields normally don't actually exist but are part
             // of a timeval struct
-            s if s.ends_with("_nsec") && struct_.starts_with("stat") => {
-                s.to_string()
-            }
+            s if s.ends_with("_nsec") && struct_.starts_with("stat") => s.to_string(),
             // FIXME: appears that `epoll_event.data` is an union
             "u64" if struct_ == "epoll_event" => "data.u64".to_string(),
             s => s.to_string(),
@@ -1767,8 +1740,7 @@ fn test_freebsd(target: &str) {
     cfg.type_name(move |ty, is_struct, is_union| {
         match ty {
             // Just pass all these through, no need for a "struct" prefix
-            "FILE" | "fd_set" | "Dl_info" | "DIR" | "Elf32_Phdr"
-            | "Elf64_Phdr" => ty.to_string(),
+            "FILE" | "fd_set" | "Dl_info" | "DIR" | "Elf32_Phdr" | "Elf64_Phdr" => ty.to_string(),
 
             // FIXME: https://github.com/rust-lang/libc/issues/1273
             "sighandler_t" => "sig_t".to_string(),
@@ -1804,8 +1776,8 @@ fn test_freebsd(target: &str) {
     cfg.skip_const(move |name| {
         match name {
             // These constants are to be introduced in yet-unreleased FreeBSD 12.2.
-            "F_ADD_SEALS" | "F_GET_SEALS" | "F_SEAL_SEAL"
-            | "F_SEAL_SHRINK" | "F_SEAL_GROW" | "F_SEAL_WRITE"
+            "F_ADD_SEALS" | "F_GET_SEALS" | "F_SEAL_SEAL" | "F_SEAL_SHRINK" | "F_SEAL_GROW"
+            | "F_SEAL_WRITE"
                 if Some(12) <= freebsd_ver =>
             {
                 true
@@ -1921,9 +1893,7 @@ fn test_freebsd(target: &str) {
             "execv" | "execve" | "execvp" | "execvpe" | "fexecve" => true,
 
             // These functions were added in FreeBSD 11:
-            "fdatasync" | "mq_getfd_np" | "sendmmsg" | "recvmmsg"
-                if Some(10) == freebsd_ver =>
-            {
+            "fdatasync" | "mq_getfd_np" | "sendmmsg" | "recvmmsg" if Some(10) == freebsd_ver => {
                 true
             }
 
@@ -1959,9 +1929,7 @@ fn test_freebsd(target: &str) {
         match i {
             // aio_buf is a volatile void** but since we cannot express that in
             // Rust types, we have to explicitly tell the checker about it here:
-            StructField(ref n, ref f) if n == "aiocb" && f == "aio_buf" => {
-                true
-            }
+            StructField(ref n, ref f) if n == "aiocb" && f == "aio_buf" => true,
             _ => false,
         }
     });
@@ -2288,9 +2256,7 @@ fn test_vxworks(target: &str) {
     });
 
     cfg.skip_field_type(move |struct_, field| match (struct_, field) {
-        ("siginfo_t", "si_value")
-        | ("stat", "st_size")
-        | ("sigaction", "sa_u") => true,
+        ("siginfo_t", "si_value") | ("stat", "st_size") | ("sigaction", "sa_u") => true,
         _ => false,
     });
 
@@ -2525,10 +2491,9 @@ fn test_linux(target: &str) {
     cfg.type_name(move |ty, is_struct, is_union| {
         match ty {
             // Just pass all these through, no need for a "struct" prefix
-            "FILE" | "fd_set" | "Dl_info" | "DIR" | "Elf32_Phdr"
-            | "Elf64_Phdr" | "Elf32_Shdr" | "Elf64_Shdr" | "Elf32_Sym"
-            | "Elf64_Sym" | "Elf32_Ehdr" | "Elf64_Ehdr" | "Elf32_Chdr"
-            | "Elf64_Chdr" => ty.to_string(),
+            "FILE" | "fd_set" | "Dl_info" | "DIR" | "Elf32_Phdr" | "Elf64_Phdr" | "Elf32_Shdr"
+            | "Elf64_Shdr" | "Elf32_Sym" | "Elf64_Sym" | "Elf32_Ehdr" | "Elf64_Ehdr"
+            | "Elf32_Chdr" | "Elf64_Chdr" => ty.to_string(),
 
             t if is_union => format!("union {}", t),
 
@@ -2861,9 +2826,7 @@ fn test_linux(target: &str) {
         match i {
             // aio_buf is a volatile void** but since we cannot express that in
             // Rust types, we have to explicitly tell the checker about it here:
-            StructField(ref n, ref f) if n == "aiocb" && f == "aio_buf" => {
-                true
-            }
+            StructField(ref n, ref f) if n == "aiocb" && f == "aio_buf" => true,
             _ => false,
         }
     });
@@ -2911,11 +2874,7 @@ fn test_linux(target: &str) {
         // FIXME: This is actually a union.
         "fpreg_t" if s390x => true,
 
-        "sockaddr_un" | "sembuf" | "ff_constant_effect"
-            if mips32 && (gnu || musl) =>
-        {
-            true
-        }
+        "sockaddr_un" | "sembuf" | "ff_constant_effect" if mips32 && (gnu || musl) => true,
         "ipv6_mreq"
         | "ip_mreq_source"
         | "sockaddr_in6"
@@ -2991,9 +2950,8 @@ fn test_linux_like_apis(target: &str) {
             .skip_fn(|_| true)
             .skip_const(move |name| match name {
                 // test fcntl constants:
-                "F_CANCELLK" | "F_ADD_SEALS" | "F_GET_SEALS"
-                | "F_SEAL_SEAL" | "F_SEAL_SHRINK" | "F_SEAL_GROW"
-                | "F_SEAL_WRITE" => false,
+                "F_CANCELLK" | "F_ADD_SEALS" | "F_GET_SEALS" | "F_SEAL_SEAL" | "F_SEAL_SHRINK"
+                | "F_SEAL_GROW" | "F_SEAL_WRITE" => false,
                 _ => true,
             })
             .type_name(move |ty, is_struct, is_union| match ty {
@@ -3285,12 +3243,12 @@ fn test_haiku(target: &str) {
     cfg.skip_const(move |name| {
         match name {
             // FIXME: these constants do not exist on Haiku
-            "DT_UNKNOWN" | "DT_FIFO" | "DT_CHR" | "DT_DIR" | "DT_BLK"
-            | "DT_REG" | "DT_LNK" | "DT_SOCK" => true,
+            "DT_UNKNOWN" | "DT_FIFO" | "DT_CHR" | "DT_DIR" | "DT_BLK" | "DT_REG" | "DT_LNK"
+            | "DT_SOCK" => true,
             "USRQUOTA" | "GRPQUOTA" => true,
             "SIGIOT" => true,
-            "ARPOP_REQUEST" | "ARPOP_REPLY" | "ATF_COM" | "ATF_PERM"
-            | "ATF_PUBL" | "ATF_USETRAILERS" => true,
+            "ARPOP_REQUEST" | "ARPOP_REPLY" | "ATF_COM" | "ATF_PERM" | "ATF_PUBL"
+            | "ATF_USETRAILERS" => true,
             // Haiku does not have MAP_FILE, but rustc requires it
             "MAP_FILE" => true,
             // The following does not exist on Haiku but is required by
@@ -3343,11 +3301,10 @@ fn test_haiku(target: &str) {
     cfg.type_name(move |ty, is_struct, is_union| {
         match ty {
             // Just pass all these through, no need for a "struct" prefix
-            "area_info" | "port_info" | "port_message_info" | "team_info"
-            | "sem_info" | "team_usage_info" | "thread_info" | "cpu_info"
-            | "system_info" | "object_wait_info" | "image_info"
-            | "attr_info" | "index_info" | "fs_info" | "FILE" | "DIR"
-            | "Dl_info" => ty.to_string(),
+            "area_info" | "port_info" | "port_message_info" | "team_info" | "sem_info"
+            | "team_usage_info" | "thread_info" | "cpu_info" | "system_info"
+            | "object_wait_info" | "image_info" | "attr_info" | "index_info" | "fs_info"
+            | "FILE" | "DIR" | "Dl_info" => ty.to_string(),
 
             // is actually a union
             "sigval" => format!("union sigval"),

--- a/libc-test/test/cmsg.rs
+++ b/libc-test/test/cmsg.rs
@@ -11,10 +11,7 @@ mod t {
 
     extern "C" {
         pub fn cmsg_firsthdr(msgh: *const msghdr) -> *mut cmsghdr;
-        pub fn cmsg_nxthdr(
-            mhdr: *const msghdr,
-            cmsg: *const cmsghdr,
-        ) -> *mut cmsghdr;
+        pub fn cmsg_nxthdr(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr;
         pub fn cmsg_space(length: c_uint) -> usize;
         pub fn cmsg_len(length: c_uint) -> usize;
         pub fn cmsg_data(cmsg: *const cmsghdr) -> *mut c_uchar;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,1 @@
-max_width = 79
-comment_width = 79
 error_on_line_overflow = true

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -3310,8 +3310,7 @@ safe_f! {
 }
 
 fn __CMSG_LEN(cmsg: *const cmsghdr) -> ::ssize_t {
-    ((unsafe { (*cmsg).cmsg_len as ::size_t } + ::mem::size_of::<::c_long>()
-        - 1)
+    ((unsafe { (*cmsg).cmsg_len as ::size_t } + ::mem::size_of::<::c_long>() - 1)
         & !(::mem::size_of::<::c_long>() - 1)) as ::ssize_t
 }
 
@@ -3320,8 +3319,7 @@ fn __CMSG_NEXT(cmsg: *const cmsghdr) -> *mut c_uchar {
 }
 
 fn __MHDR_END(mhdr: *const msghdr) -> *mut c_uchar {
-    unsafe { (*mhdr).msg_control.offset((*mhdr).msg_controllen as isize) }
-        .cast()
+    unsafe { (*mhdr).msg_control.offset((*mhdr).msg_controllen as isize) }.cast()
 }
 
 // EXTERN_FN
@@ -3363,44 +3361,24 @@ extern "C" {
     pub fn tolower(c: c_int) -> c_int;
     pub fn toupper(c: c_int) -> c_int;
     pub fn fopen(filename: *const c_char, mode: *const c_char) -> *mut FILE;
-    pub fn freopen(
-        filename: *const c_char,
-        mode: *const c_char,
-        file: *mut FILE,
-    ) -> *mut FILE;
+    pub fn freopen(filename: *const c_char, mode: *const c_char, file: *mut FILE) -> *mut FILE;
     pub fn fflush(file: *mut FILE) -> c_int;
     pub fn fclose(file: *mut FILE) -> c_int;
     pub fn remove(filename: *const c_char) -> c_int;
     pub fn rename(oldname: *const c_char, newname: *const c_char) -> c_int;
     pub fn tmpfile() -> *mut FILE;
-    pub fn setvbuf(
-        stream: *mut FILE,
-        buffer: *mut c_char,
-        mode: c_int,
-        size: size_t,
-    ) -> c_int;
+    pub fn setvbuf(stream: *mut FILE, buffer: *mut c_char, mode: c_int, size: size_t) -> c_int;
     pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
     pub fn getchar() -> c_int;
     pub fn putchar(c: c_int) -> c_int;
     pub fn fgetc(stream: *mut FILE) -> c_int;
-    pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE)
-        -> *mut c_char;
+    pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
     pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;
     pub fn fputs(s: *const c_char, stream: *mut FILE) -> c_int;
     pub fn puts(s: *const c_char) -> c_int;
     pub fn ungetc(c: c_int, stream: *mut FILE) -> c_int;
-    pub fn fread(
-        ptr: *mut c_void,
-        size: size_t,
-        nobj: size_t,
-        stream: *mut FILE,
-    ) -> size_t;
-    pub fn fwrite(
-        ptr: *const c_void,
-        size: size_t,
-        nobj: size_t,
-        stream: *mut FILE,
-    ) -> size_t;
+    pub fn fread(ptr: *mut c_void, size: size_t, nobj: size_t, stream: *mut FILE) -> size_t;
+    pub fn fwrite(ptr: *const c_void, size: size_t, nobj: size_t, stream: *mut FILE) -> size_t;
     pub fn fseek(stream: *mut FILE, offset: c_long, whence: c_int) -> c_int;
     pub fn ftell(stream: *mut FILE) -> c_long;
     pub fn rewind(stream: *mut FILE);
@@ -3411,16 +3389,8 @@ extern "C" {
     pub fn perror(s: *const c_char);
     pub fn atoi(s: *const c_char) -> c_int;
     pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
-    pub fn strtol(
-        s: *const c_char,
-        endp: *mut *mut c_char,
-        base: c_int,
-    ) -> c_long;
-    pub fn strtoul(
-        s: *const c_char,
-        endp: *mut *mut c_char,
-        base: c_int,
-    ) -> c_ulong;
+    pub fn strtol(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_long;
+    pub fn strtoul(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_ulong;
     pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;
     pub fn malloc(size: size_t) -> *mut c_void;
     pub fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
@@ -3433,17 +3403,9 @@ extern "C" {
     pub fn getenv(s: *const c_char) -> *mut c_char;
 
     pub fn strcpy(dst: *mut c_char, src: *const c_char) -> *mut c_char;
-    pub fn strncpy(
-        dst: *mut c_char,
-        src: *const c_char,
-        n: size_t,
-    ) -> *mut c_char;
+    pub fn strncpy(dst: *mut c_char, src: *const c_char, n: size_t) -> *mut c_char;
     pub fn strcat(s: *mut c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strncat(
-        s: *mut c_char,
-        ct: *const c_char,
-        n: size_t,
-    ) -> *mut c_char;
+    pub fn strncat(s: *mut c_char, ct: *const c_char, n: size_t) -> *mut c_char;
     pub fn strcmp(cs: *const c_char, ct: *const c_char) -> c_int;
     pub fn strncmp(cs: *const c_char, ct: *const c_char, n: size_t) -> c_int;
     pub fn strcoll(cs: *const c_char, ct: *const c_char) -> c_int;
@@ -3460,25 +3422,13 @@ extern "C" {
     pub fn strtok(s: *mut c_char, t: *const c_char) -> *mut c_char;
     pub fn strxfrm(s: *mut c_char, ct: *const c_char, n: size_t) -> size_t;
     pub fn wcslen(buf: *const wchar_t) -> size_t;
-    pub fn wcstombs(
-        dest: *mut c_char,
-        src: *const wchar_t,
-        n: size_t,
-    ) -> ::size_t;
+    pub fn wcstombs(dest: *mut c_char, src: *const wchar_t, n: size_t) -> ::size_t;
 
     pub fn memchr(cx: *const c_void, c: c_int, n: size_t) -> *mut c_void;
     pub fn wmemchr(cx: *const wchar_t, c: wchar_t, n: size_t) -> *mut wchar_t;
     pub fn memcmp(cx: *const c_void, ct: *const c_void, n: size_t) -> c_int;
-    pub fn memcpy(
-        dest: *mut c_void,
-        src: *const c_void,
-        n: size_t,
-    ) -> *mut c_void;
-    pub fn memmove(
-        dest: *mut c_void,
-        src: *const c_void,
-        n: size_t,
-    ) -> *mut c_void;
+    pub fn memcpy(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
+    pub fn memmove(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
     pub fn memset(dest: *mut c_void, c: c_int, n: size_t) -> *mut c_void;
 
     pub fn abs(i: c_int) -> c_int;
@@ -3490,42 +3440,20 @@ extern "C" {
     pub fn getpwnam(name: *const ::c_char) -> *mut passwd;
     pub fn getpwuid(uid: ::uid_t) -> *mut passwd;
 
-    pub fn fprintf(
-        stream: *mut ::FILE,
-        format: *const ::c_char,
-        ...
-    ) -> ::c_int;
+    pub fn fprintf(stream: *mut ::FILE, format: *const ::c_char, ...) -> ::c_int;
     pub fn printf(format: *const ::c_char, ...) -> ::c_int;
-    pub fn snprintf(
-        s: *mut ::c_char,
-        n: ::size_t,
-        format: *const ::c_char,
-        ...
-    ) -> ::c_int;
+    pub fn snprintf(s: *mut ::c_char, n: ::size_t, format: *const ::c_char, ...) -> ::c_int;
     pub fn sprintf(s: *mut ::c_char, format: *const ::c_char, ...) -> ::c_int;
-    pub fn fscanf(
-        stream: *mut ::FILE,
-        format: *const ::c_char,
-        ...
-    ) -> ::c_int;
+    pub fn fscanf(stream: *mut ::FILE, format: *const ::c_char, ...) -> ::c_int;
     pub fn scanf(format: *const ::c_char, ...) -> ::c_int;
-    pub fn sscanf(s: *const ::c_char, format: *const ::c_char, ...)
-        -> ::c_int;
+    pub fn sscanf(s: *const ::c_char, format: *const ::c_char, ...) -> ::c_int;
     pub fn getchar_unlocked() -> ::c_int;
     pub fn putchar_unlocked(c: ::c_int) -> ::c_int;
 
     pub fn socket(domain: ::c_int, ty: ::c_int, protocol: ::c_int) -> ::c_int;
-    pub fn connect(
-        socket: ::c_int,
-        address: *const sockaddr,
-        len: socklen_t,
-    ) -> ::c_int;
+    pub fn connect(socket: ::c_int, address: *const sockaddr, len: socklen_t) -> ::c_int;
     pub fn listen(socket: ::c_int, backlog: ::c_int) -> ::c_int;
-    pub fn accept(
-        socket: ::c_int,
-        address: *mut sockaddr,
-        address_len: *mut socklen_t,
-    ) -> ::c_int;
+    pub fn accept(socket: ::c_int, address: *mut sockaddr, address_len: *mut socklen_t) -> ::c_int;
     pub fn getpeername(
         socket: ::c_int,
         address: *mut sockaddr,
@@ -3578,20 +3506,12 @@ extern "C" {
 
     pub fn opendir(dirname: *const c_char) -> *mut ::DIR;
     pub fn readdir(dirp: *mut ::DIR) -> *mut ::dirent;
-    pub fn readdir_r(
-        dirp: *mut ::DIR,
-        entry: *mut ::dirent,
-        result: *mut *mut ::dirent,
-    ) -> ::c_int;
+    pub fn readdir_r(dirp: *mut ::DIR, entry: *mut ::dirent, result: *mut *mut ::dirent)
+        -> ::c_int;
     pub fn closedir(dirp: *mut ::DIR) -> ::c_int;
     pub fn rewinddir(dirp: *mut ::DIR);
 
-    pub fn openat(
-        dirfd: ::c_int,
-        pathname: *const ::c_char,
-        flags: ::c_int,
-        ...
-    ) -> ::c_int;
+    pub fn openat(dirfd: ::c_int, pathname: *const ::c_char, flags: ::c_int, ...) -> ::c_int;
     pub fn fchmodat(
         dirfd: ::c_int,
         pathname: *const ::c_char,
@@ -3619,11 +3539,7 @@ extern "C" {
         newpath: *const ::c_char,
         flags: ::c_int,
     ) -> ::c_int;
-    pub fn mkdirat(
-        dirfd: ::c_int,
-        pathname: *const ::c_char,
-        mode: ::mode_t,
-    ) -> ::c_int;
+    pub fn mkdirat(dirfd: ::c_int, pathname: *const ::c_char, mode: ::mode_t) -> ::c_int;
     pub fn readlinkat(
         dirfd: ::c_int,
         pathname: *const ::c_char,
@@ -3641,11 +3557,7 @@ extern "C" {
         newdirfd: ::c_int,
         linkpath: *const ::c_char,
     ) -> ::c_int;
-    pub fn unlinkat(
-        dirfd: ::c_int,
-        pathname: *const ::c_char,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn unlinkat(dirfd: ::c_int, pathname: *const ::c_char, flags: ::c_int) -> ::c_int;
 
     pub fn access(path: *const c_char, amode: ::c_int) -> ::c_int;
     pub fn alarm(seconds: ::c_uint) -> ::c_uint;
@@ -3656,16 +3568,8 @@ extern "C" {
     pub fn dup(fd: ::c_int) -> ::c_int;
     pub fn dup2(src: ::c_int, dst: ::c_int) -> ::c_int;
     pub fn execl(path: *const c_char, arg0: *const c_char, ...) -> ::c_int;
-    pub fn execle(
-        path: *const ::c_char,
-        arg0: *const ::c_char,
-        ...
-    ) -> ::c_int;
-    pub fn execlp(
-        file: *const ::c_char,
-        arg0: *const ::c_char,
-        ...
-    ) -> ::c_int;
+    pub fn execle(path: *const ::c_char, arg0: *const ::c_char, ...) -> ::c_int;
+    pub fn execlp(file: *const ::c_char, arg0: *const ::c_char, ...) -> ::c_int;
     pub fn execv(prog: *const c_char, argv: *const *const c_char) -> ::c_int;
     pub fn execve(
         prog: *const c_char,
@@ -3681,11 +3585,7 @@ extern "C" {
     pub fn getgid() -> gid_t;
     pub fn getgroups(ngroups_max: ::c_int, groups: *mut gid_t) -> ::c_int;
     pub fn getlogin() -> *mut c_char;
-    pub fn getopt(
-        argc: ::c_int,
-        argv: *const *mut c_char,
-        optstr: *const c_char,
-    ) -> ::c_int;
+    pub fn getopt(argc: ::c_int, argv: *const *mut c_char, optstr: *const c_char) -> ::c_int;
     pub fn getpgid(pid: pid_t) -> pid_t;
     pub fn getpgrp() -> pid_t;
     pub fn getpid() -> pid_t;
@@ -3697,13 +3597,8 @@ extern "C" {
     pub fn pathconf(path: *const c_char, name: ::c_int) -> c_long;
     pub fn pause() -> ::c_int;
     pub fn pipe(fds: *mut ::c_int) -> ::c_int;
-    pub fn posix_memalign(
-        memptr: *mut *mut ::c_void,
-        align: ::size_t,
-        size: ::size_t,
-    ) -> ::c_int;
-    pub fn read(fd: ::c_int, buf: *mut ::c_void, count: ::size_t)
-        -> ::ssize_t;
+    pub fn posix_memalign(memptr: *mut *mut ::c_void, align: ::size_t, size: ::size_t) -> ::c_int;
+    pub fn read(fd: ::c_int, buf: *mut ::c_void, count: ::size_t) -> ::ssize_t;
     pub fn rmdir(path: *const c_char) -> ::c_int;
     pub fn seteuid(uid: uid_t) -> ::c_int;
     pub fn setegid(gid: gid_t) -> ::c_int;
@@ -3718,28 +3613,10 @@ extern "C" {
     pub fn ttyname(fd: ::c_int) -> *mut c_char;
     pub fn unlink(c: *const c_char) -> ::c_int;
     pub fn wait(status: *mut ::c_int) -> pid_t;
-    pub fn waitpid(
-        pid: pid_t,
-        status: *mut ::c_int,
-        options: ::c_int,
-    ) -> pid_t;
-    pub fn write(
-        fd: ::c_int,
-        buf: *const ::c_void,
-        count: ::size_t,
-    ) -> ::ssize_t;
-    pub fn pread(
-        fd: ::c_int,
-        buf: *mut ::c_void,
-        count: ::size_t,
-        offset: off_t,
-    ) -> ::ssize_t;
-    pub fn pwrite(
-        fd: ::c_int,
-        buf: *const ::c_void,
-        count: ::size_t,
-        offset: off_t,
-    ) -> ::ssize_t;
+    pub fn waitpid(pid: pid_t, status: *mut ::c_int, options: ::c_int) -> pid_t;
+    pub fn write(fd: ::c_int, buf: *const ::c_void, count: ::size_t) -> ::ssize_t;
+    pub fn pread(fd: ::c_int, buf: *mut ::c_void, count: ::size_t, offset: off_t) -> ::ssize_t;
+    pub fn pwrite(fd: ::c_int, buf: *const ::c_void, count: ::size_t, offset: off_t) -> ::ssize_t;
     pub fn umask(mask: mode_t) -> mode_t;
 
     pub fn utime(file: *const c_char, buf: *const utimbuf) -> ::c_int;
@@ -3762,20 +3639,13 @@ extern "C" {
     pub fn munmap(addr: *mut ::c_void, len: ::size_t) -> ::c_int;
 
     pub fn if_nametoindex(ifname: *const c_char) -> ::c_uint;
-    pub fn if_indextoname(
-        ifindex: ::c_uint,
-        ifname: *mut ::c_char,
-    ) -> *mut ::c_char;
+    pub fn if_indextoname(ifindex: ::c_uint, ifname: *mut ::c_char) -> *mut ::c_char;
 
     pub fn lstat(path: *const c_char, buf: *mut stat) -> ::c_int;
 
     pub fn fsync(fd: ::c_int) -> ::c_int;
 
-    pub fn setenv(
-        name: *const c_char,
-        val: *const c_char,
-        overwrite: ::c_int,
-    ) -> ::c_int;
+    pub fn setenv(name: *const c_char, val: *const c_char, overwrite: ::c_int) -> ::c_int;
     pub fn unsetenv(name: *const c_char) -> ::c_int;
 
     pub fn symlink(path1: *const c_char, path2: *const c_char) -> ::c_int;
@@ -3784,10 +3654,7 @@ extern "C" {
 
     pub fn signal(signum: ::c_int, handler: sighandler_t) -> sighandler_t;
 
-    pub fn realpath(
-        pathname: *const ::c_char,
-        resolved: *mut ::c_char,
-    ) -> *mut ::c_char;
+    pub fn realpath(pathname: *const ::c_char, resolved: *mut ::c_char) -> *mut ::c_char;
 
     pub fn flock(fd: ::c_int, operation: ::c_int) -> ::c_int;
 
@@ -3795,21 +3662,12 @@ extern "C" {
     pub fn times(buf: *mut ::tms) -> ::clock_t;
 
     pub fn pthread_self() -> ::pthread_t;
-    pub fn pthread_join(
-        native: ::pthread_t,
-        value: *mut *mut ::c_void,
-    ) -> ::c_int;
+    pub fn pthread_join(native: ::pthread_t, value: *mut *mut ::c_void) -> ::c_int;
     pub fn pthread_exit(value: *mut ::c_void) -> !;
     pub fn pthread_attr_init(attr: *mut ::pthread_attr_t) -> ::c_int;
     pub fn pthread_attr_destroy(attr: *mut ::pthread_attr_t) -> ::c_int;
-    pub fn pthread_attr_setstacksize(
-        attr: *mut ::pthread_attr_t,
-        stack_size: ::size_t,
-    ) -> ::c_int;
-    pub fn pthread_attr_setdetachstate(
-        attr: *mut ::pthread_attr_t,
-        state: ::c_int,
-    ) -> ::c_int;
+    pub fn pthread_attr_setstacksize(attr: *mut ::pthread_attr_t, stack_size: ::size_t) -> ::c_int;
+    pub fn pthread_attr_setdetachstate(attr: *mut ::pthread_attr_t, state: ::c_int) -> ::c_int;
     pub fn pthread_detach(thread: ::pthread_t) -> ::c_int;
     pub fn sched_yield() -> ::c_int;
     pub fn pthread_key_create(
@@ -3818,10 +3676,7 @@ extern "C" {
     ) -> ::c_int;
     pub fn pthread_key_delete(key: pthread_key_t) -> ::c_int;
     pub fn pthread_getspecific(key: pthread_key_t) -> *mut ::c_void;
-    pub fn pthread_setspecific(
-        key: pthread_key_t,
-        value: *const ::c_void,
-    ) -> ::c_int;
+    pub fn pthread_setspecific(key: pthread_key_t, value: *const ::c_void) -> ::c_int;
     pub fn pthread_mutex_init(
         lock: *mut pthread_mutex_t,
         attr: *const pthread_mutexattr_t,
@@ -3832,22 +3687,12 @@ extern "C" {
     pub fn pthread_mutex_unlock(lock: *mut pthread_mutex_t) -> ::c_int;
 
     pub fn pthread_mutexattr_init(attr: *mut pthread_mutexattr_t) -> ::c_int;
-    pub fn pthread_mutexattr_destroy(
-        attr: *mut pthread_mutexattr_t,
-    ) -> ::c_int;
-    pub fn pthread_mutexattr_settype(
-        attr: *mut pthread_mutexattr_t,
-        _type: ::c_int,
-    ) -> ::c_int;
+    pub fn pthread_mutexattr_destroy(attr: *mut pthread_mutexattr_t) -> ::c_int;
+    pub fn pthread_mutexattr_settype(attr: *mut pthread_mutexattr_t, _type: ::c_int) -> ::c_int;
 
-    pub fn pthread_cond_init(
-        cond: *mut pthread_cond_t,
-        attr: *const pthread_condattr_t,
-    ) -> ::c_int;
-    pub fn pthread_cond_wait(
-        cond: *mut pthread_cond_t,
-        lock: *mut pthread_mutex_t,
-    ) -> ::c_int;
+    pub fn pthread_cond_init(cond: *mut pthread_cond_t, attr: *const pthread_condattr_t)
+        -> ::c_int;
+    pub fn pthread_cond_wait(cond: *mut pthread_cond_t, lock: *mut pthread_mutex_t) -> ::c_int;
     pub fn pthread_cond_timedwait(
         cond: *mut pthread_cond_t,
         lock: *mut pthread_mutex_t,
@@ -3868,16 +3713,9 @@ extern "C" {
     pub fn pthread_rwlock_wrlock(lock: *mut pthread_rwlock_t) -> ::c_int;
     pub fn pthread_rwlock_trywrlock(lock: *mut pthread_rwlock_t) -> ::c_int;
     pub fn pthread_rwlock_unlock(lock: *mut pthread_rwlock_t) -> ::c_int;
-    pub fn pthread_rwlockattr_init(attr: *mut pthread_rwlockattr_t)
-        -> ::c_int;
-    pub fn pthread_rwlockattr_destroy(
-        attr: *mut pthread_rwlockattr_t,
-    ) -> ::c_int;
-    pub fn strerror_r(
-        errnum: ::c_int,
-        buf: *mut c_char,
-        buflen: ::size_t,
-    ) -> ::c_int;
+    pub fn pthread_rwlockattr_init(attr: *mut pthread_rwlockattr_t) -> ::c_int;
+    pub fn pthread_rwlockattr_destroy(attr: *mut pthread_rwlockattr_t) -> ::c_int;
+    pub fn strerror_r(errnum: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
 
     pub fn getsockopt(
         sockfd: ::c_int,
@@ -3887,22 +3725,12 @@ extern "C" {
         optlen: *mut ::socklen_t,
     ) -> ::c_int;
     pub fn raise(signum: ::c_int) -> ::c_int;
-    pub fn sigaction(
-        signum: ::c_int,
-        act: *const sigaction,
-        oldact: *mut sigaction,
-    ) -> ::c_int;
+    pub fn sigaction(signum: ::c_int, act: *const sigaction, oldact: *mut sigaction) -> ::c_int;
 
-    pub fn utimes(
-        filename: *const ::c_char,
-        times: *const ::timeval,
-    ) -> ::c_int;
+    pub fn utimes(filename: *const ::c_char, times: *const ::timeval) -> ::c_int;
     pub fn dlopen(filename: *const ::c_char, flag: ::c_int) -> *mut ::c_void;
     pub fn dlerror() -> *mut ::c_char;
-    pub fn dlsym(
-        handle: *mut ::c_void,
-        symbol: *const ::c_char,
-    ) -> *mut ::c_void;
+    pub fn dlsym(handle: *mut ::c_void, symbol: *const ::c_char) -> *mut ::c_void;
     pub fn dlclose(handle: *mut ::c_void) -> ::c_int;
     pub fn dladdr(addr: *const ::c_void, info: *mut Dl_info) -> ::c_int;
 
@@ -3923,32 +3751,15 @@ extern "C" {
     pub fn gmtime(time_p: *const time_t) -> *mut tm;
     pub fn localtime(time_p: *const time_t) -> *mut tm;
 
-    pub fn mknod(
-        pathname: *const ::c_char,
-        mode: ::mode_t,
-        dev: ::dev_t,
-    ) -> ::c_int;
+    pub fn mknod(pathname: *const ::c_char, mode: ::mode_t, dev: ::dev_t) -> ::c_int;
     pub fn uname(buf: *mut ::utsname) -> ::c_int;
     pub fn gethostname(name: *mut ::c_char, len: ::size_t) -> ::c_int;
-    pub fn getservbyname(
-        name: *const ::c_char,
-        proto: *const ::c_char,
-    ) -> *mut servent;
+    pub fn getservbyname(name: *const ::c_char, proto: *const ::c_char) -> *mut servent;
     pub fn getprotobyname(name: *const ::c_char) -> *mut protoent;
     pub fn getprotobynumber(proto: ::c_int) -> *mut protoent;
     pub fn usleep(secs: ::c_uint) -> ::c_int;
-    pub fn send(
-        socket: ::c_int,
-        buf: *const ::c_void,
-        len: ::size_t,
-        flags: ::c_int,
-    ) -> ::ssize_t;
-    pub fn recv(
-        socket: ::c_int,
-        buf: *mut ::c_void,
-        len: ::size_t,
-        flags: ::c_int,
-    ) -> ::ssize_t;
+    pub fn send(socket: ::c_int, buf: *const ::c_void, len: ::size_t, flags: ::c_int) -> ::ssize_t;
+    pub fn recv(socket: ::c_int, buf: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::ssize_t;
     pub fn putenv(string: *mut c_char) -> ::c_int;
     pub fn poll(fds: *mut pollfd, nfds: nfds_t, timeout: ::c_int) -> ::c_int;
     pub fn select(
@@ -3958,29 +3769,18 @@ extern "C" {
         errorfds: *mut fd_set,
         timeout: *mut timeval,
     ) -> ::c_int;
-    pub fn setlocale(
-        category: ::c_int,
-        locale: *const ::c_char,
-    ) -> *mut ::c_char;
+    pub fn setlocale(category: ::c_int, locale: *const ::c_char) -> *mut ::c_char;
     pub fn localeconv() -> *mut lconv;
 
     pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
     pub fn sem_wait(sem: *mut sem_t) -> ::c_int;
     pub fn sem_trywait(sem: *mut sem_t) -> ::c_int;
     pub fn sem_post(sem: *mut sem_t) -> ::c_int;
-    pub fn sem_init(
-        sem: *mut sem_t,
-        pshared: ::c_int,
-        value: ::c_uint,
-    ) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t, pshared: ::c_int, value: ::c_uint) -> ::c_int;
     pub fn statvfs(path: *const c_char, buf: *mut statvfs) -> ::c_int;
     pub fn fstatvfs(fd: ::c_int, buf: *mut statvfs) -> ::c_int;
 
-    pub fn readlink(
-        path: *const c_char,
-        buf: *mut c_char,
-        bufsz: ::size_t,
-    ) -> ::ssize_t;
+    pub fn readlink(path: *const c_char, buf: *mut c_char, bufsz: ::size_t) -> ::ssize_t;
 
     pub fn sigemptyset(set: *mut sigset_t) -> ::c_int;
     pub fn sigaddset(set: *mut sigset_t, signum: ::c_int) -> ::c_int;
@@ -3988,11 +3788,7 @@ extern "C" {
     pub fn sigdelset(set: *mut sigset_t, signum: ::c_int) -> ::c_int;
     pub fn sigismember(set: *const sigset_t, signum: ::c_int) -> ::c_int;
 
-    pub fn sigprocmask(
-        how: ::c_int,
-        set: *const sigset_t,
-        oldset: *mut sigset_t,
-    ) -> ::c_int;
+    pub fn sigprocmask(how: ::c_int, set: *const sigset_t, oldset: *mut sigset_t) -> ::c_int;
     pub fn sigpending(set: *mut sigset_t) -> ::c_int;
 
     pub fn timegm(tm: *mut ::tm) -> time_t;
@@ -4011,11 +3807,7 @@ extern "C" {
         timeout: *const timespec,
         sigmask: *const sigset_t,
     ) -> ::c_int;
-    pub fn fseeko(
-        stream: *mut ::FILE,
-        offset: ::off_t,
-        whence: ::c_int,
-    ) -> ::c_int;
+    pub fn fseeko(stream: *mut ::FILE, offset: ::off_t, whence: ::c_int) -> ::c_int;
     pub fn ftello(stream: *mut ::FILE) -> ::off_t;
     pub fn tcdrain(fd: ::c_int) -> ::c_int;
     pub fn cfgetispeed(termios: *const ::termios) -> ::speed_t;
@@ -4025,11 +3817,7 @@ extern "C" {
     pub fn cfsetospeed(termios: *mut ::termios, speed: ::speed_t) -> ::c_int;
     pub fn cfsetspeed(termios: *mut ::termios, speed: ::speed_t) -> ::c_int;
     pub fn tcgetattr(fd: ::c_int, termios: *mut ::termios) -> ::c_int;
-    pub fn tcsetattr(
-        fd: ::c_int,
-        optional_actions: ::c_int,
-        termios: *const ::termios,
-    ) -> ::c_int;
+    pub fn tcsetattr(fd: ::c_int, optional_actions: ::c_int, termios: *const ::termios) -> ::c_int;
     pub fn tcflow(fd: ::c_int, action: ::c_int) -> ::c_int;
     pub fn tcflush(fd: ::c_int, action: ::c_int) -> ::c_int;
     pub fn tcgetsid(fd: ::c_int) -> ::pid_t;
@@ -4052,16 +3840,10 @@ extern "C" {
     pub fn fdatasync(fd: ::c_int) -> ::c_int;
     pub fn clock_getres(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
     pub fn clock_gettime(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
-    pub fn clock_settime(
-        clk_id: ::clockid_t,
-        tp: *const ::timespec,
-    ) -> ::c_int;
+    pub fn clock_settime(clk_id: ::clockid_t, tp: *const ::timespec) -> ::c_int;
     pub fn dirfd(dirp: *mut ::DIR) -> ::c_int;
 
-    pub fn pthread_getattr_np(
-        native: ::pthread_t,
-        attr: *mut ::pthread_attr_t,
-    ) -> ::c_int;
+    pub fn pthread_getattr_np(native: ::pthread_t, attr: *mut ::pthread_attr_t) -> ::c_int;
     pub fn pthread_attr_getstack(
         attr: *const ::pthread_attr_t,
         stackaddr: *mut *mut ::c_void,
@@ -4072,18 +3854,9 @@ extern "C" {
     pub fn pipe2(fds: *mut ::c_int, flags: ::c_int) -> ::c_int;
     pub fn statfs(path: *const ::c_char, buf: *mut statfs) -> ::c_int;
     pub fn fstatfs(fd: ::c_int, buf: *mut statfs) -> ::c_int;
-    pub fn memrchr(
-        cx: *const ::c_void,
-        c: ::c_int,
-        n: ::size_t,
-    ) -> *mut ::c_void;
+    pub fn memrchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
 
-    pub fn posix_fadvise(
-        fd: ::c_int,
-        offset: ::off_t,
-        len: ::off_t,
-        advise: ::c_int,
-    ) -> ::c_int;
+    pub fn posix_fadvise(fd: ::c_int, offset: ::off_t, len: ::off_t, advise: ::c_int) -> ::c_int;
     pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
     pub fn utimensat(
         dirfd: ::c_int,
@@ -4093,11 +3866,7 @@ extern "C" {
     ) -> ::c_int;
     pub fn duplocale(base: ::locale_t) -> ::locale_t;
     pub fn freelocale(loc: ::locale_t);
-    pub fn newlocale(
-        mask: ::c_int,
-        locale: *const ::c_char,
-        base: ::locale_t,
-    ) -> ::locale_t;
+    pub fn newlocale(mask: ::c_int, locale: *const ::c_char, base: ::locale_t) -> ::locale_t;
     pub fn uselocale(loc: ::locale_t) -> ::locale_t;
 
     pub fn fdopendir(fd: ::c_int) -> *mut ::DIR;
@@ -4122,30 +3891,14 @@ extern "C" {
         len: *mut ::socklen_t,
         flg: ::c_int,
     ) -> ::c_int;
-    pub fn ptsname_r(
-        fd: ::c_int,
-        buf: *mut ::c_char,
-        buflen: ::size_t,
-    ) -> ::c_int;
+    pub fn ptsname_r(fd: ::c_int, buf: *mut ::c_char, buflen: ::size_t) -> ::c_int;
     pub fn clearenv() -> ::c_int;
-    pub fn waitid(
-        idtype: idtype_t,
-        id: id_t,
-        infop: *mut ::siginfo_t,
-        options: ::c_int,
-    ) -> ::c_int;
+    pub fn waitid(idtype: idtype_t, id: id_t, infop: *mut ::siginfo_t, options: ::c_int)
+        -> ::c_int;
     pub fn setreuid(ruid: ::uid_t, euid: ::uid_t) -> ::c_int;
     pub fn setregid(rgid: ::gid_t, egid: ::gid_t) -> ::c_int;
-    pub fn getresuid(
-        ruid: *mut ::uid_t,
-        euid: *mut ::uid_t,
-        suid: *mut ::uid_t,
-    ) -> ::c_int;
-    pub fn getresgid(
-        rgid: *mut ::gid_t,
-        egid: *mut ::gid_t,
-        sgid: *mut ::gid_t,
-    ) -> ::c_int;
+    pub fn getresuid(ruid: *mut ::uid_t, euid: *mut ::uid_t, suid: *mut ::uid_t) -> ::c_int;
+    pub fn getresgid(rgid: *mut ::gid_t, egid: *mut ::gid_t, sgid: *mut ::gid_t) -> ::c_int;
     pub fn acct(filename: *const ::c_char) -> ::c_int;
     pub fn brk(addr: *mut ::c_void) -> ::c_int;
     pub fn setresgid(rgid: ::gid_t, egid: ::gid_t, sgid: ::gid_t) -> ::c_int;
@@ -4176,40 +3929,18 @@ extern "C" {
     pub fn endpwent();
     pub fn getpwent() -> *mut passwd;
 
-    pub fn shm_open(
-        name: *const c_char,
-        oflag: ::c_int,
-        mode: mode_t,
-    ) -> ::c_int;
+    pub fn shm_open(name: *const c_char, oflag: ::c_int, mode: mode_t) -> ::c_int;
 
     // System V IPC
     pub fn shmget(key: ::key_t, size: ::size_t, shmflg: ::c_int) -> ::c_int;
-    pub fn shmat(
-        shmid: ::c_int,
-        shmaddr: *const ::c_void,
-        shmflg: ::c_int,
-    ) -> *mut ::c_void;
+    pub fn shmat(shmid: ::c_int, shmaddr: *const ::c_void, shmflg: ::c_int) -> *mut ::c_void;
     pub fn shmdt(shmaddr: *const ::c_void) -> ::c_int;
-    pub fn shmctl(
-        shmid: ::c_int,
-        cmd: ::c_int,
-        buf: *mut ::shmid_ds,
-    ) -> ::c_int;
+    pub fn shmctl(shmid: ::c_int, cmd: ::c_int, buf: *mut ::shmid_ds) -> ::c_int;
     pub fn ftok(pathname: *const ::c_char, proj_id: ::c_int) -> ::key_t;
     pub fn semget(key: ::key_t, nsems: ::c_int, semflag: ::c_int) -> ::c_int;
-    pub fn semop(
-        semid: ::c_int,
-        sops: *mut ::sembuf,
-        nsops: ::size_t,
-    ) -> ::c_int;
-    pub fn semctl(
-        semid: ::c_int,
-        semnum: ::c_int,
-        cmd: ::c_int,
-        ...
-    ) -> ::c_int;
-    pub fn msgctl(msqid: ::c_int, cmd: ::c_int, buf: *mut msqid_ds)
-        -> ::c_int;
+    pub fn semop(semid: ::c_int, sops: *mut ::sembuf, nsops: ::size_t) -> ::c_int;
+    pub fn semctl(semid: ::c_int, semnum: ::c_int, cmd: ::c_int, ...) -> ::c_int;
+    pub fn msgctl(msqid: ::c_int, cmd: ::c_int, buf: *mut msqid_ds) -> ::c_int;
     pub fn msgget(key: ::key_t, msgflg: ::c_int) -> ::c_int;
     pub fn msgrcv(
         msqid: ::c_int,
@@ -4225,57 +3956,24 @@ extern "C" {
         msgflg: ::c_int,
     ) -> ::c_int;
 
-    pub fn mprotect(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        prot: ::c_int,
-    ) -> ::c_int;
+    pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
     pub fn __errno_location() -> *mut ::c_int;
 
-    pub fn fallocate(
-        fd: ::c_int,
-        mode: ::c_int,
-        offset: ::off_t,
-        len: ::off_t,
-    ) -> ::c_int;
-    pub fn posix_fallocate(
-        fd: ::c_int,
-        offset: ::off_t,
-        len: ::off_t,
-    ) -> ::c_int;
-    pub fn readahead(
-        fd: ::c_int,
-        offset: ::off64_t,
-        count: ::size_t,
-    ) -> ::ssize_t;
-    pub fn signalfd(
-        fd: ::c_int,
-        mask: *const ::sigset_t,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn fallocate(fd: ::c_int, mode: ::c_int, offset: ::off_t, len: ::off_t) -> ::c_int;
+    pub fn posix_fallocate(fd: ::c_int, offset: ::off_t, len: ::off_t) -> ::c_int;
+    pub fn readahead(fd: ::c_int, offset: ::off64_t, count: ::size_t) -> ::ssize_t;
+    pub fn signalfd(fd: ::c_int, mask: *const ::sigset_t, flags: ::c_int) -> ::c_int;
     pub fn timerfd_create(clockid: ::c_int, flags: ::c_int) -> ::c_int;
-    pub fn timerfd_gettime(
-        fd: ::c_int,
-        curr_value: *mut itimerspec,
-    ) -> ::c_int;
+    pub fn timerfd_gettime(fd: ::c_int, curr_value: *mut itimerspec) -> ::c_int;
     pub fn timerfd_settime(
         fd: ::c_int,
         flags: ::c_int,
         new_value: *const itimerspec,
         old_value: *mut itimerspec,
     ) -> ::c_int;
-    pub fn pwritev(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-        offset: ::off_t,
-    ) -> ::ssize_t;
-    pub fn preadv(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-        offset: ::off_t,
-    ) -> ::ssize_t;
+    pub fn pwritev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t)
+        -> ::ssize_t;
+    pub fn preadv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t) -> ::ssize_t;
     pub fn quotactl(
         cmd: ::c_int,
         special: *const ::c_char,
@@ -4284,19 +3982,14 @@ extern "C" {
     ) -> ::c_int;
     pub fn dup3(oldfd: ::c_int, newfd: ::c_int, flags: ::c_int) -> ::c_int;
     pub fn mkostemp(template: *mut ::c_char, flags: ::c_int) -> ::c_int;
-    pub fn mkostemps(
-        template: *mut ::c_char,
-        suffixlen: ::c_int,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn mkostemps(template: *mut ::c_char, suffixlen: ::c_int, flags: ::c_int) -> ::c_int;
     pub fn sigtimedwait(
         set: *const sigset_t,
         info: *mut siginfo_t,
         timeout: *const ::timespec,
     ) -> ::c_int;
     pub fn sigwaitinfo(set: *const sigset_t, info: *mut siginfo_t) -> ::c_int;
-    pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t)
-        -> *mut ::c_char;
+    pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t) -> *mut ::c_char;
     pub fn getnameinfo(
         sa: *const ::sockaddr,
         salen: ::socklen_t,
@@ -4311,11 +4004,7 @@ extern "C" {
     pub fn setfsuid(uid: ::uid_t) -> ::c_int;
 
     // Not available now on Android
-    pub fn mkfifoat(
-        dirfd: ::c_int,
-        pathname: *const ::c_char,
-        mode: ::mode_t,
-    ) -> ::c_int;
+    pub fn mkfifoat(dirfd: ::c_int, pathname: *const ::c_char, mode: ::mode_t) -> ::c_int;
     pub fn if_nameindex() -> *mut if_nameindex;
     pub fn if_freenameindex(ptr: *mut if_nameindex);
     pub fn sync_file_range(
@@ -4330,35 +4019,21 @@ extern "C" {
     pub fn glob(
         pattern: *const c_char,
         flags: ::c_int,
-        errfunc: ::Option<
-            extern "C" fn(epath: *const c_char, errno: ::c_int) -> ::c_int,
-        >,
+        errfunc: ::Option<extern "C" fn(epath: *const c_char, errno: ::c_int) -> ::c_int>,
         pglob: *mut ::glob_t,
     ) -> ::c_int;
     pub fn globfree(pglob: *mut ::glob_t);
 
-    pub fn posix_madvise(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        advice: ::c_int,
-    ) -> ::c_int;
+    pub fn posix_madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
 
     pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
 
     pub fn seekdir(dirp: *mut ::DIR, loc: ::c_long);
 
     pub fn telldir(dirp: *mut ::DIR) -> ::c_long;
-    pub fn madvise(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        advice: ::c_int,
-    ) -> ::c_int;
+    pub fn madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
 
-    pub fn msync(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn msync(addr: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::c_int;
 
     pub fn recvfrom(
         socket: ::c_int,
@@ -4372,33 +4047,13 @@ extern "C" {
     pub fn futimes(fd: ::c_int, times: *const ::timeval) -> ::c_int;
     pub fn nl_langinfo(item: ::nl_item) -> *mut ::c_char;
 
-    pub fn bind(
-        socket: ::c_int,
-        address: *const ::sockaddr,
-        address_len: ::socklen_t,
-    ) -> ::c_int;
+    pub fn bind(socket: ::c_int, address: *const ::sockaddr, address_len: ::socklen_t) -> ::c_int;
 
-    pub fn writev(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-    ) -> ::ssize_t;
-    pub fn readv(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-    ) -> ::ssize_t;
+    pub fn writev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
+    pub fn readv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
 
-    pub fn sendmsg(
-        fd: ::c_int,
-        msg: *const ::msghdr,
-        flags: ::c_int,
-    ) -> ::ssize_t;
-    pub fn recvmsg(
-        fd: ::c_int,
-        msg: *mut ::msghdr,
-        flags: ::c_int,
-    ) -> ::ssize_t;
+    pub fn sendmsg(fd: ::c_int, msg: *const ::msghdr, flags: ::c_int) -> ::ssize_t;
+    pub fn recvmsg(fd: ::c_int, msg: *mut ::msghdr, flags: ::c_int) -> ::ssize_t;
     pub fn getdomainname(name: *mut ::c_char, len: ::size_t) -> ::c_int;
     pub fn setdomainname(name: *const ::c_char, len: ::size_t) -> ::c_int;
     pub fn vhangup() -> ::c_int;
@@ -4417,11 +4072,8 @@ extern "C" {
     ) -> ::c_int;
     pub fn sync();
     pub fn syscall(num: ::c_long, ...) -> ::c_long;
-    pub fn sched_getaffinity(
-        pid: ::pid_t,
-        cpusetsize: ::size_t,
-        cpuset: *mut cpu_set_t,
-    ) -> ::c_int;
+    pub fn sched_getaffinity(pid: ::pid_t, cpusetsize: ::size_t, cpuset: *mut cpu_set_t)
+        -> ::c_int;
     pub fn sched_setaffinity(
         pid: ::pid_t,
         cpusetsize: ::size_t,
@@ -4429,16 +4081,8 @@ extern "C" {
     ) -> ::c_int;
     pub fn umount(target: *const ::c_char) -> ::c_int;
     pub fn sched_get_priority_max(policy: ::c_int) -> ::c_int;
-    pub fn tee(
-        fd_in: ::c_int,
-        fd_out: ::c_int,
-        len: ::size_t,
-        flags: ::c_uint,
-    ) -> ::ssize_t;
-    pub fn settimeofday(
-        tv: *const ::timeval,
-        tz: *const ::timezone,
-    ) -> ::c_int;
+    pub fn tee(fd_in: ::c_int, fd_out: ::c_int, len: ::size_t, flags: ::c_uint) -> ::ssize_t;
+    pub fn settimeofday(tv: *const ::timeval, tz: *const ::timezone) -> ::c_int;
     pub fn splice(
         fd_in: ::c_int,
         off_in: *mut ::loff_t,
@@ -4448,17 +4092,10 @@ extern "C" {
         flags: ::c_uint,
     ) -> ::ssize_t;
     pub fn eventfd(init: ::c_uint, flags: ::c_int) -> ::c_int;
-    pub fn sched_rr_get_interval(pid: ::pid_t, tp: *mut ::timespec)
-        -> ::c_int;
-    pub fn sem_timedwait(
-        sem: *mut sem_t,
-        abstime: *const ::timespec,
-    ) -> ::c_int;
+    pub fn sched_rr_get_interval(pid: ::pid_t, tp: *mut ::timespec) -> ::c_int;
+    pub fn sem_timedwait(sem: *mut sem_t, abstime: *const ::timespec) -> ::c_int;
     pub fn sem_getvalue(sem: *mut sem_t, sval: *mut ::c_int) -> ::c_int;
-    pub fn sched_setparam(
-        pid: ::pid_t,
-        param: *const ::sched_param,
-    ) -> ::c_int;
+    pub fn sched_setparam(pid: ::pid_t, param: *const ::sched_param) -> ::c_int;
     pub fn swapoff(puath: *const ::c_char) -> ::c_int;
     pub fn vmsplice(
         fd: ::c_int,
@@ -4531,11 +4168,7 @@ extern "C" {
         result: *mut *mut ::group,
     ) -> ::c_int;
     pub fn initgroups(user: *const ::c_char, group: ::gid_t) -> ::c_int;
-    pub fn pthread_sigmask(
-        how: ::c_int,
-        set: *const sigset_t,
-        oldset: *mut sigset_t,
-    ) -> ::c_int;
+    pub fn pthread_sigmask(how: ::c_int, set: *const sigset_t, oldset: *mut sigset_t) -> ::c_int;
     pub fn sem_open(name: *const ::c_char, oflag: ::c_int, ...) -> *mut sem_t;
     pub fn getgrnam(name: *const ::c_char) -> *mut ::group;
     pub fn pthread_cancel(thread: ::pthread_t) -> ::c_int;

--- a/src/psp.rs
+++ b/src/psp.rs
@@ -54,24 +54,18 @@ pub type SceKernelVTimerHandler = unsafe extern "C" fn(
     arg3: *mut c_void,
 ) -> u32;
 
-pub type SceKernelVTimerHandlerWide = unsafe extern "C" fn(
-    uid: SceUid,
-    arg1: i64,
-    arg2: i64,
-    arg3: *mut c_void,
-) -> u32;
+pub type SceKernelVTimerHandlerWide =
+    unsafe extern "C" fn(uid: SceUid, arg1: i64, arg2: i64, arg3: *mut c_void) -> u32;
 
 pub type SceKernelThreadEventHandler =
     unsafe extern "C" fn(mask: i32, thid: SceUid, common: *mut c_void) -> i32;
 
-pub type SceKernelAlarmHandler =
-    unsafe extern "C" fn(common: *mut c_void) -> u32;
+pub type SceKernelAlarmHandler = unsafe extern "C" fn(common: *mut c_void) -> u32;
 
 pub type SceKernelCallbackFunction =
     unsafe extern "C" fn(arg1: i32, arg2: i32, arg: *mut c_void) -> i32;
 
-pub type SceKernelThreadEntry =
-    unsafe extern "C" fn(args: usize, argp: *mut c_void) -> i32;
+pub type SceKernelThreadEntry = unsafe extern "C" fn(args: usize, argp: *mut c_void) -> i32;
 
 pub type PowerCallback = extern "C" fn(unknown: i32, power_info: i32);
 
@@ -79,22 +73,15 @@ pub type IoPermissions = i32;
 
 pub type UmdCallback = fn(unknown: i32, event: i32) -> i32;
 
-pub type SceMpegRingbufferCb = ::Option<
-    unsafe extern "C" fn(
-        data: *mut c_void,
-        num_packets: i32,
-        param: *mut c_void,
-    ) -> i32,
->;
+pub type SceMpegRingbufferCb =
+    ::Option<unsafe extern "C" fn(data: *mut c_void, num_packets: i32, param: *mut c_void) -> i32>;
 
 pub type GuCallback = ::Option<extern "C" fn(id: i32, arg: *mut c_void)>;
-pub type GuSwapBuffersCallback = ::Option<
-    extern "C" fn(display: *mut *mut c_void, render: *mut *mut c_void),
->;
+pub type GuSwapBuffersCallback =
+    ::Option<extern "C" fn(display: *mut *mut c_void, render: *mut *mut c_void)>;
 
-pub type SceNetAdhocctlHandler = ::Option<
-    unsafe extern "C" fn(flag: i32, error: i32, unknown: *mut c_void),
->;
+pub type SceNetAdhocctlHandler =
+    ::Option<unsafe extern "C" fn(flag: i32, error: i32, unknown: *mut c_void)>;
 
 pub type AdhocMatchingCallback = ::Option<
     unsafe extern "C" fn(
@@ -107,17 +94,10 @@ pub type AdhocMatchingCallback = ::Option<
 >;
 
 pub type SceNetApctlHandler = ::Option<
-    unsafe extern "C" fn(
-        oldState: i32,
-        newState: i32,
-        event: i32,
-        error: i32,
-        pArg: *mut c_void,
-    ),
+    unsafe extern "C" fn(oldState: i32, newState: i32, event: i32, error: i32, pArg: *mut c_void),
 >;
 
-pub type HttpMallocFunction =
-    ::Option<unsafe extern "C" fn(size: usize) -> *mut c_void>;
+pub type HttpMallocFunction = ::Option<unsafe extern "C" fn(size: usize) -> *mut c_void>;
 pub type HttpReallocFunction =
     ::Option<unsafe extern "C" fn(p: *mut c_void, size: usize) -> *mut c_void>;
 pub type HttpFreeFunction = ::Option<unsafe extern "C" fn(p: *mut c_void)>;
@@ -2613,8 +2593,7 @@ pub const UTILITY_HTMLVIEWER_DISABLE_EXIT_DIALOG: i32 = 0x000004;
 pub const UTILITY_HTMLVIEWER_DISABLE_CURSOR: i32 = 0x000008;
 pub const UTILITY_HTMLVIEWER_DISABLE_DOWNLOAD_COMPLETE_DIALOG: i32 = 0x000010;
 pub const UTILITY_HTMLVIEWER_DISABLE_DOWNLOAD_START_DIALOG: i32 = 0x000020;
-pub const UTILITY_HTMLVIEWER_DISABLE_DOWNLOAD_DESTINATION_DIALOG: i32 =
-    0x000040;
+pub const UTILITY_HTMLVIEWER_DISABLE_DOWNLOAD_DESTINATION_DIALOG: i32 = 0x000040;
 pub const UTILITY_HTMLVIEWER_LOCK_DOWNLOAD_DESTINATION_DIALOG: i32 = 0x000080;
 pub const UTILITY_HTMLVIEWER_DISABLE_TAB_DISPLAY: i32 = 0x000100;
 pub const UTILITY_HTMLVIEWER_ENABLE_ANALOG_HOLD: i32 = 0x000200;
@@ -2622,18 +2601,10 @@ pub const UTILITY_HTMLVIEWER_ENABLE_FLASH: i32 = 0x000400;
 pub const UTILITY_HTMLVIEWER_DISABLE_LRTRIGGER: i32 = 0x000800;
 
 extern "C" {
-    pub fn sceAudioChReserve(
-        channel: i32,
-        sample_count: i32,
-        format: AudioFormat,
-    ) -> i32;
+    pub fn sceAudioChReserve(channel: i32, sample_count: i32, format: AudioFormat) -> i32;
     pub fn sceAudioChRelease(channel: i32) -> i32;
     pub fn sceAudioOutput(channel: i32, vol: i32, buf: *mut c_void) -> i32;
-    pub fn sceAudioOutputBlocking(
-        channel: i32,
-        vol: i32,
-        buf: *mut c_void,
-    ) -> i32;
+    pub fn sceAudioOutputBlocking(channel: i32, vol: i32, buf: *mut c_void) -> i32;
     pub fn sceAudioOutputPanned(
         channel: i32,
         left_vol: i32,
@@ -2649,15 +2620,8 @@ extern "C" {
     pub fn sceAudioGetChannelRestLen(channel: i32) -> i32;
     pub fn sceAudioGetChannelRestLength(channel: i32) -> i32;
     pub fn sceAudioSetChannelDataLen(channel: i32, sample_count: i32) -> i32;
-    pub fn sceAudioChangeChannelConfig(
-        channel: i32,
-        format: AudioFormat,
-    ) -> i32;
-    pub fn sceAudioChangeChannelVolume(
-        channel: i32,
-        left_vol: i32,
-        right_vol: i32,
-    ) -> i32;
+    pub fn sceAudioChangeChannelConfig(channel: i32, format: AudioFormat) -> i32;
+    pub fn sceAudioChangeChannelVolume(channel: i32, left_vol: i32, right_vol: i32) -> i32;
     pub fn sceAudioOutput2Reserve(sample_count: i32) -> i32;
     pub fn sceAudioOutput2Release() -> i32;
     pub fn sceAudioOutput2ChangeLength(sample_count: i32) -> i32;
@@ -2672,16 +2636,8 @@ extern "C" {
     pub fn sceAudioSRCOutputBlocking(vol: i32, buf: *mut c_void) -> i32;
     pub fn sceAudioInputInit(unknown1: i32, gain: i32, unknown2: i32) -> i32;
     pub fn sceAudioInputInitEx(params: *mut AudioInputParams) -> i32;
-    pub fn sceAudioInputBlocking(
-        sample_count: i32,
-        freq: AudioInputFrequency,
-        buf: *mut c_void,
-    );
-    pub fn sceAudioInput(
-        sample_count: i32,
-        freq: AudioInputFrequency,
-        buf: *mut c_void,
-    );
+    pub fn sceAudioInputBlocking(sample_count: i32, freq: AudioInputFrequency, buf: *mut c_void);
+    pub fn sceAudioInput(sample_count: i32, freq: AudioInputFrequency, buf: *mut c_void);
     pub fn sceAudioGetInputLength() -> i32;
     pub fn sceAudioWaitInputEnd() -> i32;
     pub fn sceAudioPollInputEnd() -> i32;
@@ -2695,10 +2651,7 @@ extern "C" {
         out_end: *mut i32,
         out_remain_frame: *mut i32,
     ) -> i32;
-    pub fn sceAtracGetRemainFrame(
-        atrac_id: i32,
-        out_remain_frame: *mut i32,
-    ) -> i32;
+    pub fn sceAtracGetRemainFrame(atrac_id: i32, out_remain_frame: *mut i32) -> i32;
     pub fn sceAtracGetStreamDataInfo(
         atrac_id: i32,
         write_pointer: *mut *mut u8,
@@ -2717,19 +2670,13 @@ extern "C" {
         pbuffer_info: *mut Atrac3BufferInfo,
     ) -> i32;
     pub fn sceAtracGetChannel(atrac_id: i32, pui_channel: *mut u32) -> i32;
-    pub fn sceAtracGetInternalErrorInfo(
-        atrac_id: i32,
-        pi_result: *mut i32,
-    ) -> i32;
+    pub fn sceAtracGetInternalErrorInfo(atrac_id: i32, pi_result: *mut i32) -> i32;
     pub fn sceAtracGetLoopStatus(
         atrac_id: i32,
         pi_loop_num: *mut i32,
         pui_loop_status: *mut u32,
     ) -> i32;
-    pub fn sceAtracGetNextDecodePosition(
-        atrac_id: i32,
-        pui_sample_position: *mut u32,
-    ) -> i32;
+    pub fn sceAtracGetNextDecodePosition(atrac_id: i32, pui_sample_position: *mut u32) -> i32;
     pub fn sceAtracGetSecondBufferInfo(
         atrac_id: i32,
         pui_position: *mut u32,
@@ -2747,11 +2694,7 @@ extern "C" {
         ui_write_byte_first_buf: u32,
         ui_write_byte_second_buf: u32,
     ) -> i32;
-    pub fn sceAtracSetData(
-        atrac_id: i32,
-        puc_buffer_addr: *mut u8,
-        ui_buffer_byte: u32,
-    ) -> i32;
+    pub fn sceAtracSetData(atrac_id: i32, puc_buffer_addr: *mut u8, ui_buffer_byte: u32) -> i32;
     pub fn sceAtracSetHalfwayBuffer(
         atrac_id: i32,
         puc_buffer_addr: *mut u8,
@@ -2773,41 +2716,17 @@ extern "C" {
     pub fn sceCtrlGetSamplingCycle(pcycle: *mut i32) -> i32;
     pub fn sceCtrlSetSamplingMode(mode: CtrlMode) -> i32;
     pub fn sceCtrlGetSamplingMode(pmode: *mut i32) -> i32;
-    pub fn sceCtrlPeekBufferPositive(
-        pad_data: *mut SceCtrlData,
-        count: i32,
-    ) -> i32;
-    pub fn sceCtrlPeekBufferNegative(
-        pad_data: *mut SceCtrlData,
-        count: i32,
-    ) -> i32;
-    pub fn sceCtrlReadBufferPositive(
-        pad_data: *mut SceCtrlData,
-        count: i32,
-    ) -> i32;
-    pub fn sceCtrlReadBufferNegative(
-        pad_data: *mut SceCtrlData,
-        count: i32,
-    ) -> i32;
+    pub fn sceCtrlPeekBufferPositive(pad_data: *mut SceCtrlData, count: i32) -> i32;
+    pub fn sceCtrlPeekBufferNegative(pad_data: *mut SceCtrlData, count: i32) -> i32;
+    pub fn sceCtrlReadBufferPositive(pad_data: *mut SceCtrlData, count: i32) -> i32;
+    pub fn sceCtrlReadBufferNegative(pad_data: *mut SceCtrlData, count: i32) -> i32;
     pub fn sceCtrlPeekLatch(latch_data: *mut SceCtrlLatch) -> i32;
     pub fn sceCtrlReadLatch(latch_data: *mut SceCtrlLatch) -> i32;
-    pub fn sceCtrlSetIdleCancelThreshold(idlereset: i32, idleback: i32)
-        -> i32;
-    pub fn sceCtrlGetIdleCancelThreshold(
-        idlereset: *mut i32,
-        idleback: *mut i32,
-    ) -> i32;
+    pub fn sceCtrlSetIdleCancelThreshold(idlereset: i32, idleback: i32) -> i32;
+    pub fn sceCtrlGetIdleCancelThreshold(idlereset: *mut i32, idleback: *mut i32) -> i32;
 
-    pub fn sceDisplaySetMode(
-        mode: DisplayMode,
-        width: usize,
-        height: usize,
-    ) -> u32;
-    pub fn sceDisplayGetMode(
-        pmode: *mut i32,
-        pwidth: *mut i32,
-        pheight: *mut i32,
-    ) -> i32;
+    pub fn sceDisplaySetMode(mode: DisplayMode, width: usize, height: usize) -> u32;
+    pub fn sceDisplayGetMode(pmode: *mut i32, pwidth: *mut i32, pheight: *mut i32) -> i32;
     pub fn sceDisplaySetFrameBuf(
         top_addr: *const u8,
         buffer_width: usize,
@@ -2862,10 +2781,7 @@ extern "C" {
 
     pub fn sceKernelExitGame();
     pub fn sceKernelRegisterExitCallback(id: SceUid) -> i32;
-    pub fn sceKernelLoadExec(
-        file: *const u8,
-        param: *mut SceKernelLoadExecParam,
-    ) -> i32;
+    pub fn sceKernelLoadExec(file: *const u8, param: *mut SceKernelLoadExecParam) -> i32;
 
     pub fn sceKernelAllocPartitionMemory(
         partition: SceSysMemPartitionId,
@@ -2884,52 +2800,27 @@ extern "C" {
 
     pub fn sceKernelLibcTime(t: *mut i32) -> i32;
     pub fn sceKernelLibcClock() -> u32;
-    pub fn sceKernelLibcGettimeofday(
-        tp: *mut timeval,
-        tzp: *mut timezone,
-    ) -> i32;
+    pub fn sceKernelLibcGettimeofday(tp: *mut timeval, tzp: *mut timezone) -> i32;
     pub fn sceKernelDcacheWritebackAll();
     pub fn sceKernelDcacheWritebackInvalidateAll();
     pub fn sceKernelDcacheWritebackRange(p: *const c_void, size: u32);
-    pub fn sceKernelDcacheWritebackInvalidateRange(
-        p: *const c_void,
-        size: u32,
-    );
+    pub fn sceKernelDcacheWritebackInvalidateRange(p: *const c_void, size: u32);
     pub fn sceKernelDcacheInvalidateRange(p: *const c_void, size: u32);
     pub fn sceKernelIcacheInvalidateAll();
     pub fn sceKernelIcacheInvalidateRange(p: *const c_void, size: u32);
-    pub fn sceKernelUtilsMt19937Init(
-        ctx: *mut SceKernelUtilsMt19937Context,
-        seed: u32,
-    ) -> i32;
-    pub fn sceKernelUtilsMt19937UInt(
-        ctx: *mut SceKernelUtilsMt19937Context,
-    ) -> u32;
-    pub fn sceKernelUtilsMd5Digest(
-        data: *mut u8,
-        size: u32,
-        digest: *mut u8,
-    ) -> i32;
-    pub fn sceKernelUtilsMd5BlockInit(
-        ctx: *mut SceKernelUtilsMd5Context,
-    ) -> i32;
+    pub fn sceKernelUtilsMt19937Init(ctx: *mut SceKernelUtilsMt19937Context, seed: u32) -> i32;
+    pub fn sceKernelUtilsMt19937UInt(ctx: *mut SceKernelUtilsMt19937Context) -> u32;
+    pub fn sceKernelUtilsMd5Digest(data: *mut u8, size: u32, digest: *mut u8) -> i32;
+    pub fn sceKernelUtilsMd5BlockInit(ctx: *mut SceKernelUtilsMd5Context) -> i32;
     pub fn sceKernelUtilsMd5BlockUpdate(
         ctx: *mut SceKernelUtilsMd5Context,
         data: *mut u8,
         size: u32,
     ) -> i32;
-    pub fn sceKernelUtilsMd5BlockResult(
-        ctx: *mut SceKernelUtilsMd5Context,
-        digest: *mut u8,
-    ) -> i32;
-    pub fn sceKernelUtilsSha1Digest(
-        data: *mut u8,
-        size: u32,
-        digest: *mut u8,
-    ) -> i32;
-    pub fn sceKernelUtilsSha1BlockInit(
-        ctx: *mut SceKernelUtilsSha1Context,
-    ) -> i32;
+    pub fn sceKernelUtilsMd5BlockResult(ctx: *mut SceKernelUtilsMd5Context, digest: *mut u8)
+        -> i32;
+    pub fn sceKernelUtilsSha1Digest(data: *mut u8, size: u32, digest: *mut u8) -> i32;
+    pub fn sceKernelUtilsSha1BlockInit(ctx: *mut SceKernelUtilsSha1Context) -> i32;
     pub fn sceKernelUtilsSha1BlockUpdate(
         ctx: *mut SceKernelUtilsSha1Context,
         data: *mut u8,
@@ -2997,37 +2888,22 @@ extern "C" {
         option: *mut SceKernelSMOption,
     ) -> i32;
     pub fn sceKernelUnloadModule(mod_id: SceUid) -> i32;
-    pub fn sceKernelSelfStopUnloadModule(
-        unknown: i32,
-        arg_size: usize,
-        argp: *mut c_void,
-    ) -> i32;
+    pub fn sceKernelSelfStopUnloadModule(unknown: i32, arg_size: usize, argp: *mut c_void) -> i32;
     pub fn sceKernelStopUnloadSelfModule(
         arg_size: usize,
         argp: *mut c_void,
         status: *mut i32,
         option: *mut SceKernelSMOption,
     ) -> i32;
-    pub fn sceKernelQueryModuleInfo(
-        mod_id: SceUid,
-        info: *mut SceKernelModuleInfo,
-    ) -> i32;
+    pub fn sceKernelQueryModuleInfo(mod_id: SceUid, info: *mut SceKernelModuleInfo) -> i32;
     pub fn sceKernelGetModuleIdList(
         read_buf: *mut SceUid,
         read_buf_size: i32,
         id_count: *mut i32,
     ) -> i32;
 
-    pub fn sceKernelVolatileMemLock(
-        unk: i32,
-        ptr: *mut *mut c_void,
-        size: *mut i32,
-    ) -> i32;
-    pub fn sceKernelVolatileMemTryLock(
-        unk: i32,
-        ptr: *mut *mut c_void,
-        size: *mut i32,
-    ) -> i32;
+    pub fn sceKernelVolatileMemLock(unk: i32, ptr: *mut *mut c_void, size: *mut i32) -> i32;
+    pub fn sceKernelVolatileMemTryLock(unk: i32, ptr: *mut *mut c_void, size: *mut i32) -> i32;
     pub fn sceKernelVolatileMemUnlock(unk: i32) -> i32;
 
     pub fn sceKernelStdin() -> SceUid;
@@ -3044,11 +2920,7 @@ extern "C" {
         option: *mut SceKernelThreadOptParam,
     ) -> SceUid;
     pub fn sceKernelDeleteThread(thid: SceUid) -> i32;
-    pub fn sceKernelStartThread(
-        id: SceUid,
-        arg_len: usize,
-        arg_p: *mut c_void,
-    ) -> i32;
+    pub fn sceKernelStartThread(id: SceUid, arg_len: usize, arg_p: *mut c_void) -> i32;
     pub fn sceKernelExitThread(status: i32) -> i32;
     pub fn sceKernelExitDeleteThread(status: i32) -> i32;
     pub fn sceKernelTerminateThread(thid: SceUid) -> i32;
@@ -3066,9 +2938,7 @@ extern "C" {
     pub fn sceKernelDelayThread(delay: u32) -> i32;
     pub fn sceKernelDelayThreadCB(delay: u32) -> i32;
     pub fn sceKernelDelaySysClockThread(delay: *mut SceKernelSysClock) -> i32;
-    pub fn sceKernelDelaySysClockThreadCB(
-        delay: *mut SceKernelSysClock,
-    ) -> i32;
+    pub fn sceKernelDelaySysClockThreadCB(delay: *mut SceKernelSysClock) -> i32;
     pub fn sceKernelChangeCurrentThreadAttr(unknown: i32, attr: i32) -> i32;
     pub fn sceKernelChangeThreadPriority(thid: SceUid, priority: i32) -> i32;
     pub fn sceKernelRotateThreadReadyQueue(priority: i32) -> i32;
@@ -3078,10 +2948,7 @@ extern "C" {
     pub fn sceKernelGetThreadExitStatus(thid: SceUid) -> i32;
     pub fn sceKernelCheckThreadStack() -> i32;
     pub fn sceKernelGetThreadStackFreeSize(thid: SceUid) -> i32;
-    pub fn sceKernelReferThreadStatus(
-        thid: SceUid,
-        info: *mut SceKernelThreadInfo,
-    ) -> i32;
+    pub fn sceKernelReferThreadStatus(thid: SceUid, info: *mut SceKernelThreadInfo) -> i32;
     pub fn sceKernelReferThreadRunStatus(
         thid: SceUid,
         status: *mut SceKernelThreadRunStatus,
@@ -3095,21 +2962,10 @@ extern "C" {
     ) -> SceUid;
     pub fn sceKernelDeleteSema(sema_id: SceUid) -> i32;
     pub fn sceKernelSignalSema(sema_id: SceUid, signal: i32) -> i32;
-    pub fn sceKernelWaitSema(
-        sema_id: SceUid,
-        signal: i32,
-        timeout: *mut u32,
-    ) -> i32;
-    pub fn sceKernelWaitSemaCB(
-        sema_id: SceUid,
-        signal: i32,
-        timeout: *mut u32,
-    ) -> i32;
+    pub fn sceKernelWaitSema(sema_id: SceUid, signal: i32, timeout: *mut u32) -> i32;
+    pub fn sceKernelWaitSemaCB(sema_id: SceUid, signal: i32, timeout: *mut u32) -> i32;
     pub fn sceKernelPollSema(sema_id: SceUid, signal: i32) -> i32;
-    pub fn sceKernelReferSemaStatus(
-        sema_id: SceUid,
-        info: *mut SceKernelSemaInfo,
-    ) -> i32;
+    pub fn sceKernelReferSemaStatus(sema_id: SceUid, info: *mut SceKernelSemaInfo) -> i32;
     pub fn sceKernelCreateEventFlag(
         name: *const u8,
         attr: i32,
@@ -3118,12 +2974,7 @@ extern "C" {
     ) -> SceUid;
     pub fn sceKernelSetEventFlag(ev_id: SceUid, bits: u32) -> i32;
     pub fn sceKernelClearEventFlag(ev_id: SceUid, bits: u32) -> i32;
-    pub fn sceKernelPollEventFlag(
-        ev_id: SceUid,
-        bits: u32,
-        wait: i32,
-        out_bits: *mut u32,
-    ) -> i32;
+    pub fn sceKernelPollEventFlag(ev_id: SceUid, bits: u32, wait: i32, out_bits: *mut u32) -> i32;
     pub fn sceKernelWaitEventFlag(
         ev_id: SceUid,
         bits: u32,
@@ -3139,10 +2990,8 @@ extern "C" {
         timeout: *mut u32,
     ) -> i32;
     pub fn sceKernelDeleteEventFlag(ev_id: SceUid) -> i32;
-    pub fn sceKernelReferEventFlagStatus(
-        event: SceUid,
-        status: *mut SceKernelEventFlagInfo,
-    ) -> i32;
+    pub fn sceKernelReferEventFlagStatus(event: SceUid, status: *mut SceKernelEventFlagInfo)
+        -> i32;
     pub fn sceKernelCreateMbx(
         name: *const u8,
         attr: u32,
@@ -3150,23 +2999,16 @@ extern "C" {
     ) -> SceUid;
     pub fn sceKernelDeleteMbx(mbx_id: SceUid) -> i32;
     pub fn sceKernelSendMbx(mbx_id: SceUid, message: *mut c_void) -> i32;
-    pub fn sceKernelReceiveMbx(
-        mbx_id: SceUid,
-        message: *mut *mut c_void,
-        timeout: *mut u32,
-    ) -> i32;
+    pub fn sceKernelReceiveMbx(mbx_id: SceUid, message: *mut *mut c_void, timeout: *mut u32)
+        -> i32;
     pub fn sceKernelReceiveMbxCB(
         mbx_id: SceUid,
         message: *mut *mut c_void,
         timeout: *mut u32,
     ) -> i32;
-    pub fn sceKernelPollMbx(mbx_id: SceUid, pmessage: *mut *mut c_void)
-        -> i32;
+    pub fn sceKernelPollMbx(mbx_id: SceUid, pmessage: *mut *mut c_void) -> i32;
     pub fn sceKernelCancelReceiveMbx(mbx_id: SceUid, num: *mut i32) -> i32;
-    pub fn sceKernelReferMbxStatus(
-        mbx_id: SceUid,
-        info: *mut SceKernelMbxInfo,
-    ) -> i32;
+    pub fn sceKernelReferMbxStatus(mbx_id: SceUid, info: *mut SceKernelMbxInfo) -> i32;
     pub fn sceKernelSetAlarm(
         clock: u32,
         handler: SceKernelAlarmHandler,
@@ -3178,19 +3020,13 @@ extern "C" {
         common: *mut c_void,
     ) -> SceUid;
     pub fn sceKernelCancelAlarm(alarm_id: SceUid) -> i32;
-    pub fn sceKernelReferAlarmStatus(
-        alarm_id: SceUid,
-        info: *mut SceKernelAlarmInfo,
-    ) -> i32;
+    pub fn sceKernelReferAlarmStatus(alarm_id: SceUid, info: *mut SceKernelAlarmInfo) -> i32;
     pub fn sceKernelCreateCallback(
         name: *const u8,
         func: SceKernelCallbackFunction,
         arg: *mut c_void,
     ) -> SceUid;
-    pub fn sceKernelReferCallbackStatus(
-        cb: SceUid,
-        status: *mut SceKernelCallbackInfo,
-    ) -> i32;
+    pub fn sceKernelReferCallbackStatus(cb: SceUid, status: *mut SceKernelCallbackInfo) -> i32;
     pub fn sceKernelDeleteCallback(cb: SceUid) -> i32;
     pub fn sceKernelNotifyCallback(cb: SceUid, arg2: i32) -> i32;
     pub fn sceKernelCancelCallback(cb: SceUid) -> i32;
@@ -3202,9 +3038,7 @@ extern "C" {
         read_buf_size: i32,
         id_count: *mut i32,
     ) -> i32;
-    pub fn sceKernelReferSystemStatus(
-        status: *mut SceKernelSystemStatus,
-    ) -> i32;
+    pub fn sceKernelReferSystemStatus(status: *mut SceKernelSystemStatus) -> i32;
     pub fn sceKernelCreateMsgPipe(
         name: *const u8,
         part: i32,
@@ -3259,15 +3093,8 @@ extern "C" {
         unk1: i32,
         unk2: *mut c_void,
     ) -> i32;
-    pub fn sceKernelCancelMsgPipe(
-        uid: SceUid,
-        send: *mut i32,
-        recv: *mut i32,
-    ) -> i32;
-    pub fn sceKernelReferMsgPipeStatus(
-        uid: SceUid,
-        info: *mut SceKernelMppInfo,
-    ) -> i32;
+    pub fn sceKernelCancelMsgPipe(uid: SceUid, send: *mut i32, recv: *mut i32) -> i32;
+    pub fn sceKernelReferMsgPipeStatus(uid: SceUid, info: *mut SceKernelMppInfo) -> i32;
     pub fn sceKernelCreateVpl(
         name: *const u8,
         part: i32,
@@ -3288,17 +3115,10 @@ extern "C" {
         data: *mut *mut c_void,
         timeout: *mut u32,
     ) -> i32;
-    pub fn sceKernelTryAllocateVpl(
-        uid: SceUid,
-        size: u32,
-        data: *mut *mut c_void,
-    ) -> i32;
+    pub fn sceKernelTryAllocateVpl(uid: SceUid, size: u32, data: *mut *mut c_void) -> i32;
     pub fn sceKernelFreeVpl(uid: SceUid, data: *mut c_void) -> i32;
     pub fn sceKernelCancelVpl(uid: SceUid, num: *mut i32) -> i32;
-    pub fn sceKernelReferVplStatus(
-        uid: SceUid,
-        info: *mut SceKernelVplInfo,
-    ) -> i32;
+    pub fn sceKernelReferVplStatus(uid: SceUid, info: *mut SceKernelVplInfo) -> i32;
     pub fn sceKernelCreateFpl(
         name: *const u8,
         part: i32,
@@ -3308,61 +3128,30 @@ extern "C" {
         opt: *mut SceKernelFplOptParam,
     ) -> i32;
     pub fn sceKernelDeleteFpl(uid: SceUid) -> i32;
-    pub fn sceKernelAllocateFpl(
-        uid: SceUid,
-        data: *mut *mut c_void,
-        timeout: *mut u32,
-    ) -> i32;
-    pub fn sceKernelAllocateFplCB(
-        uid: SceUid,
-        data: *mut *mut c_void,
-        timeout: *mut u32,
-    ) -> i32;
-    pub fn sceKernelTryAllocateFpl(uid: SceUid, data: *mut *mut c_void)
-        -> i32;
+    pub fn sceKernelAllocateFpl(uid: SceUid, data: *mut *mut c_void, timeout: *mut u32) -> i32;
+    pub fn sceKernelAllocateFplCB(uid: SceUid, data: *mut *mut c_void, timeout: *mut u32) -> i32;
+    pub fn sceKernelTryAllocateFpl(uid: SceUid, data: *mut *mut c_void) -> i32;
     pub fn sceKernelFreeFpl(uid: SceUid, data: *mut c_void) -> i32;
     pub fn sceKernelCancelFpl(uid: SceUid, pnum: *mut i32) -> i32;
-    pub fn sceKernelReferFplStatus(
-        uid: SceUid,
-        info: *mut SceKernelFplInfo,
-    ) -> i32;
-    pub fn sceKernelUSec2SysClock(
-        usec: u32,
-        clock: *mut SceKernelSysClock,
-    ) -> i32;
+    pub fn sceKernelReferFplStatus(uid: SceUid, info: *mut SceKernelFplInfo) -> i32;
+    pub fn sceKernelUSec2SysClock(usec: u32, clock: *mut SceKernelSysClock) -> i32;
     pub fn sceKernelUSec2SysClockWide(usec: u32) -> i64;
     pub fn sceKernelSysClock2USec(
         clock: *mut SceKernelSysClock,
         low: *mut u32,
         high: *mut u32,
     ) -> i32;
-    pub fn sceKernelSysClock2USecWide(
-        clock: i64,
-        low: *mut u32,
-        high: *mut u32,
-    ) -> i32;
+    pub fn sceKernelSysClock2USecWide(clock: i64, low: *mut u32, high: *mut u32) -> i32;
     pub fn sceKernelGetSystemTime(time: *mut SceKernelSysClock) -> i32;
     pub fn sceKernelGetSystemTimeWide() -> i64;
     pub fn sceKernelGetSystemTimeLow() -> u32;
-    pub fn sceKernelCreateVTimer(
-        name: *const u8,
-        opt: *mut SceKernelVTimerOptParam,
-    ) -> SceUid;
+    pub fn sceKernelCreateVTimer(name: *const u8, opt: *mut SceKernelVTimerOptParam) -> SceUid;
     pub fn sceKernelDeleteVTimer(uid: SceUid) -> i32;
-    pub fn sceKernelGetVTimerBase(
-        uid: SceUid,
-        base: *mut SceKernelSysClock,
-    ) -> i32;
+    pub fn sceKernelGetVTimerBase(uid: SceUid, base: *mut SceKernelSysClock) -> i32;
     pub fn sceKernelGetVTimerBaseWide(uid: SceUid) -> i64;
-    pub fn sceKernelGetVTimerTime(
-        uid: SceUid,
-        time: *mut SceKernelSysClock,
-    ) -> i32;
+    pub fn sceKernelGetVTimerTime(uid: SceUid, time: *mut SceKernelSysClock) -> i32;
     pub fn sceKernelGetVTimerTimeWide(uid: SceUid) -> i64;
-    pub fn sceKernelSetVTimerTime(
-        uid: SceUid,
-        time: *mut SceKernelSysClock,
-    ) -> i32;
+    pub fn sceKernelSetVTimerTime(uid: SceUid, time: *mut SceKernelSysClock) -> i32;
     pub fn sceKernelSetVTimerTimeWide(uid: SceUid, time: i64) -> i64;
     pub fn sceKernelStartVTimer(uid: SceUid) -> i32;
     pub fn sceKernelStopVTimer(uid: SceUid) -> i32;
@@ -3379,10 +3168,7 @@ extern "C" {
         common: *mut c_void,
     ) -> i32;
     pub fn sceKernelCancelVTimerHandler(uid: SceUid) -> i32;
-    pub fn sceKernelReferVTimerStatus(
-        uid: SceUid,
-        info: *mut SceKernelVTimerInfo,
-    ) -> i32;
+    pub fn sceKernelReferVTimerStatus(uid: SceUid, info: *mut SceKernelVTimerInfo) -> i32;
     pub fn sceKernelRegisterThreadEventHandler(
         name: *const u8,
         thread_id: SceUid,
@@ -3398,16 +3184,8 @@ extern "C" {
     pub fn sceKernelReferThreadProfiler() -> *mut DebugProfilerRegs;
     pub fn sceKernelReferGlobalProfiler() -> *mut DebugProfilerRegs;
 
-    pub fn sceUsbStart(
-        driver_name: *const u8,
-        size: i32,
-        args: *mut c_void,
-    ) -> i32;
-    pub fn sceUsbStop(
-        driver_name: *const u8,
-        size: i32,
-        args: *mut c_void,
-    ) -> i32;
+    pub fn sceUsbStart(driver_name: *const u8, size: i32, args: *mut c_void) -> i32;
+    pub fn sceUsbStop(driver_name: *const u8, size: i32, args: *mut c_void) -> i32;
     pub fn sceUsbActivate(pid: u32) -> i32;
     pub fn sceUsbDeactivate(pid: u32) -> i32;
     pub fn sceUsbGetState() -> i32;
@@ -3452,9 +3230,7 @@ extern "C" {
     pub fn sceUsbCamGetBrightness(brightness: *mut i32) -> i32;
     pub fn sceUsbCamGetContrast(contrast: *mut i32) -> i32;
     pub fn sceUsbCamGetSharpness(sharpness: *mut i32) -> i32;
-    pub fn sceUsbCamGetImageEffectMode(
-        effect_mode: *mut UsbCamEffectMode,
-    ) -> i32;
+    pub fn sceUsbCamGetImageEffectMode(effect_mode: *mut UsbCamEffectMode) -> i32;
     pub fn sceUsbCamGetEvLevel(exposure_level: *mut UsbCamEvLevel) -> i32;
     pub fn sceUsbCamGetReverseMode(reverse_flags: *mut i32) -> i32;
     pub fn sceUsbCamGetZoom(zoom: *mut i32) -> i32;
@@ -3486,11 +3262,7 @@ extern "C" {
     pub fn scePowerGetBusClockFrequency() -> i32;
     pub fn scePowerGetBusClockFrequencyInt() -> i32;
     pub fn scePowerGetBusClockFrequencyFloat() -> f32;
-    pub fn scePowerSetClockFrequency(
-        pllfreq: i32,
-        cpufreq: i32,
-        busfreq: i32,
-    ) -> i32;
+    pub fn scePowerSetClockFrequency(pllfreq: i32, cpufreq: i32, busfreq: i32) -> i32;
     pub fn scePowerLock(unknown: i32) -> i32;
     pub fn scePowerUnlock(unknown: i32) -> i32;
     pub fn scePowerTick(t: PowerTick) -> i32;
@@ -3511,14 +3283,8 @@ extern "C" {
     pub fn sceRtcGetCurrentTick(tick: *mut u64) -> i32;
     pub fn sceRtcGetCurrentClock(tm: *mut ScePspDateTime, tz: i32) -> i32;
     pub fn sceRtcGetCurrentClockLocalTime(tm: *mut ScePspDateTime) -> i32;
-    pub fn sceRtcConvertUtcToLocalTime(
-        tick_utc: *const u64,
-        tick_local: *mut u64,
-    ) -> i32;
-    pub fn sceRtcConvertLocalTimeToUTC(
-        tick_local: *const u64,
-        tick_utc: *mut u64,
-    ) -> i32;
+    pub fn sceRtcConvertUtcToLocalTime(tick_utc: *const u64, tick_local: *mut u64) -> i32;
+    pub fn sceRtcConvertLocalTimeToUTC(tick_local: *const u64, tick_utc: *mut u64) -> i32;
     pub fn sceRtcIsLeapYear(year: i32) -> i32;
     pub fn sceRtcGetDaysInMonth(year: i32, month: i32) -> i32;
     pub fn sceRtcGetDayOfWeek(year: i32, month: i32, day: i32) -> i32;
@@ -3526,106 +3292,43 @@ extern "C" {
     pub fn sceRtcSetTick(date: *mut ScePspDateTime, tick: *const u64) -> i32;
     pub fn sceRtcGetTick(date: *const ScePspDateTime, tick: *mut u64) -> i32;
     pub fn sceRtcCompareTick(tick1: *const u64, tick2: *const u64) -> i32;
-    pub fn sceRtcTickAddTicks(
-        dest_tick: *mut u64,
-        src_tick: *const u64,
-        num_ticks: u64,
-    ) -> i32;
-    pub fn sceRtcTickAddMicroseconds(
-        dest_tick: *mut u64,
-        src_tick: *const u64,
-        num_ms: u64,
-    ) -> i32;
-    pub fn sceRtcTickAddSeconds(
-        dest_tick: *mut u64,
-        src_tick: *const u64,
-        num_seconds: u64,
-    ) -> i32;
-    pub fn sceRtcTickAddMinutes(
-        dest_tick: *mut u64,
-        src_tick: *const u64,
-        num_minutes: u64,
-    ) -> i32;
-    pub fn sceRtcTickAddHours(
-        dest_tick: *mut u64,
-        src_tick: *const u64,
-        num_hours: u64,
-    ) -> i32;
-    pub fn sceRtcTickAddDays(
-        dest_tick: *mut u64,
-        src_tick: *const u64,
-        num_days: u64,
-    ) -> i32;
-    pub fn sceRtcTickAddWeeks(
-        dest_tick: *mut u64,
-        src_tick: *const u64,
-        num_weeks: u64,
-    ) -> i32;
-    pub fn sceRtcTickAddMonths(
-        dest_tick: *mut u64,
-        src_tick: *const u64,
-        num_months: u64,
-    ) -> i32;
-    pub fn sceRtcTickAddYears(
-        dest_tick: *mut u64,
-        src_tick: *const u64,
-        num_years: u64,
-    ) -> i32;
-    pub fn sceRtcSetTime_t(date: *mut ScePspDateTime, time: u32) -> i32;
-    pub fn sceRtcGetTime_t(date: *const ScePspDateTime, time: *mut u32)
+    pub fn sceRtcTickAddTicks(dest_tick: *mut u64, src_tick: *const u64, num_ticks: u64) -> i32;
+    pub fn sceRtcTickAddMicroseconds(dest_tick: *mut u64, src_tick: *const u64, num_ms: u64)
         -> i32;
+    pub fn sceRtcTickAddSeconds(dest_tick: *mut u64, src_tick: *const u64, num_seconds: u64)
+        -> i32;
+    pub fn sceRtcTickAddMinutes(dest_tick: *mut u64, src_tick: *const u64, num_minutes: u64)
+        -> i32;
+    pub fn sceRtcTickAddHours(dest_tick: *mut u64, src_tick: *const u64, num_hours: u64) -> i32;
+    pub fn sceRtcTickAddDays(dest_tick: *mut u64, src_tick: *const u64, num_days: u64) -> i32;
+    pub fn sceRtcTickAddWeeks(dest_tick: *mut u64, src_tick: *const u64, num_weeks: u64) -> i32;
+    pub fn sceRtcTickAddMonths(dest_tick: *mut u64, src_tick: *const u64, num_months: u64) -> i32;
+    pub fn sceRtcTickAddYears(dest_tick: *mut u64, src_tick: *const u64, num_years: u64) -> i32;
+    pub fn sceRtcSetTime_t(date: *mut ScePspDateTime, time: u32) -> i32;
+    pub fn sceRtcGetTime_t(date: *const ScePspDateTime, time: *mut u32) -> i32;
     pub fn sceRtcSetTime64_t(date: *mut ScePspDateTime, time: u64) -> i32;
-    pub fn sceRtcGetTime64_t(
-        date: *const ScePspDateTime,
-        time: *mut u64,
-    ) -> i32;
+    pub fn sceRtcGetTime64_t(date: *const ScePspDateTime, time: *mut u64) -> i32;
     pub fn sceRtcSetDosTime(date: *mut ScePspDateTime, dos_time: u32) -> i32;
     pub fn sceRtcGetDosTime(date: *mut ScePspDateTime, dos_time: u32) -> i32;
-    pub fn sceRtcSetWin32FileTime(
-        date: *mut ScePspDateTime,
-        time: *mut u64,
-    ) -> i32;
-    pub fn sceRtcGetWin32FileTime(
-        date: *mut ScePspDateTime,
-        time: *mut u64,
-    ) -> i32;
-    pub fn sceRtcParseDateTime(
-        dest_tick: *mut u64,
-        date_string: *const u8,
-    ) -> i32;
+    pub fn sceRtcSetWin32FileTime(date: *mut ScePspDateTime, time: *mut u64) -> i32;
+    pub fn sceRtcGetWin32FileTime(date: *mut ScePspDateTime, time: *mut u64) -> i32;
+    pub fn sceRtcParseDateTime(dest_tick: *mut u64, date_string: *const u8) -> i32;
     pub fn sceRtcFormatRFC3339(
         psz_date_time: *mut char,
         p_utc: *const u64,
         time_zone_minutes: i32,
     ) -> i32;
-    pub fn sceRtcFormatRFC3339LocalTime(
-        psz_date_time: *mut char,
-        p_utc: *const u64,
-    ) -> i32;
-    pub fn sceRtcParseRFC3339(
-        p_utc: *mut u64,
-        psz_date_time: *const u8,
-    ) -> i32;
+    pub fn sceRtcFormatRFC3339LocalTime(psz_date_time: *mut char, p_utc: *const u64) -> i32;
+    pub fn sceRtcParseRFC3339(p_utc: *mut u64, psz_date_time: *const u8) -> i32;
     pub fn sceRtcFormatRFC2822(
         psz_date_time: *mut char,
         p_utc: *const u64,
         time_zone_minutes: i32,
     ) -> i32;
-    pub fn sceRtcFormatRFC2822LocalTime(
-        psz_date_time: *mut char,
-        p_utc: *const u64,
-    ) -> i32;
+    pub fn sceRtcFormatRFC2822LocalTime(psz_date_time: *mut char, p_utc: *const u64) -> i32;
 
-    pub fn sceIoOpen(
-        file: *const u8,
-        flags: i32,
-        permissions: IoPermissions,
-    ) -> SceUid;
-    pub fn sceIoOpenAsync(
-        file: *const u8,
-        flags: i32,
-        permissions: IoPermissions,
-    ) -> SceUid;
+    pub fn sceIoOpen(file: *const u8, flags: i32, permissions: IoPermissions) -> SceUid;
+    pub fn sceIoOpenAsync(file: *const u8, flags: i32, permissions: IoPermissions) -> SceUid;
     pub fn sceIoClose(fd: SceUid) -> i32;
     pub fn sceIoCloseAsync(fd: SceUid) -> i32;
     pub fn sceIoRead(fd: SceUid, data: *mut c_void, size: u32) -> i32;
@@ -3635,8 +3338,7 @@ extern "C" {
     pub fn sceIoLseek(fd: SceUid, offset: i64, whence: IoWhence) -> i64;
     pub fn sceIoLseekAsync(fd: SceUid, offset: i64, whence: IoWhence) -> i32;
     pub fn sceIoLseek32(fd: SceUid, offset: i32, whence: IoWhence) -> i32;
-    pub fn sceIoLseek32Async(fd: SceUid, offset: i32, whence: IoWhence)
-        -> i32;
+    pub fn sceIoLseek32Async(fd: SceUid, offset: i32, whence: IoWhence) -> i32;
     pub fn sceIoRemove(file: *const u8) -> i32;
     pub fn sceIoMkdir(dir: *const u8, mode: IoPermissions) -> i32;
     pub fn sceIoRmdir(path: *const u8) -> i32;
@@ -3663,11 +3365,7 @@ extern "C" {
     ) -> i32;
     pub fn sceIoUnassign(dev: *const u8) -> i32;
     pub fn sceIoGetstat(file: *const u8, stat: *mut SceIoStat) -> i32;
-    pub fn sceIoChstat(
-        file: *const u8,
-        stat: *mut SceIoStat,
-        bits: i32,
-    ) -> i32;
+    pub fn sceIoChstat(file: *const u8, stat: *mut SceIoStat, bits: i32) -> i32;
     pub fn sceIoIoctl(
         fd: SceUid,
         cmd: u32,
@@ -3692,22 +3390,13 @@ extern "C" {
     pub fn sceIoCancel(fd: SceUid) -> i32;
     pub fn sceIoGetDevType(fd: SceUid) -> i32;
     pub fn sceIoChangeAsyncPriority(fd: SceUid, pri: i32) -> i32;
-    pub fn sceIoSetAsyncCallback(
-        fd: SceUid,
-        cb: SceUid,
-        argp: *mut c_void,
-    ) -> i32;
+    pub fn sceIoSetAsyncCallback(fd: SceUid, cb: SceUid, argp: *mut c_void) -> i32;
 
     pub fn sceJpegInitMJpeg() -> i32;
     pub fn sceJpegFinishMJpeg() -> i32;
     pub fn sceJpegCreateMJpeg(width: i32, height: i32) -> i32;
     pub fn sceJpegDeleteMJpeg() -> i32;
-    pub fn sceJpegDecodeMJpeg(
-        jpeg_buf: *mut u8,
-        size: usize,
-        rgba: *mut c_void,
-        unk: u32,
-    ) -> i32;
+    pub fn sceJpegDecodeMJpeg(jpeg_buf: *mut u8, size: usize, rgba: *mut c_void, unk: u32) -> i32;
 
     pub fn sceUmdCheckMedium() -> i32;
     pub fn sceUmdGetDiscInfo(info: *mut UmdInfo) -> i32;
@@ -3736,9 +3425,7 @@ extern "C" {
         cb_param: *mut c_void,
     ) -> i32;
     pub fn sceMpegRingbufferDestruct(ringbuffer: *mut SceMpegRingbuffer);
-    pub fn sceMpegRingbufferAvailableSize(
-        ringbuffer: *mut SceMpegRingbuffer,
-    ) -> i32;
+    pub fn sceMpegRingbufferAvailableSize(ringbuffer: *mut SceMpegRingbuffer) -> i32;
     pub fn sceMpegRingbufferPut(
         ringbuffer: *mut SceMpegRingbuffer,
         num_packets: i32,
@@ -3755,41 +3442,22 @@ extern "C" {
         unk2: i32,
     ) -> i32;
     pub fn sceMpegDelete(handle: SceMpeg);
-    pub fn sceMpegQueryStreamOffset(
-        handle: SceMpeg,
-        buffer: *mut c_void,
-        offset: *mut i32,
-    ) -> i32;
+    pub fn sceMpegQueryStreamOffset(handle: SceMpeg, buffer: *mut c_void, offset: *mut i32) -> i32;
     pub fn sceMpegQueryStreamSize(buffer: *mut c_void, size: *mut i32) -> i32;
-    pub fn sceMpegRegistStream(
-        handle: SceMpeg,
-        stream_id: i32,
-        unk: i32,
-    ) -> SceMpegStream;
+    pub fn sceMpegRegistStream(handle: SceMpeg, stream_id: i32, unk: i32) -> SceMpegStream;
     pub fn sceMpegUnRegistStream(handle: SceMpeg, stream: SceMpegStream);
     pub fn sceMpegFlushAllStream(handle: SceMpeg) -> i32;
     pub fn sceMpegMallocAvcEsBuf(handle: SceMpeg) -> *mut c_void;
     pub fn sceMpegFreeAvcEsBuf(handle: SceMpeg, buf: *mut c_void);
-    pub fn sceMpegQueryAtracEsSize(
-        handle: SceMpeg,
-        es_size: *mut i32,
-        out_size: *mut i32,
-    ) -> i32;
-    pub fn sceMpegInitAu(
-        handle: SceMpeg,
-        es_buffer: *mut c_void,
-        au: *mut SceMpegAu,
-    ) -> i32;
+    pub fn sceMpegQueryAtracEsSize(handle: SceMpeg, es_size: *mut i32, out_size: *mut i32) -> i32;
+    pub fn sceMpegInitAu(handle: SceMpeg, es_buffer: *mut c_void, au: *mut SceMpegAu) -> i32;
     pub fn sceMpegGetAvcAu(
         handle: SceMpeg,
         stream: SceMpegStream,
         au: *mut SceMpegAu,
         unk: *mut i32,
     ) -> i32;
-    pub fn sceMpegAvcDecodeMode(
-        handle: SceMpeg,
-        mode: *mut SceMpegAvcMode,
-    ) -> i32;
+    pub fn sceMpegAvcDecodeMode(handle: SceMpeg, mode: *mut SceMpegAvcMode) -> i32;
     pub fn sceMpegAvcDecode(
         handle: SceMpeg,
         au: *mut SceMpegAu,
@@ -3816,11 +3484,7 @@ extern "C" {
         init: i32,
     ) -> i32;
 
-    pub fn sceMpegBaseYCrCbCopyVme(
-        yuv_buffer: *mut c_void,
-        buffer: *mut i32,
-        type_: i32,
-    ) -> i32;
+    pub fn sceMpegBaseYCrCbCopyVme(yuv_buffer: *mut c_void, buffer: *mut i32, type_: i32) -> i32;
     pub fn sceMpegBaseCscInit(width: i32) -> i32;
     pub fn sceMpegBaseCscVme(
         rgb_buffer: *mut c_void,
@@ -3838,22 +3502,9 @@ extern "C" {
     pub fn sceHprmIsMicrophoneExist() -> i32;
 
     pub fn sceGuDepthBuffer(zbp: *mut c_void, zbw: i32);
-    pub fn sceGuDispBuffer(
-        width: i32,
-        height: i32,
-        dispbp: *mut c_void,
-        dispbw: i32,
-    );
-    pub fn sceGuDrawBuffer(
-        psm: DisplayPixelFormat,
-        fbp: *mut c_void,
-        fbw: i32,
-    );
-    pub fn sceGuDrawBufferList(
-        psm: DisplayPixelFormat,
-        fbp: *mut c_void,
-        fbw: i32,
-    );
+    pub fn sceGuDispBuffer(width: i32, height: i32, dispbp: *mut c_void, dispbw: i32);
+    pub fn sceGuDrawBuffer(psm: DisplayPixelFormat, fbp: *mut c_void, fbw: i32);
+    pub fn sceGuDrawBufferList(psm: DisplayPixelFormat, fbp: *mut c_void, fbw: i32);
     pub fn sceGuDisplay(state: bool) -> bool;
     pub fn sceGuDepthFunc(function: DepthFunc);
     pub fn sceGuDepthMask(mask: i32);
@@ -3864,10 +3515,7 @@ extern "C" {
     pub fn sceGuTerm();
     pub fn sceGuBreak(mode: i32);
     pub fn sceGuContinue();
-    pub fn sceGuSetCallback(
-        signal: GuCallbackId,
-        callback: GuCallback,
-    ) -> GuCallback;
+    pub fn sceGuSetCallback(signal: GuCallbackId, callback: GuCallback) -> GuCallback;
     pub fn sceGuSignal(behavior: SignalBehavior, signal: i32);
     pub fn sceGuSendCommandf(cmd: GeCommand, argument: f32);
     pub fn sceGuSendCommandi(cmd: GeCommand, argument: i32);
@@ -3878,16 +3526,9 @@ extern "C" {
     pub fn sceGuCallList(list: *const c_void);
     pub fn sceGuCallMode(mode: i32);
     pub fn sceGuCheckList() -> i32;
-    pub fn sceGuSendList(
-        mode: GuQueueMode,
-        list: *const c_void,
-        context: *mut GeContext,
-    );
+    pub fn sceGuSendList(mode: GuQueueMode, list: *const c_void, context: *mut GeContext);
     pub fn sceGuSwapBuffers() -> *mut c_void;
-    pub fn sceGuSync(
-        mode: GuSyncMode,
-        behavior: GuSyncBehavior,
-    ) -> GeListState;
+    pub fn sceGuSync(mode: GuSyncMode, behavior: GuSyncBehavior) -> GeListState;
     pub fn sceGuDrawArray(
         prim: GuPrimitive,
         vtype: i32,
@@ -3908,21 +3549,11 @@ extern "C" {
     pub fn sceGuGetAllStatus() -> i32;
     pub fn sceGuEnable(state: GuState);
     pub fn sceGuDisable(state: GuState);
-    pub fn sceGuLight(
-        light: i32,
-        type_: LightType,
-        components: i32,
-        position: &ScePspFVector3,
-    );
+    pub fn sceGuLight(light: i32, type_: LightType, components: i32, position: &ScePspFVector3);
     pub fn sceGuLightAtt(light: i32, atten0: f32, atten1: f32, atten2: f32);
     pub fn sceGuLightColor(light: i32, component: i32, color: u32);
     pub fn sceGuLightMode(mode: LightMode);
-    pub fn sceGuLightSpot(
-        light: i32,
-        direction: &ScePspFVector3,
-        exponent: f32,
-        cutoff: f32,
-    );
+    pub fn sceGuLightSpot(light: i32, direction: &ScePspFVector3, exponent: f32, cutoff: f32);
     pub fn sceGuClear(flags: i32);
     pub fn sceGuClearColor(color: u32);
     pub fn sceGuClearDepth(depth: u32);
@@ -3934,26 +3565,11 @@ extern "C" {
     pub fn sceGuAlphaFunc(func: AlphaFunc, value: i32, mask: i32);
     pub fn sceGuAmbient(color: u32);
     pub fn sceGuAmbientColor(color: u32);
-    pub fn sceGuBlendFunc(
-        op: BlendOp,
-        src: BlendSrc,
-        dest: BlendDst,
-        src_fix: u32,
-        dest_fix: u32,
-    );
+    pub fn sceGuBlendFunc(op: BlendOp, src: BlendSrc, dest: BlendDst, src_fix: u32, dest_fix: u32);
     pub fn sceGuMaterial(components: i32, color: u32);
-    pub fn sceGuModelColor(
-        emissive: u32,
-        ambient: u32,
-        diffuse: u32,
-        specular: u32,
-    );
+    pub fn sceGuModelColor(emissive: u32, ambient: u32, diffuse: u32, specular: u32);
     pub fn sceGuStencilFunc(func: StencilFunc, ref_: i32, mask: i32);
-    pub fn sceGuStencilOp(
-        fail: StencilOperation,
-        zfail: StencilOperation,
-        zpass: StencilOperation,
-    );
+    pub fn sceGuStencilOp(fail: StencilOperation, zfail: StencilOperation, zpass: StencilOperation);
     pub fn sceGuSpecular(power: f32);
     pub fn sceGuFrontFace(order: FrontFaceDirection);
     pub fn sceGuLogicalOp(op: LogicalOperation);
@@ -3985,12 +3601,7 @@ extern "C" {
     );
     pub fn sceGuTexLevelMode(mode: TextureLevelMode, bias: f32);
     pub fn sceGuTexMapMode(mode: TextureMapMode, a1: u32, a2: u32);
-    pub fn sceGuTexMode(
-        tpsm: TexturePixelFormat,
-        maxmips: i32,
-        a2: i32,
-        swizzle: i32,
-    );
+    pub fn sceGuTexMode(tpsm: TexturePixelFormat, maxmips: i32, a2: i32, swizzle: i32);
     pub fn sceGuTexOffset(u: f32, v: f32);
     pub fn sceGuTexProjMapMode(mode: TextureProjectionMapMode);
     pub fn sceGuTexScale(u: f32, v: f32);
@@ -3998,12 +3609,7 @@ extern "C" {
     pub fn sceGuTexSync();
     pub fn sceGuTexWrap(u: GuTexWrapMode, v: GuTexWrapMode);
     pub fn sceGuClutLoad(num_blocks: i32, cbp: *const c_void);
-    pub fn sceGuClutMode(
-        cpsm: ClutPixelFormat,
-        shift: u32,
-        mask: u32,
-        a3: u32,
-    );
+    pub fn sceGuClutMode(cpsm: ClutPixelFormat, shift: u32, mask: u32, a3: u32);
     pub fn sceGuOffset(x: u32, y: u32);
     pub fn sceGuScissor(x: i32, y: i32, w: i32, h: i32);
     pub fn sceGuViewport(cx: i32, cy: i32, width: i32, height: i32);
@@ -4073,21 +3679,10 @@ extern "C" {
     pub fn sceGumFullInverse();
     pub fn sceGumLoadIdentity();
     pub fn sceGumLoadMatrix(m: &ScePspFMatrix4);
-    pub fn sceGumLookAt(
-        eye: &ScePspFVector3,
-        center: &ScePspFVector3,
-        up: &ScePspFVector3,
-    );
+    pub fn sceGumLookAt(eye: &ScePspFVector3, center: &ScePspFVector3, up: &ScePspFVector3);
     pub fn sceGumMatrixMode(mode: MatrixMode);
     pub fn sceGumMultMatrix(m: &ScePspFMatrix4);
-    pub fn sceGumOrtho(
-        left: f32,
-        right: f32,
-        bottom: f32,
-        top: f32,
-        near: f32,
-        far: f32,
-    );
+    pub fn sceGumOrtho(left: f32, right: f32, bottom: f32, top: f32, near: f32, far: f32);
     pub fn sceGumPerspective(fovy: f32, aspect: f32, near: f32, far: f32);
     pub fn sceGumPopMatrix();
     pub fn sceGumPushMatrix();
@@ -4124,11 +3719,7 @@ extern "C" {
     pub fn sceMp3GetMp3ChannelNum(handle: Mp3Handle) -> i32;
     pub fn sceMp3ResetPlayPosition(handle: Mp3Handle) -> i32;
 
-    pub fn sceRegOpenRegistry(
-        reg: *mut Key,
-        mode: i32,
-        handle: *mut RegHandle,
-    ) -> i32;
+    pub fn sceRegOpenRegistry(reg: *mut Key, mode: i32, handle: *mut RegHandle) -> i32;
     pub fn sceRegFlushRegistry(handle: RegHandle) -> i32;
     pub fn sceRegCloseRegistry(handle: RegHandle) -> i32;
     pub fn sceRegOpenCategory(
@@ -4172,21 +3763,13 @@ extern "C" {
         size: usize,
     ) -> i32;
     pub fn sceRegGetKeysNum(dir_handle: RegHandle, num: *mut i32) -> i32;
-    pub fn sceRegGetKeys(dir_handle: RegHandle, buf: *mut u8, num: i32)
-        -> i32;
-    pub fn sceRegCreateKey(
-        dir_handle: RegHandle,
-        name: *const u8,
-        type_: i32,
-        size: usize,
-    ) -> i32;
+    pub fn sceRegGetKeys(dir_handle: RegHandle, buf: *mut u8, num: i32) -> i32;
+    pub fn sceRegCreateKey(dir_handle: RegHandle, name: *const u8, type_: i32, size: usize) -> i32;
     pub fn sceRegRemoveRegistry(key: *mut Key) -> i32;
 
     pub fn sceOpenPSIDGetOpenPSID(openpsid: *mut OpenPSID) -> i32;
 
-    pub fn sceUtilityMsgDialogInitStart(
-        params: *mut UtilityMsgDialogParams,
-    ) -> i32;
+    pub fn sceUtilityMsgDialogInitStart(params: *mut UtilityMsgDialogParams) -> i32;
     pub fn sceUtilityMsgDialogShutdownStart();
     pub fn sceUtilityMsgDialogGetStatus() -> i32;
     pub fn sceUtilityMsgDialogUpdate(n: i32);
@@ -4196,43 +3779,23 @@ extern "C" {
     pub fn sceUtilityNetconfUpdate(unknown: i32) -> i32;
     pub fn sceUtilityNetconfGetStatus() -> i32;
     pub fn sceUtilityCheckNetParam(id: i32) -> i32;
-    pub fn sceUtilityGetNetParam(
-        conf: i32,
-        param: NetParam,
-        data: *mut UtilityNetData,
-    ) -> i32;
-    pub fn sceUtilitySavedataInitStart(
-        params: *mut SceUtilitySavedataParam,
-    ) -> i32;
+    pub fn sceUtilityGetNetParam(conf: i32, param: NetParam, data: *mut UtilityNetData) -> i32;
+    pub fn sceUtilitySavedataInitStart(params: *mut SceUtilitySavedataParam) -> i32;
     pub fn sceUtilitySavedataGetStatus() -> i32;
     pub fn sceUtilitySavedataShutdownStart() -> i32;
     pub fn sceUtilitySavedataUpdate(unknown: i32);
-    pub fn sceUtilityGameSharingInitStart(
-        params: *mut UtilityGameSharingParams,
-    ) -> i32;
+    pub fn sceUtilityGameSharingInitStart(params: *mut UtilityGameSharingParams) -> i32;
     pub fn sceUtilityGameSharingShutdownStart();
     pub fn sceUtilityGameSharingGetStatus() -> i32;
     pub fn sceUtilityGameSharingUpdate(n: i32);
-    pub fn sceUtilityHtmlViewerInitStart(
-        params: *mut UtilityHtmlViewerParam,
-    ) -> i32;
+    pub fn sceUtilityHtmlViewerInitStart(params: *mut UtilityHtmlViewerParam) -> i32;
     pub fn sceUtilityHtmlViewerShutdownStart() -> i32;
     pub fn sceUtilityHtmlViewerUpdate(n: i32) -> i32;
     pub fn sceUtilityHtmlViewerGetStatus() -> i32;
     pub fn sceUtilitySetSystemParamInt(id: SystemParamId, value: i32) -> i32;
-    pub fn sceUtilitySetSystemParamString(
-        id: SystemParamId,
-        str: *const u8,
-    ) -> i32;
-    pub fn sceUtilityGetSystemParamInt(
-        id: SystemParamId,
-        value: *mut i32,
-    ) -> i32;
-    pub fn sceUtilityGetSystemParamString(
-        id: SystemParamId,
-        str: *mut u8,
-        len: i32,
-    ) -> i32;
+    pub fn sceUtilitySetSystemParamString(id: SystemParamId, str: *const u8) -> i32;
+    pub fn sceUtilityGetSystemParamInt(id: SystemParamId, value: *mut i32) -> i32;
+    pub fn sceUtilityGetSystemParamString(id: SystemParamId, str: *mut u8, len: i32) -> i32;
     pub fn sceUtilityOskInitStart(params: *mut SceUtilityOskParams) -> i32;
     pub fn sceUtilityOskShutdownStart() -> i32;
     pub fn sceUtilityOskUpdate(n: i32) -> i32;
@@ -4291,48 +3854,29 @@ extern "C" {
         timeout: u32,
         unknown: i32,
     ) -> i32;
-    pub fn sceNetAdhocctlGetGameModeInfo(
-        gamemodeinfo: *mut SceNetAdhocctlGameModeInfo,
-    ) -> i32;
+    pub fn sceNetAdhocctlGetGameModeInfo(gamemodeinfo: *mut SceNetAdhocctlGameModeInfo) -> i32;
     pub fn sceNetAdhocctlExitGameMode() -> i32;
-    pub fn sceNetAdhocctlGetPeerList(
-        length: *mut i32,
-        buf: *mut c_void,
-    ) -> i32;
+    pub fn sceNetAdhocctlGetPeerList(length: *mut i32, buf: *mut c_void) -> i32;
     pub fn sceNetAdhocctlGetPeerInfo(
         mac: *mut u8,
         size: i32,
         peerinfo: *mut SceNetAdhocctlPeerInfo,
     ) -> i32;
     pub fn sceNetAdhocctlScan() -> i32;
-    pub fn sceNetAdhocctlGetScanInfo(
-        length: *mut i32,
-        buf: *mut c_void,
-    ) -> i32;
-    pub fn sceNetAdhocctlAddHandler(
-        handler: SceNetAdhocctlHandler,
-        unknown: *mut c_void,
-    ) -> i32;
+    pub fn sceNetAdhocctlGetScanInfo(length: *mut i32, buf: *mut c_void) -> i32;
+    pub fn sceNetAdhocctlAddHandler(handler: SceNetAdhocctlHandler, unknown: *mut c_void) -> i32;
     pub fn sceNetAdhocctlDelHandler(id: i32) -> i32;
-    pub fn sceNetAdhocctlGetNameByAddr(mac: *mut u8, nickname: *mut u8)
-        -> i32;
+    pub fn sceNetAdhocctlGetNameByAddr(mac: *mut u8, nickname: *mut u8) -> i32;
     pub fn sceNetAdhocctlGetAddrByName(
         nickname: *mut u8,
         length: *mut i32,
         buf: *mut c_void,
     ) -> i32;
-    pub fn sceNetAdhocctlGetParameter(
-        params: *mut SceNetAdhocctlParams,
-    ) -> i32;
+    pub fn sceNetAdhocctlGetParameter(params: *mut SceNetAdhocctlParams) -> i32;
 
     pub fn sceNetAdhocInit() -> i32;
     pub fn sceNetAdhocTerm() -> i32;
-    pub fn sceNetAdhocPdpCreate(
-        mac: *mut u8,
-        port: u16,
-        buf_size: u32,
-        unk1: i32,
-    ) -> i32;
+    pub fn sceNetAdhocPdpCreate(mac: *mut u8, port: u16, buf_size: u32, unk1: i32) -> i32;
     pub fn sceNetAdhocPdpDelete(id: i32, unk1: i32) -> i32;
     pub fn sceNetAdhocPdpSend(
         id: i32,
@@ -4352,19 +3896,9 @@ extern "C" {
         timeout: u32,
         nonblock: i32,
     ) -> i32;
-    pub fn sceNetAdhocGetPdpStat(
-        size: *mut i32,
-        stat: *mut SceNetAdhocPdpStat,
-    ) -> i32;
-    pub fn sceNetAdhocGameModeCreateMaster(
-        data: *mut c_void,
-        size: i32,
-    ) -> i32;
-    pub fn sceNetAdhocGameModeCreateReplica(
-        mac: *mut u8,
-        data: *mut c_void,
-        size: i32,
-    ) -> i32;
+    pub fn sceNetAdhocGetPdpStat(size: *mut i32, stat: *mut SceNetAdhocPdpStat) -> i32;
+    pub fn sceNetAdhocGameModeCreateMaster(data: *mut c_void, size: i32) -> i32;
+    pub fn sceNetAdhocGameModeCreateReplica(mac: *mut u8, data: *mut c_void, size: i32) -> i32;
     pub fn sceNetAdhocGameModeUpdateMaster() -> i32;
     pub fn sceNetAdhocGameModeUpdateReplica(id: i32, unk1: i32) -> i32;
     pub fn sceNetAdhocGameModeDeleteMaster() -> i32;
@@ -4412,10 +3946,7 @@ extern "C" {
     ) -> i32;
     pub fn sceNetAdhocPtpFlush(id: i32, timeout: u32, nonblock: i32) -> i32;
     pub fn sceNetAdhocPtpClose(id: i32, unk1: i32) -> i32;
-    pub fn sceNetAdhocGetPtpStat(
-        size: *mut i32,
-        stat: *mut SceNetAdhocPtpStat,
-    ) -> i32;
+    pub fn sceNetAdhocGetPtpStat(size: *mut i32, stat: *mut SceNetAdhocPtpStat) -> i32;
 }
 
 extern "C" {
@@ -4449,10 +3980,7 @@ extern "C" {
         opt_len: i32,
         opt_data: *mut c_void,
     ) -> i32;
-    pub fn sceNetAdhocMatchingCancelTarget(
-        matching_id: i32,
-        mac: *mut u8,
-    ) -> i32;
+    pub fn sceNetAdhocMatchingCancelTarget(matching_id: i32, mac: *mut u8) -> i32;
     pub fn sceNetAdhocMatchingCancelTargetWithOpt(
         matching_id: i32,
         mac: *mut u8,
@@ -4465,10 +3993,7 @@ extern "C" {
         data_len: i32,
         data: *mut c_void,
     ) -> i32;
-    pub fn sceNetAdhocMatchingAbortSendData(
-        matching_id: i32,
-        mac: *mut u8,
-    ) -> i32;
+    pub fn sceNetAdhocMatchingAbortSendData(matching_id: i32, mac: *mut u8) -> i32;
     pub fn sceNetAdhocMatchingSetHelloOpt(
         matching_id: i32,
         opt_len: i32,
@@ -4485,21 +4010,14 @@ extern "C" {
         buf: *mut c_void,
     ) -> i32;
     pub fn sceNetAdhocMatchingGetPoolMaxAlloc() -> i32;
-    pub fn sceNetAdhocMatchingGetPoolStat(poolstat: *mut AdhocPoolStat)
-        -> i32;
+    pub fn sceNetAdhocMatchingGetPoolStat(poolstat: *mut AdhocPoolStat) -> i32;
 }
 
 extern "C" {
     pub fn sceNetApctlInit(stack_size: i32, init_priority: i32) -> i32;
     pub fn sceNetApctlTerm() -> i32;
-    pub fn sceNetApctlGetInfo(
-        code: ApctlInfo,
-        pinfo: *mut SceNetApctlInfo,
-    ) -> i32;
-    pub fn sceNetApctlAddHandler(
-        handler: SceNetApctlHandler,
-        parg: *mut c_void,
-    ) -> i32;
+    pub fn sceNetApctlGetInfo(code: ApctlInfo, pinfo: *mut SceNetApctlInfo) -> i32;
+    pub fn sceNetApctlAddHandler(handler: SceNetApctlHandler, parg: *mut c_void) -> i32;
     pub fn sceNetApctlDelHandler(handler_id: i32) -> i32;
     pub fn sceNetApctlConnect(conn_index: i32) -> i32;
     pub fn sceNetApctlDisconnect() -> i32;
@@ -4507,21 +4025,9 @@ extern "C" {
 
     pub fn sceNetInetInit() -> i32;
     pub fn sceNetInetTerm() -> i32;
-    pub fn sceNetInetAccept(
-        s: i32,
-        addr: *mut sockaddr,
-        addr_len: *mut socklen_t,
-    ) -> i32;
-    pub fn sceNetInetBind(
-        s: i32,
-        my_addr: *const sockaddr,
-        addr_len: socklen_t,
-    ) -> i32;
-    pub fn sceNetInetConnect(
-        s: i32,
-        serv_addr: *const sockaddr,
-        addr_len: socklen_t,
-    ) -> i32;
+    pub fn sceNetInetAccept(s: i32, addr: *mut sockaddr, addr_len: *mut socklen_t) -> i32;
+    pub fn sceNetInetBind(s: i32, my_addr: *const sockaddr, addr_len: socklen_t) -> i32;
+    pub fn sceNetInetConnect(s: i32, serv_addr: *const sockaddr, addr_len: socklen_t) -> i32;
     pub fn sceNetInetGetsockopt(
         s: i32,
         level: i32,
@@ -4530,12 +4036,7 @@ extern "C" {
         optl_en: *mut socklen_t,
     ) -> i32;
     pub fn sceNetInetListen(s: i32, backlog: i32) -> i32;
-    pub fn sceNetInetRecv(
-        s: i32,
-        buf: *mut c_void,
-        len: usize,
-        flags: i32,
-    ) -> usize;
+    pub fn sceNetInetRecv(s: i32, buf: *mut c_void, len: usize, flags: i32) -> usize;
     pub fn sceNetInetRecvfrom(
         s: i32,
         buf: *mut c_void,
@@ -4544,12 +4045,7 @@ extern "C" {
         from: *mut sockaddr,
         from_len: *mut socklen_t,
     ) -> usize;
-    pub fn sceNetInetSend(
-        s: i32,
-        buf: *const c_void,
-        len: usize,
-        flags: i32,
-    ) -> usize;
+    pub fn sceNetInetSend(s: i32, buf: *const c_void, len: usize, flags: i32) -> usize;
     pub fn sceNetInetSendto(
         s: i32,
         buf: *const c_void,
@@ -4577,11 +4073,7 @@ extern "C" {
 
     pub fn sceHttpInit(unknown1: u32) -> i32;
     pub fn sceHttpEnd() -> i32;
-    pub fn sceHttpCreateTemplate(
-        agent: *mut u8,
-        unknown1: i32,
-        unknown2: i32,
-    ) -> i32;
+    pub fn sceHttpCreateTemplate(agent: *mut u8, unknown1: i32, unknown2: i32) -> i32;
     pub fn sceHttpDeleteTemplate(templateid: i32) -> i32;
     pub fn sceHttpCreateConnection(
         templateid: i32,
@@ -4590,11 +4082,7 @@ extern "C" {
         port: u16,
         unknown2: i32,
     ) -> i32;
-    pub fn sceHttpCreateConnectionWithURL(
-        templateid: i32,
-        url: *const u8,
-        unknown1: i32,
-    ) -> i32;
+    pub fn sceHttpCreateConnectionWithURL(templateid: i32, url: *const u8, unknown1: i32) -> i32;
     pub fn sceHttpDeleteConnection(connection_id: i32) -> i32;
     pub fn sceHttpCreateRequest(
         connection_id: i32,
@@ -4609,23 +4097,11 @@ extern "C" {
         content_length: u64,
     ) -> i32;
     pub fn sceHttpDeleteRequest(request_id: i32) -> i32;
-    pub fn sceHttpSendRequest(
-        request_id: i32,
-        data: *mut c_void,
-        data_size: u32,
-    ) -> i32;
+    pub fn sceHttpSendRequest(request_id: i32, data: *mut c_void, data_size: u32) -> i32;
     pub fn sceHttpAbortRequest(request_id: i32) -> i32;
-    pub fn sceHttpReadData(
-        request_id: i32,
-        data: *mut c_void,
-        data_size: u32,
-    ) -> i32;
-    pub fn sceHttpGetContentLength(
-        request_id: i32,
-        content_length: *mut u64,
-    ) -> i32;
-    pub fn sceHttpGetStatusCode(request_id: i32, status_code: *mut i32)
-        -> i32;
+    pub fn sceHttpReadData(request_id: i32, data: *mut c_void, data_size: u32) -> i32;
+    pub fn sceHttpGetContentLength(request_id: i32, content_length: *mut u64) -> i32;
+    pub fn sceHttpGetStatusCode(request_id: i32, status_code: *mut i32) -> i32;
     pub fn sceHttpSetResolveTimeOut(id: i32, timeout: u32) -> i32;
     pub fn sceHttpSetResolveRetry(id: i32, count: i32) -> i32;
     pub fn sceHttpSetConnectTimeOut(id: i32, timeout: u32) -> i32;
@@ -4639,19 +4115,9 @@ extern "C" {
     pub fn sceHttpDisableCookie(id: i32) -> i32;
     pub fn sceHttpSaveSystemCookie() -> i32;
     pub fn sceHttpLoadSystemCookie() -> i32;
-    pub fn sceHttpAddExtraHeader(
-        id: i32,
-        name: *mut u8,
-        value: *mut u8,
-        unknown1: i32,
-    ) -> i32;
+    pub fn sceHttpAddExtraHeader(id: i32, name: *mut u8, value: *mut u8, unknown1: i32) -> i32;
     pub fn sceHttpDeleteHeader(id: i32, name: *const u8) -> i32;
-    pub fn sceHttpsInit(
-        unknown1: i32,
-        unknown2: i32,
-        unknown3: i32,
-        unknown4: i32,
-    ) -> i32;
+    pub fn sceHttpsInit(unknown1: i32, unknown2: i32, unknown3: i32, unknown4: i32) -> i32;
     pub fn sceHttpsEnd() -> i32;
     pub fn sceHttpsLoadDefaultCert(unknown1: i32, unknown2: i32) -> i32;
     pub fn sceHttpDisableAuth(id: i32) -> i32;
@@ -4659,11 +4125,7 @@ extern "C" {
     pub fn sceHttpEnableAuth(id: i32) -> i32;
     pub fn sceHttpEnableCache(id: i32) -> i32;
     pub fn sceHttpEndCache() -> i32;
-    pub fn sceHttpGetAllHeader(
-        request: i32,
-        header: *mut *mut u8,
-        header_size: *mut u32,
-    ) -> i32;
+    pub fn sceHttpGetAllHeader(request: i32, header: *mut *mut u8, header_size: *mut u32) -> i32;
     pub fn sceHttpGetNetworkErrno(request: i32, err_num: *mut i32) -> i32;
     pub fn sceHttpGetProxy(
         id: i32,
@@ -4690,11 +4152,7 @@ extern "C" {
     ) -> i32;
 
     pub fn sceNetResolverInit() -> i32;
-    pub fn sceNetResolverCreate(
-        rid: *mut i32,
-        buf: *mut c_void,
-        buf_length: u32,
-    ) -> i32;
+    pub fn sceNetResolverCreate(rid: *mut i32, buf: *mut c_void, buf_length: u32) -> i32;
     pub fn sceNetResolverDelete(rid: i32) -> i32;
     pub fn sceNetResolverStartNtoA(
         rid: i32,

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -3039,11 +3039,8 @@ pub const AI_PASSIVE: ::c_int = 0x00000001;
 pub const AI_CANONNAME: ::c_int = 0x00000002;
 pub const AI_NUMERICHOST: ::c_int = 0x00000004;
 pub const AI_NUMERICSERV: ::c_int = 0x00001000;
-pub const AI_MASK: ::c_int = AI_PASSIVE
-    | AI_CANONNAME
-    | AI_NUMERICHOST
-    | AI_NUMERICSERV
-    | AI_ADDRCONFIG;
+pub const AI_MASK: ::c_int =
+    AI_PASSIVE | AI_CANONNAME | AI_NUMERICHOST | AI_NUMERICSERV | AI_ADDRCONFIG;
 pub const AI_ALL: ::c_int = 0x00000100;
 pub const AI_V4MAPPED_CFG: ::c_int = 0x00000200;
 pub const AI_ADDRCONFIG: ::c_int = 0x00000400;
@@ -3451,11 +3448,7 @@ extern "C" {
     pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
     #[doc(hidden)]
     #[deprecated(since = "0.2.49", note = "Deprecated in MacOSX 10.10")]
-    pub fn sem_init(
-        sem: *mut sem_t,
-        pshared: ::c_int,
-        value: ::c_uint,
-    ) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t, pshared: ::c_int, value: ::c_uint) -> ::c_int;
     pub fn aio_read(aiocbp: *mut aiocb) -> ::c_int;
     pub fn aio_write(aiocbp: *mut aiocb) -> ::c_int;
     pub fn aio_fsync(op: ::c_int, aiocbp: *mut aiocb) -> ::c_int;
@@ -3504,11 +3497,7 @@ extern "C" {
         sevlen: ::socklen_t,
         flags: ::c_int,
     ) -> ::c_int;
-    pub fn mincore(
-        addr: *const ::c_void,
-        len: ::size_t,
-        vec: *mut ::c_char,
-    ) -> ::c_int;
+    pub fn mincore(addr: *const ::c_void, len: ::size_t, vec: *mut ::c_char) -> ::c_int;
     pub fn sysctlnametomib(
         name: *const ::c_char,
         mibp: *mut ::c_int,
@@ -3518,44 +3507,23 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "mprotect$UNIX2003"
     )]
-    pub fn mprotect(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        prot: ::c_int,
-    ) -> ::c_int;
+    pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
     pub fn semget(key: key_t, nsems: ::c_int, semflg: ::c_int) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "semctl$UNIX2003"
     )]
-    pub fn semctl(
-        semid: ::c_int,
-        semnum: ::c_int,
-        cmd: ::c_int,
-        ...
-    ) -> ::c_int;
-    pub fn semop(
-        semid: ::c_int,
-        sops: *mut sembuf,
-        nsops: ::size_t,
-    ) -> ::c_int;
+    pub fn semctl(semid: ::c_int, semnum: ::c_int, cmd: ::c_int, ...) -> ::c_int;
+    pub fn semop(semid: ::c_int, sops: *mut sembuf, nsops: ::size_t) -> ::c_int;
     pub fn shm_open(name: *const ::c_char, oflag: ::c_int, ...) -> ::c_int;
     pub fn ftok(pathname: *const c_char, proj_id: ::c_int) -> key_t;
-    pub fn shmat(
-        shmid: ::c_int,
-        shmaddr: *const ::c_void,
-        shmflg: ::c_int,
-    ) -> *mut ::c_void;
+    pub fn shmat(shmid: ::c_int, shmaddr: *const ::c_void, shmflg: ::c_int) -> *mut ::c_void;
     pub fn shmdt(shmaddr: *const ::c_void) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "shmctl$UNIX2003"
     )]
-    pub fn shmctl(
-        shmid: ::c_int,
-        cmd: ::c_int,
-        buf: *mut ::shmid_ds,
-    ) -> ::c_int;
+    pub fn shmctl(shmid: ::c_int, cmd: ::c_int, buf: *mut ::shmid_ds) -> ::c_int;
     pub fn shmget(key: key_t, size: ::size_t, shmflg: ::c_int) -> ::c_int;
     pub fn sysctl(
         name: *mut ::c_int,
@@ -3578,18 +3546,11 @@ extern "C" {
     #[allow(deprecated)]
     pub fn mach_timebase_info(info: *mut ::mach_timebase_info) -> ::c_int;
     pub fn pthread_setname_np(name: *const ::c_char) -> ::c_int;
-    pub fn pthread_getname_np(
-        thread: ::pthread_t,
-        name: *mut ::c_char,
-        len: ::size_t,
-    ) -> ::c_int;
+    pub fn pthread_getname_np(thread: ::pthread_t, name: *mut ::c_char, len: ::size_t) -> ::c_int;
     pub fn pthread_from_mach_thread_np(port: ::mach_port_t) -> ::pthread_t;
     pub fn pthread_get_stackaddr_np(thread: ::pthread_t) -> *mut ::c_void;
     pub fn pthread_get_stacksize_np(thread: ::pthread_t) -> ::size_t;
-    pub fn pthread_condattr_setpshared(
-        attr: *mut pthread_condattr_t,
-        pshared: ::c_int,
-    ) -> ::c_int;
+    pub fn pthread_condattr_setpshared(attr: *mut pthread_condattr_t, pshared: ::c_int) -> ::c_int;
     pub fn pthread_condattr_getpshared(
         attr: *const pthread_condattr_t,
         pshared: *mut ::c_int,
@@ -3606,10 +3567,7 @@ extern "C" {
         attr: *const pthread_rwlockattr_t,
         val: *mut ::c_int,
     ) -> ::c_int;
-    pub fn pthread_rwlockattr_setpshared(
-        attr: *mut pthread_rwlockattr_t,
-        val: ::c_int,
-    ) -> ::c_int;
+    pub fn pthread_rwlockattr_setpshared(attr: *mut pthread_rwlockattr_t, val: ::c_int) -> ::c_int;
     pub fn __error() -> *mut ::c_int;
     pub fn backtrace(buf: *mut *mut ::c_void, sz: ::c_int) -> ::c_int;
     #[cfg_attr(
@@ -3645,12 +3603,7 @@ extern "C" {
         flags: ::c_int,
         data: *mut ::c_void,
     ) -> ::c_int;
-    pub fn ptrace(
-        request: ::c_int,
-        pid: ::pid_t,
-        addr: *mut ::c_char,
-        data: ::c_int,
-    ) -> ::c_int;
+    pub fn ptrace(request: ::c_int, pid: ::pid_t, addr: *mut ::c_char, data: ::c_int) -> ::c_int;
     pub fn quotactl(
         special: *const ::c_char,
         cmd: ::c_int,
@@ -3690,29 +3643,16 @@ extern "C" {
     pub fn duplocale(base: ::locale_t) -> ::locale_t;
     pub fn freelocale(loc: ::locale_t) -> ::c_int;
     pub fn localeconv_l(loc: ::locale_t) -> *mut lconv;
-    pub fn newlocale(
-        mask: ::c_int,
-        locale: *const ::c_char,
-        base: ::locale_t,
-    ) -> ::locale_t;
+    pub fn newlocale(mask: ::c_int, locale: *const ::c_char, base: ::locale_t) -> ::locale_t;
     pub fn uselocale(loc: ::locale_t) -> ::locale_t;
     pub fn querylocale(mask: ::c_int, loc: ::locale_t) -> *const ::c_char;
     pub fn getpriority(which: ::c_int, who: ::id_t) -> ::c_int;
     pub fn setpriority(which: ::c_int, who: ::id_t, prio: ::c_int) -> ::c_int;
     pub fn getdomainname(name: *mut ::c_char, len: ::c_int) -> ::c_int;
     pub fn setdomainname(name: *const ::c_char, len: ::c_int) -> ::c_int;
-    pub fn preadv(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-        offset: ::off_t,
-    ) -> ::ssize_t;
-    pub fn pwritev(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-        offset: ::off_t,
-    ) -> ::ssize_t;
+    pub fn preadv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t) -> ::ssize_t;
+    pub fn pwritev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t)
+        -> ::ssize_t;
     pub fn getxattr(
         path: *const ::c_char,
         name: *const ::c_char,
@@ -3757,16 +3697,8 @@ extern "C" {
         size: ::size_t,
         flags: ::c_int,
     ) -> ::ssize_t;
-    pub fn removexattr(
-        path: *const ::c_char,
-        name: *const ::c_char,
-        flags: ::c_int,
-    ) -> ::c_int;
-    pub fn renamex_np(
-        from: *const ::c_char,
-        to: *const ::c_char,
-        flags: ::c_uint,
-    ) -> ::c_int;
+    pub fn removexattr(path: *const ::c_char, name: *const ::c_char, flags: ::c_int) -> ::c_int;
+    pub fn renamex_np(from: *const ::c_char, to: *const ::c_char, flags: ::c_uint) -> ::c_int;
     pub fn renameatx_np(
         fromfd: ::c_int,
         from: *const ::c_char,
@@ -3774,11 +3706,7 @@ extern "C" {
         to: *const ::c_char,
         flags: ::c_uint,
     ) -> ::c_int;
-    pub fn fremovexattr(
-        filedes: ::c_int,
-        name: *const ::c_char,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn fremovexattr(filedes: ::c_int, name: *const ::c_char, flags: ::c_int) -> ::c_int;
 
     pub fn getgrouplist(
         name: *const ::c_char,
@@ -3792,18 +3720,11 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "waitid$UNIX2003"
     )]
-    pub fn waitid(
-        idtype: idtype_t,
-        id: id_t,
-        infop: *mut ::siginfo_t,
-        options: ::c_int,
-    ) -> ::c_int;
+    pub fn waitid(idtype: idtype_t, id: id_t, infop: *mut ::siginfo_t, options: ::c_int)
+        -> ::c_int;
     pub fn brk(addr: *const ::c_void) -> *mut ::c_void;
     pub fn sbrk(increment: ::c_int) -> *mut ::c_void;
-    pub fn settimeofday(
-        tv: *const ::timeval,
-        tz: *const ::timezone,
-    ) -> ::c_int;
+    pub fn settimeofday(tv: *const ::timeval, tz: *const ::timezone) -> ::c_int;
     #[deprecated(since = "0.2.55", note = "Use the mach crate")]
     pub fn _dyld_image_count() -> u32;
     #[deprecated(since = "0.2.55", note = "Use the mach crate")]
@@ -3852,25 +3773,15 @@ extern "C" {
         attr: *const posix_spawnattr_t,
         flags: *mut ::c_short,
     ) -> ::c_int;
-    pub fn posix_spawnattr_setflags(
-        attr: *mut posix_spawnattr_t,
-        flags: ::c_short,
-    ) -> ::c_int;
+    pub fn posix_spawnattr_setflags(attr: *mut posix_spawnattr_t, flags: ::c_short) -> ::c_int;
     pub fn posix_spawnattr_getpgroup(
         attr: *const posix_spawnattr_t,
         flags: *mut ::pid_t,
     ) -> ::c_int;
-    pub fn posix_spawnattr_setpgroup(
-        attr: *mut posix_spawnattr_t,
-        flags: ::pid_t,
-    ) -> ::c_int;
+    pub fn posix_spawnattr_setpgroup(attr: *mut posix_spawnattr_t, flags: ::pid_t) -> ::c_int;
 
-    pub fn posix_spawn_file_actions_init(
-        actions: *mut posix_spawn_file_actions_t,
-    ) -> ::c_int;
-    pub fn posix_spawn_file_actions_destroy(
-        actions: *mut posix_spawn_file_actions_t,
-    ) -> ::c_int;
+    pub fn posix_spawn_file_actions_init(actions: *mut posix_spawn_file_actions_t) -> ::c_int;
+    pub fn posix_spawn_file_actions_destroy(actions: *mut posix_spawn_file_actions_t) -> ::c_int;
     pub fn posix_spawn_file_actions_addopen(
         actions: *mut posix_spawn_file_actions_t,
         fd: ::c_int,
@@ -3899,11 +3810,7 @@ extern "C" {
         len: *mut ::size_t,
         connid: *mut sae_connid_t,
     ) -> ::c_int;
-    pub fn disconnectx(
-        socket: ::c_int,
-        associd: sae_associd_t,
-        connid: sae_connid_t,
-    ) -> ::c_int;
+    pub fn disconnectx(socket: ::c_int, associd: sae_associd_t, connid: sae_connid_t) -> ::c_int;
 
     pub fn ntp_adjtime(buf: *mut timex) -> ::c_int;
     pub fn ntp_gettime(buf: *mut ntptimeval) -> ::c_int;
@@ -3917,16 +3824,9 @@ extern "C" {
         all(target_os = "macos", not(target_arch = "aarch64")),
         link_name = "getfsstat$INODE64"
     )]
-    pub fn getfsstat(
-        mntbufp: *mut statfs,
-        bufsize: ::c_int,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn getfsstat(mntbufp: *mut statfs, bufsize: ::c_int, flags: ::c_int) -> ::c_int;
 
-    pub fn iconv_open(
-        tocode: *const ::c_char,
-        fromcode: *const ::c_char,
-    ) -> iconv_t;
+    pub fn iconv_open(tocode: *const ::c_char, fromcode: *const ::c_char) -> iconv_t;
     pub fn iconv(
         cd: iconv_t,
         inbuf: *mut *mut ::c_char,

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1067,18 +1067,11 @@ safe_f! {
 extern "C" {
     pub fn __errno_location() -> *mut ::c_int;
     pub fn setgrent();
-    pub fn mprotect(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        prot: ::c_int,
-    ) -> ::c_int;
+    pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
 
     pub fn setutxdb(_type: ::c_uint, file: *mut ::c_char) -> ::c_int;
 
-    pub fn aio_waitcomplete(
-        iocbp: *mut *mut aiocb,
-        timeout: *mut ::timespec,
-    ) -> ::c_int;
+    pub fn aio_waitcomplete(iocbp: *mut *mut aiocb, timeout: *mut ::timespec) -> ::c_int;
 
     pub fn waitid(
         idtype: idtype_t,

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
@@ -198,11 +198,7 @@ extern "C" {
 
     // Type of `addr` argument changed from `const void*` to `void*`
     // in FreeBSD 12
-    pub fn mprotect(
-        addr: *const ::c_void,
-        len: ::size_t,
-        prot: ::c_int,
-    ) -> ::c_int;
+    pub fn mprotect(addr: *const ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
 
     // Return type ::c_int was removed in FreeBSD 12
     pub fn freelocale(loc: ::locale_t) -> ::c_int;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -208,11 +208,7 @@ pub const ELAST: ::c_int = 96;
 
 extern "C" {
     pub fn setgrent();
-    pub fn mprotect(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        prot: ::c_int,
-    ) -> ::c_int;
+    pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
     pub fn freelocale(loc: ::locale_t);
     pub fn msgrcv(
         msqid: ::c_int,
@@ -230,11 +226,7 @@ extern "C" {
 
     pub fn fdatasync(fd: ::c_int) -> ::c_int;
 
-    pub fn getrandom(
-        buf: *mut ::c_void,
-        buflen: ::size_t,
-        flags: ::c_uint,
-    ) -> ::ssize_t;
+    pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
 }
 
 cfg_if! {

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -212,11 +212,7 @@ extern "C" {
     pub fn aio_readv(aiocbp: *mut ::aiocb) -> ::c_int;
     pub fn aio_writev(aiocbp: *mut ::aiocb) -> ::c_int;
     pub fn setgrent();
-    pub fn mprotect(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        prot: ::c_int,
-    ) -> ::c_int;
+    pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
     pub fn freelocale(loc: ::locale_t);
     pub fn msgrcv(
         msqid: ::c_int,
@@ -234,11 +230,7 @@ extern "C" {
 
     pub fn fdatasync(fd: ::c_int) -> ::c_int;
 
-    pub fn getrandom(
-        buf: *mut ::c_void,
-        buflen: ::size_t,
-        flags: ::c_uint,
-    ) -> ::ssize_t;
+    pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
 }
 
 cfg_if! {

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -771,10 +771,7 @@ pub const IFF_PROMISC: ::c_int = 0x100; // (n) receive all packets
 pub const IFF_ALLMULTI: ::c_int = 0x200; // (n) receive all multicast packets
 pub const IFF_OACTIVE: ::c_int = 0x400; // (d) tx hardware queue is full
 #[doc(hidden)]
-#[deprecated(
-    since = "0.2.54",
-    note = "Use the portable `IFF_OACTIVE` instead"
-)]
+#[deprecated(since = "0.2.54", note = "Use the portable `IFF_OACTIVE` instead")]
 pub const IFF_DRV_OACTIVE: ::c_int = 0x400;
 pub const IFF_SIMPLEX: ::c_int = 0x800; // (i) can't hear own transmissions
 pub const IFF_LINK0: ::c_int = 0x1000; // per link layer defined bit
@@ -1369,16 +1366,8 @@ extern "C" {
     pub fn jail(jail: *mut ::jail) -> ::c_int;
     pub fn jail_attach(jid: ::c_int) -> ::c_int;
     pub fn jail_remove(jid: ::c_int) -> ::c_int;
-    pub fn jail_get(
-        iov: *mut ::iovec,
-        niov: ::c_uint,
-        flags: ::c_int,
-    ) -> ::c_int;
-    pub fn jail_set(
-        iov: *mut ::iovec,
-        niov: ::c_uint,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn jail_get(iov: *mut ::iovec, niov: ::c_uint, flags: ::c_int) -> ::c_int;
+    pub fn jail_set(iov: *mut ::iovec, niov: ::c_uint, flags: ::c_int) -> ::c_int;
 
     pub fn lio_listio(
         mode: ::c_int,
@@ -1387,31 +1376,15 @@ extern "C" {
         sevp: *mut sigevent,
     ) -> ::c_int;
 
-    pub fn posix_fallocate(
-        fd: ::c_int,
-        offset: ::off_t,
-        len: ::off_t,
-    ) -> ::c_int;
-    pub fn posix_fadvise(
-        fd: ::c_int,
-        offset: ::off_t,
-        len: ::off_t,
-        advise: ::c_int,
-    ) -> ::c_int;
+    pub fn posix_fallocate(fd: ::c_int, offset: ::off_t, len: ::off_t) -> ::c_int;
+    pub fn posix_fadvise(fd: ::c_int, offset: ::off_t, len: ::off_t, advise: ::c_int) -> ::c_int;
     pub fn mkostemp(template: *mut ::c_char, flags: ::c_int) -> ::c_int;
-    pub fn mkostemps(
-        template: *mut ::c_char,
-        suffixlen: ::c_int,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn mkostemps(template: *mut ::c_char, suffixlen: ::c_int, flags: ::c_int) -> ::c_int;
 
     pub fn getutxuser(user: *const ::c_char) -> *mut utmpx;
     pub fn setutxdb(_type: ::c_int, file: *const ::c_char) -> ::c_int;
 
-    pub fn aio_waitcomplete(
-        iocbp: *mut *mut aiocb,
-        timeout: *mut ::timespec,
-    ) -> ::ssize_t;
+    pub fn aio_waitcomplete(iocbp: *mut *mut aiocb, timeout: *mut ::timespec) -> ::ssize_t;
     pub fn mq_getfd_np(mqd: ::mqd_t) -> ::c_int;
 
     pub fn waitid(
@@ -1423,22 +1396,10 @@ extern "C" {
 
     pub fn ftok(pathname: *const ::c_char, proj_id: ::c_int) -> ::key_t;
     pub fn shmget(key: ::key_t, size: ::size_t, shmflg: ::c_int) -> ::c_int;
-    pub fn shmat(
-        shmid: ::c_int,
-        shmaddr: *const ::c_void,
-        shmflg: ::c_int,
-    ) -> *mut ::c_void;
+    pub fn shmat(shmid: ::c_int, shmaddr: *const ::c_void, shmflg: ::c_int) -> *mut ::c_void;
     pub fn shmdt(shmaddr: *const ::c_void) -> ::c_int;
-    pub fn shmctl(
-        shmid: ::c_int,
-        cmd: ::c_int,
-        buf: *mut ::shmid_ds,
-    ) -> ::c_int;
-    pub fn msgctl(
-        msqid: ::c_int,
-        cmd: ::c_int,
-        buf: *mut ::msqid_ds,
-    ) -> ::c_int;
+    pub fn shmctl(shmid: ::c_int, cmd: ::c_int, buf: *mut ::shmid_ds) -> ::c_int;
+    pub fn msgctl(msqid: ::c_int, cmd: ::c_int, buf: *mut ::msqid_ds) -> ::c_int;
     pub fn msgget(key: ::key_t, msgflg: ::c_int) -> ::c_int;
     pub fn msgsnd(
         msqid: ::c_int,
@@ -1457,11 +1418,7 @@ extern "C" {
     pub fn pdgetpid(fd: ::c_int, pidp: *mut ::pid_t) -> ::c_int;
     pub fn pdkill(fd: ::c_int, signum: ::c_int) -> ::c_int;
 
-    pub fn rtprio_thread(
-        function: ::c_int,
-        lwpid: ::lwpid_t,
-        rtp: *mut super::rtprio,
-    ) -> ::c_int;
+    pub fn rtprio_thread(function: ::c_int, lwpid: ::lwpid_t, rtp: *mut super::rtprio) -> ::c_int;
 
     pub fn posix_spawn(
         pid: *mut ::pid_t,
@@ -1501,26 +1458,17 @@ extern "C" {
         attr: *const posix_spawnattr_t,
         flags: *mut ::c_short,
     ) -> ::c_int;
-    pub fn posix_spawnattr_setflags(
-        attr: *mut posix_spawnattr_t,
-        flags: ::c_short,
-    ) -> ::c_int;
+    pub fn posix_spawnattr_setflags(attr: *mut posix_spawnattr_t, flags: ::c_short) -> ::c_int;
     pub fn posix_spawnattr_getpgroup(
         attr: *const posix_spawnattr_t,
         flags: *mut ::pid_t,
     ) -> ::c_int;
-    pub fn posix_spawnattr_setpgroup(
-        attr: *mut posix_spawnattr_t,
-        flags: ::pid_t,
-    ) -> ::c_int;
+    pub fn posix_spawnattr_setpgroup(attr: *mut posix_spawnattr_t, flags: ::pid_t) -> ::c_int;
     pub fn posix_spawnattr_getschedpolicy(
         attr: *const posix_spawnattr_t,
         flags: *mut ::c_int,
     ) -> ::c_int;
-    pub fn posix_spawnattr_setschedpolicy(
-        attr: *mut posix_spawnattr_t,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn posix_spawnattr_setschedpolicy(attr: *mut posix_spawnattr_t, flags: ::c_int) -> ::c_int;
     pub fn posix_spawnattr_getschedparam(
         attr: *const posix_spawnattr_t,
         param: *mut ::sched_param,
@@ -1530,12 +1478,8 @@ extern "C" {
         param: *const ::sched_param,
     ) -> ::c_int;
 
-    pub fn posix_spawn_file_actions_init(
-        actions: *mut posix_spawn_file_actions_t,
-    ) -> ::c_int;
-    pub fn posix_spawn_file_actions_destroy(
-        actions: *mut posix_spawn_file_actions_t,
-    ) -> ::c_int;
+    pub fn posix_spawn_file_actions_init(actions: *mut posix_spawn_file_actions_t) -> ::c_int;
+    pub fn posix_spawn_file_actions_destroy(actions: *mut posix_spawn_file_actions_t) -> ::c_int;
     pub fn posix_spawn_file_actions_addopen(
         actions: *mut posix_spawn_file_actions_t,
         fd: ::c_int,
@@ -1553,15 +1497,9 @@ extern "C" {
         newfd: ::c_int,
     ) -> ::c_int;
 
-    #[cfg_attr(
-        all(target_os = "freebsd", freebsd11),
-        link_name = "statfs@FBSD_1.0"
-    )]
+    #[cfg_attr(all(target_os = "freebsd", freebsd11), link_name = "statfs@FBSD_1.0")]
     pub fn statfs(path: *const ::c_char, buf: *mut statfs) -> ::c_int;
-    #[cfg_attr(
-        all(target_os = "freebsd", freebsd11),
-        link_name = "fstatfs@FBSD_1.0"
-    )]
+    #[cfg_attr(all(target_os = "freebsd", freebsd11), link_name = "fstatfs@FBSD_1.0")]
     pub fn fstatfs(fd: ::c_int, buf: *mut statfs) -> ::c_int;
 
     pub fn dup3(src: ::c_int, dst: ::c_int, flags: ::c_int) -> ::c_int;
@@ -1587,11 +1525,7 @@ extern "C" {
         needlelen: ::size_t,
     ) -> *mut ::c_void;
 
-    pub fn nmount(
-        iov: *mut ::iovec,
-        niov: ::c_uint,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn nmount(iov: *mut ::iovec, niov: ::c_uint, flags: ::c_int) -> ::c_int;
 }
 
 #[link(name = "util")]

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -396,12 +396,15 @@ cfg_if! {
 }
 
 // Non-public helper constant
-#[cfg(all(not(libc_const_size_of), target_pointer_width = "32"))]
-const SIZEOF_LONG: usize = 4;
-#[cfg(all(not(libc_const_size_of), target_pointer_width = "64"))]
-const SIZEOF_LONG: usize = 8;
-#[cfg(libc_const_size_of)]
-const SIZEOF_LONG: usize = ::mem::size_of::<::c_long>();
+cfg_if! {
+    if #[cfg(all(not(libc_const_size_of), target_pointer_width = "32"))] {
+        const SIZEOF_LONG: usize = 4;
+    } else if #[cfg(all(not(libc_const_size_of), target_pointer_width = "64"))] {
+        const SIZEOF_LONG: usize = 8;
+    } else if #[cfg(libc_const_size_of)] {
+        const SIZEOF_LONG: usize = ::mem::size_of::<::c_long>();
+    }
+}
 
 #[deprecated(
     since = "0.2.64",
@@ -1359,11 +1362,7 @@ safe_f! {
 
 extern "C" {
     pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
-    pub fn sem_init(
-        sem: *mut sem_t,
-        pshared: ::c_int,
-        value: ::c_uint,
-    ) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t, pshared: ::c_int, value: ::c_uint) -> ::c_int;
 
     pub fn daemon(nochdir: ::c_int, noclose: ::c_int) -> ::c_int;
     pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::timezone) -> ::c_int;
@@ -1383,14 +1382,8 @@ extern "C" {
 
     pub fn clock_getres(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
     pub fn clock_gettime(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
-    pub fn clock_settime(
-        clk_id: ::clockid_t,
-        tp: *const ::timespec,
-    ) -> ::c_int;
-    pub fn clock_getcpuclockid(
-        pid: ::pid_t,
-        clk_id: *mut ::clockid_t,
-    ) -> ::c_int;
+    pub fn clock_settime(clk_id: ::clockid_t, tp: *const ::timespec) -> ::c_int;
+    pub fn clock_getcpuclockid(pid: ::pid_t, clk_id: *mut ::clockid_t) -> ::c_int;
 
     pub fn dirfd(dirp: *mut ::DIR) -> ::c_int;
     pub fn duplocale(base: ::locale_t) -> ::locale_t;
@@ -1444,16 +1437,8 @@ extern "C" {
     ) -> ::c_int;
     pub fn lchflags(path: *const ::c_char, flags: ::c_ulong) -> ::c_int;
     pub fn lutimes(file: *const ::c_char, times: *const ::timeval) -> ::c_int;
-    pub fn memrchr(
-        cx: *const ::c_void,
-        c: ::c_int,
-        n: ::size_t,
-    ) -> *mut ::c_void;
-    pub fn mkfifoat(
-        dirfd: ::c_int,
-        pathname: *const ::c_char,
-        mode: ::mode_t,
-    ) -> ::c_int;
+    pub fn memrchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
+    pub fn mkfifoat(dirfd: ::c_int, pathname: *const ::c_char, mode: ::mode_t) -> ::c_int;
     #[cfg_attr(
         all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "mknodat@FBSD_1.1"
@@ -1464,18 +1449,9 @@ extern "C" {
         mode: ::mode_t,
         dev: dev_t,
     ) -> ::c_int;
-    pub fn mincore(
-        addr: *const ::c_void,
-        len: ::size_t,
-        vec: *mut ::c_char,
-    ) -> ::c_int;
-    pub fn newlocale(
-        mask: ::c_int,
-        locale: *const ::c_char,
-        base: ::locale_t,
-    ) -> ::locale_t;
-    pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t)
-        -> *mut ::c_char;
+    pub fn mincore(addr: *const ::c_void, len: ::size_t, vec: *mut ::c_char) -> ::c_int;
+    pub fn newlocale(mask: ::c_int, locale: *const ::c_char, base: ::locale_t) -> ::locale_t;
+    pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t) -> *mut ::c_char;
     pub fn pipe2(fds: *mut ::c_int, flags: ::c_int) -> ::c_int;
     pub fn ppoll(
         fds: *mut ::pollfd,
@@ -1483,16 +1459,8 @@ extern "C" {
         timeout: *const ::timespec,
         sigmask: *const sigset_t,
     ) -> ::c_int;
-    pub fn preadv(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-        offset: ::off_t,
-    ) -> ::ssize_t;
-    pub fn pthread_attr_get_np(
-        tid: ::pthread_t,
-        attr: *mut ::pthread_attr_t,
-    ) -> ::c_int;
+    pub fn preadv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t) -> ::ssize_t;
+    pub fn pthread_attr_get_np(tid: ::pthread_t, attr: *mut ::pthread_attr_t) -> ::c_int;
     pub fn pthread_attr_getguardsize(
         attr: *const ::pthread_attr_t,
         guardsize: *mut ::size_t,
@@ -1514,10 +1482,7 @@ extern "C" {
         attr: *mut pthread_condattr_t,
         clock_id: ::clockid_t,
     ) -> ::c_int;
-    pub fn pthread_condattr_setpshared(
-        attr: *mut pthread_condattr_t,
-        pshared: ::c_int,
-    ) -> ::c_int;
+    pub fn pthread_condattr_setpshared(attr: *mut pthread_condattr_t, pshared: ::c_int) -> ::c_int;
     pub fn pthread_main_np() -> ::c_int;
     pub fn pthread_mutex_timedlock(
         lock: *mut pthread_mutex_t,
@@ -1535,30 +1500,14 @@ extern "C" {
         attr: *const pthread_rwlockattr_t,
         val: *mut ::c_int,
     ) -> ::c_int;
-    pub fn pthread_rwlockattr_setpshared(
-        attr: *mut pthread_rwlockattr_t,
-        val: ::c_int,
-    ) -> ::c_int;
+    pub fn pthread_rwlockattr_setpshared(attr: *mut pthread_rwlockattr_t, val: ::c_int) -> ::c_int;
     pub fn pthread_set_name_np(tid: ::pthread_t, name: *const ::c_char);
-    pub fn ptrace(
-        request: ::c_int,
-        pid: ::pid_t,
-        addr: *mut ::c_char,
-        data: ::c_int,
-    ) -> ::c_int;
+    pub fn ptrace(request: ::c_int, pid: ::pid_t, addr: *mut ::c_char, data: ::c_int) -> ::c_int;
     pub fn pututxline(ut: *const utmpx) -> *mut utmpx;
-    pub fn pwritev(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-        offset: ::off_t,
-    ) -> ::ssize_t;
+    pub fn pwritev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t)
+        -> ::ssize_t;
     pub fn querylocale(mask: ::c_int, loc: ::locale_t) -> *const ::c_char;
-    pub fn rtprio(
-        function: ::c_int,
-        pid: ::pid_t,
-        rtp: *mut rtprio,
-    ) -> ::c_int;
+    pub fn rtprio(function: ::c_int, pid: ::pid_t, rtp: *mut rtprio) -> ::c_int;
     pub fn sched_getscheduler(pid: ::pid_t) -> ::c_int;
     pub fn sched_setscheduler(
         pid: ::pid_t,
@@ -1566,10 +1515,7 @@ extern "C" {
         param: *const ::sched_param,
     ) -> ::c_int;
     pub fn sem_getvalue(sem: *mut sem_t, sval: *mut ::c_int) -> ::c_int;
-    pub fn sem_timedwait(
-        sem: *mut sem_t,
-        abstime: *const ::timespec,
-    ) -> ::c_int;
+    pub fn sem_timedwait(sem: *mut sem_t, abstime: *const ::timespec) -> ::c_int;
     pub fn sendfile(
         fd: ::c_int,
         s: ::c_int,
@@ -1581,20 +1527,12 @@ extern "C" {
     ) -> ::c_int;
     pub fn setdomainname(name: *const ::c_char, len: ::c_int) -> ::c_int;
     pub fn sethostname(name: *const ::c_char, len: ::c_int) -> ::c_int;
-    pub fn setpriority(which: ::c_int, who: ::c_int, prio: ::c_int)
-        -> ::c_int;
+    pub fn setpriority(which: ::c_int, who: ::c_int, prio: ::c_int) -> ::c_int;
     pub fn setresgid(rgid: ::gid_t, egid: ::gid_t, sgid: ::gid_t) -> ::c_int;
     pub fn setresuid(ruid: ::uid_t, euid: ::uid_t, suid: ::uid_t) -> ::c_int;
-    pub fn settimeofday(
-        tv: *const ::timeval,
-        tz: *const ::timezone,
-    ) -> ::c_int;
+    pub fn settimeofday(tv: *const ::timeval, tz: *const ::timezone) -> ::c_int;
     pub fn setutxent();
-    pub fn shm_open(
-        name: *const ::c_char,
-        oflag: ::c_int,
-        mode: ::mode_t,
-    ) -> ::c_int;
+    pub fn shm_open(name: *const ::c_char, oflag: ::c_int, mode: ::mode_t) -> ::c_int;
     pub fn sigtimedwait(
         set: *const sigset_t,
         info: *mut siginfo_t,
@@ -1644,10 +1582,7 @@ extern "C" {
         data: *mut ::c_void,
     ) -> ::c_int;
 
-    pub fn iconv_open(
-        tocode: *const ::c_char,
-        fromcode: *const ::c_char,
-    ) -> iconv_t;
+    pub fn iconv_open(tocode: *const ::c_char, fromcode: *const ::c_char) -> iconv_t;
     pub fn iconv(
         cd: iconv_t,
         inbuf: *mut *mut ::c_char,
@@ -1662,8 +1597,7 @@ extern "C" {
 extern "C" {
     pub fn mq_close(mqd: ::mqd_t) -> ::c_int;
     pub fn mq_getattr(mqd: ::mqd_t, attr: *mut ::mq_attr) -> ::c_int;
-    pub fn mq_notify(mqd: ::mqd_t, notification: *const ::sigevent)
-        -> ::c_int;
+    pub fn mq_notify(mqd: ::mqd_t, notification: *const ::sigevent) -> ::c_int;
     pub fn mq_open(name: *const ::c_char, oflag: ::c_int, ...) -> ::mqd_t;
     pub fn mq_receive(
         mqd: ::mqd_t,
@@ -1677,11 +1611,7 @@ extern "C" {
         msg_len: ::size_t,
         msg_prio: ::c_uint,
     ) -> ::c_int;
-    pub fn mq_setattr(
-        mqd: ::mqd_t,
-        newattr: *const ::mq_attr,
-        oldattr: *mut ::mq_attr,
-    ) -> ::c_int;
+    pub fn mq_setattr(mqd: ::mqd_t, newattr: *const ::mq_attr, oldattr: *mut ::mq_attr) -> ::c_int;
     pub fn mq_timedreceive(
         mqd: ::mqd_t,
         msg_ptr: *mut ::c_char,

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -587,11 +587,7 @@ extern "C" {
     )]
     pub fn setrlimit(resource: ::c_int, rlim: *const ::rlimit) -> ::c_int;
 
-    pub fn strerror_r(
-        errnum: ::c_int,
-        buf: *mut c_char,
-        buflen: ::size_t,
-    ) -> ::c_int;
+    pub fn strerror_r(errnum: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
     pub fn abs(i: ::c_int) -> ::c_int;
     pub fn atof(s: *const ::c_char) -> ::c_double;
     pub fn labs(i: ::c_long) -> ::c_long;
@@ -626,11 +622,7 @@ extern "C" {
     pub fn if_nameindex() -> *mut if_nameindex;
     pub fn if_freenameindex(ptr: *mut if_nameindex);
 
-    pub fn getpeereid(
-        socket: ::c_int,
-        euid: *mut ::uid_t,
-        egid: *mut ::gid_t,
-    ) -> ::c_int;
+    pub fn getpeereid(socket: ::c_int, euid: *mut ::uid_t, egid: *mut ::gid_t) -> ::c_int;
 
     #[cfg_attr(
         all(target_os = "macos", not(target_arch = "aarch64")),
@@ -644,9 +636,7 @@ extern "C" {
     pub fn glob(
         pattern: *const ::c_char,
         flags: ::c_int,
-        errfunc: ::Option<
-            extern "C" fn(epath: *const ::c_char, errno: ::c_int) -> ::c_int,
-        >,
+        errfunc: ::Option<extern "C" fn(epath: *const ::c_char, errno: ::c_int) -> ::c_int>,
         pglob: *mut ::glob_t,
     ) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__globfree30")]
@@ -656,11 +646,7 @@ extern "C" {
     )]
     pub fn globfree(pglob: *mut ::glob_t);
 
-    pub fn posix_madvise(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        advice: ::c_int,
-    ) -> ::c_int;
+    pub fn posix_madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
 
     pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
 
@@ -683,22 +669,14 @@ extern "C" {
         link_name = "telldir$INODE64$UNIX2003"
     )]
     pub fn telldir(dirp: *mut ::DIR) -> ::c_long;
-    pub fn madvise(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        advice: ::c_int,
-    ) -> ::c_int;
+    pub fn madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
 
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "msync$UNIX2003"
     )]
     #[cfg_attr(target_os = "netbsd", link_name = "__msync13")]
-    pub fn msync(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn msync(addr: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::c_int;
 
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
@@ -721,49 +699,29 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "bind$UNIX2003"
     )]
-    pub fn bind(
-        socket: ::c_int,
-        address: *const ::sockaddr,
-        address_len: ::socklen_t,
-    ) -> ::c_int;
+    pub fn bind(socket: ::c_int, address: *const ::sockaddr, address_len: ::socklen_t) -> ::c_int;
 
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "writev$UNIX2003"
     )]
-    pub fn writev(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-    ) -> ::ssize_t;
+    pub fn writev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "readv$UNIX2003"
     )]
-    pub fn readv(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-    ) -> ::ssize_t;
+    pub fn readv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
 
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "sendmsg$UNIX2003"
     )]
-    pub fn sendmsg(
-        fd: ::c_int,
-        msg: *const ::msghdr,
-        flags: ::c_int,
-    ) -> ::ssize_t;
+    pub fn sendmsg(fd: ::c_int, msg: *const ::msghdr, flags: ::c_int) -> ::ssize_t;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "recvmsg$UNIX2003"
     )]
-    pub fn recvmsg(
-        fd: ::c_int,
-        msg: *mut ::msghdr,
-        flags: ::c_int,
-    ) -> ::ssize_t;
+    pub fn recvmsg(fd: ::c_int, msg: *mut ::msghdr, flags: ::c_int) -> ::ssize_t;
 
     pub fn sync();
     pub fn getgrgid_r(
@@ -792,11 +750,7 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "pthread_sigmask$UNIX2003"
     )]
-    pub fn pthread_sigmask(
-        how: ::c_int,
-        set: *const sigset_t,
-        oldset: *mut sigset_t,
-    ) -> ::c_int;
+    pub fn pthread_sigmask(how: ::c_int, set: *const sigset_t, oldset: *mut sigset_t) -> ::c_int;
     pub fn sem_open(name: *const ::c_char, oflag: ::c_int, ...) -> *mut sem_t;
     pub fn getgrnam(name: *const ::c_char) -> *mut ::group;
     #[cfg_attr(
@@ -880,11 +834,7 @@ extern "C" {
         old_value: *mut ::itimerval,
     ) -> ::c_int;
 
-    pub fn regcomp(
-        preg: *mut regex_t,
-        pattern: *const ::c_char,
-        cflags: ::c_int,
-    ) -> ::c_int;
+    pub fn regcomp(preg: *mut regex_t, pattern: *const ::c_char, cflags: ::c_int) -> ::c_int;
 
     pub fn regexec(
         preg: *const regex_t,

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -639,11 +639,7 @@ pub const TIMER_ABSTIME: ::c_int = 1;
 extern "C" {
     pub fn setgrent();
     pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
-    pub fn sem_init(
-        sem: *mut sem_t,
-        pshared: ::c_int,
-        value: ::c_uint,
-    ) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t, pshared: ::c_int, value: ::c_uint) -> ::c_int;
 
     pub fn daemon(nochdir: ::c_int, noclose: ::c_int) -> ::c_int;
     pub fn accept4(
@@ -652,49 +648,21 @@ extern "C" {
         addrlen: *mut ::socklen_t,
         flags: ::c_int,
     ) -> ::c_int;
-    pub fn mincore(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        vec: *mut ::c_char,
-    ) -> ::c_int;
+    pub fn mincore(addr: *mut ::c_void, len: ::size_t, vec: *mut ::c_char) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__clock_getres50")]
     pub fn clock_getres(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__clock_gettime50")]
     pub fn clock_gettime(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__clock_settime50")]
-    pub fn clock_settime(
-        clk_id: ::clockid_t,
-        tp: *const ::timespec,
-    ) -> ::c_int;
+    pub fn clock_settime(clk_id: ::clockid_t, tp: *const ::timespec) -> ::c_int;
     pub fn __errno() -> *mut ::c_int;
-    pub fn shm_open(
-        name: *const ::c_char,
-        oflag: ::c_int,
-        mode: ::mode_t,
-    ) -> ::c_int;
-    pub fn memrchr(
-        cx: *const ::c_void,
-        c: ::c_int,
-        n: ::size_t,
-    ) -> *mut ::c_void;
+    pub fn shm_open(name: *const ::c_char, oflag: ::c_int, mode: ::mode_t) -> ::c_int;
+    pub fn memrchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
     pub fn mkostemp(template: *mut ::c_char, flags: ::c_int) -> ::c_int;
-    pub fn mkostemps(
-        template: *mut ::c_char,
-        suffixlen: ::c_int,
-        flags: ::c_int,
-    ) -> ::c_int;
-    pub fn pwritev(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-        offset: ::off_t,
-    ) -> ::ssize_t;
-    pub fn preadv(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-        offset: ::off_t,
-    ) -> ::ssize_t;
+    pub fn mkostemps(template: *mut ::c_char, suffixlen: ::c_int, flags: ::c_int) -> ::c_int;
+    pub fn pwritev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t)
+        -> ::ssize_t;
+    pub fn preadv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t) -> ::ssize_t;
     pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
     pub fn utimensat(
         dirfd: ::c_int,
@@ -726,15 +694,8 @@ extern "C" {
         mode: ::mode_t,
         dev: dev_t,
     ) -> ::c_int;
-    pub fn mkfifoat(
-        dirfd: ::c_int,
-        pathname: *const ::c_char,
-        mode: ::mode_t,
-    ) -> ::c_int;
-    pub fn sem_timedwait(
-        sem: *mut sem_t,
-        abstime: *const ::timespec,
-    ) -> ::c_int;
+    pub fn mkfifoat(dirfd: ::c_int, pathname: *const ::c_char, mode: ::mode_t) -> ::c_int;
+    pub fn sem_timedwait(sem: *mut sem_t, abstime: *const ::timespec) -> ::c_int;
     pub fn sem_getvalue(sem: *mut sem_t, sval: *mut ::c_int) -> ::c_int;
     pub fn pthread_condattr_setclock(
         attr: *mut pthread_condattr_t,
@@ -759,17 +720,9 @@ extern "C" {
     pub fn uname(buf: *mut ::utsname) -> ::c_int;
 
     pub fn shmget(key: ::key_t, size: ::size_t, shmflg: ::c_int) -> ::c_int;
-    pub fn shmat(
-        shmid: ::c_int,
-        shmaddr: *const ::c_void,
-        shmflg: ::c_int,
-    ) -> *mut ::c_void;
+    pub fn shmat(shmid: ::c_int, shmaddr: *const ::c_void, shmflg: ::c_int) -> *mut ::c_void;
     pub fn shmdt(shmaddr: *const ::c_void) -> ::c_int;
-    pub fn shmctl(
-        shmid: ::c_int,
-        cmd: ::c_int,
-        buf: *mut ::shmid_ds,
-    ) -> ::c_int;
+    pub fn shmctl(shmid: ::c_int, cmd: ::c_int, buf: *mut ::shmid_ds) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1937,11 +1937,7 @@ extern "C" {
         sevlen: ::socklen_t,
         flags: ::c_int,
     ) -> ::c_int;
-    pub fn mprotect(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        prot: ::c_int,
-    ) -> ::c_int;
+    pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
     pub fn sysctl(
         name: *const ::c_int,
         namelen: ::c_uint,
@@ -1977,8 +1973,7 @@ extern "C" {
     pub fn mq_open(name: *const ::c_char, oflag: ::c_int, ...) -> ::mqd_t;
     pub fn mq_close(mqd: ::mqd_t) -> ::c_int;
     pub fn mq_getattr(mqd: ::mqd_t, attr: *mut ::mq_attr) -> ::c_int;
-    pub fn mq_notify(mqd: ::mqd_t, notification: *const ::sigevent)
-        -> ::c_int;
+    pub fn mq_notify(mqd: ::mqd_t, notification: *const ::sigevent) -> ::c_int;
     pub fn mq_receive(
         mqd: ::mqd_t,
         msg_ptr: *mut ::c_char,
@@ -1991,11 +1986,7 @@ extern "C" {
         msg_len: ::size_t,
         msg_prio: ::c_uint,
     ) -> ::c_int;
-    pub fn mq_setattr(
-        mqd: ::mqd_t,
-        newattr: *const ::mq_attr,
-        oldattr: *mut ::mq_attr,
-    ) -> ::c_int;
+    pub fn mq_setattr(mqd: ::mqd_t, newattr: *const ::mq_attr, oldattr: *mut ::mq_attr) -> ::c_int;
     #[link_name = "__mq_timedreceive50"]
     pub fn mq_timedreceive(
         mqd: ::mqd_t,
@@ -2013,25 +2004,14 @@ extern "C" {
         abs_timeout: *const ::timespec,
     ) -> ::c_int;
     pub fn mq_unlink(name: *const ::c_char) -> ::c_int;
-    pub fn ptrace(
-        request: ::c_int,
-        pid: ::pid_t,
-        addr: *mut ::c_void,
-        data: ::c_int,
-    ) -> ::c_int;
+    pub fn ptrace(request: ::c_int, pid: ::pid_t, addr: *mut ::c_void, data: ::c_int) -> ::c_int;
     pub fn pthread_setname_np(
         t: ::pthread_t,
         name: *const ::c_char,
         arg: *const ::c_void,
     ) -> ::c_int;
-    pub fn pthread_attr_get_np(
-        thread: ::pthread_t,
-        attr: *mut ::pthread_attr_t,
-    ) -> ::c_int;
-    pub fn pthread_getattr_np(
-        native: ::pthread_t,
-        attr: *mut ::pthread_attr_t,
-    ) -> ::c_int;
+    pub fn pthread_attr_get_np(thread: ::pthread_t, attr: *mut ::pthread_attr_t) -> ::c_int;
+    pub fn pthread_getattr_np(native: ::pthread_t, attr: *mut ::pthread_attr_t) -> ::c_int;
     pub fn pthread_attr_getguardsize(
         attr: *const ::pthread_attr_t,
         guardsize: *mut ::size_t,
@@ -2051,11 +2031,7 @@ extern "C" {
     pub fn duplocale(base: ::locale_t) -> ::locale_t;
     pub fn freelocale(loc: ::locale_t);
     pub fn localeconv_l(loc: ::locale_t) -> *mut lconv;
-    pub fn newlocale(
-        mask: ::c_int,
-        locale: *const ::c_char,
-        base: ::locale_t,
-    ) -> ::locale_t;
+    pub fn newlocale(mask: ::c_int, locale: *const ::c_char, base: ::locale_t) -> ::locale_t;
     #[link_name = "__settimeofday50"]
     pub fn settimeofday(tv: *const ::timeval, tz: *const ::c_void) -> ::c_int;
 
@@ -2096,10 +2072,7 @@ extern "C" {
         data: *mut ::c_void,
     ) -> ::c_int;
 
-    pub fn iconv_open(
-        tocode: *const ::c_char,
-        fromcode: *const ::c_char,
-    ) -> iconv_t;
+    pub fn iconv_open(tocode: *const ::c_char, fromcode: *const ::c_char) -> iconv_t;
     pub fn iconv(
         cd: iconv_t,
         inbuf: *mut *mut ::c_char,
@@ -2127,16 +2100,8 @@ extern "C" {
     ) -> ::c_int;
 
     pub fn updwtmpx(file: *const ::c_char, ut: *const utmpx) -> ::c_int;
-    pub fn getlastlogx(
-        fname: *const ::c_char,
-        uid: ::uid_t,
-        ll: *mut lastlogx,
-    ) -> *mut lastlogx;
-    pub fn updlastlogx(
-        fname: *const ::c_char,
-        uid: ::uid_t,
-        ll: *mut lastlogx,
-    ) -> ::c_int;
+    pub fn getlastlogx(fname: *const ::c_char, uid: ::uid_t, ll: *mut lastlogx) -> *mut lastlogx;
+    pub fn updlastlogx(fname: *const ::c_char, uid: ::uid_t, ll: *mut lastlogx) -> ::c_int;
     pub fn utmpxname(file: *const ::c_char) -> ::c_int;
     pub fn getutxent() -> *mut utmpx;
     pub fn getutxid(ut: *const utmpx) -> *mut utmpx;

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1457,19 +1457,13 @@ safe_f! {
 
 extern "C" {
     pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::timezone) -> ::c_int;
-    pub fn settimeofday(
-        tp: *const ::timeval,
-        tz: *const ::timezone,
-    ) -> ::c_int;
+    pub fn settimeofday(tp: *const ::timeval, tz: *const ::timezone) -> ::c_int;
     pub fn execvpe(
         file: *const ::c_char,
         argv: *const *const ::c_char,
         envp: *const *const ::c_char,
     ) -> ::c_int;
-    pub fn pledge(
-        promises: *const ::c_char,
-        execpromises: *const ::c_char,
-    ) -> ::c_int;
+    pub fn pledge(promises: *const ::c_char, execpromises: *const ::c_char) -> ::c_int;
     pub fn strtonum(
         nptr: *const ::c_char,
         minval: ::c_longlong,
@@ -1503,11 +1497,7 @@ extern "C" {
         nevents: ::c_int,
         timeout: *const ::timespec,
     ) -> ::c_int;
-    pub fn mprotect(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        prot: ::c_int,
-    ) -> ::c_int;
+    pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
     pub fn pthread_attr_getguardsize(
         attr: *const ::pthread_attr_t,
         guardsize: *mut ::size_t,
@@ -1519,10 +1509,7 @@ extern "C" {
     ) -> ::c_int;
     pub fn pthread_main_np() -> ::c_int;
     pub fn pthread_set_name_np(tid: ::pthread_t, name: *const ::c_char);
-    pub fn pthread_stackseg_np(
-        thread: ::pthread_t,
-        sinfo: *mut ::stack_t,
-    ) -> ::c_int;
+    pub fn pthread_stackseg_np(thread: ::pthread_t, sinfo: *mut ::stack_t) -> ::c_int;
     pub fn sysctl(
         name: *const ::c_int,
         namelen: ::c_uint,
@@ -1534,12 +1521,7 @@ extern "C" {
     pub fn getentropy(buf: *mut ::c_void, buflen: ::size_t) -> ::c_int;
     pub fn setresgid(rgid: ::gid_t, egid: ::gid_t, sgid: ::gid_t) -> ::c_int;
     pub fn setresuid(ruid: ::uid_t, euid: ::uid_t, suid: ::uid_t) -> ::c_int;
-    pub fn ptrace(
-        request: ::c_int,
-        pid: ::pid_t,
-        addr: caddr_t,
-        data: ::c_int,
-    ) -> ::c_int;
+    pub fn ptrace(request: ::c_int, pid: ::pid_t, addr: caddr_t, data: ::c_int) -> ::c_int;
     pub fn memmem(
         haystack: *const ::c_void,
         haystacklen: ::size_t,

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -1354,11 +1354,7 @@ extern "C" {
     pub fn getrlimit(resource: ::c_int, rlim: *mut ::rlimit) -> ::c_int;
     pub fn setrlimit(resource: ::c_int, rlim: *const ::rlimit) -> ::c_int;
     pub fn getpriority(which: ::c_int, who: id_t) -> ::c_int;
-    pub fn setpriority(
-        which: ::c_int,
-        who: id_t,
-        priority: ::c_int,
-    ) -> ::c_int;
+    pub fn setpriority(which: ::c_int, who: id_t, priority: ::c_int) -> ::c_int;
 
     pub fn utimensat(
         fd: ::c_int,
@@ -1367,11 +1363,7 @@ extern "C" {
         flag: ::c_int,
     ) -> ::c_int;
     pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
-    pub fn strerror_r(
-        errnum: ::c_int,
-        buf: *mut c_char,
-        buflen: ::size_t,
-    ) -> ::c_int;
+    pub fn strerror_r(errnum: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
     pub fn _errnop() -> *mut ::c_int;
 
     pub fn abs(i: ::c_int) -> ::c_int;
@@ -1384,11 +1376,7 @@ extern "C" {
 #[link(name = "bsd")]
 extern "C" {
     pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
-    pub fn sem_init(
-        sem: *mut sem_t,
-        pshared: ::c_int,
-        value: ::c_uint,
-    ) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t, pshared: ::c_int, value: ::c_uint) -> ::c_int;
 
     pub fn clock_gettime(clk_id: ::c_int, tp: *mut ::timespec) -> ::c_int;
     pub fn clock_settime(clk_id: ::c_int, tp: *const ::timespec) -> ::c_int;
@@ -1418,11 +1406,7 @@ extern "C" {
     pub fn memalign(align: ::size_t, size: ::size_t) -> *mut ::c_void;
     pub fn setgroups(ngroups: ::c_int, ptr: *const ::gid_t) -> ::c_int;
     pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
-    pub fn mprotect(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        prot: ::c_int,
-    ) -> ::c_int;
+    pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
     pub fn dirfd(dirp: *mut ::DIR) -> ::c_int;
     pub fn getnameinfo(
         sa: *const ::sockaddr,
@@ -1437,50 +1421,28 @@ extern "C" {
         lock: *mut pthread_mutex_t,
         abstime: *const ::timespec,
     ) -> ::c_int;
-    pub fn waitid(
-        idtype: idtype_t,
-        id: id_t,
-        infop: *mut ::siginfo_t,
-        options: ::c_int,
-    ) -> ::c_int;
+    pub fn waitid(idtype: idtype_t, id: id_t, infop: *mut ::siginfo_t, options: ::c_int)
+        -> ::c_int;
 
     pub fn glob(
         pattern: *const ::c_char,
         flags: ::c_int,
-        errfunc: ::Option<
-            extern "C" fn(epath: *const ::c_char, errno: ::c_int) -> ::c_int,
-        >,
+        errfunc: ::Option<extern "C" fn(epath: *const ::c_char, errno: ::c_int) -> ::c_int>,
         pglob: *mut ::glob_t,
     ) -> ::c_int;
     pub fn globfree(pglob: *mut ::glob_t);
     pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::c_void) -> ::c_int;
-    pub fn posix_madvise(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        advice: ::c_int,
-    ) -> ::c_int;
+    pub fn posix_madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
 
-    pub fn shm_open(
-        name: *const ::c_char,
-        oflag: ::c_int,
-        mode: ::mode_t,
-    ) -> ::c_int;
+    pub fn shm_open(name: *const ::c_char, oflag: ::c_int, mode: ::mode_t) -> ::c_int;
     pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
 
     pub fn seekdir(dirp: *mut ::DIR, loc: ::c_long);
 
     pub fn telldir(dirp: *mut ::DIR) -> ::c_long;
-    pub fn madvise(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        advice: ::c_int,
-    ) -> ::c_int;
+    pub fn madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
 
-    pub fn msync(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn msync(addr: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::c_int;
 
     pub fn recvfrom(
         socket: ::c_int,
@@ -1494,33 +1456,13 @@ extern "C" {
     pub fn lutimes(file: *const ::c_char, times: *const ::timeval) -> ::c_int;
     pub fn nl_langinfo(item: ::nl_item) -> *mut ::c_char;
 
-    pub fn bind(
-        socket: ::c_int,
-        address: *const ::sockaddr,
-        address_len: ::socklen_t,
-    ) -> ::c_int;
+    pub fn bind(socket: ::c_int, address: *const ::sockaddr, address_len: ::socklen_t) -> ::c_int;
 
-    pub fn writev(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        count: ::c_int,
-    ) -> ::ssize_t;
-    pub fn readv(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        count: ::c_int,
-    ) -> ::ssize_t;
+    pub fn writev(fd: ::c_int, iov: *const ::iovec, count: ::c_int) -> ::ssize_t;
+    pub fn readv(fd: ::c_int, iov: *const ::iovec, count: ::c_int) -> ::ssize_t;
 
-    pub fn sendmsg(
-        fd: ::c_int,
-        msg: *const ::msghdr,
-        flags: ::c_int,
-    ) -> ::ssize_t;
-    pub fn recvmsg(
-        fd: ::c_int,
-        msg: *mut ::msghdr,
-        flags: ::c_int,
-    ) -> ::ssize_t;
+    pub fn sendmsg(fd: ::c_int, msg: *const ::msghdr, flags: ::c_int) -> ::ssize_t;
+    pub fn recvmsg(fd: ::c_int, msg: *mut ::msghdr, flags: ::c_int) -> ::ssize_t;
     pub fn execvpe(
         file: *const ::c_char,
         argv: *const *const ::c_char,
@@ -1543,11 +1485,7 @@ extern "C" {
         buflen: ::size_t,
         result: *mut *mut ::group,
     ) -> ::c_int;
-    pub fn pthread_sigmask(
-        how: ::c_int,
-        set: *const sigset_t,
-        oldset: *mut sigset_t,
-    ) -> ::c_int;
+    pub fn pthread_sigmask(how: ::c_int, set: *const sigset_t, oldset: *mut sigset_t) -> ::c_int;
     pub fn sem_open(name: *const ::c_char, oflag: ::c_int, ...) -> *mut sem_t;
     pub fn getgrnam(name: *const ::c_char) -> *mut ::group;
     pub fn pthread_kill(thread: ::pthread_t, sig: ::c_int) -> ::c_int;

--- a/src/unix/haiku/native.rs
+++ b/src/unix/haiku/native.rs
@@ -20,10 +20,7 @@
 
 macro_rules! haiku_constant {
     ($a:tt, $b:tt, $c:tt, $d:tt) => {
-        (($a as u32) << 24)
-            + (($b as u32) << 16)
-            + (($c as u32) << 8)
-            + ($d as u32)
+        (($a as u32) << 24) + (($b as u32) << 16) + (($c as u32) << 8) + ($d as u32)
     };
 }
 
@@ -236,8 +233,7 @@ pub const B_INFINITE_TIMEOUT: usize = 9223372036854775807;
 pub const B_RELATIVE_TIMEOUT: u32 = 0x8;
 pub const B_ABSOLUTE_TIMEOUT: u32 = 0x10;
 pub const B_TIMEOUT_REAL_TIME_BASE: u32 = 0x40;
-pub const B_ABSOLUTE_REAL_TIME_TIMEOUT: u32 =
-    B_ABSOLUTE_TIMEOUT | B_TIMEOUT_REAL_TIME_BASE;
+pub const B_ABSOLUTE_REAL_TIME_TIMEOUT: u32 = B_ABSOLUTE_TIMEOUT | B_TIMEOUT_REAL_TIME_BASE;
 
 pub const B_NO_LOCK: u32 = 0;
 pub const B_LAZY_LOCK: u32 = 1;
@@ -440,8 +436,7 @@ pub const B_LAUNCH_FAILED_EXECUTABLE: status_t = B_APP_ERROR_BASE + 10;
 pub const B_LAUNCH_FAILED_APP_NOT_FOUND: status_t = B_APP_ERROR_BASE + 11;
 pub const B_LAUNCH_FAILED_APP_IN_TRASH: status_t = B_APP_ERROR_BASE + 12;
 pub const B_LAUNCH_FAILED_NO_PREFERRED_APP: status_t = B_APP_ERROR_BASE + 13;
-pub const B_LAUNCH_FAILED_FILES_APP_NOT_FOUND: status_t =
-    B_APP_ERROR_BASE + 14;
+pub const B_LAUNCH_FAILED_FILES_APP_NOT_FOUND: status_t = B_APP_ERROR_BASE + 14;
 pub const B_BAD_MIME_SNIFFER_RULE: status_t = B_APP_ERROR_BASE + 15;
 pub const B_NOT_A_MESSAGE: status_t = B_APP_ERROR_BASE + 16;
 pub const B_SHUTDOWN_CANCELLED: status_t = B_APP_ERROR_BASE + 17;
@@ -586,11 +581,9 @@ pub const B_INT32_TYPE: u32 = haiku_constant!('L', 'O', 'N', 'G');
 pub const B_INT64_TYPE: u32 = haiku_constant!('L', 'L', 'N', 'G');
 pub const B_INT8_TYPE: u32 = haiku_constant!('B', 'Y', 'T', 'E');
 pub const B_LARGE_ICON_TYPE: u32 = haiku_constant!('I', 'C', 'O', 'N');
-pub const B_MEDIA_PARAMETER_GROUP_TYPE: u32 =
-    haiku_constant!('B', 'M', 'C', 'G');
+pub const B_MEDIA_PARAMETER_GROUP_TYPE: u32 = haiku_constant!('B', 'M', 'C', 'G');
 pub const B_MEDIA_PARAMETER_TYPE: u32 = haiku_constant!('B', 'M', 'C', 'T');
-pub const B_MEDIA_PARAMETER_WEB_TYPE: u32 =
-    haiku_constant!('B', 'M', 'C', 'W');
+pub const B_MEDIA_PARAMETER_WEB_TYPE: u32 = haiku_constant!('B', 'M', 'C', 'W');
 pub const B_MESSAGE_TYPE: u32 = haiku_constant!('M', 'S', 'G', 'G');
 pub const B_MESSENGER_TYPE: u32 = haiku_constant!('M', 'S', 'N', 'G');
 pub const B_MIME_TYPE: u32 = haiku_constant!('M', 'I', 'M', 'E');
@@ -645,11 +638,7 @@ extern "C" {
     pub fn delete_area(id: area_id) -> status_t;
     pub fn resize_area(id: area_id, newSize: usize) -> status_t;
     pub fn set_area_protection(id: area_id, newProtection: u32) -> status_t;
-    pub fn _get_area_info(
-        id: area_id,
-        areaInfo: *mut area_info,
-        size: usize,
-    ) -> status_t;
+    pub fn _get_area_info(id: area_id, areaInfo: *mut area_info, size: usize) -> status_t;
     pub fn _get_next_area_info(
         team: team_id,
         cookie: *mut isize,
@@ -690,19 +679,11 @@ extern "C" {
     pub fn close_port(port: port_id) -> status_t;
     pub fn delete_port(port: port_id) -> status_t;
     pub fn port_buffer_size(port: port_id) -> ::ssize_t;
-    pub fn port_buffer_size_etc(
-        port: port_id,
-        flags: u32,
-        timeout: bigtime_t,
-    ) -> ::ssize_t;
+    pub fn port_buffer_size_etc(port: port_id, flags: u32, timeout: bigtime_t) -> ::ssize_t;
     pub fn port_count(port: port_id) -> ::ssize_t;
     pub fn set_port_owner(port: port_id, team: team_id) -> status_t;
 
-    pub fn _get_port_info(
-        port: port_id,
-        buf: *mut port_info,
-        portInfoSize: ::size_t,
-    ) -> status_t;
+    pub fn _get_port_info(port: port_id, buf: *mut port_info, portInfoSize: ::size_t) -> status_t;
     pub fn _get_next_port_info(
         port: port_id,
         cookie: *mut i32,
@@ -720,12 +701,7 @@ extern "C" {
     pub fn create_sem(count: i32, name: *const ::c_char) -> sem_id;
     pub fn delete_sem(id: sem_id) -> status_t;
     pub fn acquire_sem(id: sem_id) -> status_t;
-    pub fn acquire_sem_etc(
-        id: sem_id,
-        count: i32,
-        flags: u32,
-        timeout: bigtime_t,
-    ) -> status_t;
+    pub fn acquire_sem_etc(id: sem_id, count: i32, flags: u32, timeout: bigtime_t) -> status_t;
     pub fn release_sem(id: sem_id) -> status_t;
     pub fn release_sem_etc(id: sem_id, count: i32, flags: u32) -> status_t;
     pub fn switch_sem(semToBeReleased: sem_id, id: sem_id) -> status_t;
@@ -738,11 +714,7 @@ extern "C" {
     ) -> status_t;
     pub fn get_sem_count(id: sem_id, threadCount: *mut i32) -> status_t;
     pub fn set_sem_owner(id: sem_id, team: team_id) -> status_t;
-    pub fn _get_sem_info(
-        id: sem_id,
-        info: *mut sem_info,
-        infoSize: ::size_t,
-    ) -> status_t;
+    pub fn _get_sem_info(id: sem_id, info: *mut sem_info, infoSize: ::size_t) -> status_t;
     pub fn _get_next_sem_info(
         team: team_id,
         cookie: *mut i32,
@@ -751,16 +723,8 @@ extern "C" {
     ) -> status_t;
 
     pub fn kill_team(team: team_id) -> status_t;
-    pub fn _get_team_info(
-        team: team_id,
-        info: *mut team_info,
-        size: ::size_t,
-    ) -> status_t;
-    pub fn _get_next_team_info(
-        cookie: *mut i32,
-        info: *mut team_info,
-        size: ::size_t,
-    ) -> status_t;
+    pub fn _get_team_info(team: team_id, info: *mut team_info, size: ::size_t) -> status_t;
+    pub fn _get_next_team_info(cookie: *mut i32, info: *mut team_info, size: ::size_t) -> status_t;
 
     pub fn spawn_thread(
         func: thread_func,
@@ -772,23 +736,11 @@ extern "C" {
     pub fn resume_thread(thread: thread_id) -> status_t;
     pub fn suspend_thread(thread: thread_id) -> status_t;
 
-    pub fn rename_thread(
-        thread: thread_id,
-        newName: *const ::c_char,
-    ) -> status_t;
-    pub fn set_thread_priority(
-        thread: thread_id,
-        newPriority: i32,
-    ) -> status_t;
+    pub fn rename_thread(thread: thread_id, newName: *const ::c_char) -> status_t;
+    pub fn set_thread_priority(thread: thread_id, newPriority: i32) -> status_t;
     pub fn exit_thread(status: status_t);
-    pub fn wait_for_thread(
-        thread: thread_id,
-        returnValue: *mut status_t,
-    ) -> status_t;
-    pub fn on_exit_thread(
-        callback: extern "C" fn(*mut ::c_void),
-        data: *mut ::c_void,
-    ) -> status_t;
+    pub fn wait_for_thread(thread: thread_id, returnValue: *mut status_t) -> status_t;
+    pub fn on_exit_thread(callback: extern "C" fn(*mut ::c_void), data: *mut ::c_void) -> status_t;
 
     pub fn find_thread(name: *const ::c_char) -> thread_id;
 
@@ -798,26 +750,15 @@ extern "C" {
         buffer: *const ::c_void,
         bufferSize: ::size_t,
     ) -> status_t;
-    pub fn receive_data(
-        sender: *mut thread_id,
-        buffer: *mut ::c_void,
-        bufferSize: ::size_t,
-    ) -> i32;
+    pub fn receive_data(sender: *mut thread_id, buffer: *mut ::c_void, bufferSize: ::size_t)
+        -> i32;
     pub fn has_data(thread: thread_id) -> bool;
 
     pub fn snooze(amount: bigtime_t) -> status_t;
-    pub fn snooze_etc(
-        amount: bigtime_t,
-        timeBase: ::c_int,
-        flags: u32,
-    ) -> status_t;
+    pub fn snooze_etc(amount: bigtime_t, timeBase: ::c_int, flags: u32) -> status_t;
     pub fn snooze_until(time: bigtime_t, timeBase: ::c_int) -> status_t;
 
-    pub fn _get_thread_info(
-        id: thread_id,
-        info: *mut thread_info,
-        size: ::size_t,
-    ) -> status_t;
+    pub fn _get_thread_info(id: thread_id, info: *mut thread_info, size: ::size_t) -> status_t;
     pub fn _get_next_thread_info(
         team: team_id,
         cookie: *mut i32,
@@ -848,20 +789,13 @@ extern "C" {
     // TODO: cpuid_info struct and the get_cpuid() function
 
     pub fn get_system_info(info: *mut system_info) -> status_t;
-    pub fn get_cpu_info(
-        firstCPU: u32,
-        cpuCount: u32,
-        info: *mut cpu_info,
-    ) -> status_t;
+    pub fn get_cpu_info(firstCPU: u32, cpuCount: u32, info: *mut cpu_info) -> status_t;
     pub fn is_computer_on() -> i32;
     pub fn is_computer_on_fire() -> ::c_double;
     pub fn send_signal(threadID: thread_id, signal: ::c_uint) -> ::c_int;
     pub fn set_signal_stack(base: *mut ::c_void, size: ::size_t);
 
-    pub fn wait_for_objects(
-        infos: *mut object_wait_info,
-        numInfos: ::c_int,
-    ) -> ::ssize_t;
+    pub fn wait_for_objects(infos: *mut object_wait_info, numInfos: ::c_int) -> ::ssize_t;
     pub fn wait_for_objects_etc(
         infos: *mut object_wait_info,
         numInfos: ::c_int,
@@ -939,11 +873,7 @@ extern "C" {
     pub fn fs_stat_dev(dev: ::dev_t, info: *mut fs_info) -> ::c_int;
 
     // kernel/fs_query.h
-    pub fn fs_open_query(
-        device: ::dev_t,
-        query: *const ::c_char,
-        flags: u32,
-    ) -> *mut ::DIR;
+    pub fn fs_open_query(device: ::dev_t, query: *const ::c_char, flags: u32) -> *mut ::DIR;
     pub fn fs_open_live_query(
         device: ::dev_t,
         query: *const ::c_char,
@@ -953,11 +883,7 @@ extern "C" {
     ) -> *mut ::DIR;
     pub fn fs_close_query(d: *mut ::DIR) -> ::c_int;
     pub fn fs_read_query(d: *mut ::DIR) -> *mut ::dirent;
-    pub fn get_path_for_dirent(
-        dent: *mut ::dirent,
-        buf: *mut ::c_char,
-        len: ::size_t,
-    ) -> status_t;
+    pub fn get_path_for_dirent(dent: *mut ::dirent, buf: *mut ::c_char, len: ::size_t) -> status_t;
 
     // kernel/fs_volume.h
     pub fn fs_mount_volume(
@@ -992,11 +918,7 @@ extern "C" {
         symbolLocation: *mut *mut ::c_void,
     ) -> status_t;
     pub fn clear_caches(address: *mut ::c_void, length: ::size_t, flags: u32);
-    pub fn _get_image_info(
-        image: image_id,
-        info: *mut image_info,
-        size: ::size_t,
-    ) -> status_t;
+    pub fn _get_image_info(image: image_id, info: *mut image_info, size: ::size_t) -> status_t;
     pub fn _get_next_image_info(
         team: team_id,
         cookie: *mut i32,
@@ -1059,11 +981,7 @@ pub unsafe fn get_sem_info(id: sem_id, info: *mut sem_info) -> status_t {
     _get_sem_info(id, info, core::mem::size_of::<sem_info>() as ::size_t)
 }
 
-pub unsafe fn get_next_sem_info(
-    team: team_id,
-    cookie: *mut i32,
-    info: *mut sem_info,
-) -> status_t {
+pub unsafe fn get_next_sem_info(team: team_id, cookie: *mut i32, info: *mut sem_info) -> status_t {
     _get_next_sem_info(
         team,
         cookie,
@@ -1076,22 +994,11 @@ pub unsafe fn get_team_info(team: team_id, info: *mut team_info) -> status_t {
     _get_team_info(team, info, core::mem::size_of::<team_info>() as ::size_t)
 }
 
-pub unsafe fn get_next_team_info(
-    cookie: *mut i32,
-    info: *mut team_info,
-) -> status_t {
-    _get_next_team_info(
-        cookie,
-        info,
-        core::mem::size_of::<team_info>() as ::size_t,
-    )
+pub unsafe fn get_next_team_info(cookie: *mut i32, info: *mut team_info) -> status_t {
+    _get_next_team_info(cookie, info, core::mem::size_of::<team_info>() as ::size_t)
 }
 
-pub unsafe fn get_team_usage_info(
-    team: team_id,
-    who: i32,
-    info: *mut team_usage_info,
-) -> status_t {
+pub unsafe fn get_team_usage_info(team: team_id, who: i32, info: *mut team_usage_info) -> status_t {
     _get_team_usage_info(
         team,
         who,
@@ -1100,10 +1007,7 @@ pub unsafe fn get_team_usage_info(
     )
 }
 
-pub unsafe fn get_thread_info(
-    id: thread_id,
-    info: *mut thread_info,
-) -> status_t {
+pub unsafe fn get_thread_info(id: thread_id, info: *mut thread_info) -> status_t {
     _get_thread_info(id, info, core::mem::size_of::<thread_info>() as ::size_t)
 }
 
@@ -1121,15 +1025,8 @@ pub unsafe fn get_next_thread_info(
 }
 
 // kernel/image.h
-pub unsafe fn get_image_info(
-    image: image_id,
-    info: *mut image_info,
-) -> status_t {
-    _get_image_info(
-        image,
-        info,
-        core::mem::size_of::<image_info>() as ::size_t,
-    )
+pub unsafe fn get_image_info(image: image_id, info: *mut image_info) -> status_t {
+    _get_image_info(image, info, core::mem::size_of::<image_info>() as ::size_t)
 }
 
 pub unsafe fn get_next_image_info(

--- a/src/unix/hermit/mod.rs
+++ b/src/unix/hermit/mod.rs
@@ -960,18 +960,10 @@ safe_f! {
 extern "C" {
     pub fn getrlimit(resource: ::c_int, rlim: *mut ::rlimit) -> ::c_int;
     pub fn setrlimit(resource: ::c_int, rlim: *const ::rlimit) -> ::c_int;
-    pub fn strerror_r(
-        errnum: ::c_int,
-        buf: *mut c_char,
-        buflen: ::size_t,
-    ) -> ::c_int;
+    pub fn strerror_r(errnum: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
 
     pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
-    pub fn sem_init(
-        sem: *mut sem_t,
-        pshared: ::c_int,
-        value: ::c_uint,
-    ) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t, pshared: ::c_int, value: ::c_uint) -> ::c_int;
 
     pub fn abs(i: ::c_int) -> ::c_int;
     pub fn atof(s: *const ::c_char) -> ::c_double;
@@ -979,16 +971,9 @@ extern "C" {
     pub fn rand() -> ::c_int;
     pub fn srand(seed: ::c_uint);
 
-    pub fn bind(
-        s: ::c_int,
-        name: *const ::sockaddr,
-        namelen: ::socklen_t,
-    ) -> ::c_int;
+    pub fn bind(s: ::c_int, name: *const ::sockaddr, namelen: ::socklen_t) -> ::c_int;
 
-    pub fn clock_gettime(
-        clock_id: ::clockid_t,
-        tp: *mut ::timespec,
-    ) -> ::c_int;
+    pub fn clock_gettime(clock_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
 
     pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::c_void) -> ::c_int;
     pub fn getpwuid_r(
@@ -1011,11 +996,7 @@ extern "C" {
         arg: *mut ::c_void,
     ) -> ::c_int;
 
-    pub fn pthread_sigmask(
-        how: ::c_int,
-        set: *const ::sigset_t,
-        oset: *mut ::sigset_t,
-    ) -> ::c_int;
+    pub fn pthread_sigmask(how: ::c_int, set: *const ::sigset_t, oset: *mut ::sigset_t) -> ::c_int;
 
     pub fn recvfrom(
         s: ::c_int,

--- a/src/unix/linux_like/android/b32/mod.rs
+++ b/src/unix/linux_like/android/b32/mod.rs
@@ -197,10 +197,8 @@ pub const PTRACE_SETFPREGS: ::c_int = 15;
 pub const PTRACE_GETREGS: ::c_int = 12;
 pub const PTRACE_SETREGS: ::c_int = 13;
 
-pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t =
-    pthread_mutex_t { value: 0 };
-pub const PTHREAD_COND_INITIALIZER: pthread_cond_t =
-    pthread_cond_t { value: 0 };
+pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t { value: 0 };
+pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = pthread_cond_t { value: 0 };
 pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
     lock: PTHREAD_MUTEX_INITIALIZER,
     cond: PTHREAD_COND_INITIALIZER,

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -1259,11 +1259,8 @@ pub const AI_PASSIVE: ::c_int = 0x00000001;
 pub const AI_CANONNAME: ::c_int = 0x00000002;
 pub const AI_NUMERICHOST: ::c_int = 0x00000004;
 pub const AI_NUMERICSERV: ::c_int = 0x00000008;
-pub const AI_MASK: ::c_int = AI_PASSIVE
-    | AI_CANONNAME
-    | AI_NUMERICHOST
-    | AI_NUMERICSERV
-    | AI_ADDRCONFIG;
+pub const AI_MASK: ::c_int =
+    AI_PASSIVE | AI_CANONNAME | AI_NUMERICHOST | AI_NUMERICSERV | AI_ADDRCONFIG;
 pub const AI_ALL: ::c_int = 0x00000100;
 pub const AI_V4MAPPED_CFG: ::c_int = 0x00000200;
 pub const AI_ADDRCONFIG: ::c_int = 0x00000400;
@@ -2219,8 +2216,7 @@ pub const FUTEX_CMP_REQUEUE_PI: ::c_int = 12;
 
 pub const FUTEX_PRIVATE_FLAG: ::c_int = 128;
 pub const FUTEX_CLOCK_REALTIME: ::c_int = 256;
-pub const FUTEX_CMD_MASK: ::c_int =
-    !(FUTEX_PRIVATE_FLAG | FUTEX_CLOCK_REALTIME);
+pub const FUTEX_CMD_MASK: ::c_int = !(FUTEX_PRIVATE_FLAG | FUTEX_CLOCK_REALTIME);
 
 // linux/errqueue.h
 pub const SO_EE_ORIGIN_NONE: u8 = 0;
@@ -2371,29 +2367,13 @@ extern "C" {
         new_limit: *const ::rlimit64,
         old_limit: *mut ::rlimit64,
     ) -> ::c_int;
-    pub fn strerror_r(
-        errnum: ::c_int,
-        buf: *mut c_char,
-        buflen: ::size_t,
-    ) -> ::c_int;
+    pub fn strerror_r(errnum: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
 
     pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::timezone) -> ::c_int;
-    pub fn madvise(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        advice: ::c_int,
-    ) -> ::c_int;
+    pub fn madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
     pub fn ioctl(fd: ::c_int, request: ::c_int, ...) -> ::c_int;
-    pub fn msync(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        flags: ::c_int,
-    ) -> ::c_int;
-    pub fn mprotect(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        prot: ::c_int,
-    ) -> ::c_int;
+    pub fn msync(addr: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::c_int;
+    pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
     pub fn recvfrom(
         socket: ::c_int,
         buf: *mut ::c_void,
@@ -2411,18 +2391,8 @@ extern "C" {
         sevlen: ::size_t,
         flags: ::c_int,
     ) -> ::c_int;
-    pub fn preadv(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        count: ::c_int,
-        offset: ::off_t,
-    ) -> ::ssize_t;
-    pub fn pwritev(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        count: ::c_int,
-        offset: ::off_t,
-    ) -> ::ssize_t;
+    pub fn preadv(fd: ::c_int, iov: *const ::iovec, count: ::c_int, offset: ::off_t) -> ::ssize_t;
+    pub fn pwritev(fd: ::c_int, iov: *const ::iovec, count: ::c_int, offset: ::off_t) -> ::ssize_t;
     pub fn process_vm_readv(
         pid: ::pid_t,
         local_iov: *const ::iovec,
@@ -2444,10 +2414,7 @@ extern "C" {
     pub fn setpriority(which: ::c_int, who: ::id_t, prio: ::c_int) -> ::c_int;
     pub fn __sched_cpualloc(count: ::size_t) -> *mut ::cpu_set_t;
     pub fn __sched_cpufree(set: *mut ::cpu_set_t);
-    pub fn __sched_cpucount(
-        setsize: ::size_t,
-        set: *const cpu_set_t,
-    ) -> ::c_int;
+    pub fn __sched_cpucount(setsize: ::size_t, set: *const cpu_set_t) -> ::c_int;
     pub fn sched_getcpu() -> ::c_int;
 
     pub fn utmpname(name: *const ::c_char) -> ::c_int;
@@ -2456,28 +2423,10 @@ extern "C" {
 
     pub fn seekdir(dirp: *mut ::DIR, loc: ::c_long);
     pub fn telldir(dirp: *mut ::DIR) -> ::c_long;
-    pub fn fallocate(
-        fd: ::c_int,
-        mode: ::c_int,
-        offset: ::off_t,
-        len: ::off_t,
-    ) -> ::c_int;
-    pub fn fallocate64(
-        fd: ::c_int,
-        mode: ::c_int,
-        offset: ::off64_t,
-        len: ::off64_t,
-    ) -> ::c_int;
-    pub fn posix_fallocate(
-        fd: ::c_int,
-        offset: ::off_t,
-        len: ::off_t,
-    ) -> ::c_int;
-    pub fn posix_fallocate64(
-        fd: ::c_int,
-        offset: ::off64_t,
-        len: ::off64_t,
-    ) -> ::c_int;
+    pub fn fallocate(fd: ::c_int, mode: ::c_int, offset: ::off_t, len: ::off_t) -> ::c_int;
+    pub fn fallocate64(fd: ::c_int, mode: ::c_int, offset: ::off64_t, len: ::off64_t) -> ::c_int;
+    pub fn posix_fallocate(fd: ::c_int, offset: ::off_t, len: ::off_t) -> ::c_int;
+    pub fn posix_fallocate64(fd: ::c_int, offset: ::off64_t, len: ::off64_t) -> ::c_int;
     pub fn getxattr(
         path: *const c_char,
         name: *const c_char,
@@ -2517,34 +2466,15 @@ extern "C" {
         size: ::size_t,
         flags: ::c_int,
     ) -> ::c_int;
-    pub fn listxattr(
-        path: *const c_char,
-        list: *mut c_char,
-        size: ::size_t,
-    ) -> ::ssize_t;
-    pub fn llistxattr(
-        path: *const c_char,
-        list: *mut c_char,
-        size: ::size_t,
-    ) -> ::ssize_t;
-    pub fn flistxattr(
-        filedes: ::c_int,
-        list: *mut c_char,
-        size: ::size_t,
-    ) -> ::ssize_t;
+    pub fn listxattr(path: *const c_char, list: *mut c_char, size: ::size_t) -> ::ssize_t;
+    pub fn llistxattr(path: *const c_char, list: *mut c_char, size: ::size_t) -> ::ssize_t;
+    pub fn flistxattr(filedes: ::c_int, list: *mut c_char, size: ::size_t) -> ::ssize_t;
     pub fn removexattr(path: *const c_char, name: *const c_char) -> ::c_int;
     pub fn lremovexattr(path: *const c_char, name: *const c_char) -> ::c_int;
     pub fn fremovexattr(filedes: ::c_int, name: *const c_char) -> ::c_int;
-    pub fn signalfd(
-        fd: ::c_int,
-        mask: *const ::sigset_t,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn signalfd(fd: ::c_int, mask: *const ::sigset_t, flags: ::c_int) -> ::c_int;
     pub fn timerfd_create(clock: ::clockid_t, flags: ::c_int) -> ::c_int;
-    pub fn timerfd_gettime(
-        fd: ::c_int,
-        current_value: *mut itimerspec,
-    ) -> ::c_int;
+    pub fn timerfd_gettime(fd: ::c_int, current_value: *mut itimerspec) -> ::c_int;
     pub fn timerfd_settime(
         fd: ::c_int,
         flags: ::c_int,
@@ -2552,11 +2482,8 @@ extern "C" {
         old_value: *mut itimerspec,
     ) -> ::c_int;
     pub fn syscall(num: ::c_long, ...) -> ::c_long;
-    pub fn sched_getaffinity(
-        pid: ::pid_t,
-        cpusetsize: ::size_t,
-        cpuset: *mut cpu_set_t,
-    ) -> ::c_int;
+    pub fn sched_getaffinity(pid: ::pid_t, cpusetsize: ::size_t, cpuset: *mut cpu_set_t)
+        -> ::c_int;
     pub fn sched_setaffinity(
         pid: ::pid_t,
         cpusetsize: ::size_t,
@@ -2570,12 +2497,8 @@ extern "C" {
         maxevents: ::c_int,
         timeout: ::c_int,
     ) -> ::c_int;
-    pub fn epoll_ctl(
-        epfd: ::c_int,
-        op: ::c_int,
-        fd: ::c_int,
-        event: *mut ::epoll_event,
-    ) -> ::c_int;
+    pub fn epoll_ctl(epfd: ::c_int, op: ::c_int, fd: ::c_int, event: *mut ::epoll_event)
+        -> ::c_int;
     pub fn pthread_getschedparam(
         native: ::pthread_t,
         policy: *mut ::c_int,
@@ -2584,16 +2507,8 @@ extern "C" {
     pub fn unshare(flags: ::c_int) -> ::c_int;
     pub fn umount(target: *const ::c_char) -> ::c_int;
     pub fn sched_get_priority_max(policy: ::c_int) -> ::c_int;
-    pub fn tee(
-        fd_in: ::c_int,
-        fd_out: ::c_int,
-        len: ::size_t,
-        flags: ::c_uint,
-    ) -> ::ssize_t;
-    pub fn settimeofday(
-        tv: *const ::timeval,
-        tz: *const ::timezone,
-    ) -> ::c_int;
+    pub fn tee(fd_in: ::c_int, fd_out: ::c_int, len: ::size_t, flags: ::c_uint) -> ::ssize_t;
+    pub fn settimeofday(tv: *const ::timeval, tz: *const ::timezone) -> ::c_int;
     pub fn splice(
         fd_in: ::c_int,
         off_in: *mut ::loff_t,
@@ -2603,17 +2518,10 @@ extern "C" {
         flags: ::c_uint,
     ) -> ::ssize_t;
     pub fn eventfd(init: ::c_uint, flags: ::c_int) -> ::c_int;
-    pub fn sched_rr_get_interval(pid: ::pid_t, tp: *mut ::timespec)
-        -> ::c_int;
-    pub fn sem_timedwait(
-        sem: *mut sem_t,
-        abstime: *const ::timespec,
-    ) -> ::c_int;
+    pub fn sched_rr_get_interval(pid: ::pid_t, tp: *mut ::timespec) -> ::c_int;
+    pub fn sem_timedwait(sem: *mut sem_t, abstime: *const ::timespec) -> ::c_int;
     pub fn sem_getvalue(sem: *mut sem_t, sval: *mut ::c_int) -> ::c_int;
-    pub fn sched_setparam(
-        pid: ::pid_t,
-        param: *const ::sched_param,
-    ) -> ::c_int;
+    pub fn sched_setparam(pid: ::pid_t, param: *const ::sched_param) -> ::c_int;
     pub fn setns(fd: ::c_int, nstype: ::c_int) -> ::c_int;
     pub fn swapoff(puath: *const ::c_char) -> ::c_int;
     pub fn vmsplice(
@@ -2704,11 +2612,7 @@ extern "C" {
         buflen: ::size_t,
         result: *mut *mut ::group,
     ) -> ::c_int;
-    pub fn pthread_sigmask(
-        how: ::c_int,
-        set: *const sigset_t,
-        oldset: *mut sigset_t,
-    ) -> ::c_int;
+    pub fn pthread_sigmask(how: ::c_int, set: *const sigset_t, oldset: *mut sigset_t) -> ::c_int;
     pub fn sem_open(name: *const ::c_char, oflag: ::c_int, ...) -> *mut sem_t;
     pub fn getgrnam(name: *const ::c_char) -> *mut ::group;
     pub fn pthread_kill(thread: ::pthread_t, sig: ::c_int) -> ::c_int;
@@ -2781,17 +2685,9 @@ extern "C" {
     ) -> ::c_int;
     pub fn inotify_init() -> ::c_int;
     pub fn inotify_init1(flags: ::c_int) -> ::c_int;
-    pub fn inotify_add_watch(
-        fd: ::c_int,
-        path: *const ::c_char,
-        mask: u32,
-    ) -> ::c_int;
+    pub fn inotify_add_watch(fd: ::c_int, path: *const ::c_char, mask: u32) -> ::c_int;
 
-    pub fn regcomp(
-        preg: *mut ::regex_t,
-        pattern: *const ::c_char,
-        cflags: ::c_int,
-    ) -> ::c_int;
+    pub fn regcomp(preg: *mut ::regex_t, pattern: *const ::c_char, cflags: ::c_int) -> ::c_int;
 
     pub fn regexec(
         preg: *const ::regex_t,

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1776,11 +1776,7 @@ extern "C" {
     pub fn setrlimit64(resource: ::c_int, rlim: *const rlimit64) -> ::c_int;
     pub fn getrlimit(resource: ::c_int, rlim: *mut ::rlimit) -> ::c_int;
     pub fn setrlimit(resource: ::c_int, rlim: *const ::rlimit) -> ::c_int;
-    pub fn strerror_r(
-        errnum: ::c_int,
-        buf: *mut c_char,
-        buflen: ::size_t,
-    ) -> ::c_int;
+    pub fn strerror_r(errnum: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
 
     pub fn abs(i: ::c_int) -> ::c_int;
     pub fn atof(s: *const ::c_char) -> ::c_double;
@@ -1794,23 +1790,12 @@ extern "C" {
     pub fn endpwent();
     pub fn getpwent() -> *mut passwd;
 
-    pub fn shm_open(
-        name: *const c_char,
-        oflag: ::c_int,
-        mode: mode_t,
-    ) -> ::c_int;
+    pub fn shm_open(name: *const c_char, oflag: ::c_int, mode: mode_t) -> ::c_int;
 
-    pub fn mprotect(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        prot: ::c_int,
-    ) -> ::c_int;
+    pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
     pub fn __errno_location() -> *mut ::c_int;
 
-    pub fn fopen64(
-        filename: *const c_char,
-        mode: *const c_char,
-    ) -> *mut ::FILE;
+    pub fn fopen64(filename: *const c_char, mode: *const c_char) -> *mut ::FILE;
     pub fn freopen64(
         filename: *const c_char,
         mode: *const c_char,
@@ -1819,38 +1804,16 @@ extern "C" {
     pub fn tmpfile64() -> *mut ::FILE;
     pub fn fgetpos64(stream: *mut ::FILE, ptr: *mut fpos64_t) -> ::c_int;
     pub fn fsetpos64(stream: *mut ::FILE, ptr: *const fpos64_t) -> ::c_int;
-    pub fn fseeko64(
-        stream: *mut ::FILE,
-        offset: ::off64_t,
-        whence: ::c_int,
-    ) -> ::c_int;
+    pub fn fseeko64(stream: *mut ::FILE, offset: ::off64_t, whence: ::c_int) -> ::c_int;
     pub fn ftello64(stream: *mut ::FILE) -> ::off64_t;
-    pub fn posix_fallocate(
-        fd: ::c_int,
-        offset: ::off_t,
-        len: ::off_t,
-    ) -> ::c_int;
-    pub fn pwritev(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-        offset: ::off_t,
-    ) -> ::ssize_t;
-    pub fn preadv(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-        offset: ::off_t,
-    ) -> ::ssize_t;
+    pub fn posix_fallocate(fd: ::c_int, offset: ::off_t, len: ::off_t) -> ::c_int;
+    pub fn pwritev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t)
+        -> ::ssize_t;
+    pub fn preadv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t) -> ::ssize_t;
     pub fn dup3(oldfd: ::c_int, newfd: ::c_int, flags: ::c_int) -> ::c_int;
     pub fn mkostemp(template: *mut ::c_char, flags: ::c_int) -> ::c_int;
-    pub fn mkostemps(
-        template: *mut ::c_char,
-        suffixlen: ::c_int,
-        flags: ::c_int,
-    ) -> ::c_int;
-    pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t)
-        -> *mut ::c_char;
+    pub fn mkostemps(template: *mut ::c_char, suffixlen: ::c_int, flags: ::c_int) -> ::c_int;
+    pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t) -> *mut ::c_char;
     pub fn accept4(
         fd: ::c_int,
         addr: *mut ::sockaddr,
@@ -1869,11 +1832,7 @@ extern "C" {
     pub fn getloadavg(loadavg: *mut ::c_double, nelem: ::c_int) -> ::c_int;
 
     // Not available now on Android
-    pub fn mkfifoat(
-        dirfd: ::c_int,
-        pathname: *const ::c_char,
-        mode: ::mode_t,
-    ) -> ::c_int;
+    pub fn mkfifoat(dirfd: ::c_int, pathname: *const ::c_char, mode: ::mode_t) -> ::c_int;
     pub fn if_nameindex() -> *mut if_nameindex;
     pub fn if_freenameindex(ptr: *mut if_nameindex);
 
@@ -1888,35 +1847,21 @@ extern "C" {
     pub fn glob(
         pattern: *const c_char,
         flags: ::c_int,
-        errfunc: ::Option<
-            extern "C" fn(epath: *const c_char, errno: ::c_int) -> ::c_int,
-        >,
+        errfunc: ::Option<extern "C" fn(epath: *const c_char, errno: ::c_int) -> ::c_int>,
         pglob: *mut ::glob_t,
     ) -> ::c_int;
     pub fn globfree(pglob: *mut ::glob_t);
 
-    pub fn posix_madvise(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        advice: ::c_int,
-    ) -> ::c_int;
+    pub fn posix_madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
 
     pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
 
     pub fn seekdir(dirp: *mut ::DIR, loc: ::c_long);
 
     pub fn telldir(dirp: *mut ::DIR) -> ::c_long;
-    pub fn madvise(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        advice: ::c_int,
-    ) -> ::c_int;
+    pub fn madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
 
-    pub fn msync(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn msync(addr: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::c_int;
 
     pub fn recvfrom(
         socket: ::c_int,

--- a/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
@@ -1169,16 +1169,8 @@ pub const REG_SS: ::c_int = 18;
 extern "C" {
     pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;
     pub fn setcontext(ucp: *const ucontext_t) -> ::c_int;
-    pub fn makecontext(
-        ucp: *mut ucontext_t,
-        func: extern "C" fn(),
-        argc: ::c_int,
-        ...
-    );
-    pub fn swapcontext(
-        uocp: *mut ucontext_t,
-        ucp: *const ucontext_t,
-    ) -> ::c_int;
+    pub fn makecontext(ucp: *mut ucontext_t, func: extern "C" fn(), argc: ::c_int, ...);
+    pub fn swapcontext(uocp: *mut ucontext_t, ucp: *const ucontext_t) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -1041,14 +1041,6 @@ extern "C" {
     ) -> ::c_int;
     pub fn getcontext(ucp: *mut ::ucontext_t) -> ::c_int;
     pub fn setcontext(ucp: *const ::ucontext_t) -> ::c_int;
-    pub fn makecontext(
-        ucp: *mut ::ucontext_t,
-        func: extern "C" fn(),
-        argc: ::c_int,
-        ...
-    );
-    pub fn swapcontext(
-        uocp: *mut ::ucontext_t,
-        ucp: *const ::ucontext_t,
-    ) -> ::c_int;
+    pub fn makecontext(ucp: *mut ::ucontext_t, func: extern "C" fn(), argc: ::c_int, ...);
+    pub fn swapcontext(uocp: *mut ::ucontext_t, ucp: *const ::ucontext_t) -> ::c_int;
 }

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -920,22 +920,10 @@ pub const REG_CR2: ::c_int = 22;
 extern "C" {
     pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;
     pub fn setcontext(ucp: *const ucontext_t) -> ::c_int;
-    pub fn makecontext(
-        ucp: *mut ucontext_t,
-        func: extern "C" fn(),
-        argc: ::c_int,
-        ...
-    );
-    pub fn swapcontext(
-        uocp: *mut ucontext_t,
-        ucp: *const ucontext_t,
-    ) -> ::c_int;
+    pub fn makecontext(ucp: *mut ucontext_t, func: extern "C" fn(), argc: ::c_int, ...);
+    pub fn swapcontext(uocp: *mut ucontext_t, ucp: *const ucontext_t) -> ::c_int;
     pub fn iopl(level: ::c_int) -> ::c_int;
-    pub fn ioperm(
-        from: ::c_ulong,
-        num: ::c_ulong,
-        turn_on: ::c_int,
-    ) -> ::c_int;
+    pub fn ioperm(from: ::c_ulong, num: ::c_ulong, turn_on: ::c_int) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1335,11 +1335,7 @@ extern "C" {
         num: ::size_t,
         size: ::size_t,
         compar: ::Option<
-            unsafe extern "C" fn(
-                *const ::c_void,
-                *const ::c_void,
-                *mut ::c_void,
-            ) -> ::c_int,
+            unsafe extern "C" fn(*const ::c_void, *const ::c_void, *mut ::c_void) -> ::c_int,
         >,
         arg: *mut ::c_void,
     );
@@ -1357,22 +1353,10 @@ extern "C" {
         timeout: *mut ::timespec,
     ) -> ::c_int;
 
-    pub fn getrlimit64(
-        resource: ::__rlimit_resource_t,
-        rlim: *mut ::rlimit64,
-    ) -> ::c_int;
-    pub fn setrlimit64(
-        resource: ::__rlimit_resource_t,
-        rlim: *const ::rlimit64,
-    ) -> ::c_int;
-    pub fn getrlimit(
-        resource: ::__rlimit_resource_t,
-        rlim: *mut ::rlimit,
-    ) -> ::c_int;
-    pub fn setrlimit(
-        resource: ::__rlimit_resource_t,
-        rlim: *const ::rlimit,
-    ) -> ::c_int;
+    pub fn getrlimit64(resource: ::__rlimit_resource_t, rlim: *mut ::rlimit64) -> ::c_int;
+    pub fn setrlimit64(resource: ::__rlimit_resource_t, rlim: *const ::rlimit64) -> ::c_int;
+    pub fn getrlimit(resource: ::__rlimit_resource_t, rlim: *mut ::rlimit) -> ::c_int;
+    pub fn setrlimit(resource: ::__rlimit_resource_t, rlim: *const ::rlimit) -> ::c_int;
     pub fn prlimit(
         pid: ::pid_t,
         resource: ::__rlimit_resource_t,
@@ -1403,11 +1387,7 @@ extern "C" {
         mask: ::c_uint,
         statxbuf: *mut statx,
     ) -> ::c_int;
-    pub fn getrandom(
-        buf: *mut ::c_void,
-        buflen: ::size_t,
-        flags: ::c_uint,
-    ) -> ::ssize_t;
+    pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
 
     pub fn memmem(
         haystack: *const ::c_void,
@@ -1465,9 +1445,7 @@ extern "C" {
     pub fn glob64(
         pattern: *const ::c_char,
         flags: ::c_int,
-        errfunc: ::Option<
-            extern "C" fn(epath: *const ::c_char, errno: ::c_int) -> ::c_int,
-        >,
+        errfunc: ::Option<extern "C" fn(epath: *const ::c_char, errno: ::c_int) -> ::c_int>,
         pglob: *mut glob64_t,
     ) -> ::c_int;
     pub fn globfree64(pglob: *mut glob64_t);
@@ -1483,11 +1461,7 @@ extern "C" {
         cpuset: *const ::cpu_set_t,
     ) -> ::c_int;
     pub fn getpriority(which: ::__priority_which_t, who: ::id_t) -> ::c_int;
-    pub fn setpriority(
-        which: ::__priority_which_t,
-        who: ::id_t,
-        prio: ::c_int,
-    ) -> ::c_int;
+    pub fn setpriority(which: ::__priority_which_t, who: ::id_t, prio: ::c_int) -> ::c_int;
     pub fn pthread_getaffinity_np(
         thread: ::pthread_t,
         cpusetsize: ::size_t,
@@ -1521,28 +1495,13 @@ extern "C" {
         buflen: ::size_t,
         result: *mut *mut ::group,
     ) -> ::c_int;
-    pub fn pthread_getname_np(
-        thread: ::pthread_t,
-        name: *mut ::c_char,
-        len: ::size_t,
-    ) -> ::c_int;
-    pub fn pthread_setname_np(
-        thread: ::pthread_t,
-        name: *const ::c_char,
-    ) -> ::c_int;
+    pub fn pthread_getname_np(thread: ::pthread_t, name: *mut ::c_char, len: ::size_t) -> ::c_int;
+    pub fn pthread_setname_np(thread: ::pthread_t, name: *const ::c_char) -> ::c_int;
 }
 
 extern "C" {
-    pub fn dlmopen(
-        lmid: Lmid_t,
-        filename: *const ::c_char,
-        flag: ::c_int,
-    ) -> *mut ::c_void;
-    pub fn dlinfo(
-        handle: *mut ::c_void,
-        request: ::c_int,
-        info: *mut ::c_void,
-    ) -> ::c_int;
+    pub fn dlmopen(lmid: Lmid_t, filename: *const ::c_char, flag: ::c_int) -> *mut ::c_void;
+    pub fn dlinfo(handle: *mut ::c_void, request: ::c_int, info: *mut ::c_void) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -2688,8 +2688,7 @@ pub const FUTEX_CMP_REQUEUE_PI: ::c_int = 12;
 
 pub const FUTEX_PRIVATE_FLAG: ::c_int = 128;
 pub const FUTEX_CLOCK_REALTIME: ::c_int = 256;
-pub const FUTEX_CMD_MASK: ::c_int =
-    !(FUTEX_PRIVATE_FLAG | FUTEX_CLOCK_REALTIME);
+pub const FUTEX_CMD_MASK: ::c_int = !(FUTEX_PRIVATE_FLAG | FUTEX_CLOCK_REALTIME);
 
 // linux/reboot.h
 pub const LINUX_REBOOT_MAGIC1: ::c_int = 0xfee1dead;
@@ -3011,11 +3010,7 @@ cfg_if! {
 
 extern "C" {
     #[cfg_attr(not(target_env = "musl"), link_name = "__xpg_strerror_r")]
-    pub fn strerror_r(
-        errnum: ::c_int,
-        buf: *mut c_char,
-        buflen: ::size_t,
-    ) -> ::c_int;
+    pub fn strerror_r(errnum: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
 
     pub fn abs(i: ::c_int) -> ::c_int;
     pub fn atof(s: *const ::c_char) -> ::c_double;
@@ -3047,40 +3042,18 @@ extern "C" {
         spbufp: *mut *mut spwd,
     ) -> ::c_int;
 
-    pub fn shm_open(
-        name: *const c_char,
-        oflag: ::c_int,
-        mode: mode_t,
-    ) -> ::c_int;
+    pub fn shm_open(name: *const c_char, oflag: ::c_int, mode: mode_t) -> ::c_int;
 
     // System V IPC
     pub fn shmget(key: ::key_t, size: ::size_t, shmflg: ::c_int) -> ::c_int;
-    pub fn shmat(
-        shmid: ::c_int,
-        shmaddr: *const ::c_void,
-        shmflg: ::c_int,
-    ) -> *mut ::c_void;
+    pub fn shmat(shmid: ::c_int, shmaddr: *const ::c_void, shmflg: ::c_int) -> *mut ::c_void;
     pub fn shmdt(shmaddr: *const ::c_void) -> ::c_int;
-    pub fn shmctl(
-        shmid: ::c_int,
-        cmd: ::c_int,
-        buf: *mut ::shmid_ds,
-    ) -> ::c_int;
+    pub fn shmctl(shmid: ::c_int, cmd: ::c_int, buf: *mut ::shmid_ds) -> ::c_int;
     pub fn ftok(pathname: *const ::c_char, proj_id: ::c_int) -> ::key_t;
     pub fn semget(key: ::key_t, nsems: ::c_int, semflag: ::c_int) -> ::c_int;
-    pub fn semop(
-        semid: ::c_int,
-        sops: *mut ::sembuf,
-        nsops: ::size_t,
-    ) -> ::c_int;
-    pub fn semctl(
-        semid: ::c_int,
-        semnum: ::c_int,
-        cmd: ::c_int,
-        ...
-    ) -> ::c_int;
-    pub fn msgctl(msqid: ::c_int, cmd: ::c_int, buf: *mut msqid_ds)
-        -> ::c_int;
+    pub fn semop(semid: ::c_int, sops: *mut ::sembuf, nsops: ::size_t) -> ::c_int;
+    pub fn semctl(semid: ::c_int, semnum: ::c_int, cmd: ::c_int, ...) -> ::c_int;
+    pub fn msgctl(msqid: ::c_int, cmd: ::c_int, buf: *mut msqid_ds) -> ::c_int;
     pub fn msgget(key: ::key_t, msgflg: ::c_int) -> ::c_int;
     pub fn msgrcv(
         msqid: ::c_int,
@@ -3096,17 +3069,10 @@ extern "C" {
         msgflg: ::c_int,
     ) -> ::c_int;
 
-    pub fn mprotect(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        prot: ::c_int,
-    ) -> ::c_int;
+    pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
     pub fn __errno_location() -> *mut ::c_int;
 
-    pub fn fopen64(
-        filename: *const c_char,
-        mode: *const c_char,
-    ) -> *mut ::FILE;
+    pub fn fopen64(filename: *const c_char, mode: *const c_char) -> *mut ::FILE;
     pub fn freopen64(
         filename: *const c_char,
         mode: *const c_char,
@@ -3115,39 +3081,13 @@ extern "C" {
     pub fn tmpfile64() -> *mut ::FILE;
     pub fn fgetpos64(stream: *mut ::FILE, ptr: *mut fpos64_t) -> ::c_int;
     pub fn fsetpos64(stream: *mut ::FILE, ptr: *const fpos64_t) -> ::c_int;
-    pub fn fseeko64(
-        stream: *mut ::FILE,
-        offset: ::off64_t,
-        whence: ::c_int,
-    ) -> ::c_int;
+    pub fn fseeko64(stream: *mut ::FILE, offset: ::off64_t, whence: ::c_int) -> ::c_int;
     pub fn ftello64(stream: *mut ::FILE) -> ::off64_t;
-    pub fn fallocate(
-        fd: ::c_int,
-        mode: ::c_int,
-        offset: ::off_t,
-        len: ::off_t,
-    ) -> ::c_int;
-    pub fn fallocate64(
-        fd: ::c_int,
-        mode: ::c_int,
-        offset: ::off64_t,
-        len: ::off64_t,
-    ) -> ::c_int;
-    pub fn posix_fallocate(
-        fd: ::c_int,
-        offset: ::off_t,
-        len: ::off_t,
-    ) -> ::c_int;
-    pub fn posix_fallocate64(
-        fd: ::c_int,
-        offset: ::off64_t,
-        len: ::off64_t,
-    ) -> ::c_int;
-    pub fn readahead(
-        fd: ::c_int,
-        offset: ::off64_t,
-        count: ::size_t,
-    ) -> ::ssize_t;
+    pub fn fallocate(fd: ::c_int, mode: ::c_int, offset: ::off_t, len: ::off_t) -> ::c_int;
+    pub fn fallocate64(fd: ::c_int, mode: ::c_int, offset: ::off64_t, len: ::off64_t) -> ::c_int;
+    pub fn posix_fallocate(fd: ::c_int, offset: ::off_t, len: ::off_t) -> ::c_int;
+    pub fn posix_fallocate64(fd: ::c_int, offset: ::off64_t, len: ::off64_t) -> ::c_int;
+    pub fn readahead(fd: ::c_int, offset: ::off64_t, count: ::size_t) -> ::ssize_t;
     pub fn getxattr(
         path: *const c_char,
         name: *const c_char,
@@ -3187,34 +3127,15 @@ extern "C" {
         size: ::size_t,
         flags: ::c_int,
     ) -> ::c_int;
-    pub fn listxattr(
-        path: *const c_char,
-        list: *mut c_char,
-        size: ::size_t,
-    ) -> ::ssize_t;
-    pub fn llistxattr(
-        path: *const c_char,
-        list: *mut c_char,
-        size: ::size_t,
-    ) -> ::ssize_t;
-    pub fn flistxattr(
-        filedes: ::c_int,
-        list: *mut c_char,
-        size: ::size_t,
-    ) -> ::ssize_t;
+    pub fn listxattr(path: *const c_char, list: *mut c_char, size: ::size_t) -> ::ssize_t;
+    pub fn llistxattr(path: *const c_char, list: *mut c_char, size: ::size_t) -> ::ssize_t;
+    pub fn flistxattr(filedes: ::c_int, list: *mut c_char, size: ::size_t) -> ::ssize_t;
     pub fn removexattr(path: *const c_char, name: *const c_char) -> ::c_int;
     pub fn lremovexattr(path: *const c_char, name: *const c_char) -> ::c_int;
     pub fn fremovexattr(filedes: ::c_int, name: *const c_char) -> ::c_int;
-    pub fn signalfd(
-        fd: ::c_int,
-        mask: *const ::sigset_t,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn signalfd(fd: ::c_int, mask: *const ::sigset_t, flags: ::c_int) -> ::c_int;
     pub fn timerfd_create(clockid: ::c_int, flags: ::c_int) -> ::c_int;
-    pub fn timerfd_gettime(
-        fd: ::c_int,
-        curr_value: *mut itimerspec,
-    ) -> ::c_int;
+    pub fn timerfd_gettime(fd: ::c_int, curr_value: *mut itimerspec) -> ::c_int;
     pub fn timerfd_settime(
         fd: ::c_int,
         flags: ::c_int,
@@ -3257,11 +3178,7 @@ extern "C" {
         abs_timeout: *const ::timespec,
     ) -> ::c_int;
     pub fn mq_getattr(mqd: ::mqd_t, attr: *mut ::mq_attr) -> ::c_int;
-    pub fn mq_setattr(
-        mqd: ::mqd_t,
-        newattr: *const ::mq_attr,
-        oldattr: *mut ::mq_attr,
-    ) -> ::c_int;
+    pub fn mq_setattr(mqd: ::mqd_t, newattr: *const ::mq_attr, oldattr: *mut ::mq_attr) -> ::c_int;
     pub fn epoll_pwait(
         epfd: ::c_int,
         events: *mut ::epoll_event,
@@ -3271,39 +3188,27 @@ extern "C" {
     ) -> ::c_int;
     pub fn dup3(oldfd: ::c_int, newfd: ::c_int, flags: ::c_int) -> ::c_int;
     pub fn mkostemp(template: *mut ::c_char, flags: ::c_int) -> ::c_int;
-    pub fn mkostemps(
-        template: *mut ::c_char,
-        suffixlen: ::c_int,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn mkostemps(template: *mut ::c_char, suffixlen: ::c_int, flags: ::c_int) -> ::c_int;
     pub fn sigtimedwait(
         set: *const sigset_t,
         info: *mut siginfo_t,
         timeout: *const ::timespec,
     ) -> ::c_int;
     pub fn sigwaitinfo(set: *const sigset_t, info: *mut siginfo_t) -> ::c_int;
-    pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t)
-        -> *mut ::c_char;
+    pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t) -> *mut ::c_char;
     pub fn accept4(
         fd: ::c_int,
         addr: *mut ::sockaddr,
         len: *mut ::socklen_t,
         flg: ::c_int,
     ) -> ::c_int;
-    pub fn pthread_setschedprio(
-        native: ::pthread_t,
-        priority: ::c_int,
-    ) -> ::c_int;
+    pub fn pthread_setschedprio(native: ::pthread_t, priority: ::c_int) -> ::c_int;
     pub fn reboot(how_to: ::c_int) -> ::c_int;
     pub fn setfsgid(gid: ::gid_t) -> ::c_int;
     pub fn setfsuid(uid: ::uid_t) -> ::c_int;
 
     // Not available now on Android
-    pub fn mkfifoat(
-        dirfd: ::c_int,
-        pathname: *const ::c_char,
-        mode: ::mode_t,
-    ) -> ::c_int;
+    pub fn mkfifoat(dirfd: ::c_int, pathname: *const ::c_char, mode: ::mode_t) -> ::c_int;
     pub fn if_nameindex() -> *mut if_nameindex;
     pub fn if_freenameindex(ptr: *mut if_nameindex);
     pub fn sync_file_range(
@@ -3323,35 +3228,21 @@ extern "C" {
     pub fn glob(
         pattern: *const c_char,
         flags: ::c_int,
-        errfunc: ::Option<
-            extern "C" fn(epath: *const c_char, errno: ::c_int) -> ::c_int,
-        >,
+        errfunc: ::Option<extern "C" fn(epath: *const c_char, errno: ::c_int) -> ::c_int>,
         pglob: *mut ::glob_t,
     ) -> ::c_int;
     pub fn globfree(pglob: *mut ::glob_t);
 
-    pub fn posix_madvise(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        advice: ::c_int,
-    ) -> ::c_int;
+    pub fn posix_madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
 
     pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
 
     pub fn seekdir(dirp: *mut ::DIR, loc: ::c_long);
 
     pub fn telldir(dirp: *mut ::DIR) -> ::c_long;
-    pub fn madvise(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        advice: ::c_int,
-    ) -> ::c_int;
+    pub fn madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
 
-    pub fn msync(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn msync(addr: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::c_int;
     pub fn remap_file_pages(
         addr: *mut ::c_void,
         size: ::size_t,
@@ -3376,11 +3267,8 @@ extern "C" {
     pub fn vhangup() -> ::c_int;
     pub fn sync();
     pub fn syscall(num: ::c_long, ...) -> ::c_long;
-    pub fn sched_getaffinity(
-        pid: ::pid_t,
-        cpusetsize: ::size_t,
-        cpuset: *mut cpu_set_t,
-    ) -> ::c_int;
+    pub fn sched_getaffinity(pid: ::pid_t, cpusetsize: ::size_t, cpuset: *mut cpu_set_t)
+        -> ::c_int;
     pub fn sched_setaffinity(
         pid: ::pid_t,
         cpusetsize: ::size_t,
@@ -3394,12 +3282,8 @@ extern "C" {
         maxevents: ::c_int,
         timeout: ::c_int,
     ) -> ::c_int;
-    pub fn epoll_ctl(
-        epfd: ::c_int,
-        op: ::c_int,
-        fd: ::c_int,
-        event: *mut ::epoll_event,
-    ) -> ::c_int;
+    pub fn epoll_ctl(epfd: ::c_int, op: ::c_int, fd: ::c_int, event: *mut ::epoll_event)
+        -> ::c_int;
     pub fn pthread_getschedparam(
         native: ::pthread_t,
         policy: *mut ::c_int,
@@ -3408,16 +3292,8 @@ extern "C" {
     pub fn unshare(flags: ::c_int) -> ::c_int;
     pub fn umount(target: *const ::c_char) -> ::c_int;
     pub fn sched_get_priority_max(policy: ::c_int) -> ::c_int;
-    pub fn tee(
-        fd_in: ::c_int,
-        fd_out: ::c_int,
-        len: ::size_t,
-        flags: ::c_uint,
-    ) -> ::ssize_t;
-    pub fn settimeofday(
-        tv: *const ::timeval,
-        tz: *const ::timezone,
-    ) -> ::c_int;
+    pub fn tee(fd_in: ::c_int, fd_out: ::c_int, len: ::size_t, flags: ::c_uint) -> ::ssize_t;
+    pub fn settimeofday(tv: *const ::timeval, tz: *const ::timezone) -> ::c_int;
     pub fn splice(
         fd_in: ::c_int,
         off_in: *mut ::loff_t,
@@ -3427,17 +3303,10 @@ extern "C" {
         flags: ::c_uint,
     ) -> ::ssize_t;
     pub fn eventfd(init: ::c_uint, flags: ::c_int) -> ::c_int;
-    pub fn sched_rr_get_interval(pid: ::pid_t, tp: *mut ::timespec)
-        -> ::c_int;
-    pub fn sem_timedwait(
-        sem: *mut sem_t,
-        abstime: *const ::timespec,
-    ) -> ::c_int;
+    pub fn sched_rr_get_interval(pid: ::pid_t, tp: *mut ::timespec) -> ::c_int;
+    pub fn sem_timedwait(sem: *mut sem_t, abstime: *const ::timespec) -> ::c_int;
     pub fn sem_getvalue(sem: *mut sem_t, sval: *mut ::c_int) -> ::c_int;
-    pub fn sched_setparam(
-        pid: ::pid_t,
-        param: *const ::sched_param,
-    ) -> ::c_int;
+    pub fn sched_setparam(pid: ::pid_t, param: *const ::sched_param) -> ::c_int;
     pub fn setns(fd: ::c_int, nstype: ::c_int) -> ::c_int;
     pub fn swapoff(path: *const ::c_char) -> ::c_int;
     pub fn vmsplice(
@@ -3534,11 +3403,7 @@ extern "C" {
         result: *mut *mut ::group,
     ) -> ::c_int;
     pub fn initgroups(user: *const ::c_char, group: ::gid_t) -> ::c_int;
-    pub fn pthread_sigmask(
-        how: ::c_int,
-        set: *const sigset_t,
-        oldset: *mut sigset_t,
-    ) -> ::c_int;
+    pub fn pthread_sigmask(how: ::c_int, set: *const sigset_t, oldset: *mut sigset_t) -> ::c_int;
     pub fn sem_open(name: *const ::c_char, oflag: ::c_int, ...) -> *mut sem_t;
     pub fn getgrnam(name: *const ::c_char) -> *mut ::group;
     pub fn pthread_cancel(thread: ::pthread_t) -> ::c_int;
@@ -3600,17 +3465,11 @@ extern "C" {
         data: *mut ::c_void,
     ) -> ::c_int;
 
-    pub fn setmntent(
-        filename: *const ::c_char,
-        ty: *const ::c_char,
-    ) -> *mut ::FILE;
+    pub fn setmntent(filename: *const ::c_char, ty: *const ::c_char) -> *mut ::FILE;
     pub fn getmntent(stream: *mut ::FILE) -> *mut ::mntent;
     pub fn addmntent(stream: *mut ::FILE, mnt: *const ::mntent) -> ::c_int;
     pub fn endmntent(streamp: *mut ::FILE) -> ::c_int;
-    pub fn hasmntopt(
-        mnt: *const ::mntent,
-        opt: *const ::c_char,
-    ) -> *mut ::c_char;
+    pub fn hasmntopt(mnt: *const ::mntent, opt: *const ::c_char) -> *mut ::c_char;
 
     pub fn posix_spawn(
         pid: *mut ::pid_t,
@@ -3650,26 +3509,17 @@ extern "C" {
         attr: *const posix_spawnattr_t,
         flags: *mut ::c_short,
     ) -> ::c_int;
-    pub fn posix_spawnattr_setflags(
-        attr: *mut posix_spawnattr_t,
-        flags: ::c_short,
-    ) -> ::c_int;
+    pub fn posix_spawnattr_setflags(attr: *mut posix_spawnattr_t, flags: ::c_short) -> ::c_int;
     pub fn posix_spawnattr_getpgroup(
         attr: *const posix_spawnattr_t,
         flags: *mut ::pid_t,
     ) -> ::c_int;
-    pub fn posix_spawnattr_setpgroup(
-        attr: *mut posix_spawnattr_t,
-        flags: ::pid_t,
-    ) -> ::c_int;
+    pub fn posix_spawnattr_setpgroup(attr: *mut posix_spawnattr_t, flags: ::pid_t) -> ::c_int;
     pub fn posix_spawnattr_getschedpolicy(
         attr: *const posix_spawnattr_t,
         flags: *mut ::c_int,
     ) -> ::c_int;
-    pub fn posix_spawnattr_setschedpolicy(
-        attr: *mut posix_spawnattr_t,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn posix_spawnattr_setschedpolicy(attr: *mut posix_spawnattr_t, flags: ::c_int) -> ::c_int;
     pub fn posix_spawnattr_getschedparam(
         attr: *const posix_spawnattr_t,
         param: *mut ::sched_param,
@@ -3679,12 +3529,8 @@ extern "C" {
         param: *const ::sched_param,
     ) -> ::c_int;
 
-    pub fn posix_spawn_file_actions_init(
-        actions: *mut posix_spawn_file_actions_t,
-    ) -> ::c_int;
-    pub fn posix_spawn_file_actions_destroy(
-        actions: *mut posix_spawn_file_actions_t,
-    ) -> ::c_int;
+    pub fn posix_spawn_file_actions_init(actions: *mut posix_spawn_file_actions_t) -> ::c_int;
+    pub fn posix_spawn_file_actions_destroy(actions: *mut posix_spawn_file_actions_t) -> ::c_int;
     pub fn posix_spawn_file_actions_addopen(
         actions: *mut posix_spawn_file_actions_t,
         fd: ::c_int,
@@ -3710,18 +3556,10 @@ extern "C" {
     pub fn inotify_rm_watch(fd: ::c_int, wd: ::c_int) -> ::c_int;
     pub fn inotify_init() -> ::c_int;
     pub fn inotify_init1(flags: ::c_int) -> ::c_int;
-    pub fn inotify_add_watch(
-        fd: ::c_int,
-        path: *const ::c_char,
-        mask: u32,
-    ) -> ::c_int;
+    pub fn inotify_add_watch(fd: ::c_int, path: *const ::c_char, mask: u32) -> ::c_int;
     pub fn fanotify_init(flags: ::c_uint, event_f_flags: ::c_uint) -> ::c_int;
 
-    pub fn regcomp(
-        preg: *mut ::regex_t,
-        pattern: *const ::c_char,
-        cflags: ::c_int,
-    ) -> ::c_int;
+    pub fn regcomp(preg: *mut ::regex_t, pattern: *const ::c_char, cflags: ::c_int) -> ::c_int;
 
     pub fn regexec(
         preg: *const ::regex_t,
@@ -3740,10 +3578,7 @@ extern "C" {
 
     pub fn regfree(preg: *mut ::regex_t);
 
-    pub fn iconv_open(
-        tocode: *const ::c_char,
-        fromcode: *const ::c_char,
-    ) -> iconv_t;
+    pub fn iconv_open(tocode: *const ::c_char, fromcode: *const ::c_char) -> iconv_t;
     pub fn iconv(
         cd: iconv_t,
         inbuf: *mut *mut ::c_char,

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -856,11 +856,7 @@ pub const SYS_epoll_pwait2: ::c_long = 441;
 pub const SYS_mount_setattr: ::c_long = 442;
 
 extern "C" {
-    pub fn getrandom(
-        buf: *mut ::c_void,
-        buflen: ::size_t,
-        flags: ::c_uint,
-    ) -> ::ssize_t;
+    pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
 }
 
 cfg_if! {

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -879,9 +879,5 @@ pub const SYS_epoll_pwait2: ::c_long = 441;
 pub const SYS_mount_setattr: ::c_long = 442;
 
 extern "C" {
-    pub fn getrandom(
-        buf: *mut ::c_void,
-        buflen: ::size_t,
-        flags: ::c_uint,
-    ) -> ::ssize_t;
+    pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
 }

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -965,11 +965,7 @@ pub const UESP: ::c_int = 15;
 pub const SS: ::c_int = 16;
 
 extern "C" {
-    pub fn getrandom(
-        buf: *mut ::c_void,
-        buflen: ::size_t,
-        flags: ::c_uint,
-    ) -> ::ssize_t;
+    pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
 }
 
 cfg_if! {

--- a/src/unix/linux_like/linux/musl/b64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/mod.rs
@@ -144,11 +144,7 @@ pub const SOCK_NONBLOCK: ::c_int = 2048;
 pub const SOCK_SEQPACKET: ::c_int = 5;
 
 extern "C" {
-    pub fn getrandom(
-        buf: *mut ::c_void,
-        buflen: ::size_t,
-        flags: ::c_uint,
-    ) -> ::ssize_t;
+    pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
 }
 
 cfg_if! {

--- a/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
@@ -640,9 +640,7 @@ extern "C" {
     pub fn glob64(
         pattern: *const ::c_char,
         flags: ::c_int,
-        errfunc: ::Option<
-            extern "C" fn(epath: *const ::c_char, errno: ::c_int) -> ::c_int,
-        >,
+        errfunc: ::Option<extern "C" fn(epath: *const ::c_char, errno: ::c_int) -> ::c_int>,
         pglob: *mut glob64_t,
     ) -> ::c_int;
     pub fn globfree64(pglob: *mut glob64_t);

--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -147,8 +147,7 @@ pub const LC_ALL: ::c_int = 6;
 // end different section
 
 // MS_ flags for mount(2)
-pub const MS_RMT_MASK: ::c_ulong =
-    ::MS_RDONLY | ::MS_SYNCHRONOUS | ::MS_MANDLOCK | ::MS_I_VERSION;
+pub const MS_RMT_MASK: ::c_ulong = ::MS_RDONLY | ::MS_SYNCHRONOUS | ::MS_MANDLOCK | ::MS_I_VERSION;
 
 pub const ENOTSUP: ::c_int = EOPNOTSUPP;
 

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1438,35 +1438,18 @@ safe_f! {
 
 extern "C" {
     pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
-    pub fn sem_init(
-        sem: *mut sem_t,
-        pshared: ::c_int,
-        value: ::c_uint,
-    ) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t, pshared: ::c_int, value: ::c_uint) -> ::c_int;
     pub fn fdatasync(fd: ::c_int) -> ::c_int;
-    pub fn mincore(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        vec: *mut ::c_uchar,
-    ) -> ::c_int;
+    pub fn mincore(addr: *mut ::c_void, len: ::size_t, vec: *mut ::c_uchar) -> ::c_int;
 
     pub fn clock_getres(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
     pub fn clock_gettime(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
-    pub fn clock_settime(
-        clk_id: ::clockid_t,
-        tp: *const ::timespec,
-    ) -> ::c_int;
-    pub fn clock_getcpuclockid(
-        pid: ::pid_t,
-        clk_id: *mut ::clockid_t,
-    ) -> ::c_int;
+    pub fn clock_settime(clk_id: ::clockid_t, tp: *const ::timespec) -> ::c_int;
+    pub fn clock_getcpuclockid(pid: ::pid_t, clk_id: *mut ::clockid_t) -> ::c_int;
 
     pub fn dirfd(dirp: *mut ::DIR) -> ::c_int;
 
-    pub fn pthread_getattr_np(
-        native: ::pthread_t,
-        attr: *mut ::pthread_attr_t,
-    ) -> ::c_int;
+    pub fn pthread_getattr_np(native: ::pthread_t, attr: *mut ::pthread_attr_t) -> ::c_int;
     pub fn pthread_attr_getstack(
         attr: *const ::pthread_attr_t,
         stackaddr: *mut *mut ::c_void,
@@ -1481,18 +1464,9 @@ extern "C" {
     pub fn fstatfs64(fd: ::c_int, buf: *mut statfs64) -> ::c_int;
     pub fn statvfs64(path: *const ::c_char, buf: *mut statvfs64) -> ::c_int;
     pub fn fstatvfs64(fd: ::c_int, buf: *mut statvfs64) -> ::c_int;
-    pub fn memrchr(
-        cx: *const ::c_void,
-        c: ::c_int,
-        n: ::size_t,
-    ) -> *mut ::c_void;
+    pub fn memrchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
 
-    pub fn posix_fadvise(
-        fd: ::c_int,
-        offset: ::off_t,
-        len: ::off_t,
-        advise: ::c_int,
-    ) -> ::c_int;
+    pub fn posix_fadvise(fd: ::c_int, offset: ::off_t, len: ::off_t, advise: ::c_int) -> ::c_int;
     pub fn posix_fadvise64(
         fd: ::c_int,
         offset: ::off64_t,
@@ -1508,11 +1482,7 @@ extern "C" {
     ) -> ::c_int;
     pub fn duplocale(base: ::locale_t) -> ::locale_t;
     pub fn freelocale(loc: ::locale_t);
-    pub fn newlocale(
-        mask: ::c_int,
-        locale: *const ::c_char,
-        base: ::locale_t,
-    ) -> ::locale_t;
+    pub fn newlocale(mask: ::c_int, locale: *const ::c_char, base: ::locale_t) -> ::locale_t;
     pub fn uselocale(loc: ::locale_t) -> ::locale_t;
     pub fn creat64(path: *const c_char, mode: mode_t) -> ::c_int;
     pub fn fstat64(fildes: ::c_int, buf: *mut stat64) -> ::c_int;
@@ -1534,18 +1504,8 @@ extern "C" {
         offset: off64_t,
     ) -> *mut ::c_void;
     pub fn open64(path: *const c_char, oflag: ::c_int, ...) -> ::c_int;
-    pub fn openat64(
-        fd: ::c_int,
-        path: *const c_char,
-        oflag: ::c_int,
-        ...
-    ) -> ::c_int;
-    pub fn pread64(
-        fd: ::c_int,
-        buf: *mut ::c_void,
-        count: ::size_t,
-        offset: off64_t,
-    ) -> ::ssize_t;
+    pub fn openat64(fd: ::c_int, path: *const c_char, oflag: ::c_int, ...) -> ::c_int;
+    pub fn pread64(fd: ::c_int, buf: *mut ::c_void, count: ::size_t, offset: off64_t) -> ::ssize_t;
     pub fn pwrite64(
         fd: ::c_int,
         buf: *const ::c_void,
@@ -1575,10 +1535,7 @@ extern "C" {
         attr: *mut pthread_condattr_t,
         clock_id: ::clockid_t,
     ) -> ::c_int;
-    pub fn pthread_condattr_setpshared(
-        attr: *mut pthread_condattr_t,
-        pshared: ::c_int,
-    ) -> ::c_int;
+    pub fn pthread_condattr_setpshared(attr: *mut pthread_condattr_t, pshared: ::c_int) -> ::c_int;
     pub fn pthread_mutexattr_setpshared(
         attr: *mut pthread_mutexattr_t,
         pshared: ::c_int,
@@ -1587,34 +1544,15 @@ extern "C" {
         attr: *const pthread_rwlockattr_t,
         val: *mut ::c_int,
     ) -> ::c_int;
-    pub fn pthread_rwlockattr_setpshared(
-        attr: *mut pthread_rwlockattr_t,
-        val: ::c_int,
-    ) -> ::c_int;
-    pub fn ptsname_r(
-        fd: ::c_int,
-        buf: *mut ::c_char,
-        buflen: ::size_t,
-    ) -> ::c_int;
+    pub fn pthread_rwlockattr_setpshared(attr: *mut pthread_rwlockattr_t, val: ::c_int) -> ::c_int;
+    pub fn ptsname_r(fd: ::c_int, buf: *mut ::c_char, buflen: ::size_t) -> ::c_int;
     pub fn clearenv() -> ::c_int;
-    pub fn waitid(
-        idtype: idtype_t,
-        id: id_t,
-        infop: *mut ::siginfo_t,
-        options: ::c_int,
-    ) -> ::c_int;
+    pub fn waitid(idtype: idtype_t, id: id_t, infop: *mut ::siginfo_t, options: ::c_int)
+        -> ::c_int;
     pub fn setreuid(ruid: ::uid_t, euid: ::uid_t) -> ::c_int;
     pub fn setregid(rgid: ::gid_t, egid: ::gid_t) -> ::c_int;
-    pub fn getresuid(
-        ruid: *mut ::uid_t,
-        euid: *mut ::uid_t,
-        suid: *mut ::uid_t,
-    ) -> ::c_int;
-    pub fn getresgid(
-        rgid: *mut ::gid_t,
-        egid: *mut ::gid_t,
-        sgid: *mut ::gid_t,
-    ) -> ::c_int;
+    pub fn getresuid(ruid: *mut ::uid_t, euid: *mut ::uid_t, suid: *mut ::uid_t) -> ::c_int;
+    pub fn getresgid(rgid: *mut ::gid_t, egid: *mut ::gid_t, sgid: *mut ::gid_t) -> ::c_int;
     pub fn acct(filename: *const ::c_char) -> ::c_int;
     pub fn brk(addr: *mut ::c_void) -> ::c_int;
     pub fn sbrk(increment: ::intptr_t) -> *mut ::c_void;
@@ -1644,33 +1582,13 @@ extern "C" {
     ) -> ::c_int;
     pub fn getifaddrs(ifap: *mut *mut ::ifaddrs) -> ::c_int;
     pub fn freeifaddrs(ifa: *mut ::ifaddrs);
-    pub fn bind(
-        socket: ::c_int,
-        address: *const ::sockaddr,
-        address_len: ::socklen_t,
-    ) -> ::c_int;
+    pub fn bind(socket: ::c_int, address: *const ::sockaddr, address_len: ::socklen_t) -> ::c_int;
 
-    pub fn writev(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-    ) -> ::ssize_t;
-    pub fn readv(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-    ) -> ::ssize_t;
+    pub fn writev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
+    pub fn readv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
 
-    pub fn sendmsg(
-        fd: ::c_int,
-        msg: *const ::msghdr,
-        flags: ::c_int,
-    ) -> ::ssize_t;
-    pub fn recvmsg(
-        fd: ::c_int,
-        msg: *mut ::msghdr,
-        flags: ::c_int,
-    ) -> ::ssize_t;
+    pub fn sendmsg(fd: ::c_int, msg: *const ::msghdr, flags: ::c_int) -> ::ssize_t;
+    pub fn recvmsg(fd: ::c_int, msg: *mut ::msghdr, flags: ::c_int) -> ::ssize_t;
     pub fn uname(buf: *mut ::utsname) -> ::c_int;
 }
 

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -422,18 +422,14 @@ extern "C" {
         base: *mut c_void,
         num: size_t,
         size: size_t,
-        compar: ::Option<
-            unsafe extern "C" fn(*const c_void, *const c_void) -> c_int,
-        >,
+        compar: ::Option<unsafe extern "C" fn(*const c_void, *const c_void) -> c_int>,
     );
     pub fn bsearch(
         key: *const c_void,
         base: *const c_void,
         num: size_t,
         size: size_t,
-        compar: ::Option<
-            unsafe extern "C" fn(*const c_void, *const c_void) -> c_int,
-        >,
+        compar: ::Option<unsafe extern "C" fn(*const c_void, *const c_void) -> c_int>,
     ) -> *mut c_void;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
@@ -444,38 +440,21 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "freopen$UNIX2003"
     )]
-    pub fn freopen(
-        filename: *const c_char,
-        mode: *const c_char,
-        file: *mut FILE,
-    ) -> *mut FILE;
-    pub fn fmemopen(
-        buf: *mut c_void,
-        size: size_t,
-        mode: *const c_char,
-    ) -> *mut FILE;
-    pub fn open_memstream(
-        ptr: *mut *mut c_char,
-        sizeloc: *mut size_t,
-    ) -> *mut FILE;
+    pub fn freopen(filename: *const c_char, mode: *const c_char, file: *mut FILE) -> *mut FILE;
+    pub fn fmemopen(buf: *mut c_void, size: size_t, mode: *const c_char) -> *mut FILE;
+    pub fn open_memstream(ptr: *mut *mut c_char, sizeloc: *mut size_t) -> *mut FILE;
 
     pub fn fflush(file: *mut FILE) -> c_int;
     pub fn fclose(file: *mut FILE) -> c_int;
     pub fn remove(filename: *const c_char) -> c_int;
     pub fn rename(oldname: *const c_char, newname: *const c_char) -> c_int;
     pub fn tmpfile() -> *mut FILE;
-    pub fn setvbuf(
-        stream: *mut FILE,
-        buffer: *mut c_char,
-        mode: c_int,
-        size: size_t,
-    ) -> c_int;
+    pub fn setvbuf(stream: *mut FILE, buffer: *mut c_char, mode: c_int, size: size_t) -> c_int;
     pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
     pub fn getchar() -> c_int;
     pub fn putchar(c: c_int) -> c_int;
     pub fn fgetc(stream: *mut FILE) -> c_int;
-    pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE)
-        -> *mut c_char;
+    pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
     pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
@@ -484,22 +463,12 @@ extern "C" {
     pub fn fputs(s: *const c_char, stream: *mut FILE) -> c_int;
     pub fn puts(s: *const c_char) -> c_int;
     pub fn ungetc(c: c_int, stream: *mut FILE) -> c_int;
-    pub fn fread(
-        ptr: *mut c_void,
-        size: size_t,
-        nobj: size_t,
-        stream: *mut FILE,
-    ) -> size_t;
+    pub fn fread(ptr: *mut c_void, size: size_t, nobj: size_t, stream: *mut FILE) -> size_t;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "fwrite$UNIX2003"
     )]
-    pub fn fwrite(
-        ptr: *const c_void,
-        size: size_t,
-        nobj: size_t,
-        stream: *mut FILE,
-    ) -> size_t;
+    pub fn fwrite(ptr: *const c_void, size: size_t, nobj: size_t, stream: *mut FILE) -> size_t;
     pub fn fseek(stream: *mut FILE, offset: c_long, whence: c_int) -> c_int;
     pub fn ftell(stream: *mut FILE) -> c_long;
     pub fn rewind(stream: *mut FILE);
@@ -517,16 +486,8 @@ extern "C" {
         link_name = "strtod$UNIX2003"
     )]
     pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
-    pub fn strtol(
-        s: *const c_char,
-        endp: *mut *mut c_char,
-        base: c_int,
-    ) -> c_long;
-    pub fn strtoul(
-        s: *const c_char,
-        endp: *mut *mut c_char,
-        base: c_int,
-    ) -> c_ulong;
+    pub fn strtol(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_long;
+    pub fn strtoul(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_ulong;
     pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;
     pub fn malloc(size: size_t) -> *mut c_void;
     pub fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
@@ -543,17 +504,9 @@ extern "C" {
     pub fn getenv(s: *const c_char) -> *mut c_char;
 
     pub fn strcpy(dst: *mut c_char, src: *const c_char) -> *mut c_char;
-    pub fn strncpy(
-        dst: *mut c_char,
-        src: *const c_char,
-        n: size_t,
-    ) -> *mut c_char;
+    pub fn strncpy(dst: *mut c_char, src: *const c_char, n: size_t) -> *mut c_char;
     pub fn strcat(s: *mut c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strncat(
-        s: *mut c_char,
-        ct: *const c_char,
-        n: size_t,
-    ) -> *mut c_char;
+    pub fn strncat(s: *mut c_char, ct: *const c_char, n: size_t) -> *mut c_char;
     pub fn strcmp(cs: *const c_char, ct: *const c_char) -> c_int;
     pub fn strncmp(cs: *const c_char, ct: *const c_char, n: size_t) -> c_int;
     pub fn strcoll(cs: *const c_char, ct: *const c_char) -> c_int;
@@ -566,11 +519,7 @@ extern "C" {
     pub fn strpbrk(cs: *const c_char, ct: *const c_char) -> *mut c_char;
     pub fn strstr(cs: *const c_char, ct: *const c_char) -> *mut c_char;
     pub fn strcasecmp(s1: *const c_char, s2: *const c_char) -> c_int;
-    pub fn strncasecmp(
-        s1: *const c_char,
-        s2: *const c_char,
-        n: size_t,
-    ) -> c_int;
+    pub fn strncasecmp(s1: *const c_char, s2: *const c_char, n: size_t) -> c_int;
     pub fn strlen(cs: *const c_char) -> size_t;
     pub fn strnlen(cs: *const c_char, maxlen: size_t) -> size_t;
     #[cfg_attr(
@@ -582,25 +531,13 @@ extern "C" {
     pub fn strxfrm(s: *mut c_char, ct: *const c_char, n: size_t) -> size_t;
     pub fn strsignal(sig: c_int) -> *mut c_char;
     pub fn wcslen(buf: *const wchar_t) -> size_t;
-    pub fn wcstombs(
-        dest: *mut c_char,
-        src: *const wchar_t,
-        n: size_t,
-    ) -> ::size_t;
+    pub fn wcstombs(dest: *mut c_char, src: *const wchar_t, n: size_t) -> ::size_t;
 
     pub fn memchr(cx: *const c_void, c: c_int, n: size_t) -> *mut c_void;
     pub fn wmemchr(cx: *const wchar_t, c: wchar_t, n: size_t) -> *mut wchar_t;
     pub fn memcmp(cx: *const c_void, ct: *const c_void, n: size_t) -> c_int;
-    pub fn memcpy(
-        dest: *mut c_void,
-        src: *const c_void,
-        n: size_t,
-    ) -> *mut c_void;
-    pub fn memmove(
-        dest: *mut c_void,
-        src: *const c_void,
-        n: size_t,
-    ) -> *mut c_void;
+    pub fn memcpy(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
+    pub fn memmove(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
     pub fn memset(dest: *mut c_void, c: c_int, n: size_t) -> *mut c_void;
 }
 
@@ -610,28 +547,15 @@ extern "C" {
     #[cfg_attr(target_os = "netbsd", link_name = "__getpwuid50")]
     pub fn getpwuid(uid: ::uid_t) -> *mut passwd;
 
-    pub fn fprintf(
-        stream: *mut ::FILE,
-        format: *const ::c_char,
-        ...
-    ) -> ::c_int;
+    pub fn fprintf(stream: *mut ::FILE, format: *const ::c_char, ...) -> ::c_int;
     pub fn printf(format: *const ::c_char, ...) -> ::c_int;
-    pub fn snprintf(
-        s: *mut ::c_char,
-        n: ::size_t,
-        format: *const ::c_char,
-        ...
-    ) -> ::c_int;
+    pub fn snprintf(s: *mut ::c_char, n: ::size_t, format: *const ::c_char, ...) -> ::c_int;
     pub fn sprintf(s: *mut ::c_char, format: *const ::c_char, ...) -> ::c_int;
     #[cfg_attr(
         all(target_os = "linux", not(target_env = "uclibc")),
         link_name = "__isoc99_fscanf"
     )]
-    pub fn fscanf(
-        stream: *mut ::FILE,
-        format: *const ::c_char,
-        ...
-    ) -> ::c_int;
+    pub fn fscanf(stream: *mut ::FILE, format: *const ::c_char, ...) -> ::c_int;
     #[cfg_attr(
         all(target_os = "linux", not(target_env = "uclibc")),
         link_name = "__isoc99_scanf"
@@ -641,8 +565,7 @@ extern "C" {
         all(target_os = "linux", not(target_env = "uclibc")),
         link_name = "__isoc99_sscanf"
     )]
-    pub fn sscanf(s: *const ::c_char, format: *const ::c_char, ...)
-        -> ::c_int;
+    pub fn sscanf(s: *const ::c_char, format: *const ::c_char, ...) -> ::c_int;
     pub fn getchar_unlocked() -> ::c_int;
     pub fn putchar_unlocked(c: ::c_int) -> ::c_int;
 
@@ -664,11 +587,7 @@ extern "C" {
         link_name = "connect$UNIX2003"
     )]
     #[cfg_attr(target_os = "illumos", link_name = "__xnet_connect")]
-    pub fn connect(
-        socket: ::c_int,
-        address: *const sockaddr,
-        len: socklen_t,
-    ) -> ::c_int;
+    pub fn connect(socket: ::c_int, address: *const sockaddr, len: socklen_t) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "listen$UNIX2003"
@@ -683,11 +602,7 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "accept$UNIX2003"
     )]
-    pub fn accept(
-        socket: ::c_int,
-        address: *mut sockaddr,
-        address_len: *mut socklen_t,
-    ) -> ::c_int;
+    pub fn accept(socket: ::c_int, address: *mut sockaddr, address_len: *mut socklen_t) -> ::c_int;
     #[cfg(not(all(
         libc_cfg_target_vendor,
         target_arch = "powerpc",
@@ -895,11 +810,7 @@ extern "C" {
         newdirfd: ::c_int,
         linkpath: *const ::c_char,
     ) -> ::c_int;
-    pub fn unlinkat(
-        dirfd: ::c_int,
-        pathname: *const ::c_char,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn unlinkat(dirfd: ::c_int, pathname: *const ::c_char, flags: ::c_int) -> ::c_int;
 
     pub fn access(path: *const c_char, amode: ::c_int) -> ::c_int;
     pub fn alarm(seconds: ::c_uint) -> ::c_uint;
@@ -923,16 +834,8 @@ extern "C" {
     pub fn dup(fd: ::c_int) -> ::c_int;
     pub fn dup2(src: ::c_int, dst: ::c_int) -> ::c_int;
     pub fn execl(path: *const c_char, arg0: *const c_char, ...) -> ::c_int;
-    pub fn execle(
-        path: *const ::c_char,
-        arg0: *const ::c_char,
-        ...
-    ) -> ::c_int;
-    pub fn execlp(
-        file: *const ::c_char,
-        arg0: *const ::c_char,
-        ...
-    ) -> ::c_int;
+    pub fn execle(path: *const ::c_char, arg0: *const ::c_char, ...) -> ::c_int;
+    pub fn execlp(file: *const ::c_char, arg0: *const ::c_char, ...) -> ::c_int;
     pub fn execv(prog: *const c_char, argv: *const *const c_char) -> ::c_int;
     pub fn execve(
         prog: *const c_char,
@@ -953,11 +856,7 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "getopt$UNIX2003"
     )]
-    pub fn getopt(
-        argc: ::c_int,
-        argv: *const *mut c_char,
-        optstr: *const c_char,
-    ) -> ::c_int;
+    pub fn getopt(argc: ::c_int, argv: *const *mut c_char, optstr: *const c_char) -> ::c_int;
     pub fn getpgid(pid: pid_t) -> pid_t;
     pub fn getpgrp() -> pid_t;
     pub fn getpid() -> pid_t;
@@ -968,17 +867,12 @@ extern "C" {
     pub fn lseek(fd: ::c_int, offset: off_t, whence: ::c_int) -> off_t;
     pub fn pathconf(path: *const c_char, name: ::c_int) -> c_long;
     pub fn pipe(fds: *mut ::c_int) -> ::c_int;
-    pub fn posix_memalign(
-        memptr: *mut *mut ::c_void,
-        align: ::size_t,
-        size: ::size_t,
-    ) -> ::c_int;
+    pub fn posix_memalign(memptr: *mut *mut ::c_void, align: ::size_t, size: ::size_t) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "read$UNIX2003"
     )]
-    pub fn read(fd: ::c_int, buf: *mut ::c_void, count: ::size_t)
-        -> ::ssize_t;
+    pub fn read(fd: ::c_int, buf: *mut ::c_void, count: ::size_t) -> ::ssize_t;
     pub fn rmdir(path: *const c_char) -> ::c_int;
     pub fn seteuid(uid: uid_t) -> ::c_int;
     pub fn setegid(gid: gid_t) -> ::c_int;
@@ -1005,11 +899,7 @@ extern "C" {
         link_name = "ttyname_r$UNIX2003"
     )]
     #[cfg_attr(target_os = "illumos", link_name = "__posix_ttyname_r")]
-    pub fn ttyname_r(
-        fd: ::c_int,
-        buf: *mut c_char,
-        buflen: ::size_t,
-    ) -> ::c_int;
+    pub fn ttyname_r(fd: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
     pub fn unlink(c: *const c_char) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
@@ -1020,40 +910,22 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "waitpid$UNIX2003"
     )]
-    pub fn waitpid(
-        pid: pid_t,
-        status: *mut ::c_int,
-        options: ::c_int,
-    ) -> pid_t;
+    pub fn waitpid(pid: pid_t, status: *mut ::c_int, options: ::c_int) -> pid_t;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "write$UNIX2003"
     )]
-    pub fn write(
-        fd: ::c_int,
-        buf: *const ::c_void,
-        count: ::size_t,
-    ) -> ::ssize_t;
+    pub fn write(fd: ::c_int, buf: *const ::c_void, count: ::size_t) -> ::ssize_t;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "pread$UNIX2003"
     )]
-    pub fn pread(
-        fd: ::c_int,
-        buf: *mut ::c_void,
-        count: ::size_t,
-        offset: off_t,
-    ) -> ::ssize_t;
+    pub fn pread(fd: ::c_int, buf: *mut ::c_void, count: ::size_t, offset: off_t) -> ::ssize_t;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "pwrite$UNIX2003"
     )]
-    pub fn pwrite(
-        fd: ::c_int,
-        buf: *const ::c_void,
-        count: ::size_t,
-        offset: off_t,
-    ) -> ::ssize_t;
+    pub fn pwrite(fd: ::c_int, buf: *const ::c_void, count: ::size_t, offset: off_t) -> ::ssize_t;
     pub fn umask(mask: mode_t) -> mode_t;
 
     #[cfg_attr(target_os = "netbsd", link_name = "__utime50")]
@@ -1094,10 +966,7 @@ extern "C" {
     pub fn munmap(addr: *mut ::c_void, len: ::size_t) -> ::c_int;
 
     pub fn if_nametoindex(ifname: *const c_char) -> ::c_uint;
-    pub fn if_indextoname(
-        ifindex: ::c_uint,
-        ifname: *mut ::c_char,
-    ) -> *mut ::c_char;
+    pub fn if_indextoname(ifindex: ::c_uint, ifname: *mut ::c_char) -> *mut ::c_char;
 
     #[cfg_attr(
         all(target_os = "macos", not(target_arch = "aarch64")),
@@ -1120,11 +989,7 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "setenv$UNIX2003"
     )]
-    pub fn setenv(
-        name: *const c_char,
-        val: *const c_char,
-        overwrite: ::c_int,
-    ) -> ::c_int;
+    pub fn setenv(name: *const c_char, val: *const c_char, overwrite: ::c_int) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "unsetenv$UNIX2003"
@@ -1145,10 +1010,7 @@ extern "C" {
         any(target_os = "macos", target_os = "ios"),
         link_name = "realpath$DARWIN_EXTSN"
     )]
-    pub fn realpath(
-        pathname: *const ::c_char,
-        resolved: *mut ::c_char,
-    ) -> *mut ::c_char;
+    pub fn realpath(pathname: *const ::c_char, resolved: *mut ::c_char) -> *mut ::c_char;
 
     pub fn flock(fd: ::c_int, operation: ::c_int) -> ::c_int;
 
@@ -1160,21 +1022,12 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "pthread_join$UNIX2003"
     )]
-    pub fn pthread_join(
-        native: ::pthread_t,
-        value: *mut *mut ::c_void,
-    ) -> ::c_int;
+    pub fn pthread_join(native: ::pthread_t, value: *mut *mut ::c_void) -> ::c_int;
     pub fn pthread_exit(value: *mut ::c_void) -> !;
     pub fn pthread_attr_init(attr: *mut ::pthread_attr_t) -> ::c_int;
     pub fn pthread_attr_destroy(attr: *mut ::pthread_attr_t) -> ::c_int;
-    pub fn pthread_attr_setstacksize(
-        attr: *mut ::pthread_attr_t,
-        stack_size: ::size_t,
-    ) -> ::c_int;
-    pub fn pthread_attr_setdetachstate(
-        attr: *mut ::pthread_attr_t,
-        state: ::c_int,
-    ) -> ::c_int;
+    pub fn pthread_attr_setstacksize(attr: *mut ::pthread_attr_t, stack_size: ::size_t) -> ::c_int;
+    pub fn pthread_attr_setdetachstate(attr: *mut ::pthread_attr_t, state: ::c_int) -> ::c_int;
     pub fn pthread_detach(thread: ::pthread_t) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__libc_thr_yield")]
     pub fn sched_yield() -> ::c_int;
@@ -1184,10 +1037,7 @@ extern "C" {
     ) -> ::c_int;
     pub fn pthread_key_delete(key: pthread_key_t) -> ::c_int;
     pub fn pthread_getspecific(key: pthread_key_t) -> *mut ::c_void;
-    pub fn pthread_setspecific(
-        key: pthread_key_t,
-        value: *const ::c_void,
-    ) -> ::c_int;
+    pub fn pthread_setspecific(key: pthread_key_t, value: *const ::c_void) -> ::c_int;
     pub fn pthread_mutex_init(
         lock: *mut pthread_mutex_t,
         attr: *const pthread_mutexattr_t,
@@ -1202,30 +1052,20 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "pthread_mutexattr_destroy$UNIX2003"
     )]
-    pub fn pthread_mutexattr_destroy(
-        attr: *mut pthread_mutexattr_t,
-    ) -> ::c_int;
-    pub fn pthread_mutexattr_settype(
-        attr: *mut pthread_mutexattr_t,
-        _type: ::c_int,
-    ) -> ::c_int;
+    pub fn pthread_mutexattr_destroy(attr: *mut pthread_mutexattr_t) -> ::c_int;
+    pub fn pthread_mutexattr_settype(attr: *mut pthread_mutexattr_t, _type: ::c_int) -> ::c_int;
 
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "pthread_cond_init$UNIX2003"
     )]
-    pub fn pthread_cond_init(
-        cond: *mut pthread_cond_t,
-        attr: *const pthread_condattr_t,
-    ) -> ::c_int;
+    pub fn pthread_cond_init(cond: *mut pthread_cond_t, attr: *const pthread_condattr_t)
+        -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "pthread_cond_wait$UNIX2003"
     )]
-    pub fn pthread_cond_wait(
-        cond: *mut pthread_cond_t,
-        lock: *mut pthread_mutex_t,
-    ) -> ::c_int;
+    pub fn pthread_cond_wait(cond: *mut pthread_cond_t, lock: *mut pthread_mutex_t) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "pthread_cond_timedwait$UNIX2003"
@@ -1278,11 +1118,8 @@ extern "C" {
         link_name = "pthread_rwlock_unlock$UNIX2003"
     )]
     pub fn pthread_rwlock_unlock(lock: *mut pthread_rwlock_t) -> ::c_int;
-    pub fn pthread_rwlockattr_init(attr: *mut pthread_rwlockattr_t)
-        -> ::c_int;
-    pub fn pthread_rwlockattr_destroy(
-        attr: *mut pthread_rwlockattr_t,
-    ) -> ::c_int;
+    pub fn pthread_rwlockattr_init(attr: *mut pthread_rwlockattr_t) -> ::c_int;
+    pub fn pthread_rwlockattr_destroy(attr: *mut pthread_rwlockattr_t) -> ::c_int;
 
     #[cfg_attr(target_os = "illumos", link_name = "__xnet_getsockopt")]
     pub fn getsockopt(
@@ -1294,23 +1131,13 @@ extern "C" {
     ) -> ::c_int;
     pub fn raise(signum: ::c_int) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__sigaction14")]
-    pub fn sigaction(
-        signum: ::c_int,
-        act: *const sigaction,
-        oldact: *mut sigaction,
-    ) -> ::c_int;
+    pub fn sigaction(signum: ::c_int, act: *const sigaction, oldact: *mut sigaction) -> ::c_int;
 
     #[cfg_attr(target_os = "netbsd", link_name = "__utimes50")]
-    pub fn utimes(
-        filename: *const ::c_char,
-        times: *const ::timeval,
-    ) -> ::c_int;
+    pub fn utimes(filename: *const ::c_char, times: *const ::timeval) -> ::c_int;
     pub fn dlopen(filename: *const ::c_char, flag: ::c_int) -> *mut ::c_void;
     pub fn dlerror() -> *mut ::c_char;
-    pub fn dlsym(
-        handle: *mut ::c_void,
-        symbol: *const ::c_char,
-    ) -> *mut ::c_void;
+    pub fn dlsym(handle: *mut ::c_void, symbol: *const ::c_char) -> *mut ::c_void;
     pub fn dlclose(handle: *mut ::c_void) -> ::c_int;
     pub fn dladdr(addr: *const ::c_void, info: *mut Dl_info) -> ::c_int;
 
@@ -1342,10 +1169,7 @@ extern "C" {
         ),
         link_name = "__res_init"
     )]
-    #[cfg_attr(
-        any(target_os = "macos", target_os = "ios"),
-        link_name = "res_9_init"
-    )]
+    #[cfg_attr(any(target_os = "macos", target_os = "ios"), link_name = "res_9_init")]
     pub fn res_init() -> ::c_int;
 
     #[cfg_attr(target_os = "netbsd", link_name = "__gmtime_r50")]
@@ -1390,21 +1214,11 @@ extern "C" {
         all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "mknod@FBSD_1.0"
     )]
-    pub fn mknod(
-        pathname: *const ::c_char,
-        mode: ::mode_t,
-        dev: ::dev_t,
-    ) -> ::c_int;
+    pub fn mknod(pathname: *const ::c_char, mode: ::mode_t, dev: ::dev_t) -> ::c_int;
     pub fn gethostname(name: *mut ::c_char, len: ::size_t) -> ::c_int;
     pub fn endservent();
-    pub fn getservbyname(
-        name: *const ::c_char,
-        proto: *const ::c_char,
-    ) -> *mut servent;
-    pub fn getservbyport(
-        port: ::c_int,
-        proto: *const ::c_char,
-    ) -> *mut servent;
+    pub fn getservbyname(name: *const ::c_char, proto: *const ::c_char) -> *mut servent;
+    pub fn getservbyport(port: ::c_int, proto: *const ::c_char) -> *mut servent;
     pub fn getservent() -> *mut servent;
     pub fn setservent(stayopen: ::c_int);
     pub fn getprotobyname(name: *const ::c_char) -> *mut protoent;
@@ -1419,22 +1233,12 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "send$UNIX2003"
     )]
-    pub fn send(
-        socket: ::c_int,
-        buf: *const ::c_void,
-        len: ::size_t,
-        flags: ::c_int,
-    ) -> ::ssize_t;
+    pub fn send(socket: ::c_int, buf: *const ::c_void, len: ::size_t, flags: ::c_int) -> ::ssize_t;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "recv$UNIX2003"
     )]
-    pub fn recv(
-        socket: ::c_int,
-        buf: *mut ::c_void,
-        len: ::size_t,
-        flags: ::c_int,
-    ) -> ::ssize_t;
+    pub fn recv(socket: ::c_int, buf: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::ssize_t;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "putenv$UNIX2003"
@@ -1463,10 +1267,7 @@ extern "C" {
         timeout: *mut timeval,
     ) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__setlocale50")]
-    pub fn setlocale(
-        category: ::c_int,
-        locale: *const ::c_char,
-    ) -> *mut ::c_char;
+    pub fn setlocale(category: ::c_int, locale: *const ::c_char) -> *mut ::c_char;
     pub fn localeconv() -> *mut lconv;
 
     #[cfg_attr(
@@ -1479,11 +1280,7 @@ extern "C" {
     pub fn statvfs(path: *const c_char, buf: *mut statvfs) -> ::c_int;
     pub fn fstatvfs(fd: ::c_int, buf: *mut statvfs) -> ::c_int;
 
-    pub fn readlink(
-        path: *const c_char,
-        buf: *mut c_char,
-        bufsz: ::size_t,
-    ) -> ::ssize_t;
+    pub fn readlink(path: *const c_char, buf: *mut c_char, bufsz: ::size_t) -> ::ssize_t;
 
     #[cfg_attr(target_os = "netbsd", link_name = "__sigemptyset14")]
     pub fn sigemptyset(set: *mut sigset_t) -> ::c_int;
@@ -1497,11 +1294,7 @@ extern "C" {
     pub fn sigismember(set: *const sigset_t, signum: ::c_int) -> ::c_int;
 
     #[cfg_attr(target_os = "netbsd", link_name = "__sigprocmask14")]
-    pub fn sigprocmask(
-        how: ::c_int,
-        set: *const sigset_t,
-        oldset: *mut sigset_t,
-    ) -> ::c_int;
+    pub fn sigprocmask(how: ::c_int, set: *const sigset_t, oldset: *mut sigset_t) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__sigpending14")]
     pub fn sigpending(set: *mut sigset_t) -> ::c_int;
 
@@ -1526,11 +1319,7 @@ extern "C" {
         timeout: *const timespec,
         sigmask: *const sigset_t,
     ) -> ::c_int;
-    pub fn fseeko(
-        stream: *mut ::FILE,
-        offset: ::off_t,
-        whence: ::c_int,
-    ) -> ::c_int;
+    pub fn fseeko(stream: *mut ::FILE, offset: ::off_t, whence: ::c_int) -> ::c_int;
     pub fn ftello(stream: *mut ::FILE) -> ::off_t;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
@@ -1542,11 +1331,7 @@ extern "C" {
     pub fn cfsetispeed(termios: *mut ::termios, speed: ::speed_t) -> ::c_int;
     pub fn cfsetospeed(termios: *mut ::termios, speed: ::speed_t) -> ::c_int;
     pub fn tcgetattr(fd: ::c_int, termios: *mut ::termios) -> ::c_int;
-    pub fn tcsetattr(
-        fd: ::c_int,
-        optional_actions: ::c_int,
-        termios: *const ::termios,
-    ) -> ::c_int;
+    pub fn tcsetattr(fd: ::c_int, optional_actions: ::c_int, termios: *const ::termios) -> ::c_int;
     pub fn tcflow(fd: ::c_int, action: ::c_int) -> ::c_int;
     pub fn tcflush(fd: ::c_int, action: ::c_int) -> ::c_int;
     pub fn tcgetsid(fd: ::c_int) -> ::pid_t;
@@ -1573,11 +1358,7 @@ extern "C" {
     pub fn unlockpt(fd: ::c_int) -> ::c_int;
 
     pub fn strcasestr(cs: *const c_char, ct: *const c_char) -> *mut c_char;
-    pub fn getline(
-        lineptr: *mut *mut c_char,
-        n: *mut size_t,
-        stream: *mut FILE,
-    ) -> ssize_t;
+    pub fn getline(lineptr: *mut *mut c_char, n: *mut size_t, stream: *mut FILE) -> ssize_t;
 
     pub fn lockf(fd: ::c_int, cmd: ::c_int, len: ::off_t) -> ::c_int;
 }

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -583,18 +583,10 @@ extern "C" {
     pub fn setrlimit(resource: ::c_int, rlim: *const ::rlimit) -> ::c_int;
 
     #[cfg_attr(target_os = "linux", link_name = "__xpg_strerror_r")]
-    pub fn strerror_r(
-        errnum: ::c_int,
-        buf: *mut c_char,
-        buflen: ::size_t,
-    ) -> ::c_int;
+    pub fn strerror_r(errnum: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
 
     pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
-    pub fn sem_init(
-        sem: *mut sem_t,
-        pshared: ::c_int,
-        value: ::c_uint,
-    ) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t, pshared: ::c_int, value: ::c_uint) -> ::c_int;
 
     pub fn abs(i: ::c_int) -> ::c_int;
     pub fn atof(s: *const ::c_char) -> ::c_double;
@@ -607,20 +599,10 @@ extern "C" {
         target_arch = "powerpc",
         target_vendor = "nintendo"
     )))]
-    pub fn bind(fd: ::c_int, addr: *const sockaddr, len: socklen_t)
-        -> ::c_int;
-    pub fn clock_settime(
-        clock_id: ::clockid_t,
-        tp: *const ::timespec,
-    ) -> ::c_int;
-    pub fn clock_gettime(
-        clock_id: ::clockid_t,
-        tp: *mut ::timespec,
-    ) -> ::c_int;
-    pub fn clock_getres(
-        clock_id: ::clockid_t,
-        res: *mut ::timespec,
-    ) -> ::c_int;
+    pub fn bind(fd: ::c_int, addr: *const sockaddr, len: socklen_t) -> ::c_int;
+    pub fn clock_settime(clock_id: ::clockid_t, tp: *const ::timespec) -> ::c_int;
+    pub fn clock_gettime(clock_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
+    pub fn clock_getres(clock_id: ::clockid_t, res: *mut ::timespec) -> ::c_int;
     pub fn closesocket(sockfd: ::c_int) -> ::c_int;
     pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
     #[cfg(not(all(
@@ -674,11 +656,7 @@ extern "C" {
         buflen: ::size_t,
         result: *mut *mut ::group,
     ) -> ::c_int;
-    pub fn pthread_sigmask(
-        how: ::c_int,
-        set: *const sigset_t,
-        oldset: *mut sigset_t,
-    ) -> ::c_int;
+    pub fn pthread_sigmask(how: ::c_int, set: *const sigset_t, oldset: *mut sigset_t) -> ::c_int;
     pub fn sem_open(name: *const ::c_char, oflag: ::c_int, ...) -> *mut sem_t;
     pub fn getgrnam(name: *const ::c_char) -> *mut ::group;
     pub fn pthread_kill(thread: ::pthread_t, sig: ::c_int) -> ::c_int;

--- a/src/unix/newlib/no_align.rs
+++ b/src/unix/newlib/no_align.rs
@@ -47,5 +47,5 @@ macro_rules! expand_align {
                 size: [u8; ::__SIZEOF_PTHREAD_CONDATTR_T],
             }
         }
-    }
+    };
 }

--- a/src/unix/newlib/xtensa/mod.rs
+++ b/src/unix/newlib/xtensa/mod.rs
@@ -85,22 +85,9 @@ pub const MSG_MORE: ::c_int = 0x10;
 pub const MSG_NOSIGNAL: ::c_int = 0x20;
 
 extern "C" {
-    pub fn sendmsg(
-        s: ::c_int,
-        msg: *const ::msghdr,
-        flags: ::c_int,
-    ) -> ::ssize_t;
-    pub fn recvmsg(
-        s: ::c_int,
-        msg: *mut ::msghdr,
-        flags: ::c_int,
-    ) -> ::ssize_t;
+    pub fn sendmsg(s: ::c_int, msg: *const ::msghdr, flags: ::c_int) -> ::ssize_t;
+    pub fn recvmsg(s: ::c_int, msg: *mut ::msghdr, flags: ::c_int) -> ::ssize_t;
 
-    pub fn writev(s: ::c_int, iov: *const ::iovec, iovcnt: ::c_int)
-        -> ::c_int;
-    pub fn readv(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-    ) -> ::ssize_t;
+    pub fn writev(s: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::c_int;
+    pub fn readv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
 }

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -937,11 +937,7 @@ safe_f! {
 extern "C" {
     // errno.h
     pub fn __errno_location() -> *mut ::c_int;
-    pub fn strerror_r(
-        errnum: ::c_int,
-        buf: *mut c_char,
-        buflen: ::size_t,
-    ) -> ::c_int;
+    pub fn strerror_r(errnum: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
 
     // unistd.h
     pub fn pipe2(fds: *mut ::c_int, flags: ::c_int) -> ::c_int;
@@ -991,32 +987,16 @@ extern "C" {
         maxevents: ::c_int,
         timeout: ::c_int,
     ) -> ::c_int;
-    pub fn epoll_ctl(
-        epfd: ::c_int,
-        op: ::c_int,
-        fd: ::c_int,
-        event: *mut ::epoll_event,
-    ) -> ::c_int;
+    pub fn epoll_ctl(epfd: ::c_int, op: ::c_int, fd: ::c_int, event: *mut ::epoll_event)
+        -> ::c_int;
 
     // sys/ioctl.h
     pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
 
     // sys/mman.h
-    pub fn msync(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        flags: ::c_int,
-    ) -> ::c_int;
-    pub fn mprotect(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        prot: ::c_int,
-    ) -> ::c_int;
-    pub fn shm_open(
-        name: *const c_char,
-        oflag: ::c_int,
-        mode: mode_t,
-    ) -> ::c_int;
+    pub fn msync(addr: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::c_int;
+    pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
+    pub fn shm_open(name: *const c_char, oflag: ::c_int, mode: mode_t) -> ::c_int;
     pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
 
     // sys/resource.h
@@ -1024,11 +1004,7 @@ extern "C" {
     pub fn setrlimit(resource: ::c_int, rlim: *const ::rlimit) -> ::c_int;
 
     // sys/socket.h
-    pub fn bind(
-        socket: ::c_int,
-        address: *const ::sockaddr,
-        address_len: ::socklen_t,
-    ) -> ::c_int;
+    pub fn bind(socket: ::c_int, address: *const ::sockaddr, address_len: ::socklen_t) -> ::c_int;
     pub fn recvfrom(
         socket: ::c_int,
         buf: *mut ::c_void,
@@ -1042,16 +1018,8 @@ extern "C" {
     pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
 
     // sys/uio.h
-    pub fn readv(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-    ) -> ::ssize_t;
-    pub fn writev(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-    ) -> ::ssize_t;
+    pub fn readv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
+    pub fn writev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
 
     // sys/utsname.h
     pub fn uname(utsname: *mut utsname) -> ::c_int;

--- a/src/unix/solarish/compat.rs
+++ b/src/unix/solarish/compat.rs
@@ -7,15 +7,8 @@ const PTEM: &[u8] = b"ptem\0";
 const LDTERM: &[u8] = b"ldterm\0";
 
 pub unsafe fn cfmakeraw(termios: *mut ::termios) {
-    (*termios).c_iflag &= !(IMAXBEL
-        | IGNBRK
-        | BRKINT
-        | PARMRK
-        | ISTRIP
-        | INLCR
-        | IGNCR
-        | ICRNL
-        | IXON);
+    (*termios).c_iflag &=
+        !(IMAXBEL | IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
     (*termios).c_oflag &= !OPOST;
     (*termios).c_lflag &= !(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
     (*termios).c_cflag &= !(CSIZE | PARENB);
@@ -38,10 +31,7 @@ pub unsafe fn cfmakeraw(termios: *mut ::termios) {
     (*termios).c_cc[VTIME] = 0;
 }
 
-pub unsafe fn cfsetspeed(
-    termios: *mut ::termios,
-    speed: ::speed_t,
-) -> ::c_int {
+pub unsafe fn cfsetspeed(termios: *mut ::termios, speed: ::speed_t) -> ::c_int {
     // Neither of these functions on illumos or Solaris actually ever
     // return an error
     ::cfsetispeed(termios, speed);
@@ -100,9 +90,7 @@ pub unsafe fn openpty(
     } else if setup == 0 {
         // The line discipline is not present, so push the appropriate STREAMS
         // modules for the subordinate device:
-        if ::ioctl(fds, I_PUSH, PTEM.as_ptr()) < 0
-            || ::ioctl(fds, I_PUSH, LDTERM.as_ptr()) < 0
-        {
+        if ::ioctl(fds, I_PUSH, PTEM.as_ptr()) < 0 || ::ioctl(fds, I_PUSH, LDTERM.as_ptr()) < 0 {
             return bail(fdm, fds);
         }
     }

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -36,9 +36,5 @@ pub const F_FLOCKW: ::c_int = 56;
 extern "C" {
     pub fn eventfd(init: ::c_uint, flags: ::c_int) -> ::c_int;
 
-    pub fn mincore(
-        addr: ::caddr_t,
-        len: ::size_t,
-        vec: *mut ::c_char,
-    ) -> ::c_int;
+    pub fn mincore(addr: ::caddr_t, len: ::size_t, vec: *mut ::c_char) -> ::c_int;
 }

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2078,11 +2078,8 @@ pub const STA_PPSJITTER: i32 = 0x0200;
 pub const STA_PPSWANDER: i32 = 0x0400;
 pub const STA_PPSERROR: i32 = 0x0800;
 pub const STA_CLOCKERR: i32 = 0x1000;
-pub const STA_RONLY: i32 = STA_PPSSIGNAL
-    | STA_PPSJITTER
-    | STA_PPSWANDER
-    | STA_PPSERROR
-    | STA_CLOCKERR;
+pub const STA_RONLY: i32 =
+    STA_PPSSIGNAL | STA_PPSJITTER | STA_PPSWANDER | STA_PPSERROR | STA_CLOCKERR;
 pub const TIME_OK: i32 = 0;
 pub const TIME_INS: i32 = 1;
 pub const TIME_DEL: i32 = 2;
@@ -2218,18 +2215,10 @@ extern "C" {
     pub fn getrlimit(resource: ::c_int, rlim: *mut ::rlimit) -> ::c_int;
     pub fn setrlimit(resource: ::c_int, rlim: *const ::rlimit) -> ::c_int;
 
-    pub fn strerror_r(
-        errnum: ::c_int,
-        buf: *mut c_char,
-        buflen: ::size_t,
-    ) -> ::c_int;
+    pub fn strerror_r(errnum: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
 
     pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
-    pub fn sem_init(
-        sem: *mut sem_t,
-        pshared: ::c_int,
-        value: ::c_uint,
-    ) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t, pshared: ::c_int, value: ::c_uint) -> ::c_int;
 
     pub fn abs(i: ::c_int) -> ::c_int;
     pub fn acct(filename: *const ::c_char) -> ::c_int;
@@ -2248,11 +2237,7 @@ extern "C" {
     pub fn initgroups(name: *const ::c_char, basegid: ::gid_t) -> ::c_int;
     pub fn setgroups(ngroups: ::c_int, ptr: *const ::gid_t) -> ::c_int;
     pub fn ioctl(fildes: ::c_int, request: ::c_int, ...) -> ::c_int;
-    pub fn mprotect(
-        addr: *const ::c_void,
-        len: ::size_t,
-        prot: ::c_int,
-    ) -> ::c_int;
+    pub fn mprotect(addr: *const ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
     pub fn ___errno() -> *mut ::c_int;
     pub fn clock_getres(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
     pub fn clock_gettime(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
@@ -2262,10 +2247,7 @@ extern "C" {
         rqtp: *const ::timespec,
         rmtp: *mut ::timespec,
     ) -> ::c_int;
-    pub fn clock_settime(
-        clk_id: ::clockid_t,
-        tp: *const ::timespec,
-    ) -> ::c_int;
+    pub fn clock_settime(clk_id: ::clockid_t, tp: *const ::timespec) -> ::c_int;
     pub fn getnameinfo(
         sa: *const ::sockaddr,
         salen: ::socklen_t,
@@ -2279,22 +2261,16 @@ extern "C" {
     pub fn endpwent();
     pub fn getpwent() -> *mut passwd;
     pub fn fdatasync(fd: ::c_int) -> ::c_int;
-    pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t)
-        -> *mut ::c_char;
+    pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t) -> *mut ::c_char;
     pub fn duplocale(base: ::locale_t) -> ::locale_t;
     pub fn freelocale(loc: ::locale_t);
-    pub fn newlocale(
-        mask: ::c_int,
-        locale: *const ::c_char,
-        base: ::locale_t,
-    ) -> ::locale_t;
+    pub fn newlocale(mask: ::c_int, locale: *const ::c_char, base: ::locale_t) -> ::locale_t;
     pub fn uselocale(loc: ::locale_t) -> ::locale_t;
     pub fn getprogname() -> *const ::c_char;
     pub fn setprogname(name: *const ::c_char);
     pub fn getloadavg(loadavg: *mut ::c_double, nelem: ::c_int) -> ::c_int;
     pub fn getpriority(which: ::c_int, who: ::c_int) -> ::c_int;
-    pub fn setpriority(which: ::c_int, who: ::c_int, prio: ::c_int)
-        -> ::c_int;
+    pub fn setpriority(which: ::c_int, who: ::c_int, prio: ::c_int) -> ::c_int;
 
     pub fn mknodat(
         dirfd: ::c_int,
@@ -2302,11 +2278,7 @@ extern "C" {
         mode: ::mode_t,
         dev: dev_t,
     ) -> ::c_int;
-    pub fn mkfifoat(
-        dirfd: ::c_int,
-        pathname: *const ::c_char,
-        mode: ::mode_t,
-    ) -> ::c_int;
+    pub fn mkfifoat(dirfd: ::c_int, pathname: *const ::c_char, mode: ::mode_t) -> ::c_int;
     pub fn sethostname(name: *const ::c_char, len: ::c_int) -> ::c_int;
     pub fn if_nameindex() -> *mut if_nameindex;
     pub fn if_freenameindex(ptr: *mut if_nameindex);
@@ -2329,78 +2301,45 @@ extern "C" {
         attr: *mut pthread_condattr_t,
         clock_id: ::clockid_t,
     ) -> ::c_int;
-    pub fn sem_timedwait(
-        sem: *mut sem_t,
-        abstime: *const ::timespec,
-    ) -> ::c_int;
+    pub fn sem_timedwait(sem: *mut sem_t, abstime: *const ::timespec) -> ::c_int;
     pub fn sem_getvalue(sem: *mut sem_t, sval: *mut ::c_int) -> ::c_int;
     pub fn pthread_mutex_timedlock(
         lock: *mut pthread_mutex_t,
         abstime: *const ::timespec,
     ) -> ::c_int;
-    pub fn waitid(
-        idtype: idtype_t,
-        id: id_t,
-        infop: *mut ::siginfo_t,
-        options: ::c_int,
-    ) -> ::c_int;
+    pub fn waitid(idtype: idtype_t, id: id_t, infop: *mut ::siginfo_t, options: ::c_int)
+        -> ::c_int;
 
     #[cfg_attr(target_os = "illumos", link_name = "_glob_ext")]
     pub fn glob(
         pattern: *const ::c_char,
         flags: ::c_int,
-        errfunc: ::Option<
-            extern "C" fn(epath: *const ::c_char, errno: ::c_int) -> ::c_int,
-        >,
+        errfunc: ::Option<extern "C" fn(epath: *const ::c_char, errno: ::c_int) -> ::c_int>,
         pglob: *mut ::glob_t,
     ) -> ::c_int;
 
     #[cfg_attr(target_os = "illumos", link_name = "_globfree_ext")]
     pub fn globfree(pglob: *mut ::glob_t);
 
-    pub fn posix_madvise(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        advice: ::c_int,
-    ) -> ::c_int;
+    pub fn posix_madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
 
-    pub fn shmat(
-        shmid: ::c_int,
-        shmaddr: *const ::c_void,
-        shmflg: ::c_int,
-    ) -> *mut ::c_void;
+    pub fn shmat(shmid: ::c_int, shmaddr: *const ::c_void, shmflg: ::c_int) -> *mut ::c_void;
 
-    pub fn shmctl(
-        shmid: ::c_int,
-        cmd: ::c_int,
-        buf: *mut ::shmid_ds,
-    ) -> ::c_int;
+    pub fn shmctl(shmid: ::c_int, cmd: ::c_int, buf: *mut ::shmid_ds) -> ::c_int;
 
     pub fn shmdt(shmaddr: *const ::c_void) -> ::c_int;
 
     pub fn shmget(key: key_t, size: ::size_t, shmflg: ::c_int) -> ::c_int;
 
-    pub fn shm_open(
-        name: *const ::c_char,
-        oflag: ::c_int,
-        mode: ::mode_t,
-    ) -> ::c_int;
+    pub fn shm_open(name: *const ::c_char, oflag: ::c_int, mode: ::mode_t) -> ::c_int;
     pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
 
     pub fn seekdir(dirp: *mut ::DIR, loc: ::c_long);
 
     pub fn telldir(dirp: *mut ::DIR) -> ::c_long;
-    pub fn madvise(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        advice: ::c_int,
-    ) -> ::c_int;
+    pub fn madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
 
-    pub fn msync(
-        addr: *mut ::c_void,
-        len: ::size_t,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn msync(addr: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::c_int;
 
     pub fn memalign(align: ::size_t, size: ::size_t) -> *mut ::c_void;
 
@@ -2413,11 +2352,7 @@ extern "C" {
         addrlen: *mut ::socklen_t,
     ) -> ::ssize_t;
     pub fn mkstemps(template: *mut ::c_char, suffixlen: ::c_int) -> ::c_int;
-    pub fn futimesat(
-        fd: ::c_int,
-        path: *const ::c_char,
-        times: *const ::timeval,
-    ) -> ::c_int;
+    pub fn futimesat(fd: ::c_int, path: *const ::c_char, times: *const ::timeval) -> ::c_int;
     pub fn futimens(dirfd: ::c_int, times: *const ::timespec) -> ::c_int;
     pub fn utimensat(
         dirfd: ::c_int,
@@ -2428,35 +2363,15 @@ extern "C" {
     pub fn nl_langinfo(item: ::nl_item) -> *mut ::c_char;
 
     #[cfg_attr(target_os = "illumos", link_name = "__xnet_bind")]
-    pub fn bind(
-        socket: ::c_int,
-        address: *const ::sockaddr,
-        address_len: ::socklen_t,
-    ) -> ::c_int;
+    pub fn bind(socket: ::c_int, address: *const ::sockaddr, address_len: ::socklen_t) -> ::c_int;
 
-    pub fn writev(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-    ) -> ::ssize_t;
-    pub fn readv(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-    ) -> ::ssize_t;
+    pub fn writev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
+    pub fn readv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
 
     #[cfg_attr(target_os = "illumos", link_name = "__xnet_sendmsg")]
-    pub fn sendmsg(
-        fd: ::c_int,
-        msg: *const ::msghdr,
-        flags: ::c_int,
-    ) -> ::ssize_t;
+    pub fn sendmsg(fd: ::c_int, msg: *const ::msghdr, flags: ::c_int) -> ::ssize_t;
     #[cfg_attr(target_os = "illumos", link_name = "__xnet_recvmsg")]
-    pub fn recvmsg(
-        fd: ::c_int,
-        msg: *mut ::msghdr,
-        flags: ::c_int,
-    ) -> ::ssize_t;
+    pub fn recvmsg(fd: ::c_int, msg: *mut ::msghdr, flags: ::c_int) -> ::ssize_t;
     pub fn accept4(
         fd: ::c_int,
         address: *mut sockaddr,
@@ -2494,11 +2409,7 @@ extern "C" {
         abs_timeout: *const ::timespec,
     ) -> ::c_int;
     pub fn mq_getattr(mqd: ::mqd_t, attr: *mut ::mq_attr) -> ::c_int;
-    pub fn mq_setattr(
-        mqd: ::mqd_t,
-        newattr: *const ::mq_attr,
-        oldattr: *mut ::mq_attr,
-    ) -> ::c_int;
+    pub fn mq_setattr(mqd: ::mqd_t, newattr: *const ::mq_attr, oldattr: *mut ::mq_attr) -> ::c_int;
     pub fn port_create() -> ::c_int;
     pub fn port_associate(
         port: ::c_int,
@@ -2507,16 +2418,8 @@ extern "C" {
         events: ::c_int,
         user: *mut ::c_void,
     ) -> ::c_int;
-    pub fn port_dissociate(
-        port: ::c_int,
-        source: ::c_int,
-        object: ::uintptr_t,
-    ) -> ::c_int;
-    pub fn port_get(
-        port: ::c_int,
-        pe: *mut port_event,
-        timeout: *mut ::timespec,
-    ) -> ::c_int;
+    pub fn port_dissociate(port: ::c_int, source: ::c_int, object: ::uintptr_t) -> ::c_int;
+    pub fn port_get(port: ::c_int, pe: *mut port_event, timeout: *mut ::timespec) -> ::c_int;
     pub fn port_getn(
         port: ::c_int,
         pe_list: *mut port_event,
@@ -2524,11 +2427,7 @@ extern "C" {
         nget: *mut ::c_uint,
         timeout: *mut ::timespec,
     ) -> ::c_int;
-    pub fn port_send(
-        port: ::c_int,
-        events: ::c_int,
-        user: *mut ::c_void,
-    ) -> ::c_int;
+    pub fn port_send(port: ::c_int, events: ::c_int, user: *mut ::c_void) -> ::c_int;
     pub fn port_sendn(
         port_list: *mut ::c_int,
         error_list: *mut ::c_int,
@@ -2571,12 +2470,8 @@ extern "C" {
         maxevents: ::c_int,
         timeout: ::c_int,
     ) -> ::c_int;
-    pub fn epoll_ctl(
-        epfd: ::c_int,
-        op: ::c_int,
-        fd: ::c_int,
-        event: *mut ::epoll_event,
-    ) -> ::c_int;
+    pub fn epoll_ctl(epfd: ::c_int, op: ::c_int, fd: ::c_int, event: *mut ::epoll_event)
+        -> ::c_int;
 
     #[cfg_attr(
         any(target_os = "solaris", target_os = "illumos"),
@@ -2589,11 +2484,7 @@ extern "C" {
         buflen: ::size_t,
         result: *mut *mut ::group,
     ) -> ::c_int;
-    pub fn pthread_sigmask(
-        how: ::c_int,
-        set: *const sigset_t,
-        oldset: *mut sigset_t,
-    ) -> ::c_int;
+    pub fn pthread_sigmask(how: ::c_int, set: *const sigset_t, oldset: *mut sigset_t) -> ::c_int;
     pub fn sem_open(name: *const ::c_char, oflag: ::c_int, ...) -> *mut sem_t;
     pub fn getgrnam(name: *const ::c_char) -> *mut ::group;
     pub fn pthread_kill(thread: ::pthread_t, sig: ::c_int) -> ::c_int;
@@ -2687,11 +2578,7 @@ extern "C" {
     pub fn ntp_adjtime(buf: *mut timex) -> ::c_int;
     pub fn ntp_gettime(buf: *mut ntptimeval) -> ::c_int;
 
-    pub fn timer_create(
-        clock_id: clockid_t,
-        evp: *mut sigevent,
-        timerid: *mut timer_t,
-    ) -> ::c_int;
+    pub fn timer_create(clock_id: clockid_t, evp: *mut sigevent, timerid: *mut timer_t) -> ::c_int;
     pub fn timer_delete(timerid: timer_t) -> ::c_int;
     pub fn timer_getoverrun(timerid: timer_t) -> ::c_int;
     pub fn timer_gettime(timerid: timer_t, value: *mut itimerspec) -> ::c_int;
@@ -2713,15 +2600,11 @@ extern "C" {
     pub fn ucred_getegid(ucred: *const ucred_t) -> ::gid_t;
     pub fn ucred_getrgid(ucred: *const ucred_t) -> ::gid_t;
     pub fn ucred_getsgid(ucred: *const ucred_t) -> ::gid_t;
-    pub fn ucred_getgroups(
-        ucred: *const ucred_t,
-        groups: *mut *const ::gid_t,
-    ) -> ::c_int;
+    pub fn ucred_getgroups(ucred: *const ucred_t, groups: *mut *const ::gid_t) -> ::c_int;
     pub fn ucred_getpid(ucred: *const ucred_t) -> ::pid_t;
     pub fn ucred_getprojid(ucred: *const ucred_t) -> projid_t;
     pub fn ucred_getzoneid(ucred: *const ucred_t) -> zoneid_t;
-    pub fn ucred_getpflags(ucred: *const ucred_t, flags: ::c_uint)
-        -> ::c_uint;
+    pub fn ucred_getpflags(ucred: *const ucred_t, flags: ::c_uint) -> ::c_uint;
 
     pub fn ucred_size() -> ::size_t;
 }

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -43,11 +43,7 @@ extern "C" {
         envp: *const *const ::c_char,
     ) -> ::c_int;
 
-    pub fn mincore(
-        addr: *const ::c_void,
-        len: ::size_t,
-        vec: *mut ::c_char,
-    ) -> ::c_int;
+    pub fn mincore(addr: *const ::c_void, len: ::size_t, vec: *mut ::c_char) -> ::c_int;
 
     pub fn door_call(d: ::c_int, params: *const door_arg_t) -> ::c_int;
     pub fn door_return(
@@ -70,10 +66,7 @@ extern "C" {
 
     pub fn fattach(fildes: ::c_int, path: *const ::c_char) -> ::c_int;
 
-    pub fn pthread_getattr_np(
-        thread: ::pthread_t,
-        attr: *mut ::pthread_attr_t,
-    ) -> ::c_int;
+    pub fn pthread_getattr_np(thread: ::pthread_t, attr: *mut ::pthread_attr_t) -> ::c_int;
 }
 
 s_no_extra_traits! {

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -702,24 +702,16 @@ pub const S_nfsLib_NFSERR_NAMETOOLONG: ::c_int = ENAMETOOLONG;
 pub const S_nfsLib_NFSERR_NOTEMPTY: ::c_int = ENOTEMPTY;
 pub const S_nfsLib_NFSERR_DQUOT: ::c_int = EDQUOT;
 pub const S_nfsLib_NFSERR_STALE: ::c_int = ESTALE;
-pub const S_nfsLib_NFSERR_WFLUSH: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_WFLUSH as ::c_int;
-pub const S_nfsLib_NFSERR_REMOTE: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_REMOTE as ::c_int;
-pub const S_nfsLib_NFSERR_BADHANDLE: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_BADHANDLE as ::c_int;
-pub const S_nfsLib_NFSERR_NOT_SYNC: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_NOT_SYNC as ::c_int;
-pub const S_nfsLib_NFSERR_BAD_COOKIE: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_BAD_COOKIE as ::c_int;
+pub const S_nfsLib_NFSERR_WFLUSH: ::c_int = M_nfsStat | nfsstat::NFSERR_WFLUSH as ::c_int;
+pub const S_nfsLib_NFSERR_REMOTE: ::c_int = M_nfsStat | nfsstat::NFSERR_REMOTE as ::c_int;
+pub const S_nfsLib_NFSERR_BADHANDLE: ::c_int = M_nfsStat | nfsstat::NFSERR_BADHANDLE as ::c_int;
+pub const S_nfsLib_NFSERR_NOT_SYNC: ::c_int = M_nfsStat | nfsstat::NFSERR_NOT_SYNC as ::c_int;
+pub const S_nfsLib_NFSERR_BAD_COOKIE: ::c_int = M_nfsStat | nfsstat::NFSERR_BAD_COOKIE as ::c_int;
 pub const S_nfsLib_NFSERR_NOTSUPP: ::c_int = EOPNOTSUPP;
-pub const S_nfsLib_NFSERR_TOOSMALL: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_TOOSMALL as ::c_int;
+pub const S_nfsLib_NFSERR_TOOSMALL: ::c_int = M_nfsStat | nfsstat::NFSERR_TOOSMALL as ::c_int;
 pub const S_nfsLib_NFSERR_SERVERFAULT: ::c_int = EIO;
-pub const S_nfsLib_NFSERR_BADTYPE: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_BADTYPE as ::c_int;
-pub const S_nfsLib_NFSERR_JUKEBOX: ::c_int =
-    M_nfsStat | nfsstat::NFSERR_JUKEBOX as ::c_int;
+pub const S_nfsLib_NFSERR_BADTYPE: ::c_int = M_nfsStat | nfsstat::NFSERR_BADTYPE as ::c_int;
+pub const S_nfsLib_NFSERR_JUKEBOX: ::c_int = M_nfsStat | nfsstat::NFSERR_JUKEBOX as ::c_int;
 
 // in.h
 pub const IPPROTO_IP: ::c_int = 0;
@@ -803,8 +795,7 @@ pub const SOCK_PACKET: ::c_int = 10;
 
 pub const _SS_MAXSIZE: usize = 128;
 pub const _SS_ALIGNSIZE: usize = size_of::<u32>();
-pub const _SS_PAD1SIZE: usize =
-    _SS_ALIGNSIZE - size_of::<::c_uchar>() - size_of::<::sa_family_t>();
+pub const _SS_PAD1SIZE: usize = _SS_ALIGNSIZE - size_of::<::c_uchar>() - size_of::<::sa_family_t>();
 pub const _SS_PAD2SIZE: usize = _SS_MAXSIZE
     - size_of::<::c_uchar>()
     - size_of::<::sa_family_t>()
@@ -951,14 +942,13 @@ pub const _PARM_PATH_MAX: ::c_int = 1024;
 pub const WNOHANG: ::c_int = 0x01;
 pub const WUNTRACED: ::c_int = 0x02;
 
-const PTHREAD_MUTEXATTR_INITIALIZER: pthread_mutexattr_t =
-    pthread_mutexattr_t {
-        mutexAttrStatus: PTHREAD_INITIALIZED_OBJ,
-        mutexAttrProtocol: PTHREAD_PRIO_NONE,
-        mutexAttrPrioceiling: 0,
-        mutexAttrType: PTHREAD_MUTEX_DEFAULT,
-        mutexAttrPshared: 1,
-    };
+const PTHREAD_MUTEXATTR_INITIALIZER: pthread_mutexattr_t = pthread_mutexattr_t {
+    mutexAttrStatus: PTHREAD_INITIALIZED_OBJ,
+    mutexAttrProtocol: PTHREAD_PRIO_NONE,
+    mutexAttrPrioceiling: 0,
+    mutexAttrType: PTHREAD_MUTEX_DEFAULT,
+    mutexAttrPshared: 1,
+};
 pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
     mutexSemId: null_mut(),
     mutexValid: PTHREAD_VALID_OBJ,
@@ -984,13 +974,12 @@ pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = pthread_cond_t {
     condSemName: [0; _PTHREAD_SHARED_SEM_NAME_MAX],
 };
 
-const PTHREAD_RWLOCKATTR_INITIALIZER: pthread_rwlockattr_t =
-    pthread_rwlockattr_t {
-        rwlockAttrStatus: PTHREAD_INITIALIZED_OBJ,
-        rwlockAttrPshared: 1,
-        rwlockAttrMaxReaders: 0,
-        rwlockAttrConformOpt: 1,
-    };
+const PTHREAD_RWLOCKATTR_INITIALIZER: pthread_rwlockattr_t = pthread_rwlockattr_t {
+    rwlockAttrStatus: PTHREAD_INITIALIZED_OBJ,
+    rwlockAttrPshared: 1,
+    rwlockAttrMaxReaders: 0,
+    rwlockAttrConformOpt: 1,
+};
 pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
     rwlockSemId: null_mut(),
     rwlockReadersRefCount: 0,
@@ -1097,44 +1086,24 @@ extern "C" {
     pub fn tolower(c: c_int) -> c_int;
     pub fn toupper(c: c_int) -> c_int;
     pub fn fopen(filename: *const c_char, mode: *const c_char) -> *mut FILE;
-    pub fn freopen(
-        filename: *const c_char,
-        mode: *const c_char,
-        file: *mut FILE,
-    ) -> *mut FILE;
+    pub fn freopen(filename: *const c_char, mode: *const c_char, file: *mut FILE) -> *mut FILE;
     pub fn fflush(file: *mut FILE) -> c_int;
     pub fn fclose(file: *mut FILE) -> c_int;
     pub fn remove(filename: *const c_char) -> c_int;
     pub fn rename(oldname: *const c_char, newname: *const c_char) -> c_int;
     pub fn tmpfile() -> *mut FILE;
-    pub fn setvbuf(
-        stream: *mut FILE,
-        buffer: *mut c_char,
-        mode: c_int,
-        size: size_t,
-    ) -> c_int;
+    pub fn setvbuf(stream: *mut FILE, buffer: *mut c_char, mode: c_int, size: size_t) -> c_int;
     pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
     pub fn getchar() -> c_int;
     pub fn putchar(c: c_int) -> c_int;
     pub fn fgetc(stream: *mut FILE) -> c_int;
-    pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE)
-        -> *mut c_char;
+    pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
     pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;
     pub fn fputs(s: *const c_char, stream: *mut FILE) -> c_int;
     pub fn puts(s: *const c_char) -> c_int;
     pub fn ungetc(c: c_int, stream: *mut FILE) -> c_int;
-    pub fn fread(
-        ptr: *mut c_void,
-        size: size_t,
-        nobj: size_t,
-        stream: *mut FILE,
-    ) -> size_t;
-    pub fn fwrite(
-        ptr: *const c_void,
-        size: size_t,
-        nobj: size_t,
-        stream: *mut FILE,
-    ) -> size_t;
+    pub fn fread(ptr: *mut c_void, size: size_t, nobj: size_t, stream: *mut FILE) -> size_t;
+    pub fn fwrite(ptr: *const c_void, size: size_t, nobj: size_t, stream: *mut FILE) -> size_t;
     pub fn fseek(stream: *mut FILE, offset: c_long, whence: c_int) -> c_int;
     pub fn ftell(stream: *mut FILE) -> c_long;
     pub fn rewind(stream: *mut FILE);
@@ -1145,16 +1114,8 @@ extern "C" {
     pub fn perror(s: *const c_char);
     pub fn atoi(s: *const c_char) -> c_int;
     pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
-    pub fn strtol(
-        s: *const c_char,
-        endp: *mut *mut c_char,
-        base: c_int,
-    ) -> c_long;
-    pub fn strtoul(
-        s: *const c_char,
-        endp: *mut *mut c_char,
-        base: c_int,
-    ) -> c_ulong;
+    pub fn strtol(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_long;
+    pub fn strtoul(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_ulong;
     pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;
     pub fn malloc(size: size_t) -> *mut c_void;
     pub fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
@@ -1166,17 +1127,9 @@ extern "C" {
     pub fn getenv(s: *const c_char) -> *mut c_char;
 
     pub fn strcpy(dst: *mut c_char, src: *const c_char) -> *mut c_char;
-    pub fn strncpy(
-        dst: *mut c_char,
-        src: *const c_char,
-        n: size_t,
-    ) -> *mut c_char;
+    pub fn strncpy(dst: *mut c_char, src: *const c_char, n: size_t) -> *mut c_char;
     pub fn strcat(s: *mut c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strncat(
-        s: *mut c_char,
-        ct: *const c_char,
-        n: size_t,
-    ) -> *mut c_char;
+    pub fn strncat(s: *mut c_char, ct: *const c_char, n: size_t) -> *mut c_char;
     pub fn strcmp(cs: *const c_char, ct: *const c_char) -> c_int;
     pub fn strncmp(cs: *const c_char, ct: *const c_char, n: size_t) -> c_int;
     pub fn strcoll(cs: *const c_char, ct: *const c_char) -> c_int;
@@ -1188,60 +1141,30 @@ extern "C" {
     pub fn strpbrk(cs: *const c_char, ct: *const c_char) -> *mut c_char;
     pub fn strstr(cs: *const c_char, ct: *const c_char) -> *mut c_char;
     pub fn strcasecmp(s1: *const c_char, s2: *const c_char) -> c_int;
-    pub fn strncasecmp(
-        s1: *const c_char,
-        s2: *const c_char,
-        n: size_t,
-    ) -> c_int;
+    pub fn strncasecmp(s1: *const c_char, s2: *const c_char, n: size_t) -> c_int;
     pub fn strlen(cs: *const c_char) -> size_t;
     pub fn strerror(n: c_int) -> *mut c_char;
     pub fn strtok(s: *mut c_char, t: *const c_char) -> *mut c_char;
     pub fn strxfrm(s: *mut c_char, ct: *const c_char, n: size_t) -> size_t;
     pub fn wcslen(buf: *const wchar_t) -> size_t;
-    pub fn wcstombs(
-        dest: *mut c_char,
-        src: *const wchar_t,
-        n: size_t,
-    ) -> ::size_t;
+    pub fn wcstombs(dest: *mut c_char, src: *const wchar_t, n: size_t) -> ::size_t;
 
     pub fn memchr(cx: *const c_void, c: c_int, n: size_t) -> *mut c_void;
     pub fn wmemchr(cx: *const wchar_t, c: wchar_t, n: size_t) -> *mut wchar_t;
     pub fn memcmp(cx: *const c_void, ct: *const c_void, n: size_t) -> c_int;
-    pub fn memcpy(
-        dest: *mut c_void,
-        src: *const c_void,
-        n: size_t,
-    ) -> *mut c_void;
-    pub fn memmove(
-        dest: *mut c_void,
-        src: *const c_void,
-        n: size_t,
-    ) -> *mut c_void;
+    pub fn memcpy(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
+    pub fn memmove(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
     pub fn memset(dest: *mut c_void, c: c_int, n: size_t) -> *mut c_void;
 }
 
 extern "C" {
-    pub fn fprintf(
-        stream: *mut ::FILE,
-        format: *const ::c_char,
-        ...
-    ) -> ::c_int;
+    pub fn fprintf(stream: *mut ::FILE, format: *const ::c_char, ...) -> ::c_int;
     pub fn printf(format: *const ::c_char, ...) -> ::c_int;
-    pub fn snprintf(
-        s: *mut ::c_char,
-        n: ::size_t,
-        format: *const ::c_char,
-        ...
-    ) -> ::c_int;
+    pub fn snprintf(s: *mut ::c_char, n: ::size_t, format: *const ::c_char, ...) -> ::c_int;
     pub fn sprintf(s: *mut ::c_char, format: *const ::c_char, ...) -> ::c_int;
-    pub fn fscanf(
-        stream: *mut ::FILE,
-        format: *const ::c_char,
-        ...
-    ) -> ::c_int;
+    pub fn fscanf(stream: *mut ::FILE, format: *const ::c_char, ...) -> ::c_int;
     pub fn scanf(format: *const ::c_char, ...) -> ::c_int;
-    pub fn sscanf(s: *const ::c_char, format: *const ::c_char, ...)
-        -> ::c_int;
+    pub fn sscanf(s: *const ::c_char, format: *const ::c_char, ...) -> ::c_int;
     pub fn getchar_unlocked() -> ::c_int;
     pub fn putchar_unlocked(c: ::c_int) -> ::c_int;
     pub fn stat(path: *const c_char, buf: *mut stat) -> ::c_int;
@@ -1259,11 +1182,7 @@ extern "C" {
     pub fn geteuid() -> uid_t;
     pub fn getgroups(ngroups_max: ::c_int, groups: *mut gid_t) -> ::c_int;
     pub fn getlogin() -> *mut c_char;
-    pub fn getopt(
-        argc: ::c_int,
-        argv: *const *mut c_char,
-        optstr: *const c_char,
-    ) -> ::c_int;
+    pub fn getopt(argc: ::c_int, argv: *const *mut c_char, optstr: *const c_char) -> ::c_int;
     pub fn pathconf(path: *const c_char, name: ::c_int) -> c_long;
     pub fn pause() -> ::c_int;
     pub fn seteuid(uid: uid_t) -> ::c_int;
@@ -1289,27 +1208,13 @@ extern "C" {
 
     pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::c_void) -> ::c_int;
     pub fn pthread_exit(value: *mut ::c_void) -> !;
-    pub fn pthread_attr_setdetachstate(
-        attr: *mut ::pthread_attr_t,
-        state: ::c_int,
-    ) -> ::c_int;
+    pub fn pthread_attr_setdetachstate(attr: *mut ::pthread_attr_t, state: ::c_int) -> ::c_int;
 
-    pub fn strerror_r(
-        errnum: ::c_int,
-        buf: *mut c_char,
-        buflen: ::size_t,
-    ) -> ::c_int;
+    pub fn strerror_r(errnum: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
 
-    pub fn sigaction(
-        signum: ::c_int,
-        act: *const sigaction,
-        oldact: *mut sigaction,
-    ) -> ::c_int;
+    pub fn sigaction(signum: ::c_int, act: *const sigaction, oldact: *mut sigaction) -> ::c_int;
 
-    pub fn utimes(
-        filename: *const ::c_char,
-        times: *const ::timeval,
-    ) -> ::c_int;
+    pub fn utimes(filename: *const ::c_char, times: *const ::timeval) -> ::c_int;
 
     #[link_name = "_rtld_dlopen"]
     pub fn dlopen(filename: *const ::c_char, flag: ::c_int) -> *mut ::c_void;
@@ -1318,10 +1223,7 @@ extern "C" {
     pub fn dlerror() -> *mut ::c_char;
 
     #[link_name = "_rtld_dlsym"]
-    pub fn dlsym(
-        handle: *mut ::c_void,
-        symbol: *const ::c_char,
-    ) -> *mut ::c_void;
+    pub fn dlsym(handle: *mut ::c_void, symbol: *const ::c_char) -> *mut ::c_void;
 
     #[link_name = "_rtld_dlclose"]
     pub fn dlclose(handle: *mut ::c_void) -> ::c_int;
@@ -1341,25 +1243,14 @@ extern "C" {
     pub fn gethostname(name: *mut ::c_char, len: ::size_t) -> ::c_int;
     pub fn usleep(secs: ::useconds_t) -> ::c_int;
     pub fn putenv(string: *mut c_char) -> ::c_int;
-    pub fn setlocale(
-        category: ::c_int,
-        locale: *const ::c_char,
-    ) -> *mut ::c_char;
+    pub fn setlocale(category: ::c_int, locale: *const ::c_char) -> *mut ::c_char;
 
-    pub fn sigprocmask(
-        how: ::c_int,
-        set: *const sigset_t,
-        oldset: *mut sigset_t,
-    ) -> ::c_int;
+    pub fn sigprocmask(how: ::c_int, set: *const sigset_t, oldset: *mut sigset_t) -> ::c_int;
     pub fn sigpending(set: *mut sigset_t) -> ::c_int;
 
     pub fn mkfifo(path: *const c_char, mode: mode_t) -> ::c_int;
 
-    pub fn fseeko(
-        stream: *mut ::FILE,
-        offset: ::off_t,
-        whence: ::c_int,
-    ) -> ::c_int;
+    pub fn fseeko(stream: *mut ::FILE, offset: ::off_t, whence: ::c_int) -> ::c_int;
     pub fn ftello(stream: *mut ::FILE) -> ::off_t;
     pub fn mkstemp(template: *mut ::c_char) -> ::c_int;
 
@@ -1369,18 +1260,13 @@ extern "C" {
     pub fn closelog();
     pub fn setlogmask(maskpri: ::c_int) -> ::c_int;
     pub fn syslog(priority: ::c_int, message: *const ::c_char, ...);
-    pub fn getline(
-        lineptr: *mut *mut c_char,
-        n: *mut size_t,
-        stream: *mut FILE,
-    ) -> ssize_t;
+    pub fn getline(lineptr: *mut *mut c_char, n: *mut size_t, stream: *mut FILE) -> ssize_t;
 
 }
 
 extern "C" {
     // stdlib.h
-    pub fn memalign(block_size: ::size_t, size_arg: ::size_t)
-        -> *mut ::c_void;
+    pub fn memalign(block_size: ::size_t, size_arg: ::size_t) -> *mut ::c_void;
 
     // ioLib.h
     pub fn getcwd(buf: *mut ::c_char, size: ::size_t) -> *mut ::c_char;
@@ -1392,15 +1278,10 @@ extern "C" {
     pub fn pthread_mutexattr_init(attr: *mut pthread_mutexattr_t) -> ::c_int;
 
     // pthread.h
-    pub fn pthread_mutexattr_destroy(
-        attr: *mut pthread_mutexattr_t,
-    ) -> ::c_int;
+    pub fn pthread_mutexattr_destroy(attr: *mut pthread_mutexattr_t) -> ::c_int;
 
     // pthread.h
-    pub fn pthread_mutexattr_settype(
-        pAttr: *mut ::pthread_mutexattr_t,
-        pType: ::c_int,
-    ) -> ::c_int;
+    pub fn pthread_mutexattr_settype(pAttr: *mut ::pthread_mutexattr_t, pType: ::c_int) -> ::c_int;
 
     // pthread.h
     pub fn pthread_mutex_init(
@@ -1418,31 +1299,20 @@ extern "C" {
     pub fn pthread_mutex_trylock(mutex: *mut pthread_mutex_t) -> ::c_int;
 
     // pthread.h
-    pub fn pthread_mutex_timedlock(
-        attr: *mut pthread_mutex_t,
-        spec: *const timespec,
-    ) -> ::c_int;
+    pub fn pthread_mutex_timedlock(attr: *mut pthread_mutex_t, spec: *const timespec) -> ::c_int;
 
     // pthread.h
     pub fn pthread_mutex_unlock(mutex: *mut pthread_mutex_t) -> ::c_int;
 
     // pthread.h
-    pub fn pthread_attr_setname(
-        pAttr: *mut ::pthread_attr_t,
-        name: *mut ::c_char,
-    ) -> ::c_int;
+    pub fn pthread_attr_setname(pAttr: *mut ::pthread_attr_t, name: *mut ::c_char) -> ::c_int;
 
     // pthread.h
-    pub fn pthread_attr_setstacksize(
-        attr: *mut ::pthread_attr_t,
-        stacksize: ::size_t,
-    ) -> ::c_int;
+    pub fn pthread_attr_setstacksize(attr: *mut ::pthread_attr_t, stacksize: ::size_t) -> ::c_int;
 
     // pthread.h
-    pub fn pthread_attr_getstacksize(
-        attr: *const ::pthread_attr_t,
-        size: *mut ::size_t,
-    ) -> ::c_int;
+    pub fn pthread_attr_getstacksize(attr: *const ::pthread_attr_t, size: *mut ::size_t)
+        -> ::c_int;
 
     // pthread.h
     pub fn pthread_attr_init(attr: *mut ::pthread_attr_t) -> ::c_int;
@@ -1477,11 +1347,8 @@ extern "C" {
     pub fn ftruncate(fd: ::c_int, length: off_t) -> ::c_int;
 
     // dirent.h
-    pub fn readdir_r(
-        pDir: *mut ::DIR,
-        entry: *mut ::dirent,
-        result: *mut *mut ::dirent,
-    ) -> ::c_int;
+    pub fn readdir_r(pDir: *mut ::DIR, entry: *mut ::dirent, result: *mut *mut ::dirent)
+        -> ::c_int;
 
     // dirent.h
     pub fn readdir(pDir: *mut ::DIR) -> *mut ::dirent;
@@ -1497,9 +1364,7 @@ extern "C" {
     pub fn pthread_condattr_init(attr: *mut ::pthread_condattr_t) -> ::c_int;
 
     // pthread.h
-    pub fn pthread_condattr_destroy(
-        attr: *mut ::pthread_condattr_t,
-    ) -> ::c_int;
+    pub fn pthread_condattr_destroy(attr: *mut ::pthread_condattr_t) -> ::c_int;
 
     // pthread.h
     pub fn pthread_condattr_getclock(
@@ -1529,20 +1394,14 @@ extern "C" {
     pub fn pthread_cond_broadcast(cond: *mut ::pthread_cond_t) -> ::c_int;
 
     // pthread.h
-    pub fn pthread_cond_wait(
-        cond: *mut ::pthread_cond_t,
-        mutex: *mut ::pthread_mutex_t,
-    ) -> ::c_int;
+    pub fn pthread_cond_wait(cond: *mut ::pthread_cond_t, mutex: *mut ::pthread_mutex_t)
+        -> ::c_int;
 
     // pthread.h
-    pub fn pthread_rwlockattr_init(
-        attr: *mut ::pthread_rwlockattr_t,
-    ) -> ::c_int;
+    pub fn pthread_rwlockattr_init(attr: *mut ::pthread_rwlockattr_t) -> ::c_int;
 
     // pthread.h
-    pub fn pthread_rwlockattr_destroy(
-        attr: *mut ::pthread_rwlockattr_t,
-    ) -> ::c_int;
+    pub fn pthread_rwlockattr_destroy(attr: *mut ::pthread_rwlockattr_t) -> ::c_int;
 
     // pthread.h
     pub fn pthread_rwlockattr_setmaxreaders(
@@ -1596,10 +1455,7 @@ extern "C" {
     pub fn pthread_key_delete(key: ::pthread_key_t) -> ::c_int;
 
     // pthread.h
-    pub fn pthread_setspecific(
-        key: ::pthread_key_t,
-        value: *const ::c_void,
-    ) -> ::c_int;
+    pub fn pthread_setspecific(key: ::pthread_key_t, value: *const ::c_void) -> ::c_int;
 
     // pthread.h
     pub fn pthread_getspecific(key: ::pthread_key_t) -> *mut ::c_void;
@@ -1612,37 +1468,22 @@ extern "C" {
     ) -> ::c_int;
 
     // pthread.h
-    pub fn pthread_attr_getname(
-        attr: *mut ::pthread_attr_t,
-        name: *mut *mut ::c_char,
-    ) -> ::c_int;
+    pub fn pthread_attr_getname(attr: *mut ::pthread_attr_t, name: *mut *mut ::c_char) -> ::c_int;
 
     // pthread.h
-    pub fn pthread_join(
-        thread: ::pthread_t,
-        status: *mut *mut ::c_void,
-    ) -> ::c_int;
+    pub fn pthread_join(thread: ::pthread_t, status: *mut *mut ::c_void) -> ::c_int;
 
     // pthread.h
     pub fn pthread_self() -> ::pthread_t;
 
     // clockLib.h
-    pub fn clock_gettime(
-        clock_id: ::clockid_t,
-        tp: *mut ::timespec,
-    ) -> ::c_int;
+    pub fn clock_gettime(clock_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
 
     // clockLib.h
-    pub fn clock_settime(
-        clock_id: ::clockid_t,
-        tp: *const ::timespec,
-    ) -> ::c_int;
+    pub fn clock_settime(clock_id: ::clockid_t, tp: *const ::timespec) -> ::c_int;
 
     // clockLib.h
-    pub fn clock_getres(
-        clock_id: ::clockid_t,
-        res: *mut ::timespec,
-    ) -> ::c_int;
+    pub fn clock_getres(clock_id: ::clockid_t, res: *mut ::timespec) -> ::c_int;
 
     // clockLib.h
     pub fn clock_nanosleep(
@@ -1653,35 +1494,19 @@ extern "C" {
     ) -> ::c_int;
 
     // timerLib.h
-    pub fn nanosleep(
-        rqtp: *const ::timespec,
-        rmtp: *mut ::timespec,
-    ) -> ::c_int;
+    pub fn nanosleep(rqtp: *const ::timespec, rmtp: *mut ::timespec) -> ::c_int;
 
     // socket.h
-    pub fn accept(
-        s: ::c_int,
-        addr: *mut ::sockaddr,
-        addrlen: *mut ::socklen_t,
-    ) -> ::c_int;
+    pub fn accept(s: ::c_int, addr: *mut ::sockaddr, addrlen: *mut ::socklen_t) -> ::c_int;
 
     // socket.h
-    pub fn bind(fd: ::c_int, addr: *const sockaddr, len: socklen_t)
-        -> ::c_int;
+    pub fn bind(fd: ::c_int, addr: *const sockaddr, len: socklen_t) -> ::c_int;
 
     // socket.h
-    pub fn connect(
-        s: ::c_int,
-        name: *const ::sockaddr,
-        namelen: ::socklen_t,
-    ) -> ::c_int;
+    pub fn connect(s: ::c_int, name: *const ::sockaddr, namelen: ::socklen_t) -> ::c_int;
 
     // socket.h
-    pub fn getpeername(
-        s: ::c_int,
-        name: *mut ::sockaddr,
-        namelen: *mut ::socklen_t,
-    ) -> ::c_int;
+    pub fn getpeername(s: ::c_int, name: *mut ::sockaddr, namelen: *mut ::socklen_t) -> ::c_int;
 
     // socket.h
     pub fn getsockname(
@@ -1703,12 +1528,7 @@ extern "C" {
     pub fn listen(socket: ::c_int, backlog: ::c_int) -> ::c_int;
 
     // socket.h
-    pub fn recv(
-        s: ::c_int,
-        buf: *mut ::c_void,
-        bufLen: ::size_t,
-        flags: ::c_int,
-    ) -> ::ssize_t;
+    pub fn recv(s: ::c_int, buf: *mut ::c_void, bufLen: ::size_t, flags: ::c_int) -> ::ssize_t;
 
     // socket.h
     pub fn recvfrom(
@@ -1720,25 +1540,12 @@ extern "C" {
         pFromLen: *mut ::socklen_t,
     ) -> ::ssize_t;
 
-    pub fn recvmsg(
-        socket: ::c_int,
-        mp: *mut ::msghdr,
-        flags: ::c_int,
-    ) -> ::ssize_t;
+    pub fn recvmsg(socket: ::c_int, mp: *mut ::msghdr, flags: ::c_int) -> ::ssize_t;
 
     // socket.h
-    pub fn send(
-        socket: ::c_int,
-        buf: *const ::c_void,
-        len: ::size_t,
-        flags: ::c_int,
-    ) -> ::ssize_t;
+    pub fn send(socket: ::c_int, buf: *const ::c_void, len: ::size_t, flags: ::c_int) -> ::ssize_t;
 
-    pub fn sendmsg(
-        socket: ::c_int,
-        mp: *const ::msghdr,
-        flags: ::c_int,
-    ) -> ::ssize_t;
+    pub fn sendmsg(socket: ::c_int, mp: *const ::msghdr, flags: ::c_int) -> ::ssize_t;
 
     // socket.h
     pub fn sendto(
@@ -1763,11 +1570,7 @@ extern "C" {
     pub fn shutdown(s: ::c_int, how: ::c_int) -> ::c_int;
 
     // socket.h
-    pub fn socket(
-        domain: ::c_int,
-        _type: ::c_int,
-        protocol: ::c_int,
-    ) -> ::c_int;
+    pub fn socket(domain: ::c_int, _type: ::c_int, protocol: ::c_int) -> ::c_int;
 
     // icotl.h
     pub fn ioctl(fd: ::c_int, request: ::c_int, ...) -> ::c_int;
@@ -1785,16 +1588,11 @@ extern "C" {
 
     // ioLib.h or
     // unistd.h
-    pub fn read(fd: ::c_int, buf: *mut ::c_void, count: ::size_t)
-        -> ::ssize_t;
+    pub fn read(fd: ::c_int, buf: *mut ::c_void, count: ::size_t) -> ::ssize_t;
 
     // ioLib.h or
     // unistd.h
-    pub fn write(
-        fd: ::c_int,
-        buf: *const ::c_void,
-        count: ::size_t,
-    ) -> ::ssize_t;
+    pub fn write(fd: ::c_int, buf: *const ::c_void, count: ::size_t) -> ::ssize_t;
 
     // ioLib.h or
     // unistd.h
@@ -1841,8 +1639,7 @@ extern "C" {
     pub fn getppid() -> pid_t;
 
     // wait.h
-    pub fn waitpid(pid: pid_t, status: *mut ::c_int, optons: ::c_int)
-        -> pid_t;
+    pub fn waitpid(pid: pid_t, status: *mut ::c_int, optons: ::c_int) -> pid_t;
 
     // unistd.h
     pub fn sysconf(attr: ::c_int) -> ::c_long;
@@ -1862,20 +1659,13 @@ extern "C" {
     ) -> ::c_int;
 
     // stdlib.h
-    pub fn realpath(
-        fileName: *const ::c_char,
-        resolvedName: *mut ::c_char,
-    ) -> *mut ::c_char;
+    pub fn realpath(fileName: *const ::c_char, resolvedName: *mut ::c_char) -> *mut ::c_char;
 
     // unistd.h
     pub fn link(src: *const ::c_char, dst: *const ::c_char) -> ::c_int;
 
     // unistd.h
-    pub fn readlink(
-        path: *const ::c_char,
-        buf: *mut ::c_char,
-        bufsize: ::size_t,
-    ) -> ::ssize_t;
+    pub fn readlink(path: *const ::c_char, buf: *mut ::c_char, bufsize: ::size_t) -> ::ssize_t;
 
     // unistd.h
     pub fn symlink(path1: *const ::c_char, path2: *const ::c_char) -> ::c_int;
@@ -1940,11 +1730,7 @@ extern "C" {
     pub fn kill(__pid: pid_t, __signo: ::c_int) -> ::c_int;
 
     // signal.h for user
-    pub fn sigqueue(
-        __pid: pid_t,
-        __signo: ::c_int,
-        __value: ::sigval,
-    ) -> ::c_int;
+    pub fn sigqueue(__pid: pid_t, __signo: ::c_int, __value: ::sigval) -> ::c_int;
 
     // signal.h for user
     pub fn _sigqueue(
@@ -1977,27 +1763,13 @@ extern "C" {
     ) -> RTP_ID;
 
     // ioLib.h
-    pub fn _realpath(
-        fileName: *const ::c_char,
-        resolvedName: *mut ::c_char,
-    ) -> *mut ::c_char;
+    pub fn _realpath(fileName: *const ::c_char, resolvedName: *mut ::c_char) -> *mut ::c_char;
 
     // pathLib.h
-    pub fn _pathIsAbsolute(
-        filepath: *const ::c_char,
-        pNameTail: *mut *const ::c_char,
-    ) -> BOOL;
+    pub fn _pathIsAbsolute(filepath: *const ::c_char, pNameTail: *mut *const ::c_char) -> BOOL;
 
-    pub fn writev(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-    ) -> ::ssize_t;
-    pub fn readv(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-    ) -> ::ssize_t;
+    pub fn writev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
+    pub fn readv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
 
     // randomNumGen.h
     pub fn randBytes(buf: *mut c_uchar, length: c_int) -> c_int;
@@ -2036,11 +1808,7 @@ extern "C" {
         abs_timeout: *const ::timespec,
     ) -> ::c_int;
     pub fn mq_getattr(mqd: ::mqd_t, attr: *mut ::mq_attr) -> ::c_int;
-    pub fn mq_setattr(
-        mqd: ::mqd_t,
-        newattr: *const ::mq_attr,
-        oldattr: *mut ::mq_attr,
-    ) -> ::c_int;
+    pub fn mq_setattr(mqd: ::mqd_t, newattr: *const ::mq_attr, oldattr: *mut ::mq_attr) -> ::c_int;
 }
 
 //Dummy functions, these don't really exist in VxWorks.
@@ -2067,12 +1835,7 @@ safe_f! {
     }
 }
 
-pub fn pread(
-    _fd: ::c_int,
-    _buf: *mut ::c_void,
-    _count: ::size_t,
-    _offset: off64_t,
-) -> ::ssize_t {
+pub fn pread(_fd: ::c_int, _buf: *mut ::c_void, _count: ::size_t, _offset: off64_t) -> ::ssize_t {
     -1
 }
 
@@ -2084,16 +1847,10 @@ pub fn pwrite(
 ) -> ::ssize_t {
     -1
 }
-pub fn posix_memalign(
-    memptr: *mut *mut ::c_void,
-    align: ::size_t,
-    size: ::size_t,
-) -> ::c_int {
+pub fn posix_memalign(memptr: *mut *mut ::c_void, align: ::size_t, size: ::size_t) -> ::c_int {
     // check to see if align is a power of 2 and if align is a multiple
     //  of sizeof(void *)
-    if (align & align - 1 != 0)
-        || (align as usize % size_of::<::size_t>() != 0)
-    {
+    if (align & align - 1 != 0) || (align as usize % size_of::<::size_t>() != 0) {
         return ::EINVAL;
     }
 

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -358,11 +358,7 @@ extern "C" {
     pub fn write(fd: c_int, ptr: *const c_void, size: size_t) -> ssize_t;
     pub static mut environ: *mut *mut c_char;
     pub fn fopen(a: *const c_char, b: *const c_char) -> *mut FILE;
-    pub fn freopen(
-        a: *const c_char,
-        b: *const c_char,
-        f: *mut FILE,
-    ) -> *mut FILE;
+    pub fn freopen(a: *const c_char, b: *const c_char, f: *mut FILE) -> *mut FILE;
     pub fn fclose(f: *mut FILE) -> c_int;
     pub fn remove(a: *const c_char) -> c_int;
     pub fn rename(a: *const c_char, b: *const c_char) -> c_int;
@@ -375,18 +371,8 @@ extern "C" {
     pub fn rewind(f: *mut FILE);
     pub fn fgetpos(f: *mut FILE, pos: *mut fpos_t) -> c_int;
     pub fn fsetpos(f: *mut FILE, pos: *const fpos_t) -> c_int;
-    pub fn fread(
-        buf: *mut c_void,
-        a: size_t,
-        b: size_t,
-        f: *mut FILE,
-    ) -> size_t;
-    pub fn fwrite(
-        buf: *const c_void,
-        a: size_t,
-        b: size_t,
-        f: *mut FILE,
-    ) -> size_t;
+    pub fn fread(buf: *mut c_void, a: size_t, b: size_t, f: *mut FILE) -> size_t;
+    pub fn fwrite(buf: *const c_void, a: size_t, b: size_t, f: *mut FILE) -> size_t;
     pub fn fgetc(f: *mut FILE) -> c_int;
     pub fn getc(f: *mut FILE) -> c_int;
     pub fn getchar() -> c_int;
@@ -410,12 +396,7 @@ extern "C" {
     pub fn time(a: *mut time_t) -> time_t;
     pub fn difftime(a: time_t, b: time_t) -> c_double;
     pub fn mktime(a: *mut tm) -> time_t;
-    pub fn strftime(
-        a: *mut c_char,
-        b: size_t,
-        c: *const c_char,
-        d: *const tm,
-    ) -> size_t;
+    pub fn strftime(a: *mut c_char, b: size_t, c: *const c_char, d: *const tm) -> size_t;
     pub fn gmtime(a: *const time_t) -> *mut tm;
     pub fn gmtime_r(a: *const time_t, b: *mut tm) -> *mut tm;
     pub fn localtime(a: *const time_t) -> *mut tm;
@@ -447,41 +428,19 @@ extern "C" {
     pub fn isblank(c: c_int) -> c_int;
     pub fn tolower(c: c_int) -> c_int;
     pub fn toupper(c: c_int) -> c_int;
-    pub fn setvbuf(
-        stream: *mut FILE,
-        buffer: *mut c_char,
-        mode: c_int,
-        size: size_t,
-    ) -> c_int;
+    pub fn setvbuf(stream: *mut FILE, buffer: *mut c_char, mode: c_int, size: size_t) -> c_int;
     pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
-    pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE)
-        -> *mut c_char;
+    pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
     pub fn atoi(s: *const c_char) -> c_int;
     pub fn atof(s: *const c_char) -> c_double;
     pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
-    pub fn strtol(
-        s: *const c_char,
-        endp: *mut *mut c_char,
-        base: c_int,
-    ) -> c_long;
-    pub fn strtoul(
-        s: *const c_char,
-        endp: *mut *mut c_char,
-        base: c_int,
-    ) -> c_ulong;
+    pub fn strtol(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_long;
+    pub fn strtoul(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_ulong;
 
     pub fn strcpy(dst: *mut c_char, src: *const c_char) -> *mut c_char;
-    pub fn strncpy(
-        dst: *mut c_char,
-        src: *const c_char,
-        n: size_t,
-    ) -> *mut c_char;
+    pub fn strncpy(dst: *mut c_char, src: *const c_char, n: size_t) -> *mut c_char;
     pub fn strcat(s: *mut c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strncat(
-        s: *mut c_char,
-        ct: *const c_char,
-        n: size_t,
-    ) -> *mut c_char;
+    pub fn strncat(s: *mut c_char, ct: *const c_char, n: size_t) -> *mut c_char;
     pub fn strcmp(cs: *const c_char, ct: *const c_char) -> c_int;
     pub fn strncmp(cs: *const c_char, ct: *const c_char, n: size_t) -> c_int;
     pub fn strcoll(cs: *const c_char, ct: *const c_char) -> c_int;
@@ -494,11 +453,7 @@ extern "C" {
     pub fn strpbrk(cs: *const c_char, ct: *const c_char) -> *mut c_char;
     pub fn strstr(cs: *const c_char, ct: *const c_char) -> *mut c_char;
     pub fn strcasecmp(s1: *const c_char, s2: *const c_char) -> c_int;
-    pub fn strncasecmp(
-        s1: *const c_char,
-        s2: *const c_char,
-        n: size_t,
-    ) -> c_int;
+    pub fn strncasecmp(s1: *const c_char, s2: *const c_char, n: size_t) -> c_int;
     pub fn strlen(cs: *const c_char) -> size_t;
     pub fn strnlen(cs: *const c_char, maxlen: size_t) -> size_t;
     pub fn strerror(n: c_int) -> *mut c_char;
@@ -507,39 +462,17 @@ extern "C" {
 
     pub fn memchr(cx: *const c_void, c: c_int, n: size_t) -> *mut c_void;
     pub fn memcmp(cx: *const c_void, ct: *const c_void, n: size_t) -> c_int;
-    pub fn memcpy(
-        dest: *mut c_void,
-        src: *const c_void,
-        n: size_t,
-    ) -> *mut c_void;
-    pub fn memmove(
-        dest: *mut c_void,
-        src: *const c_void,
-        n: size_t,
-    ) -> *mut c_void;
+    pub fn memcpy(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
+    pub fn memmove(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
     pub fn memset(dest: *mut c_void, c: c_int, n: size_t) -> *mut c_void;
 
-    pub fn fprintf(
-        stream: *mut ::FILE,
-        format: *const ::c_char,
-        ...
-    ) -> ::c_int;
+    pub fn fprintf(stream: *mut ::FILE, format: *const ::c_char, ...) -> ::c_int;
     pub fn printf(format: *const ::c_char, ...) -> ::c_int;
-    pub fn snprintf(
-        s: *mut ::c_char,
-        n: ::size_t,
-        format: *const ::c_char,
-        ...
-    ) -> ::c_int;
+    pub fn snprintf(s: *mut ::c_char, n: ::size_t, format: *const ::c_char, ...) -> ::c_int;
     pub fn sprintf(s: *mut ::c_char, format: *const ::c_char, ...) -> ::c_int;
-    pub fn fscanf(
-        stream: *mut ::FILE,
-        format: *const ::c_char,
-        ...
-    ) -> ::c_int;
+    pub fn fscanf(stream: *mut ::FILE, format: *const ::c_char, ...) -> ::c_int;
     pub fn scanf(format: *const ::c_char, ...) -> ::c_int;
-    pub fn sscanf(s: *const ::c_char, format: *const ::c_char, ...)
-        -> ::c_int;
+    pub fn sscanf(s: *const ::c_char, format: *const ::c_char, ...) -> ::c_int;
     pub fn getchar_unlocked() -> ::c_int;
     pub fn putchar_unlocked(c: ::c_int) -> ::c_int;
 
@@ -561,12 +494,7 @@ extern "C" {
     pub fn seekdir(dirp: *mut ::DIR, loc: ::c_long);
     pub fn telldir(dirp: *mut ::DIR) -> ::c_long;
 
-    pub fn openat(
-        dirfd: ::c_int,
-        pathname: *const ::c_char,
-        flags: ::c_int,
-        ...
-    ) -> ::c_int;
+    pub fn openat(dirfd: ::c_int, pathname: *const ::c_char, flags: ::c_int, ...) -> ::c_int;
     pub fn fstatat(
         dirfd: ::c_int,
         pathname: *const ::c_char,
@@ -580,11 +508,7 @@ extern "C" {
         newpath: *const ::c_char,
         flags: ::c_int,
     ) -> ::c_int;
-    pub fn mkdirat(
-        dirfd: ::c_int,
-        pathname: *const ::c_char,
-        mode: ::mode_t,
-    ) -> ::c_int;
+    pub fn mkdirat(dirfd: ::c_int, pathname: *const ::c_char, mode: ::mode_t) -> ::c_int;
     pub fn readlinkat(
         dirfd: ::c_int,
         pathname: *const ::c_char,
@@ -602,20 +526,12 @@ extern "C" {
         newdirfd: ::c_int,
         linkpath: *const ::c_char,
     ) -> ::c_int;
-    pub fn unlinkat(
-        dirfd: ::c_int,
-        pathname: *const ::c_char,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn unlinkat(dirfd: ::c_int, pathname: *const ::c_char, flags: ::c_int) -> ::c_int;
 
     pub fn access(path: *const c_char, amode: ::c_int) -> ::c_int;
     pub fn close(fd: ::c_int) -> ::c_int;
     pub fn fpathconf(filedes: ::c_int, name: ::c_int) -> c_long;
-    pub fn getopt(
-        argc: ::c_int,
-        argv: *const *mut c_char,
-        optstr: *const c_char,
-    ) -> ::c_int;
+    pub fn getopt(argc: ::c_int, argv: *const *mut c_char, optstr: *const c_char) -> ::c_int;
     pub fn isatty(fd: ::c_int) -> ::c_int;
     pub fn link(src: *const c_char, dst: *const c_char) -> ::c_int;
     pub fn lseek(fd: ::c_int, offset: off_t, whence: ::c_int) -> off_t;
@@ -623,18 +539,8 @@ extern "C" {
     pub fn rmdir(path: *const c_char) -> ::c_int;
     pub fn sleep(secs: ::c_uint) -> ::c_uint;
     pub fn unlink(c: *const c_char) -> ::c_int;
-    pub fn pread(
-        fd: ::c_int,
-        buf: *mut ::c_void,
-        count: ::size_t,
-        offset: off_t,
-    ) -> ::ssize_t;
-    pub fn pwrite(
-        fd: ::c_int,
-        buf: *const ::c_void,
-        count: ::size_t,
-        offset: off_t,
-    ) -> ::ssize_t;
+    pub fn pread(fd: ::c_int, buf: *mut ::c_void, count: ::size_t, offset: off_t) -> ::ssize_t;
+    pub fn pwrite(fd: ::c_int, buf: *const ::c_void, count: ::size_t, offset: off_t) -> ::ssize_t;
 
     pub fn lstat(path: *const c_char, buf: *mut stat) -> ::c_int;
 
@@ -651,37 +557,16 @@ extern "C" {
     pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::c_void) -> ::c_int;
     pub fn times(buf: *mut ::tms) -> ::clock_t;
 
-    pub fn strerror_r(
-        errnum: ::c_int,
-        buf: *mut c_char,
-        buflen: ::size_t,
-    ) -> ::c_int;
+    pub fn strerror_r(errnum: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
 
     pub fn usleep(secs: ::c_uint) -> ::c_int;
-    pub fn send(
-        socket: ::c_int,
-        buf: *const ::c_void,
-        len: ::size_t,
-        flags: ::c_int,
-    ) -> ::ssize_t;
-    pub fn recv(
-        socket: ::c_int,
-        buf: *mut ::c_void,
-        len: ::size_t,
-        flags: ::c_int,
-    ) -> ::ssize_t;
+    pub fn send(socket: ::c_int, buf: *const ::c_void, len: ::size_t, flags: ::c_int) -> ::ssize_t;
+    pub fn recv(socket: ::c_int, buf: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::ssize_t;
     pub fn poll(fds: *mut pollfd, nfds: nfds_t, timeout: ::c_int) -> ::c_int;
-    pub fn setlocale(
-        category: ::c_int,
-        locale: *const ::c_char,
-    ) -> *mut ::c_char;
+    pub fn setlocale(category: ::c_int, locale: *const ::c_char) -> *mut ::c_char;
     pub fn localeconv() -> *mut lconv;
 
-    pub fn readlink(
-        path: *const c_char,
-        buf: *mut c_char,
-        bufsz: ::size_t,
-    ) -> ::ssize_t;
+    pub fn readlink(path: *const c_char, buf: *mut c_char, bufsz: ::size_t) -> ::ssize_t;
 
     pub fn timegm(tm: *mut ::tm) -> time_t;
 
@@ -689,24 +574,12 @@ extern "C" {
 
     pub fn ioctl(fd: ::c_int, request: ::c_int, ...) -> ::c_int;
 
-    pub fn fseeko(
-        stream: *mut ::FILE,
-        offset: ::off_t,
-        whence: ::c_int,
-    ) -> ::c_int;
+    pub fn fseeko(stream: *mut ::FILE, offset: ::off_t, whence: ::c_int) -> ::c_int;
     pub fn ftello(stream: *mut ::FILE) -> ::off_t;
-    pub fn posix_fallocate(
-        fd: ::c_int,
-        offset: ::off_t,
-        len: ::off_t,
-    ) -> ::c_int;
+    pub fn posix_fallocate(fd: ::c_int, offset: ::off_t, len: ::off_t) -> ::c_int;
 
     pub fn strcasestr(cs: *const c_char, ct: *const c_char) -> *mut c_char;
-    pub fn getline(
-        lineptr: *mut *mut c_char,
-        n: *mut size_t,
-        stream: *mut FILE,
-    ) -> ssize_t;
+    pub fn getline(lineptr: *mut *mut c_char, n: *mut size_t, stream: *mut FILE) -> ssize_t;
 
     pub fn faccessat(
         dirfd: ::c_int,
@@ -714,34 +587,12 @@ extern "C" {
         mode: ::c_int,
         flags: ::c_int,
     ) -> ::c_int;
-    pub fn writev(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-    ) -> ::ssize_t;
-    pub fn readv(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-    ) -> ::ssize_t;
-    pub fn pwritev(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-        offset: ::off_t,
-    ) -> ::ssize_t;
-    pub fn preadv(
-        fd: ::c_int,
-        iov: *const ::iovec,
-        iovcnt: ::c_int,
-        offset: ::off_t,
-    ) -> ::ssize_t;
-    pub fn posix_fadvise(
-        fd: ::c_int,
-        offset: ::off_t,
-        len: ::off_t,
-        advise: ::c_int,
-    ) -> ::c_int;
+    pub fn writev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
+    pub fn readv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
+    pub fn pwritev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t)
+        -> ::ssize_t;
+    pub fn preadv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t) -> ::ssize_t;
+    pub fn posix_fadvise(fd: ::c_int, offset: ::off_t, len: ::off_t, advise: ::c_int) -> ::c_int;
     pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
     pub fn utimensat(
         dirfd: ::c_int,
@@ -750,27 +601,16 @@ extern "C" {
         flag: ::c_int,
     ) -> ::c_int;
     pub fn getentropy(buf: *mut ::c_void, buflen: ::size_t) -> ::c_int;
-    pub fn memrchr(
-        cx: *const ::c_void,
-        c: ::c_int,
-        n: ::size_t,
-    ) -> *mut ::c_void;
+    pub fn memrchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
     pub fn abs(i: c_int) -> c_int;
     pub fn labs(i: c_long) -> c_long;
     pub fn duplocale(base: ::locale_t) -> ::locale_t;
     pub fn freelocale(loc: ::locale_t);
-    pub fn newlocale(
-        mask: ::c_int,
-        locale: *const ::c_char,
-        base: ::locale_t,
-    ) -> ::locale_t;
+    pub fn newlocale(mask: ::c_int, locale: *const ::c_char, base: ::locale_t) -> ::locale_t;
     pub fn uselocale(loc: ::locale_t) -> ::locale_t;
     pub fn sched_yield() -> ::c_int;
 
-    pub fn __wasilibc_register_preopened_fd(
-        fd: c_int,
-        path: *const c_char,
-    ) -> c_int;
+    pub fn __wasilibc_register_preopened_fd(fd: c_int, path: *const c_char) -> c_int;
     pub fn __wasilibc_fd_renumber(fd: c_int, newfd: c_int) -> c_int;
     pub fn __wasilibc_unlinkat(fd: c_int, path: *const c_char) -> c_int;
     pub fn __wasilibc_rmdirat(fd: c_int, path: *const c_char) -> c_int;
@@ -781,14 +621,8 @@ extern "C" {
         relative_path_len: usize,
     ) -> c_int;
     pub fn __wasilibc_tell(fd: c_int) -> ::off_t;
-    pub fn __wasilibc_nocwd___wasilibc_unlinkat(
-        dirfd: c_int,
-        path: *const c_char,
-    ) -> c_int;
-    pub fn __wasilibc_nocwd___wasilibc_rmdirat(
-        dirfd: c_int,
-        path: *const c_char,
-    ) -> c_int;
+    pub fn __wasilibc_nocwd___wasilibc_unlinkat(dirfd: c_int, path: *const c_char) -> c_int;
+    pub fn __wasilibc_nocwd___wasilibc_rmdirat(dirfd: c_int, path: *const c_char) -> c_int;
     pub fn __wasilibc_nocwd_linkat(
         olddirfd: c_int,
         oldpath: *const c_char,
@@ -819,51 +653,30 @@ extern "C" {
         newdirfd: c_int,
         newpath: *const c_char,
     ) -> c_int;
-    pub fn __wasilibc_nocwd_openat_nomode(
-        dirfd: c_int,
-        path: *const c_char,
-        flags: c_int,
-    ) -> c_int;
+    pub fn __wasilibc_nocwd_openat_nomode(dirfd: c_int, path: *const c_char, flags: c_int)
+        -> c_int;
     pub fn __wasilibc_nocwd_fstatat(
         dirfd: c_int,
         path: *const c_char,
         buf: *mut stat,
         flags: c_int,
     ) -> c_int;
-    pub fn __wasilibc_nocwd_mkdirat_nomode(
-        dirfd: c_int,
-        path: *const c_char,
-    ) -> c_int;
+    pub fn __wasilibc_nocwd_mkdirat_nomode(dirfd: c_int, path: *const c_char) -> c_int;
     pub fn __wasilibc_nocwd_utimensat(
         dirfd: c_int,
         path: *const c_char,
         times: *const ::timespec,
         flags: c_int,
     ) -> c_int;
-    pub fn __wasilibc_nocwd_opendirat(
-        dirfd: c_int,
-        path: *const c_char,
-    ) -> *mut ::DIR;
-    pub fn __wasilibc_access(
-        pathname: *const c_char,
-        mode: c_int,
-        flags: c_int,
-    ) -> c_int;
-    pub fn __wasilibc_stat(
-        pathname: *const c_char,
-        buf: *mut stat,
-        flags: c_int,
-    ) -> c_int;
+    pub fn __wasilibc_nocwd_opendirat(dirfd: c_int, path: *const c_char) -> *mut ::DIR;
+    pub fn __wasilibc_access(pathname: *const c_char, mode: c_int, flags: c_int) -> c_int;
+    pub fn __wasilibc_stat(pathname: *const c_char, buf: *mut stat, flags: c_int) -> c_int;
     pub fn __wasilibc_utimens(
         pathname: *const c_char,
         times: *const ::timespec,
         flags: c_int,
     ) -> c_int;
-    pub fn __wasilibc_link(
-        oldpath: *const c_char,
-        newpath: *const c_char,
-        flags: c_int,
-    ) -> c_int;
+    pub fn __wasilibc_link(oldpath: *const c_char, newpath: *const c_char, flags: c_int) -> c_int;
     pub fn __wasilibc_link_oldat(
         olddirfd: c_int,
         oldpath: *const c_char,

--- a/src/windows/gnu/mod.rs
+++ b/src/windows/gnu/mod.rs
@@ -8,19 +8,11 @@ pub const STDERR_FILENO: ::c_int = 2;
 
 extern "C" {
     pub fn strcasecmp(s1: *const ::c_char, s2: *const ::c_char) -> ::c_int;
-    pub fn strncasecmp(
-        s1: *const ::c_char,
-        s2: *const ::c_char,
-        n: ::size_t,
-    ) -> ::c_int;
+    pub fn strncasecmp(s1: *const ::c_char, s2: *const ::c_char, n: ::size_t) -> ::c_int;
 
     // NOTE: For MSVC target, `wmemchr` is only a inline function in `<wchar.h>`
     //      header file. We cannot find a way to link to that symbol from Rust.
-    pub fn wmemchr(
-        cx: *const ::wchar_t,
-        c: ::wchar_t,
-        n: ::size_t,
-    ) -> *mut ::wchar_t;
+    pub fn wmemchr(cx: *const ::wchar_t, c: ::wchar_t, n: ::size_t) -> *mut ::wchar_t;
 }
 
 cfg_if! {

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -274,44 +274,24 @@ extern "C" {
     pub fn tolower(c: c_int) -> c_int;
     pub fn toupper(c: c_int) -> c_int;
     pub fn fopen(filename: *const c_char, mode: *const c_char) -> *mut FILE;
-    pub fn freopen(
-        filename: *const c_char,
-        mode: *const c_char,
-        file: *mut FILE,
-    ) -> *mut FILE;
+    pub fn freopen(filename: *const c_char, mode: *const c_char, file: *mut FILE) -> *mut FILE;
     pub fn fflush(file: *mut FILE) -> c_int;
     pub fn fclose(file: *mut FILE) -> c_int;
     pub fn remove(filename: *const c_char) -> c_int;
     pub fn rename(oldname: *const c_char, newname: *const c_char) -> c_int;
     pub fn tmpfile() -> *mut FILE;
-    pub fn setvbuf(
-        stream: *mut FILE,
-        buffer: *mut c_char,
-        mode: c_int,
-        size: size_t,
-    ) -> c_int;
+    pub fn setvbuf(stream: *mut FILE, buffer: *mut c_char, mode: c_int, size: size_t) -> c_int;
     pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
     pub fn getchar() -> c_int;
     pub fn putchar(c: c_int) -> c_int;
     pub fn fgetc(stream: *mut FILE) -> c_int;
-    pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE)
-        -> *mut c_char;
+    pub fn fgets(buf: *mut c_char, n: c_int, stream: *mut FILE) -> *mut c_char;
     pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;
     pub fn fputs(s: *const c_char, stream: *mut FILE) -> c_int;
     pub fn puts(s: *const c_char) -> c_int;
     pub fn ungetc(c: c_int, stream: *mut FILE) -> c_int;
-    pub fn fread(
-        ptr: *mut c_void,
-        size: size_t,
-        nobj: size_t,
-        stream: *mut FILE,
-    ) -> size_t;
-    pub fn fwrite(
-        ptr: *const c_void,
-        size: size_t,
-        nobj: size_t,
-        stream: *mut FILE,
-    ) -> size_t;
+    pub fn fread(ptr: *mut c_void, size: size_t, nobj: size_t, stream: *mut FILE) -> size_t;
+    pub fn fwrite(ptr: *const c_void, size: size_t, nobj: size_t, stream: *mut FILE) -> size_t;
     pub fn fseek(stream: *mut FILE, offset: c_long, whence: c_int) -> c_int;
     pub fn ftell(stream: *mut FILE) -> c_long;
     pub fn rewind(stream: *mut FILE);
@@ -322,16 +302,8 @@ extern "C" {
     pub fn perror(s: *const c_char);
     pub fn atoi(s: *const c_char) -> c_int;
     pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
-    pub fn strtol(
-        s: *const c_char,
-        endp: *mut *mut c_char,
-        base: c_int,
-    ) -> c_long;
-    pub fn strtoul(
-        s: *const c_char,
-        endp: *mut *mut c_char,
-        base: c_int,
-    ) -> c_ulong;
+    pub fn strtol(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_long;
+    pub fn strtoul(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_ulong;
     pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;
     pub fn malloc(size: size_t) -> *mut c_void;
     pub fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
@@ -344,17 +316,9 @@ extern "C" {
     pub fn getenv(s: *const c_char) -> *mut c_char;
 
     pub fn strcpy(dst: *mut c_char, src: *const c_char) -> *mut c_char;
-    pub fn strncpy(
-        dst: *mut c_char,
-        src: *const c_char,
-        n: size_t,
-    ) -> *mut c_char;
+    pub fn strncpy(dst: *mut c_char, src: *const c_char, n: size_t) -> *mut c_char;
     pub fn strcat(s: *mut c_char, ct: *const c_char) -> *mut c_char;
-    pub fn strncat(
-        s: *mut c_char,
-        ct: *const c_char,
-        n: size_t,
-    ) -> *mut c_char;
+    pub fn strncat(s: *mut c_char, ct: *const c_char, n: size_t) -> *mut c_char;
     pub fn strcmp(cs: *const c_char, ct: *const c_char) -> c_int;
     pub fn strncmp(cs: *const c_char, ct: *const c_char, n: size_t) -> c_int;
     pub fn strcoll(cs: *const c_char, ct: *const c_char) -> c_int;
@@ -371,24 +335,12 @@ extern "C" {
     pub fn strtok(s: *mut c_char, t: *const c_char) -> *mut c_char;
     pub fn strxfrm(s: *mut c_char, ct: *const c_char, n: size_t) -> size_t;
     pub fn wcslen(buf: *const wchar_t) -> size_t;
-    pub fn wcstombs(
-        dest: *mut c_char,
-        src: *const wchar_t,
-        n: size_t,
-    ) -> ::size_t;
+    pub fn wcstombs(dest: *mut c_char, src: *const wchar_t, n: size_t) -> ::size_t;
 
     pub fn memchr(cx: *const c_void, c: c_int, n: size_t) -> *mut c_void;
     pub fn memcmp(cx: *const c_void, ct: *const c_void, n: size_t) -> c_int;
-    pub fn memcpy(
-        dest: *mut c_void,
-        src: *const c_void,
-        n: size_t,
-    ) -> *mut c_void;
-    pub fn memmove(
-        dest: *mut c_void,
-        src: *const c_void,
-        n: size_t,
-    ) -> *mut c_void;
+    pub fn memcpy(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
+    pub fn memmove(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
     pub fn memset(dest: *mut c_void, c: c_int, n: size_t) -> *mut c_void;
 
     pub fn abs(i: c_int) -> c_int;
@@ -447,37 +399,21 @@ extern "C" {
     #[link_name = "_execl"]
     pub fn execl(path: *const c_char, arg0: *const c_char, ...) -> intptr_t;
     #[link_name = "_wexecl"]
-    pub fn wexecl(path: *const wchar_t, arg0: *const wchar_t, ...)
-        -> intptr_t;
+    pub fn wexecl(path: *const wchar_t, arg0: *const wchar_t, ...) -> intptr_t;
     #[link_name = "_execle"]
     pub fn execle(path: *const c_char, arg0: *const c_char, ...) -> intptr_t;
     #[link_name = "_wexecle"]
-    pub fn wexecle(
-        path: *const wchar_t,
-        arg0: *const wchar_t,
-        ...
-    ) -> intptr_t;
+    pub fn wexecle(path: *const wchar_t, arg0: *const wchar_t, ...) -> intptr_t;
     #[link_name = "_execlp"]
     pub fn execlp(path: *const c_char, arg0: *const c_char, ...) -> intptr_t;
     #[link_name = "_wexeclp"]
-    pub fn wexeclp(
-        path: *const wchar_t,
-        arg0: *const wchar_t,
-        ...
-    ) -> intptr_t;
+    pub fn wexeclp(path: *const wchar_t, arg0: *const wchar_t, ...) -> intptr_t;
     #[link_name = "_execlpe"]
     pub fn execlpe(path: *const c_char, arg0: *const c_char, ...) -> intptr_t;
     #[link_name = "_wexeclpe"]
-    pub fn wexeclpe(
-        path: *const wchar_t,
-        arg0: *const wchar_t,
-        ...
-    ) -> intptr_t;
+    pub fn wexeclpe(path: *const wchar_t, arg0: *const wchar_t, ...) -> intptr_t;
     #[link_name = "_execv"]
-    pub fn execv(
-        prog: *const c_char,
-        argv: *const *const c_char,
-    ) -> ::intptr_t;
+    pub fn execv(prog: *const c_char, argv: *const *const c_char) -> ::intptr_t;
     #[link_name = "_execve"]
     pub fn execve(
         prog: *const c_char,
@@ -493,10 +429,7 @@ extern "C" {
         envp: *const *const c_char,
     ) -> ::c_int;
     #[link_name = "_wexecv"]
-    pub fn wexecv(
-        prog: *const wchar_t,
-        argv: *const *const wchar_t,
-    ) -> ::intptr_t;
+    pub fn wexecv(prog: *const wchar_t, argv: *const *const wchar_t) -> ::intptr_t;
     #[link_name = "_wexecve"]
     pub fn wexecve(
         prog: *const wchar_t,
@@ -504,10 +437,7 @@ extern "C" {
         envp: *const *const wchar_t,
     ) -> ::intptr_t;
     #[link_name = "_wexecvp"]
-    pub fn wexecvp(
-        c: *const wchar_t,
-        argv: *const *const wchar_t,
-    ) -> ::intptr_t;
+    pub fn wexecvp(c: *const wchar_t, argv: *const *const wchar_t) -> ::intptr_t;
     #[link_name = "_wexecvpe"]
     pub fn wexecvpe(
         c: *const wchar_t,
@@ -523,17 +453,9 @@ extern "C" {
     #[link_name = "_lseek"]
     pub fn lseek(fd: ::c_int, offset: c_long, origin: ::c_int) -> c_long;
     #[link_name = "_lseeki64"]
-    pub fn lseek64(
-        fd: ::c_int,
-        offset: c_longlong,
-        origin: ::c_int,
-    ) -> c_longlong;
+    pub fn lseek64(fd: ::c_int, offset: c_longlong, origin: ::c_int) -> c_longlong;
     #[link_name = "_pipe"]
-    pub fn pipe(
-        fds: *mut ::c_int,
-        psize: ::c_uint,
-        textmode: ::c_int,
-    ) -> ::c_int;
+    pub fn pipe(fds: *mut ::c_int, psize: ::c_uint, textmode: ::c_int) -> ::c_int;
     #[link_name = "_read"]
     pub fn read(fd: ::c_int, buf: *mut ::c_void, count: ::c_uint) -> ::c_int;
     #[link_name = "_rmdir"]
@@ -541,11 +463,7 @@ extern "C" {
     #[link_name = "_unlink"]
     pub fn unlink(c: *const c_char) -> ::c_int;
     #[link_name = "_write"]
-    pub fn write(
-        fd: ::c_int,
-        buf: *const ::c_void,
-        count: ::c_uint,
-    ) -> ::c_int;
+    pub fn write(fd: ::c_int, buf: *const ::c_void, count: ::c_uint) -> ::c_int;
     #[link_name = "_commit"]
     pub fn commit(fd: ::c_int) -> ::c_int;
     #[link_name = "_get_osfhandle"]
@@ -554,41 +472,18 @@ extern "C" {
     pub fn open_osfhandle(osfhandle: ::intptr_t, flags: ::c_int) -> ::c_int;
     pub fn setlocale(category: ::c_int, locale: *const c_char) -> *mut c_char;
     #[link_name = "_wsetlocale"]
-    pub fn wsetlocale(
-        category: ::c_int,
-        locale: *const wchar_t,
-    ) -> *mut wchar_t;
+    pub fn wsetlocale(category: ::c_int, locale: *const wchar_t) -> *mut wchar_t;
     #[link_name = "_aligned_malloc"]
     pub fn aligned_malloc(size: size_t, alignment: size_t) -> *mut c_void;
 }
 
 extern "system" {
     pub fn listen(s: SOCKET, backlog: ::c_int) -> ::c_int;
-    pub fn accept(
-        s: SOCKET,
-        addr: *mut ::sockaddr,
-        addrlen: *mut ::c_int,
-    ) -> SOCKET;
-    pub fn bind(
-        s: SOCKET,
-        name: *const ::sockaddr,
-        namelen: ::c_int,
-    ) -> ::c_int;
-    pub fn connect(
-        s: SOCKET,
-        name: *const ::sockaddr,
-        namelen: ::c_int,
-    ) -> ::c_int;
-    pub fn getpeername(
-        s: SOCKET,
-        name: *mut ::sockaddr,
-        nameln: *mut ::c_int,
-    ) -> ::c_int;
-    pub fn getsockname(
-        s: SOCKET,
-        name: *mut ::sockaddr,
-        nameln: *mut ::c_int,
-    ) -> ::c_int;
+    pub fn accept(s: SOCKET, addr: *mut ::sockaddr, addrlen: *mut ::c_int) -> SOCKET;
+    pub fn bind(s: SOCKET, name: *const ::sockaddr, namelen: ::c_int) -> ::c_int;
+    pub fn connect(s: SOCKET, name: *const ::sockaddr, namelen: ::c_int) -> ::c_int;
+    pub fn getpeername(s: SOCKET, name: *mut ::sockaddr, nameln: *mut ::c_int) -> ::c_int;
+    pub fn getsockname(s: SOCKET, name: *mut ::sockaddr, nameln: *mut ::c_int) -> ::c_int;
     pub fn getsockopt(
         s: SOCKET,
         level: ::c_int,
@@ -619,11 +514,7 @@ extern "system" {
         optval: *const ::c_char,
         optlen: ::c_int,
     ) -> ::c_int;
-    pub fn socket(
-        af: ::c_int,
-        socket_type: ::c_int,
-        protocol: ::c_int,
-    ) -> SOCKET;
+    pub fn socket(af: ::c_int, socket_type: ::c_int, protocol: ::c_int) -> SOCKET;
 }
 
 cfg_if! {

--- a/src/windows/msvc.rs
+++ b/src/windows/msvc.rs
@@ -9,9 +9,5 @@ extern "C" {
     #[link_name = "_stricmp"]
     pub fn stricmp(s1: *const ::c_char, s2: *const ::c_char) -> ::c_int;
     #[link_name = "_strnicmp"]
-    pub fn strnicmp(
-        s1: *const ::c_char,
-        s2: *const ::c_char,
-        n: ::size_t,
-    ) -> ::c_int;
+    pub fn strnicmp(s1: *const ::c_char, s2: *const ::c_char, n: ::size_t) -> ::c_int;
 }


### PR DESCRIPTION
- Only run the cfg check for single lines
  - This is a temporary workaround for the multiline `cfg`s.
- Allow long comments containing a link
  - I don't think it makes much sense to break comments containing the reference links.
- Relax the line length limit to 100
  - Given the `cfg` condition often becomes complex, the 80 characters limit is too strict for me.