### PR TITLE
Define `MADV_SOFT_OFFLINE` for risc-v.

### DIFF
--- a/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
@@ -221,6 +221,7 @@ pub const O_SYNC: ::c_int = 1052672;
 pub const O_RSYNC: ::c_int = 1052672;
 pub const O_DSYNC: ::c_int = 4096;
 pub const O_FSYNC: ::c_int = 1052672;
+pub const MADV_SOFT_OFFLINE: ::c_int = 101;
 pub const MAP_GROWSDOWN: ::c_int = 256;
 pub const EDEADLK: ::c_int = 35;
 pub const ENAMETOOLONG: ::c_int = 36;

--- a/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
@@ -226,6 +226,7 @@ pub const O_FSYNC: ::c_int = 1052672;
 pub const O_NOATIME: ::c_int = 262144;
 pub const O_PATH: ::c_int = 2097152;
 pub const O_TMPFILE: ::c_int = 4259840;
+pub const MADV_SOFT_OFFLINE: ::c_int = 101;
 pub const MAP_GROWSDOWN: ::c_int = 256;
 pub const EDEADLK: ::c_int = 35;
 pub const ENAMETOOLONG: ::c_int = 36;


### PR DESCRIPTION
Define `MADV_SOFT_OFFLINE` for riscv32 and riscv64 on *-unknown-linux-gnu.