### PR TITLE
Define `O_CLOEXEC` for WASI.

### DIFF
--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -201,6 +201,7 @@ pub const O_EXEC: c_int = 0x02000000;
 pub const O_RDONLY: c_int = 0x04000000;
 pub const O_SEARCH: c_int = 0x08000000;
 pub const O_WRONLY: c_int = 0x10000000;
+pub const O_CLOEXEC: c_int = 0x0;
 pub const O_RDWR: c_int = O_WRONLY | O_RDONLY;
 pub const O_ACCMODE: c_int = O_EXEC | O_RDWR | O_SEARCH;
 pub const O_NOCTTY: c_int = 0x0;


### PR DESCRIPTION
`O_CLOEXEC` is defined to be 0 in WASI libc:

https://github.com/WebAssembly/wasi-libc/blob/659ff414560721b1660a19685110e484a081c3d4/libc-bottom-half/headers/public/__header_fcntl.h#L24

so define it accordingly in Rust's `libc` bindings.