### PR TITLE
Add `ucontext_t` and `mcontext_t` on NetBSD/x86_64

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -939,6 +939,7 @@ fn test_netbsd(target: &str) {
         "sys/time.h",
         "sys/times.h",
         "sys/timex.h",
+        "sys/ucontext.h",
         "sys/uio.h",
         "sys/un.h",
         "sys/utsname.h",

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -907,6 +907,7 @@ fn test_netbsd(target: &str) {
         "grp.h",
         "ifaddrs.h",
         "langinfo.h",
+        "net/bpf.h",
         "net/if.h",
         "net/if_arp.h",
         "net/if_dl.h",

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -72,8 +72,14 @@ s! {
         pub uid: ::uid_t,
         pub gid: ::gid_t,
         pub mode: ::mode_t,
+        #[cfg(target_os = "openbsd")]
         pub seq: ::c_ushort,
+        #[cfg(target_os = "netbsd")]
+        pub _seq: ::c_ushort,
+        #[cfg(target_os = "openbsd")]
         pub key: ::key_t,
+        #[cfg(target_os = "netbsd")]
+        pub _key: ::key_t,
     }
 
     pub struct ptrace_io_desc {

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -7,7 +7,7 @@ pub type fsfilcnt_t = u64;
 pub type idtype_t = ::c_int;
 pub type mqd_t = ::c_int;
 type __pthread_spin_t = __cpu_simple_lock_nv_t;
-pub type vm_size_t = ::uintptr_t;
+pub type vm_size_t = ::uintptr_t; // FIXME: deprecated since long time
 pub type lwpid_t = ::c_uint;
 pub type shmatt_t = ::c_uint;
 
@@ -427,7 +427,7 @@ s_no_extra_traits! {
         pub ut_session: u16,
         pub ut_type: u16,
         pub ut_pid: ::pid_t,
-        pub ut_exit: __exit_status,
+        pub ut_exit: __exit_status, // FIXME: when anonymous struct are supported
         pub ut_ss: sockaddr_storage,
         pub ut_tv: ::timeval,
         pub ut_pad: [u8; _UTX_PADSIZE],

--- a/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
@@ -3,7 +3,25 @@ use PT_FIRSTMACH;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type c_char = i8;
+pub type c___greg_t = u64;
 pub type __cpu_simple_lock_nv_t = ::c_uchar;
+
+s! {
+    #[repr(align(16))]
+    pub struct mcontext_t {
+        pub __gregs: [c___greg_t; 26],
+        pub _mc_tlsbase: c___greg_t,
+        pub __fpregs: [[::c_char;32]; 16],
+    }
+
+    pub struct ucontext_t {
+        pub uc_flags: ::c_uint,
+        pub uc_link: *mut ::ucontext_t,
+        pub uc_sigmask: ::sigset_t,
+        pub uc_stack: ::stack_t,
+        pub uc_mcontext: ::mcontext_t,
+    }
+}
 
 // should be pub(crate), but that requires Rust 1.18.0
 cfg_if! {

--- a/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
@@ -7,7 +7,6 @@ pub type c___greg_t = u64;
 pub type __cpu_simple_lock_nv_t = ::c_uchar;
 
 s! {
-    #[repr(align(16))]
     pub struct mcontext_t {
         pub __gregs: [c___greg_t; 26],
         pub _mc_tlsbase: c___greg_t,


### PR DESCRIPTION
ucontext_t/mcontext_t exposure on x86_64 architecture.