### PR TITLE
Bump version to `0.2.95`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.94"
+version = "0.2.95"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-test"
-version = "0.2.94"
+version = "0.2.95"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.94"
+version = "0.2.95"
 default-features = false
 
 [build-dependencies]


### PR DESCRIPTION
Hiya, I'm eager to use the recently added constant in #2168. Thus, here's a PR to bump the `libc` version to allow a new version to be released.