### PR TITLE
dragonflybsd readjust stack_t stack type had been void pointer since …

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -189,7 +189,7 @@ s! {
     }
 
     pub struct stack_t {
-        pub ss_sp: *mut ::c_char,
+        pub ss_sp: *mut ::c_void,
         pub ss_size: ::size_t,
         pub ss_flags: ::c_int,
     }


### PR DESCRIPTION
…2019 causing issue in some crates.