### PR TITLE
Add kqueue1 to NetBSD

### DIFF
--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -1110,6 +1110,7 @@ kevent
 key_t
 killpg
 kqueue
+kqueue1
 labs
 lastlog
 lastlogx

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2037,6 +2037,8 @@ extern "C" {
 
     pub fn dup3(src: ::c_int, dst: ::c_int, flags: ::c_int) -> ::c_int;
 
+    pub fn kqueue1(flags: ::c_int) -> ::c_int;
+
     pub fn sendmmsg(
         sockfd: ::c_int,
         msgvec: *mut ::mmsghdr,


### PR DESCRIPTION
Add `kqueue1` to NetBSD as described [in the `man`](https://www.freebsd.org/cgi/man.cgi?query=kqueue1&manpath=NetBSD+9.1).