### PR TITLE
Add SYS_fcntl to aarch64 android

### DIFF
--- a/libc-test/semver/android-aarch64.txt
+++ b/libc-test/semver/android-aarch64.txt
@@ -9,3 +9,4 @@ HWCAP2_SVESHA3
 HWCAP2_SVESM4
 SYS_arch_specific_syscall
 SYS_syscalls
+SYS_fcntl

--- a/src/unix/linux_like/android/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/android/b64/aarch64/mod.rs
@@ -126,6 +126,7 @@ pub const SYS_epoll_ctl: ::c_long = 21;
 pub const SYS_epoll_pwait: ::c_long = 22;
 pub const SYS_dup: ::c_long = 23;
 pub const SYS_dup3: ::c_long = 24;
+pub const SYS_fcntl: ::c_long = 25;
 pub const SYS_inotify_init1: ::c_long = 26;
 pub const SYS_inotify_add_watch: ::c_long = 27;
 pub const SYS_inotify_rm_watch: ::c_long = 28;


### PR DESCRIPTION
The fcntl syscall is supported on aarch64-linux-android

[googlesource.com](https://android.googlesource.com/platform/bionic/+/bc1b267454cd305d2bbaa0f22914b98a23ef1ffa/libc/kernel/uapi/asm-generic/unistd.h#62)