### PR TITLE
Fix `unused borrow` lint warning

### DIFF
--- a/src/unix/linux_like/android/b32/arm.rs
+++ b/src/unix/linux_like/android/b32/arm.rs
@@ -138,7 +138,7 @@ cfg_if! {
                         self.uc_stack.hash(state);
                         self.uc_mcontext.hash(state);
                         self.uc_sigmask__c_anonymous_union.hash(state);
-                        &self.uc_regspace[..].hash(state);
+                        self.uc_regspace[..].hash(state);
                         // Ignore padding field
                     }
                 }


### PR DESCRIPTION
r? @ghost