### PR TITLE
Add `mallinfo2` support

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2650,6 +2650,9 @@ fn test_linux(target: &str) {
             // FIXME: CI's kernel header version is old.
             "sockaddr_can" => true,
 
+            // Requires glibc 2.33 or newer.
+            "mallinfo2" => true,
+
             _ => false,
         }
     });
@@ -2852,6 +2855,9 @@ fn test_linux(target: &str) {
 
             // FIXME: This needs musl 1.2.2 or later.
             "gettid" if musl => true,
+
+            // Needs glibc 2.33 or later.
+            "mallinfo2" => true,
 
             _ => false,
         }

--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -546,6 +546,7 @@ glob_t
 globfree
 globfree64
 mallinfo
+mallinfo2
 malloc_usable_size
 mallopt
 nl_mmap_hdr

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -128,6 +128,19 @@ s! {
         pub keepcost: ::c_int,
     }
 
+    pub struct mallinfo2 {
+        pub arena: ::size_t,
+        pub ordblks: ::size_t,
+        pub smblks: ::size_t,
+        pub hblks: ::size_t,
+        pub hblkhd: ::size_t,
+        pub usmblks: ::size_t,
+        pub fsmblks: ::size_t,
+        pub uordblks: ::size_t,
+        pub fordblks: ::size_t,
+        pub keepcost: ::size_t,
+    }
+
     pub struct nlmsghdr {
         pub nlmsg_len: u32,
         pub nlmsg_type: u16,
@@ -1281,6 +1294,7 @@ extern "C" {
     ) -> ::c_int;
     pub fn sched_getcpu() -> ::c_int;
     pub fn mallinfo() -> ::mallinfo;
+    pub fn mallinfo2() -> ::mallinfo2;
     pub fn malloc_usable_size(ptr: *mut ::c_void) -> ::size_t;
     pub fn getpwent_r(
         pwd: *mut ::passwd,


### PR DESCRIPTION
This function was added in glibc 2.33 and fixes a shortcoming of the mallinfo API: it was unable to handle memory usage of more than 2 GB due to its use of `int` as the field types. This was fixed by duplicating the API and changing them to `size_t`.