### PR TITLE
add `devname_r` to freebsd and dragonfly

### DIFF
--- a/libc-test/semver/dragonfly.txt
+++ b/libc-test/semver/dragonfly.txt
@@ -1211,6 +1211,7 @@ clock_settime
 cmsgcred
 cmsghdr
 daemon
+devname_r
 difftime
 dirfd
 dl_iterate_phdr

--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -1410,6 +1410,7 @@ cmsgcred
 cmsghdr
 daemon
 dallocx
+devname_r
 difftime
 dirfd
 dl_iterate_phdr

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1410,6 +1410,12 @@ extern "C" {
     pub fn sem_init(sem: *mut sem_t, pshared: ::c_int, value: ::c_uint) -> ::c_int;
 
     pub fn daemon(nochdir: ::c_int, noclose: ::c_int) -> ::c_int;
+    pub fn devname_r(
+        dev: ::dev_t,
+        mode: ::mode_t,
+        buf: *mut ::c_char,
+        len: ::c_int,
+    ) -> *mut ::c_char;
     pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::timezone) -> ::c_int;
     pub fn accept4(
         s: ::c_int,


### PR DESCRIPTION
## Rationale
I need this function specifically to re-implement some parts of `libdrm` in Rust for FreeBSD: https://cgit.freedesktop.org/drm/libdrm/tree/xf86drm.c#n905 Just so happened that dragonfly also has `devname_r` so that is included.
