### PR TITLE
Don't unconditionally link libiconv on macOS.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,6 @@ fn main() {
     let align_cargo_feature = env::var("CARGO_FEATURE_ALIGN").is_ok();
     let const_extern_fn_cargo_feature = env::var("CARGO_FEATURE_CONST_EXTERN_FN").is_ok();
     let libc_ci = env::var("LIBC_CI").is_ok();
-    let target = env::var("TARGET").unwrap();
 
     if env::var("CARGO_FEATURE_USE_STD").is_ok() {
         println!(
@@ -83,12 +82,6 @@ fn main() {
             panic!("const-extern-fn requires a nightly compiler >= 1.40")
         }
         println!("cargo:rustc-cfg=libc_const_extern_fn");
-    }
-
-    // For unknown reason, libiconv can't be linked by adding #[link(name = iconv)] to
-    // a macOS-specific struct, so we do the linking here.
-    if target.contains("-apple-") {
-        println!("cargo:rustc-link-lib=iconv");
     }
 }
 

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -3826,16 +3826,6 @@ extern "C" {
     )]
     pub fn getfsstat(mntbufp: *mut statfs, bufsize: ::c_int, flags: ::c_int) -> ::c_int;
 
-    pub fn iconv_open(tocode: *const ::c_char, fromcode: *const ::c_char) -> iconv_t;
-    pub fn iconv(
-        cd: iconv_t,
-        inbuf: *mut *mut ::c_char,
-        inbytesleft: *mut ::size_t,
-        outbuf: *mut *mut ::c_char,
-        outbytesleft: *mut ::size_t,
-    ) -> ::size_t;
-    pub fn iconv_close(cd: iconv_t) -> ::c_int;
-
     // Copy-on-write functions.
     // According to the man page `flags` is an `int` but in the header
     // this is a `uint32_t`.
@@ -3853,6 +3843,19 @@ extern "C" {
         dst: *const ::c_char,
         flags: u32,
     ) -> ::c_int;
+}
+
+#[link(name = "iconv")]
+extern "C" {
+    pub fn iconv_open(tocode: *const ::c_char, fromcode: *const ::c_char) -> iconv_t;
+    pub fn iconv(
+        cd: iconv_t,
+        inbuf: *mut *mut ::c_char,
+        inbytesleft: *mut ::size_t,
+        outbuf: *mut *mut ::c_char,
+        outbytesleft: *mut ::size_t,
+    ) -> ::size_t;
+    pub fn iconv_close(cd: iconv_t) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
This adds `#[link(name = "iconv")]` to just the iconv symbols so that the
library is only linked if the symbols are used.

#2037 added a build.rs directive to always link libiconv on Apple platforms,
but that shouldn't be necessary. With this change, we can see using `otool -L`
that a binary that uses an `iconv` symbol links libiconv, but other binaries
don't.

Note that this can only be seen with a rustc prior to nightly-2021-03-09, as
nightly-2021-03-10 includes https://github.com/rust-lang/rust/pull/82731 which
includes #2037, therefore unconditionally linking all Rust binaries to
libiconv.