### PR TITLE
Add sched_get/setparam for FreeBSD and DragonFlyBSD

### DIFF
--- a/libc-test/semver/dragonfly.txt
+++ b/libc-test/semver/dragonfly.txt
@@ -1358,10 +1358,12 @@ regfree
 regmatch_t
 regoff_t
 rtprio
+sched_getparam
 sched_getscheduler
 sched_get_priority_max
 sched_get_priority_min
 sched_param
+sched_setparam
 sched_setscheduler
 seekdir
 sem

--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -1625,10 +1625,12 @@ regoff_t
 rtprio
 rtprio_thread
 sallocx
+sched_getparam
 sched_getscheduler
 sched_get_priority_max
 sched_get_priority_min
 sched_param
+sched_setparam
 sched_setscheduler
 sdallocx
 seekdir

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1554,6 +1554,8 @@ extern "C" {
         -> ::ssize_t;
     pub fn querylocale(mask: ::c_int, loc: ::locale_t) -> *const ::c_char;
     pub fn rtprio(function: ::c_int, pid: ::pid_t, rtp: *mut rtprio) -> ::c_int;
+    pub fn sched_getparam(pid: ::pid_t, param: *mut sched_param) -> ::c_int;
+    pub fn sched_setparam(pid: ::pid_t, param: *const sched_param) -> ::c_int;
     pub fn sched_getscheduler(pid: ::pid_t) -> ::c_int;
     pub fn sched_setscheduler(
         pid: ::pid_t,


### PR DESCRIPTION
FreeBSD and DragonFlyBSD support `sched_getparam()` and `sched_setparam()` with the same signature as NetBSD.