### PR TITLE
Add sched_get/setscheduler for NetBSD

### DIFF
--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -1269,10 +1269,12 @@ regfree
 regmatch_t
 regoff_t
 sched_getparam
+sched_getscheduler
 sched_get_priority_max
 sched_get_priority_min
 sched_param
 sched_setparam
+sched_setscheduler
 secure_path
 seekdir
 sem

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2239,6 +2239,12 @@ extern "C" {
 
     pub fn sched_setparam(pid: ::pid_t, param: *const sched_param) -> ::c_int;
     pub fn sched_getparam(pid: ::pid_t, param: *mut sched_param) -> ::c_int;
+    pub fn sched_getscheduler(pid: ::pid_t) -> ::c_int;
+    pub fn sched_setscheduler(
+        pid: ::pid_t,
+        policy: ::c_int,
+        param: *const ::sched_param,
+    ) -> ::c_int;
 }
 
 #[link(name = "util")]


### PR DESCRIPTION
NetBSD supports `sched_getscheduler()` and `sched_setscheduler()` with the same signature as FreeBSD-like operating systems.