### PR TITLE
Some CI cleanups

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,3 @@
-env:
-  # Temporary fix for https://github.com/rust-lang/rustup/issues/2774.
-  RUSTUP_UPDATE_ROOT: "https://dev-static.rust-lang.org/rustup"
-
 task:
   name: stable x86_64-unknown-freebsd-11
   freebsd_instance:

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -72,6 +72,9 @@ jobs:
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2
+      - name: Self-update rustup
+        run: rustup self update
+        shell: bash
       - name: Setup Rust toolchain
         run: TARGET=${{ matrix.target }} sh ./ci/install-rust.sh
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,9 @@ jobs:
           - target: i686-pc-windows-msvc
     steps:
       - uses: actions/checkout@v2
+      - name: Self-update rustup
+        run: rustup self update
+        shell: bash
       - name: Setup Rust toolchain
         run: TARGET=${{ matrix.target }} sh ./ci/install-rust.sh
         shell: bash

--- a/ci/install-rust.sh
+++ b/ci/install-rust.sh
@@ -12,7 +12,6 @@ else
 fi
 if [ "$OS" = "windows" ]; then
   : "${TARGET?The TARGET environment variable must be set.}"
-  rustup self update
   rustup set profile minimal
   rustup update --force $toolchain-"$TARGET"
   rustup default $toolchain-"$TARGET"


### PR DESCRIPTION
Rustup 1.24.3 is now released officially: https://blog.rust-lang.org/2021/06/08/Rustup-1.24.3.html
And do rustup self-update as a separate step to avoid "device or resource busy" error.
