### PR TITLE
openbsd: add sys/param.h include for MAXPATHLEN in tests

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -456,6 +456,7 @@ fn test_openbsd(target: &str) {
         "pthread_np.h",
         "sys/syscall.h",
         "sys/shm.h",
+        "sys/param.h",
     }
 
     cfg.skip_struct(move |ty| {


### PR DESCRIPTION
unbreak OpenBSD test target after #2332 .

I checked if the value was right, but not tested it. my bad.