### PR TITLE
OpenBSD: add signal-stack machine context struct on x86_64.

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/x86_64.rs
@@ -4,6 +4,44 @@ pub type c_long = i64;
 pub type c_ulong = u64;
 pub type c_char = i8;
 
+s! {
+    // Defined in <machine/signal.h>.
+    pub struct sigcontext_t {
+        pub sc_rdi: ::c_long,
+        pub sc_rsi: ::c_long,
+        pub sc_rdx: ::c_long,
+        pub sc_rcx: ::c_long,
+        pub sc_r8: ::c_long,
+        pub sc_r9: ::c_long,
+        pub sc_r10: ::c_long,
+        pub sc_r11: ::c_long,
+        pub sc_r12: ::c_long,
+        pub sc_r13: ::c_long,
+        pub sc_r14: ::c_long,
+        pub sc_r15: ::c_long,
+        pub sc_rbp: ::c_long,
+        pub sc_rbx: ::c_long,
+        pub sc_rax: ::c_long,
+        pub sc_gs: ::c_long,
+        pub sc_fs: ::c_long,
+        pub sc_es: ::c_long,
+        pub sc_ds: ::c_long,
+        pub sc_trapno: ::c_long,
+        pub sc_err: ::c_long,
+        pub sc_rip: ::c_long,
+        pub sc_cs: ::c_long,
+        pub sc_rflags: ::c_long,
+        pub sc_rsp: ::c_long,
+        pub sc_ss: ::c_long,
+        pub sc_fpstate: *mut ::c_char,
+        pub __sc_unused: ::c_int,
+        pub sc_mask: ::c_int,
+        pub sc_cookie: ::c_long,
+    }
+}
+
+pub type ucontext_t = sigcontext_t;
+
 // should be pub(crate), but that requires Rust 1.18.0
 cfg_if! {
     if #[cfg(libc_const_size_of)] {


### PR DESCRIPTION
The `ucontext_t` struct on OpenBSD (which is actually a typedef to
`struct sigcontext`) represents the on-stack saved state that is
available for a signal handler on OpenBSD to read and/or modify. Its
definition comes from <machine/signal.h>, and was copied from OpenBSD
6.9, which is the current version. Note that OpenBSD does not guarantee
ABI compatibility across versions, so this would have to be updated if
the frame format ever does change; however, it is very useful to have
(it is not possible to know the faulting PC in a signal handler
otherwise), so I suspect including this definition is worthwhile.