### PR TITLE
Add missing `ioctl` function to s390x MUSL target

### DIFF
--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -752,3 +752,7 @@ pub const SYS_faccessat2: ::c_long = 439;
 pub const SYS_process_madvise: ::c_long = 440;
 pub const SYS_epoll_pwait2: ::c_long = 441;
 pub const SYS_mount_setattr: ::c_long = 442;
+
+extern "C" {
+    pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
+}


### PR DESCRIPTION
Currently the Rust std library doesn't build for s390x MUSL target:

```
error[E0425]: cannot find function `ioctl` in crate `libc`
   --> /root/.rustup/toolchains/nightly-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/unix/fd.rs:246:23
    |
246 |             cvt(libc::ioctl(self.fd, libc::FIONBIO, &v))?;
    |                       ^^^^^ not found in `libc`

error[E0425]: cannot find function `ioctl` in crate `libc`
   --> /root/.rustup/toolchains/nightly-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/unix/net.rs:393:28
    |
393 |         cvt(unsafe { libc::ioctl(*self.as_inner(), libc::FIONBIO, &mut nonblocking) }).map(drop)
    |                            ^^^^^ not found in `libc`

error: aborting due to 2 previous errors; 1 warning emitted

For more information about this error, try `rustc --explain E0425`.
```