### PR TITLE
Add explicit/volatile memset/memzero functions

### DIFF
--- a/libc-test/semver/dragonfly.txt
+++ b/libc-test/semver/dragonfly.txt
@@ -1174,6 +1174,7 @@ endpwent
 endservent
 endutxent
 exit_status
+explicit_bzero
 faccessat
 fchdir
 fchflags
@@ -1243,6 +1244,7 @@ lwpid_t
 madvise
 memmem
 memrchr
+memset_s
 mincore
 mkdirat
 mkfifoat

--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -1350,6 +1350,7 @@ endgrent
 endpwent
 endservent
 endutxent
+explicit_bzero
 extattr_delete_fd
 extattr_delete_file
 extattr_delete_link
@@ -1442,6 +1443,7 @@ lwpid_t
 madvise
 memmem
 memrchr
+memset_s
 mincore
 mkdirat
 mkfifoat

--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -529,6 +529,7 @@ copy_file_range
 dlinfo
 dlmopen
 endutxent
+explicit_bzero
 fgetspent_r
 getgrent_r
 getpt

--- a/libc-test/semver/linux-musl.txt
+++ b/libc-test/semver/linux-musl.txt
@@ -1,1 +1,2 @@
 # TODO: musl.
+explicit_bzero

--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -1034,6 +1034,7 @@ endpwent
 endservent
 endutent
 endutxent
+explicit_memset
 extattr_delete_fd
 extattr_delete_file
 extattr_delete_link

--- a/libc-test/semver/openbsd.txt
+++ b/libc-test/semver/openbsd.txt
@@ -897,6 +897,7 @@ endgrent
 endpwent
 endservent
 execvpe
+explicit_bzero
 export_args
 faccessat
 fchdir

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1593,6 +1593,14 @@ extern "C" {
     pub fn iconv_close(cd: iconv_t) -> ::c_int;
 }
 
+extern "C" {
+    // Added in `FreeBSD` 11.0
+    // Added in `DragonFly BSD` 5.4
+    pub fn explicit_bzero(s: *mut ::c_void, len: ::size_t);
+    // ISO/IEC 9899:2011 ("ISO C11") K.3.7.4.1
+    pub fn memset_s(s: *mut ::c_void, smax: ::rsize_t, c: ::c_int, n: ::rsize_t) -> ::errno_t;
+}
+
 #[link(name = "rt")]
 extern "C" {
     pub fn mq_close(mqd: ::mqd_t) -> ::c_int;

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2085,6 +2085,11 @@ extern "C" {
     pub fn iconv_close(cd: iconv_t) -> ::c_int;
 }
 
+extern "C" {
+    // Added in `NetBSD` 7.0
+    pub fn explicit_memset(b: *mut ::c_void, c: ::c_int, len: ::size_t);
+}
+
 #[link(name = "util")]
 extern "C" {
     #[cfg_attr(target_os = "netbsd", link_name = "__getpwent_r50")]

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1545,6 +1545,11 @@ extern "C" {
     pub fn duplocale(base: ::locale_t) -> ::locale_t;
 }
 
+extern "C" {
+    // Added in `OpenBSD` 5.5
+    pub fn explicit_bzero(s: *mut ::c_void, len: ::size_t);
+}
+
 cfg_if! {
     if #[cfg(libc_union)] {
         extern {

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1300,6 +1300,11 @@ extern "C" {
     pub fn dlinfo(handle: *mut ::c_void, request: ::c_int, info: *mut ::c_void) -> ::c_int;
 }
 
+extern "C" {
+    // Added in `glibc` 2.25
+    pub fn explicit_bzero(s: *mut ::c_void, len: ::size_t);
+}
+
 cfg_if! {
     if #[cfg(any(target_arch = "x86",
                  target_arch = "arm",

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -699,6 +699,11 @@ extern "C" {
     pub fn getauxval(type_: ::c_ulong) -> ::c_ulong;
 }
 
+extern "C" {
+    // Added in `musl` 1.1.20
+    pub fn explicit_bzero(s: *mut ::c_void, len: ::size_t);
+}
+
 cfg_if! {
     if #[cfg(any(target_arch = "x86_64",
                  target_arch = "aarch64",


### PR DESCRIPTION
Adds the following functions to platforms that support them:
* `explicit_bzero` (de facto standard): Glibc, MUSL, FreeBSD, DragonFly BSD, OpenBSD
* `explicit_memset`: NetBSD
* `memset_s` (C11 standard): FreeBSD, DragonFly BSD

These functions are useful for zeroing secret memory.

Closes issue #2009 