### PR TITLE
Define EINTEGRITY on FreeBSD 12

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -204,7 +204,8 @@ pub const RAND_MAX: ::c_int = 0x7fff_fffd;
 
 pub const SO_DOMAIN: ::c_int = 0x1019;
 
-pub const ELAST: ::c_int = 96;
+pub const EINTEGRITY: ::c_int = 97;
+pub const ELAST: ::c_int = 97;
 
 extern "C" {
     pub fn setgrent();


### PR DESCRIPTION
At the time that @pizzamig added it here, it was only available in
FreeBSD 13.  But it has subsequently been MFCed and released in
FreeBSD 12.2.