### PR TITLE
Do debug build for `x86_64-unknown-linux-gnux32`

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -82,13 +82,6 @@ if [ "$QEMU" != "" ]; then
   exec egrep "^(PASSED)|(test result: ok)" "${CARGO_TARGET_DIR}/out.log"
 fi
 
-# FIXME: x86_64-unknown-linux-gnux32 fails to compile without --release
-# See https://github.com/rust-lang/rust/issues/59220
-opt=
-if [ "$TARGET" = "x86_64-unknown-linux-gnux32" ]; then
-  opt="--release"
-fi
-
 if [ "$TARGET" = "s390x-unknown-linux-gnu" ]; then
   # FIXME: s390x-unknown-linux-gnu often fails to test due to timeout,
   # so we retry this N times.
@@ -103,12 +96,12 @@ if [ "$TARGET" = "s390x-unknown-linux-gnu" ]; then
         continue
       fi
     elif [ "$passed" = "1" ]; then
-      if cargo test $opt --manifest-path libc-test/Cargo.toml --target "${TARGET}" ; then
+      if cargo test --manifest-path libc-test/Cargo.toml --target "${TARGET}" ; then
         passed=$((passed+1))
         continue
       fi
     elif [ "$passed" = "2" ]; then
-      if cargo test $opt --features extra_traits --manifest-path libc-test/Cargo.toml --target "${TARGET}"; then
+      if cargo test --features extra_traits --manifest-path libc-test/Cargo.toml --target "${TARGET}"; then
         break
       fi
     fi
@@ -116,11 +109,11 @@ if [ "$TARGET" = "s390x-unknown-linux-gnu" ]; then
     sleep 1
   done
 else
-  cargo test $opt --no-default-features --manifest-path libc-test/Cargo.toml \
+  cargo test --no-default-features --manifest-path libc-test/Cargo.toml \
     --target "${TARGET}"
 
-  cargo test $opt --manifest-path libc-test/Cargo.toml --target "${TARGET}"
+  cargo test --manifest-path libc-test/Cargo.toml --target "${TARGET}"
 
-  RUST_BACKTRACE=1 cargo test $opt --features extra_traits --manifest-path libc-test/Cargo.toml \
+  RUST_BACKTRACE=1 cargo test --features extra_traits --manifest-path libc-test/Cargo.toml \
     --target "${TARGET}"
 fi


### PR DESCRIPTION
The mentioned issue has been fixed, let's see if we can remove the `--release` flag.
r? @ghost