### PR TITLE
linux: add syncfs(2)

### DIFF
--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -3007,6 +3007,7 @@ swapoff
 swapon
 sync
 sync_file_range
+syncfs
 syscall
 sysinfo
 tee

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -3257,6 +3257,7 @@ extern "C" {
     pub fn setdomainname(name: *const ::c_char, len: ::size_t) -> ::c_int;
     pub fn vhangup() -> ::c_int;
     pub fn sync();
+    pub fn syncfs(fd: ::c_int) -> ::c_int;
     pub fn syscall(num: ::c_long, ...) -> ::c_long;
     pub fn sched_getaffinity(pid: ::pid_t, cpusetsize: ::size_t, cpuset: *mut cpu_set_t)
         -> ::c_int;


### PR DESCRIPTION
This adds binding for `syncfs` on Linux, which is implemented by
all supported libraries.

Ref: https://man7.org/linux/man-pages/man2/syncfs.2.html