### PR TITLE
Add preadv/pwritev for illumos.

### DIFF
--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -45,4 +45,8 @@ extern "C" {
         opset: *mut ::psetid_t,
     ) -> ::c_int;
     pub fn pset_getloadavg(pset: ::psetid_t, load: *mut ::c_double, num: ::c_int) -> ::c_int;
+
+    pub fn preadv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t) -> ::ssize_t;
+    pub fn pwritev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t)
+        -> ::ssize_t;
 }


### PR DESCRIPTION
Illumos man pages: [`preadv`](https://illumos.org/man/2/preadv) / [`pwritev`](https://illumos.org/man/2/pwritev).

These are Illumos specific because I don't think they exist in Solaris.