### PR TITLE
Add "_aligned_free" on the Windows platform

### DIFF
--- a/libc-test/semver/windows.txt
+++ b/libc-test/semver/windows.txt
@@ -148,6 +148,7 @@ abs
 accept
 access
 aligned_malloc
+aligned_free
 atexit
 atof
 atoi

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -492,6 +492,8 @@ extern "C" {
     pub fn wsetlocale(category: ::c_int, locale: *const wchar_t) -> *mut wchar_t;
     #[link_name = "_aligned_malloc"]
     pub fn aligned_malloc(size: size_t, alignment: size_t) -> *mut c_void;
+    #[link_name = "_aligned_free"]
+    pub fn aligned_free(ptr: *mut ::c_void);
 }
 
 extern "system" {


### PR DESCRIPTION
All the memory blocks allocated with "_aligned_malloc" must be
deallocated using the "_aligned_free" function.

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>