### PR TITLE
Support for the ESP-IDF framework (Xtensa and RiscV arch)

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -297,8 +297,8 @@ pub const ATF_PUBL: ::c_int = 0x08;
 pub const ATF_USETRAILERS: ::c_int = 0x10;
 
 cfg_if! {
-    if #[cfg(target_os = "l4re")] {
-        // required libraries for L4Re are linked externally, ATM
+    if #[cfg(any(target_os = "l4re", target_os = "espidf"))] {
+        // required libraries for L4Re and the ESP-IDF framework are linked externally, ATM
     } else if #[cfg(feature = "std")] {
         // cargo build, don't pull in anything extra as the libstd dep
         // already pulls in all libs.
@@ -576,6 +576,7 @@ extern "C" {
     )))]
     #[cfg_attr(target_os = "netbsd", link_name = "__socket30")]
     #[cfg_attr(target_os = "illumos", link_name = "__xnet_socket")]
+    #[cfg_attr(target_os = "espidf", link_name = "lwip_socket")]
     pub fn socket(domain: ::c_int, ty: ::c_int, protocol: ::c_int) -> ::c_int;
     #[cfg(not(all(
         libc_cfg_target_vendor,
@@ -587,11 +588,13 @@ extern "C" {
         link_name = "connect$UNIX2003"
     )]
     #[cfg_attr(target_os = "illumos", link_name = "__xnet_connect")]
+    #[cfg_attr(target_os = "espidf", link_name = "lwip_connect")]
     pub fn connect(socket: ::c_int, address: *const sockaddr, len: socklen_t) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "listen$UNIX2003"
     )]
+    #[cfg_attr(target_os = "espidf", link_name = "lwip_listen")]
     pub fn listen(socket: ::c_int, backlog: ::c_int) -> ::c_int;
     #[cfg(not(all(
         libc_cfg_target_vendor,
@@ -602,6 +605,7 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "accept$UNIX2003"
     )]
+    #[cfg_attr(target_os = "espidf", link_name = "lwip_accept")]
     pub fn accept(socket: ::c_int, address: *mut sockaddr, address_len: *mut socklen_t) -> ::c_int;
     #[cfg(not(all(
         libc_cfg_target_vendor,
@@ -612,6 +616,7 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "getpeername$UNIX2003"
     )]
+    #[cfg_attr(target_os = "espidf", link_name = "lwip_getpeername")]
     pub fn getpeername(
         socket: ::c_int,
         address: *mut sockaddr,
@@ -626,11 +631,13 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "getsockname$UNIX2003"
     )]
+    #[cfg_attr(target_os = "espidf", link_name = "lwip_getsockname")]
     pub fn getsockname(
         socket: ::c_int,
         address: *mut sockaddr,
         address_len: *mut socklen_t,
     ) -> ::c_int;
+    #[cfg_attr(target_os = "espidf", link_name = "lwip_setsockopt")]
     pub fn setsockopt(
         socket: ::c_int,
         level: ::c_int,
@@ -659,6 +666,7 @@ extern "C" {
         link_name = "sendto$UNIX2003"
     )]
     #[cfg_attr(target_os = "illumos", link_name = "__xnet_sendto")]
+    #[cfg_attr(target_os = "espidf", link_name = "lwip_sendto")]
     pub fn sendto(
         socket: ::c_int,
         buf: *const ::c_void,
@@ -667,6 +675,7 @@ extern "C" {
         addr: *const sockaddr,
         addrlen: socklen_t,
     ) -> ::ssize_t;
+    #[cfg_attr(target_os = "espidf", link_name = "lwip_shutdown")]
     pub fn shutdown(socket: ::c_int, how: ::c_int) -> ::c_int;
 
     #[cfg_attr(
@@ -1122,6 +1131,7 @@ extern "C" {
     pub fn pthread_rwlockattr_destroy(attr: *mut pthread_rwlockattr_t) -> ::c_int;
 
     #[cfg_attr(target_os = "illumos", link_name = "__xnet_getsockopt")]
+    #[cfg_attr(target_os = "espidf", link_name = "lwip_getsockopt")]
     pub fn getsockopt(
         sockfd: ::c_int,
         level: ::c_int,
@@ -1147,6 +1157,7 @@ extern "C" {
         target_vendor = "nintendo"
     )))]
     #[cfg_attr(target_os = "illumos", link_name = "__xnet_getaddrinfo")]
+    #[cfg_attr(target_os = "espidf", link_name = "lwip_getaddrinfo")]
     pub fn getaddrinfo(
         node: *const c_char,
         service: *const c_char,
@@ -1158,6 +1169,7 @@ extern "C" {
         target_arch = "powerpc",
         target_vendor = "nintendo"
     )))]
