### PR TITLE
Deprecate XU_NGROUPS on DragonFly

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -715,6 +715,9 @@ pub const RLIMIT_POSIXLOCKS: ::c_int = 11;
 #[deprecated(since = "0.2.64", note = "Not stable across OS versions")]
 pub const RLIM_NLIMITS: ::rlim_t = 12;
 
+#[deprecated(since = "0.2.105", note = "Only exists on FreeBSD, not DragonFly BSD")]
+pub const XU_NGROUPS: ::c_int = 16;
+
 pub const Q_GETQUOTA: ::c_int = 0x300;
 pub const Q_SETQUOTA: ::c_int = 0x400;
 

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -640,6 +640,8 @@ pub const NI_NUMERICSERV: ::c_int = 0x00000008;
 pub const NI_DGRAM: ::c_int = 0x00000010;
 pub const NI_NUMERICSCOPE: ::c_int = 0x00000020;
 
+pub const XU_NGROUPS: ::c_int = 16;
+
 pub const Q_GETQUOTA: ::c_int = 0x700;
 pub const Q_SETQUOTA: ::c_int = 0x800;
 

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1167,7 +1167,6 @@ pub const ST_NOSUID: ::c_ulong = 2;
 
 pub const NI_MAXHOST: ::size_t = 1025;
 
-pub const XU_NGROUPS: ::c_int = 16;
 pub const XUCRED_VERSION: ::c_uint = 0;
 
 pub const RTLD_LOCAL: ::c_int = 0;


### PR DESCRIPTION
This constant was only ever defined on FreeBSD.

https://github.com/freebsd/freebsd-src/blob/a7d137fcbcac7182d4fcdc97a46b10edc5c7041d/sys/sys/ucred.h
https://github.com/DragonFlyBSD/DragonFlyBSD/blob/c2e500ae4c06466901674883b4593bd9c249cdc1/sys/sys/ucred.h