### PR TITLE
Add dladdr1 for GNU/Linux platforms

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1342,7 +1342,12 @@ extern "C" {
 extern "C" {
     pub fn dlmopen(lmid: Lmid_t, filename: *const ::c_char, flag: ::c_int) -> *mut ::c_void;
     pub fn dlinfo(handle: *mut ::c_void, request: ::c_int, info: *mut ::c_void) -> ::c_int;
-    pub fn dladdr1(addr: *const ::c_void, info: *mut ::Dl_info, extra_info: *mut *mut ::c_void, flags: ::c_int) -> ::c_int;
+    pub fn dladdr1(
+        addr: *const ::c_void,
+        info: *mut ::Dl_info,
+        extra_info: *mut *mut ::c_void,
+        flags: ::c_int,
+    ) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1342,6 +1342,7 @@ extern "C" {
 extern "C" {
     pub fn dlmopen(lmid: Lmid_t, filename: *const ::c_char, flag: ::c_int) -> *mut ::c_void;
     pub fn dlinfo(handle: *mut ::c_void, request: ::c_int, info: *mut ::c_void) -> ::c_int;
+    pub fn dladdr1(addr: *const ::c_void, info: *mut ::Dl_info, extra_info: *mut *mut ::c_void, flags: ::c_int) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
Hey, this is my first pull request in a large open source project. Let me know if I'm missing anything or if you see any compile errors. This addresses dladdr1 missing in the libc library for GNU/Linux platforms.