+    #[cfg_attr(target_os = "espidf", link_name = "lwip_freeaddrinfo")]
     pub fn freeaddrinfo(res: *mut addrinfo);
     pub fn gai_strerror(errcode: ::c_int) -> *const ::c_char;
     #[cfg_attr(
@@ -1233,11 +1245,13 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "send$UNIX2003"
     )]
+    #[cfg_attr(target_os = "espidf", link_name = "lwip_send")]
     pub fn send(socket: ::c_int, buf: *const ::c_void, len: ::size_t, flags: ::c_int) -> ::ssize_t;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "recv$UNIX2003"
     )]
+    #[cfg_attr(target_os = "espidf", link_name = "lwip_recv")]
     pub fn recv(socket: ::c_int, buf: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::ssize_t;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),

--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -84,10 +84,20 @@ pub const MSG_WAITALL: ::c_int = 0x02;
 pub const MSG_MORE: ::c_int = 0x10;
 pub const MSG_NOSIGNAL: ::c_int = 0x20;
 
-extern "C" {
-    pub fn sendmsg(s: ::c_int, msg: *const ::msghdr, flags: ::c_int) -> ::ssize_t;
-    pub fn recvmsg(s: ::c_int, msg: *mut ::msghdr, flags: ::c_int) -> ::ssize_t;
+pub const PTHREAD_STACK_MIN: ::size_t = 768;
 
-    pub fn writev(s: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::c_int;
-    pub fn readv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
+extern "C" {
+    pub fn pthread_create(
+        native: *mut ::pthread_t,
+        attr: *const ::pthread_attr_t,
+        f: extern "C" fn(_: *mut ::c_void) -> *mut ::c_void,
+        value: *mut ::c_void,
+    ) -> ::c_int;
+
+    pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
+
+    #[link_name = "lwip_sendmsg"]
+    pub fn sendmsg(s: ::c_int, msg: *const ::msghdr, flags: ::c_int) -> ::ssize_t;
+    #[link_name = "lwip_recvmsg"]
+    pub fn recvmsg(s: ::c_int, msg: *mut ::msghdr, flags: ::c_int) -> ::ssize_t;
 }


### PR DESCRIPTION
Dear all,

This PR is implementing support for the [ESP-IDF](https://github.com/espressif/esp-idf) newlib-based framework, which is the open source SDK provided by Espressif for their MCU family (esp32, esp32s2, esp32c3 and all other forthcoming ones).

Note that this is the second PR on that topic. Approx. an year ago, @reitermarkus contributed an [initial set of changes](https://github.com/rust-lang/libc/commit/0dec549f8d649d661c4992cf59a2b6283eef7569#diff-6c07c29bb7b11b27a308055cca03f299266fd8f05af5a65208b64ff715359c89) which are merged already.

Note also that this PR has a [sibling PR against Rust's libStd](https://github.com/rust-lang/rust/pull/87666) which enables **full STD support for the Espressif chipsets** (that is, modulo process support as we are obviously talking about non-kernel bare metal platform here).

A short overview of the changes:
* The original contribution of @reitermarkus is renamed from `xtensa.rs` to `espidf.rs` and all branching through this patch is no longer done based on `target_arch = "xtensa"`, but based on `target_os = "espidf"` (this `target_os` value is to be used by the upcoming Rust targets for the ESP-IDF framework). The primary reason for this change is that branching for ESP-IDF based only on the architecture is no longer valid: the newer Espressif chips (esp32c3 and other upcoming ones) are based on the RISCV32IM(A)C architecture, so this patch now supports both Xtensa and RiscV32. Moreover, I would expect that - given the popularity of the riscv ISA - there will be *other* ports of newlib to riscv which will surely have the layout and sizes of the structures etc. different from the ESP-IDF framework.  
*  The `pthread` structures had sizes which did not match what is used in the ESP-IDF. Ditto for the various `*_INITIALIZER` constants, which do not use 0x00, but 0xff sequences there
* The BSD socket API on ESP-IDF is prefixed with `lwip_`. Rather than doing heavyweight proxying in Rust libStd, it is best to just address this here with a custom `link_name`, just like it had been done for MacOS and other systems.
* Similar to the `l4re` case, the libc crate should NOT issue a link command  to the CRT lib for the ESP-IDF, due to the way the SDK is linked
* Various other small fixes: primarily - declaration of standard APIs that are available in the ESP-IDF SDK

I should also admit that the patch has one little ESP-IDF-specific cheat:
* Since the `pthread` support in ESP-IDF is still lacking RW-locks, I've implemented it as a temporary workaround by simply remapping (with `"link_name"`) the `pthread_rwlock_*` symbols to their equivalent `pthread_mutex_*` symbols. While this implementation is suboptimal, it reduces significantly the PR changeset surface of the other PR which is against Rust libStd. 

