### PR TITLE
Add `strtof` for all platforms that have `strtod`

### DIFF
--- a/libc-test/semver/android.txt
+++ b/libc-test/semver/android.txt
@@ -3215,6 +3215,7 @@ strsignal
 strspn
 strstr
 strtod
+strtof
 strtok
 strtol
 strtoul

--- a/libc-test/semver/unix.txt
+++ b/libc-test/semver/unix.txt
@@ -814,6 +814,7 @@ strrchr
 strspn
 strstr
 strtod
+strtof
 strtok
 strtol
 strtoul

--- a/libc-test/semver/windows.txt
+++ b/libc-test/semver/windows.txt
@@ -298,6 +298,7 @@ strrchr
 strspn
 strstr
 strtod
+strtof
 strtok
 strtol
 strtoul

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -3394,6 +3394,7 @@ extern "C" {
     pub fn perror(s: *const c_char);
     pub fn atoi(s: *const c_char) -> c_int;
     pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
+    pub fn strtof(s: *const c_char, endp: *mut *mut c_char) -> c_float;
     pub fn strtol(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_long;
     pub fn strtoul(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_ulong;
     pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -486,6 +486,7 @@ extern "C" {
         link_name = "strtod$UNIX2003"
     )]
     pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
+    pub fn strtof(s: *const c_char, endp: *mut *mut c_char) -> c_float;
     pub fn strtol(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_long;
     pub fn strtoul(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_ulong;
     pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -1121,6 +1121,7 @@ extern "C" {
     pub fn perror(s: *const c_char);
     pub fn atoi(s: *const c_char) -> c_int;
     pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
+    pub fn strtof(s: *const c_char, endp: *mut *mut c_char) -> c_float;
     pub fn strtol(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_long;
     pub fn strtoul(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_ulong;
     pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -447,6 +447,7 @@ extern "C" {
     pub fn atoi(s: *const c_char) -> c_int;
     pub fn atof(s: *const c_char) -> c_double;
     pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
+    pub fn strtof(s: *const c_char, endp: *mut *mut c_char) -> c_float;
     pub fn strtol(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_long;
     pub fn strtoul(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_ulong;
 

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -319,6 +319,7 @@ extern "C" {
     pub fn perror(s: *const c_char);
     pub fn atoi(s: *const c_char) -> c_int;
     pub fn strtod(s: *const c_char, endp: *mut *mut c_char) -> c_double;
+    pub fn strtof(s: *const c_char, endp: *mut *mut c_char) -> c_float;
     pub fn strtol(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_long;
     pub fn strtoul(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_ulong;
     pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;


### PR DESCRIPTION
All platforms that have `strtod` very likely also have `strtof`. Having `strtof` allows for fuzzing of [`hexf-parse::parse_hexf32`](https://github.com/lifthrasiir/hexf) comparing against `strtof`, which can't (easily) be done with `strtod`, due to float rounding and over-/underflow behavior.

I'm unsure of whether the `strtof` declaration in `src/unix/mod.rs` also needs a link name adjustment for x86 macos. I haven't been able to find anything about this after a rough search in this repo and on Google. I haven't added it for now since only `strtod` (edit: out of the `strtoX` functions) seems to have the changed link name (and I don't have a mac handy to test the available symbols with), but feel free to tell me if it's needed and I'll adjust the PR accordingly.