### PR TITLE
Haiku: mark all struct fields public

### DIFF
--- a/src/unix/haiku/native.rs
+++ b/src/unix/haiku/native.rs
@@ -96,29 +96,29 @@ s! {
     }
 
     pub struct team_info {
-        team: team_id,
-        thread_count: i32,
-        image_count: i32,
-        area_count: i32,
-        debugger_nub_thread: thread_id,
-        debugger_nub_port: port_id,
-        argc: i32,
-        args: [::c_char; 64],
-        uid: ::uid_t,
-        gid: ::gid_t
+        pub team: team_id,
+        pub thread_count: i32,
+        pub image_count: i32,
+        pub area_count: i32,
+        pub debugger_nub_thread: thread_id,
+        pub debugger_nub_port: port_id,
+        pub argc: i32,
+        pub args: [::c_char; 64],
+        pub uid: ::uid_t,
+        pub gid: ::gid_t
     }
 
     pub struct sem_info {
-        sem: sem_id,
-        team: team_id,
-        name: [::c_char; B_OS_NAME_LENGTH],
-        count: i32,
-        latest_holder: thread_id
+        pub sem: sem_id,
+        pub team: team_id,
+        pub name: [::c_char; B_OS_NAME_LENGTH],
+        pub count: i32,
+        pub latest_holder: thread_id
     }
 
     pub struct team_usage_info {
-        user_time: bigtime_t,
-        kernel_time: bigtime_t
+        pub user_time: bigtime_t,
+        pub kernel_time: bigtime_t
     }
 
     pub struct thread_info {
@@ -175,34 +175,34 @@ s! {
 
     // kernel/fs_attr.h
     pub struct attr_info {
-        type_: u32,
-        size: ::off_t
+        pub type_: u32,
+        pub size: ::off_t
     }
 
     // kernel/fs_index.h
     pub struct index_info {
-        type_: u32,
-        size: ::off_t,
-        modification_time: ::time_t,
-        creation_time: ::time_t,
-        uid: ::uid_t,
-        gid: ::gid_t
+        pub type_: u32,
+        pub size: ::off_t,
+        pub modification_time: ::time_t,
+        pub creation_time: ::time_t,
+        pub uid: ::uid_t,
+        pub gid: ::gid_t
     }
 
     //kernel/fs_info.h
     pub struct fs_info {
-        dev: ::dev_t,
-        root: ::ino_t,
-        flags: u32,
-        block_size: ::off_t,
-        io_size: ::off_t,
-        total_blocks: ::off_t,
-        free_blocks: ::off_t,
-        total_nodes: ::off_t,
-        free_nodes: ::off_t,
-        device_name: [::c_char; 128],
-        volume_name: [::c_char; B_FILE_NAME_LENGTH],
-        fsh_name: [::c_char; B_OS_NAME_LENGTH]
+        pub dev: ::dev_t,
+        pub root: ::ino_t,
+        pub flags: u32,
+        pub block_size: ::off_t,
+        pub io_size: ::off_t,
+        pub total_blocks: ::off_t,
+        pub free_blocks: ::off_t,
+        pub total_nodes: ::off_t,
+        pub free_nodes: ::off_t,
+        pub device_name: [::c_char; 128],
+        pub volume_name: [::c_char; B_FILE_NAME_LENGTH],
+        pub fsh_name: [::c_char; B_OS_NAME_LENGTH]
     }
 
     // kernel/image.h


### PR DESCRIPTION
This corrects an oversight when the structs were added.