### PR TITLE
Clarify that MAP_RENAME and MAP_NORESERVE are deprecated in DragonFlyBSD

### DIFF
--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -986,10 +986,16 @@ pub const LOCK_UN: ::c_int = 8;
 
 pub const MAP_COPY: ::c_int = 0x0002;
 #[doc(hidden)]
-#[deprecated(since = "0.2.54", note = "Removed in FreeBSD 11")]
+#[deprecated(
+    since = "0.2.54",
+    note = "Removed in FreeBSD 11, unused in DragonFlyBSD"
+)]
 pub const MAP_RENAME: ::c_int = 0x0020;
 #[doc(hidden)]
-#[deprecated(since = "0.2.54", note = "Removed in FreeBSD 11")]
+#[deprecated(
+    since = "0.2.54",
+    note = "Removed in FreeBSD 11, unused in DragonFlyBSD"
+)]
 pub const MAP_NORESERVE: ::c_int = 0x0040;
 pub const MAP_HASSEMAPHORE: ::c_int = 0x0200;
 pub const MAP_STACK: ::c_int = 0x0400;


### PR DESCRIPTION
MAP_RENAME and MAP_NORESERVE are marked as deprecated for freebsdlike, but the note only mentions FreeBSD. Clarify the status of these constants on DragonFlyBSD.

From the EFnet #dragonflybsd channel:

```
<rtzoeller> Hi all, I've got a question about how some DragonFlyBSD #define's are being reflected in Rust's libc, and what the expected behavior should be.
<rtzoeller> Rust's libc has marked MAP_RENAME and MAP_NORESERVE as deprecated/removed for both FreeBSD and DragonFlyBSD, perhaps erroneously. https://github.com/rust-lang/libc/blob/2cffe84529fb86a150c6848409d75aa96d237944/src/unix/bsd/freebsdlike/mod.rs#L990
<rtzoeller> DragonFlyBSD hasn't removed these, so ostensibly the answer is to just mark them as not deprecated in Rust's libc.
<rtzoeller> At the same time, I can't find any usage of them in the rest of the DragonFlyBSD kernel... so maybe they are deprecated in practice, but not officially?
<rtzoeller> Ultimately the question is: should Rust's libc advertise MAP_RENAME and MAP_NORESERVE for DragonFlyBSD, or should it mark them as deprecated like it does for FreeBSD?
<rtzoeller> DragonFlyBSD's definition of them: https://github.com/DragonFlyBSD/DragonFlyBSD/blob/c163a4d7ee9c6857ee4e04a3a2cbb50c3de29da1/sys/sys/mman.h#L86
<swildner`> rtzoeller: git log -S shows that we only inherited the defines from freebsd but never implemented them either, so they can be marked deprecated for dfly too
```

The existing note has evidently caused some confusion, as the nix crate excludes these constants for FreeBSD but not for DragonFlyBSD.