### PR TITLE
Adds pthread_mutexattr_[g|s]etrobust and pthread_mutex_consistent bindings

### DIFF
--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -1650,9 +1650,12 @@ pthread_getcpuclockid
 pthread_getthreadid_np
 pthread_kill
 pthread_main_np
+pthread_mutex_consistent
 pthread_mutex_timedlock
 pthread_mutexattr_getpshared
 pthread_mutexattr_setpshared
+pthread_mutexattr_getrobust
+pthread_mutexattr_setrobust
 pthread_rwlockattr_getpshared
 pthread_rwlockattr_setpshared
 pthread_setaffinity_np

--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -2897,9 +2897,12 @@ pthread_getattr_np
 pthread_getcpuclockid
 pthread_getschedparam
 pthread_kill
+pthread_mutex_consistent
 pthread_mutex_timedlock
 pthread_mutexattr_getpshared
 pthread_mutexattr_setpshared
+pthread_mutexattr_getrobust
+pthread_mutexattr_setrobust
 pthread_rwlockattr_setpshared
 pthread_setaffinity_np
 pthread_setschedparam

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -609,6 +609,8 @@ pub const EXTATTR_NAMESPACE_SYSTEM: ::c_int = 2;
 
 pub const PTHREAD_STACK_MIN: ::size_t = MINSIGSTKSZ;
 pub const PTHREAD_MUTEX_ADAPTIVE_NP: ::c_int = 4;
+pub const PTHREAD_MUTEX_STALLED: ::c_int = 0;
+pub const PTHREAD_MUTEX_ROBUST: ::c_int = 1;
 pub const SIGSTKSZ: ::size_t = MINSIGSTKSZ + 32768;
 pub const SF_NODISKIO: ::c_int = 0x00000001;
 pub const SF_MNOWAIT: ::c_int = 0x00000002;
@@ -1804,6 +1806,17 @@ extern "C" {
         td: ::pthread_t,
         cpusetsize: ::size_t,
         cpusetp: *const cpuset_t,
+    ) -> ::c_int;
+
+    pub fn pthread_mutex_consistent(mutex: *mut ::pthread_mutex_t) -> ::c_int;
+
+    pub fn pthread_mutexattr_getrobust(
+        attr: *mut ::pthread_mutexattr_t,
+        robust: *mut ::c_int,
+    ) -> ::c_int;
+    pub fn pthread_mutexattr_setrobust(
+        attr: *mut ::pthread_mutexattr_t,
+        robust: ::c_int,
     ) -> ::c_int;
 
     pub fn pthread_spin_init(lock: *mut pthread_spinlock_t, pshared: ::c_int) -> ::c_int;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1491,6 +1491,8 @@ pub const PTHREAD_MUTEX_NORMAL: ::c_int = 0;
 pub const PTHREAD_MUTEX_RECURSIVE: ::c_int = 1;
 pub const PTHREAD_MUTEX_ERRORCHECK: ::c_int = 2;
 pub const PTHREAD_MUTEX_DEFAULT: ::c_int = PTHREAD_MUTEX_NORMAL;
+pub const PTHREAD_MUTEX_STALLED: ::c_int = 0;
+pub const PTHREAD_MUTEX_ROBUST: ::c_int = 1;
 pub const PTHREAD_PROCESS_PRIVATE: ::c_int = 0;
 pub const PTHREAD_PROCESS_SHARED: ::c_int = 1;
 pub const __SIZEOF_PTHREAD_COND_T: usize = 48;
@@ -3619,6 +3621,7 @@ extern "C" {
         timeout: *const ::timespec,
         sigmask: *const sigset_t,
     ) -> ::c_int;
+    pub fn pthread_mutex_consistent(mutex: *mut pthread_mutex_t) -> ::c_int;
     pub fn pthread_mutex_timedlock(
         lock: *mut pthread_mutex_t,
         abstime: *const ::timespec,
@@ -3733,6 +3736,14 @@ extern "C" {
     pub fn pthread_mutexattr_getpshared(
         attr: *const pthread_mutexattr_t,
         pshared: *mut ::c_int,
+    ) -> ::c_int;
+    pub fn pthread_mutexattr_getrobust(
+        attr: *const pthread_mutexattr_t,
+        robustness: *mut ::c_int,
+    ) -> ::c_int;
+    pub fn pthread_mutexattr_setrobust(
+        attr: *mut pthread_mutexattr_t,
+        robustness: ::c_int,
     ) -> ::c_int;
     pub fn popen(command: *const c_char, mode: *const c_char) -> *mut ::FILE;
     pub fn faccessat(


### PR DESCRIPTION
Adds pthread_mutexattr_[g|s]etrobust and pthread_mutex_consistent bindings

FreeBSD:
https://cgit.freebsd.org/src/tree/include/pthread.h?id=65436b2e1207a98a1c752c14f8c059238c0eafda#n140

Linux:
https://sourceware.org/git?p=glibc.git;a=blob;f=sysdeps/htl/bits/pthreadtypes.h;h=74127aea488a69af8fb63b8f353307e5d401a62b;hb=HEAD#l83