### PR TITLE
sched_get_priority_max/min apply to all BSDs and Solaris

### DIFF
--- a/libc-test/semver/dragonfly.txt
+++ b/libc-test/semver/dragonfly.txt
@@ -1359,6 +1359,8 @@ regmatch_t
 regoff_t
 rtprio
 sched_getscheduler
+sched_get_priority_max
+sched_get_priority_min
 sched_param
 sched_setscheduler
 seekdir

--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -1626,6 +1626,8 @@ rtprio
 rtprio_thread
 sallocx
 sched_getscheduler
+sched_get_priority_max
+sched_get_priority_min
 sched_param
 sched_setscheduler
 sdallocx

--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -1265,6 +1265,8 @@ regfree
 regmatch_t
 regoff_t
 sched_getparam
+sched_get_priority_max
+sched_get_priority_min
 sched_param
 sched_setparam
 secure_path

--- a/libc-test/semver/openbsd.txt
+++ b/libc-test/semver/openbsd.txt
@@ -1040,6 +1040,8 @@ regexec
 regfree
 regmatch_t
 regoff_t
+sched_get_priority_max
+sched_get_priority_min
 seekdir
 sem
 sem_close

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -4037,8 +4037,6 @@ extern "C" {
         policy: ::c_int,
         param: *const sched_param,
     ) -> ::c_int;
-    pub fn sched_get_priority_min(policy: ::c_int) -> ::c_int;
-    pub fn sched_get_priority_max(policy: ::c_int) -> ::c_int;
     pub fn thread_policy_set(
         thread: thread_t,
         flavor: thread_policy_flavor_t,

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -767,6 +767,8 @@ extern "C" {
     )]
     pub fn pthread_cancel(thread: ::pthread_t) -> ::c_int;
     pub fn pthread_kill(thread: ::pthread_t, sig: ::c_int) -> ::c_int;
+    pub fn sched_get_priority_min(policy: ::c_int) -> ::c_int;
+    pub fn sched_get_priority_max(policy: ::c_int) -> ::c_int;
     pub fn sem_unlink(name: *const ::c_char) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__getpwnam_r50")]
     pub fn getpwnam_r(

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2510,6 +2510,8 @@ extern "C" {
     pub fn sem_open(name: *const ::c_char, oflag: ::c_int, ...) -> *mut sem_t;
     pub fn getgrnam(name: *const ::c_char) -> *mut ::group;
     pub fn pthread_kill(thread: ::pthread_t, sig: ::c_int) -> ::c_int;
+    pub fn sched_get_priority_min(policy: ::c_int) -> ::c_int;
+    pub fn sched_get_priority_max(policy: ::c_int) -> ::c_int;
     pub fn sem_unlink(name: *const ::c_char) -> ::c_int;
     pub fn daemon(nochdir: ::c_int, noclose: ::c_int) -> ::c_int;
     #[cfg_attr(


### PR DESCRIPTION
`sched_get_priority_max()` and `sched_get_priority_min()` apply to all the BSDs as Solaris-like operating systems.

Applying to all Unix-like OSes failed due to emscripten, among possibly others.