### PR TITLE
Bump version to 0.2.104

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.103"
+version = "0.2.104"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-test"
-version = "0.2.103"
+version = "0.2.104"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.103"
+version = "0.2.104"
 default-features = false
 
 [build-dependencies]


### PR DESCRIPTION
I'd like to get https://github.com/rust-lang/libc/pull/2415 into a release so I can use the new API in a change I'm working on for the `nix` crate, please.