### PR TITLE
Bump to 0.2.101

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.100"
+version = "0.2.101"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-test"
-version = "0.2.100"
+version = "0.2.101"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.100"
+version = "0.2.101"
 default-features = false
 
 [build-dependencies]


### PR DESCRIPTION
New release to allow for usage of `strtof` introduced in #2358 for
fuzzing of `hexf-parse` while comparing against `strtof` results.