### PR TITLE
Add gethostuuid and uuid_t on macOS

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -361,6 +361,8 @@ fn test_apple(target: &str) {
     cfg.skip_roundtrip(move |s| match s {
         // FIXME: this type has the wrong ABI
         "max_align_t" if i686 => true,
+        // Can't return an array from a C function.
+        "uuid_t" => true,
         _ => false,
     });
     cfg.generate("../src/lib.rs", "main.rs");

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -29,6 +29,7 @@ pub type cpu_subtype_t = integer_t;
 pub type natural_t = u32;
 pub type mach_msg_type_number_t = natural_t;
 pub type kern_return_t = ::c_int;
+pub type uuid_t = [u8; 16];
 
 pub type posix_spawnattr_t = *mut ::c_void;
 pub type posix_spawn_file_actions_t = *mut ::c_void;
@@ -4098,6 +4099,10 @@ extern "C" {
         buffersize: u32,
     ) -> ::c_int;
     pub fn proc_libversion(major: *mut ::c_int, mintor: *mut ::c_int) -> ::c_int;
+    /// # Notes
+    ///
+    /// `id` is of type [`uuid_t`].
+    pub fn gethostuuid(id: *mut u8, timeout: *const ::timespec) -> ::c_int;
 }
 
 #[link(name = "iconv")]


### PR DESCRIPTION
This adds the `gethostuuid` function and the `uuid_t` for macOS.

I'm not sure the function signature is correct. It's defined as the following in C:

```C
int gethostuuid(uuid_t id, const struct timespec *wait);

typedef unsigned char   __darwin_uuid_t[16];
typedef __darwin_uuid_t uuid_t;
```

Because C doesn't really has arrays, the accept parameter can't be `uuid_t` in Rust, as Rust does have arrays and thus expect an array to be passed by value, where the C function expects a pointer.