### PR TITLE
Bump version to 0.2.97

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.96"
+version = "0.2.97"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-test"
-version = "0.2.96"
+version = "0.2.97"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.96"
+version = "0.2.97"
 default-features = false
 
 [build-dependencies]


### PR DESCRIPTION
I'd like to get a new release published, since I want to make use of https://github.com/rust-lang/libc/pull/2228 in https://github.com/rust-analyzer/rust-analyzer/pull/9204