### PR TITLE
Set `RUSTUP_IO_THREADS=1` to avoid the installation failure on FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,7 +35,7 @@ task:
 task:
   name: nightly x86_64-unknown-freebsd-13
   freebsd_instance:
-    image: freebsd-13-0-alpha3-amd64
+    image: freebsd-13-0-release-amd64
   setup_script:
     - pkg install -y curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,7 @@
+env:
+  # Temporary fix for https://github.com/rust-lang/rustup/issues/2774.
+  RUSTUP_IO_THREADS: "1"
+
 task:
   name: stable x86_64-unknown-freebsd-11
   freebsd_instance:


### PR DESCRIPTION
r? @ghost