### PR TITLE
openbsd update to latest release for few constants.

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -231,6 +231,7 @@ extern "C" {
     pub fn fdatasync(fd: ::c_int) -> ::c_int;
 
     pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
+    pub fn getentropy(buf: *mut ::c_void, buflen: ::size_t) -> ::c_int;
     pub fn elf_aux_info(aux: ::c_int, buf: *mut ::c_void, buflen: ::c_int) -> ::c_int;
 }
 

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -936,6 +936,10 @@ pub const NET_RT_STATS: ::c_int = 4;
 pub const NET_RT_TABLE: ::c_int = 5;
 pub const NET_RT_IFNAMES: ::c_int = 6;
 #[doc(hidden)]
+#[deprecated(
+    since = "0.2.95",
+    note = "Possbily increasing over the releases and might not be so used in the field"
+)]
 pub const NET_RT_MAXID: ::c_int = 7;
 
 pub const IPV6_JOIN_GROUP: ::c_int = 12;
@@ -1272,6 +1276,10 @@ pub const KERN_AUDIO: ::c_int = 84;
 pub const KERN_CPUSTATS: ::c_int = 85;
 pub const KERN_PFSTATUS: ::c_int = 86;
 pub const KERN_TIMEOUT_STATS: ::c_int = 87;
+#[deprecated(
+    since = "0.2.95",
+    note = "Possbily increasing over the releases and might not be so used in the field"
+)]
 pub const KERN_MAXID: ::c_int = 88;
 
 pub const KERN_PROC_ALL: ::c_int = 0;


### PR DESCRIPTION
Those values might be correct in 6.8 but not in 6.9. Handling release N and release N-1 would be too complicated I suggest we prioritize the lastest.