### PR TITLE
Revert "fuchsia add getrandom equivalent zx_cprng_draw."

### DIFF
--- a/libc-test/semver/fuchsia.txt
+++ b/libc-test/semver/fuchsia.txt
@@ -1384,6 +1384,3 @@ utimensat
 vhangup
 vmsplice
 waitid
-zx_cprng_add_entropy
-zx_cprng_draw
-zx_status_t

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -89,8 +89,6 @@ pub type rlim_t = ::c_ulonglong;
 pub type c_long = i64;
 pub type c_ulong = u64;
 
-pub type zx_status_t = i32;
-
 // FIXME: why are these uninhabited types? that seems... wrong?
 // Presumably these should be `()` or an `extern type` (when that stabilizes).
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
@@ -4231,9 +4229,6 @@ extern "C" {
         >,
         data: *mut ::c_void,
     ) -> ::c_int;
-
-    pub fn zx_cprng_draw(buffer: *mut ::c_void, buffer_size: ::size_t);
-    pub fn zx_cprng_add_entropy(buffer: *const ::c_void, buffer_size: ::size_t) -> ::zx_status_t;
 }
 
 cfg_if! {


### PR DESCRIPTION
This reverts commit 5b8616e478d3f76cfd4bc94f9dd4499103c41d51.

I'm on the Fuchsia Rust team, and we would like this reverted for a few reasons. First, these functions are not actually exposed in our `libc`. Instead, it comes from our `libzircon` library. Second, we haven't solidified these APIs, nor have we committed to exactly which library to expose them from.

Instead, we've created https://crates.io/crates/fuchsia-cprng to expose this functionality. This lets us more easily track our downstream users, and help them update if we ever make a breaking change.

cc @devnexen and @anp