### PR TITLE
Move Linux's `POLLRDHUP` into `linux_like` and fix its type.

### DIFF
--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -3037,8 +3037,16 @@ pub const SOL_CAN_BASE: ::c_int = 100;
 pub const CAN_INV_FILTER: canid_t = 0x20000000;
 pub const CAN_RAW_FILTER_MAX: ::c_int = 512;
 
+#[deprecated(
+    since = "0.2.102",
+    note = "Errnoeously uses c_int; should use c_short."
+)]
 #[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))]
 pub const POLLRDHUP: ::c_int = 0x2000;
+#[deprecated(
+    since = "0.2.102",
+    note = "Errnoeously uses c_int; should use c_short."
+)]
 #[cfg(any(target_arch = "sparc", target_arch = "sparc64"))]
 pub const POLLRDHUP: ::c_int = 0x800;
 


### PR DESCRIPTION
This fixes two errors in #2247.

 - It moves the definitions of `POLLRDHUP` out of `linux_like/linux`
   and into `linux_like`, so that they're available on Android as well.

 - It changes the type from `c_int` to `c_short` to match the other
   `POLL*` flags.

This second change is a breaking change, and I'm fine reverting it and
leaving it as the old type if that's the right thing to do.