### PR TITLE
Properly expose more constants on FreeBSD

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1898,10 +1898,10 @@ fn test_freebsd(target: &str) {
 
     cfg.skip_const(move |name| {
         match name {
-            // These constants are to be introduced in yet-unreleased FreeBSD 12.2.
+            // These constants were introduced in FreeBSD 13:
             "F_ADD_SEALS" | "F_GET_SEALS" | "F_SEAL_SEAL" | "F_SEAL_SHRINK" | "F_SEAL_GROW"
             | "F_SEAL_WRITE"
-                if Some(12) <= freebsd_ver =>
+                if Some(13) > freebsd_ver =>
             {
                 true
             }
@@ -1915,6 +1915,7 @@ fn test_freebsd(target: &str) {
             | "IPV6_ORIGDSTADDR"
             | "IPV6_RECVORIGDSTADDR"
             | "NI_NUMERICSCOPE"
+            | "SO_DOMAIN"
                 if Some(11) == freebsd_ver =>
             {
                 true
@@ -1985,10 +1986,31 @@ fn test_freebsd(target: &str) {
             // commit/06b00ceaa914a3907e4e27bad924f44612bae1d7
             "MINCORE_SUPER" if Some(13) == freebsd_ver => true,
 
+            // Added in FreeBSD 12.0
+            "EINTEGRITY" if Some(11) == freebsd_ver => true,
+
             // This was increased to 97 in FreeBSD 12.2 and 13.
             // https://github.com/freebsd/freebsd/
             // commit/72a21ba0f62da5e86a1c0b462aeb3f5ff849a1b7
             "ELAST" if Some(12) == freebsd_ver => true,
+
+            // Added in FreeBSD 12.0 (r331279)
+            "GRND_NONBLOCK" | "GRND_RANDOM" if Some(11) == freebsd_ver => true,
+            // Added in FreeBSD 13.0 (r356667)
+            "GRND_INSECURE" if Some(13) > freebsd_ver => true,
+
+            // Added in FreeBSD 12.1 (r343964 and r345228)
+            "PROC_ASLR_CTL" | "PROC_ASLR_STATUS" | "PROC_PROCCTL_MD_MIN"
+                if Some(11) == freebsd_ver =>
+            {
+                true
+            }
+
+            // Added in FreeBSD 13.0 (r349609)
+            "PROC_PROTMAX_CTL" | "PROC_PROTMAX_STATUS" if Some(13) > freebsd_ver => true,
+
+            // Added in in FreeBSD 13.0 (r367776 and r367287)
+            "SCM_CREDS2" | "LOCAL_CREDS_PERSISTENT" if Some(13) > freebsd_ver => true,
 
             _ => false,
         }

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -190,26 +190,7 @@ cfg_if! {
     }
 }
 
-pub const F_ADD_SEALS: ::c_int = 19;
-pub const F_GET_SEALS: ::c_int = 20;
-pub const F_SEAL_SEAL: ::c_int = 0x0001;
-pub const F_SEAL_SHRINK: ::c_int = 0x0002;
-pub const F_SEAL_GROW: ::c_int = 0x0004;
-pub const F_SEAL_WRITE: ::c_int = 0x0008;
-
-pub const GRND_NONBLOCK: ::c_uint = 0x1;
-pub const GRND_RANDOM: ::c_uint = 0x2;
-
 pub const RAND_MAX: ::c_int = 0x7fff_fffd;
-
-pub const PROC_ASLR_CTL: ::c_int = 13;
-pub const PROC_ASLR_STATUS: ::c_int = 14;
-
-pub const PROC_PROCCTL_MD_MIN: ::c_int = 0x10000000;
-
-pub const SO_DOMAIN: ::c_int = 0x1019;
-
-pub const EINTEGRITY: ::c_int = 97;
 pub const ELAST: ::c_int = 97;
 
 extern "C" {

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -201,32 +201,8 @@ cfg_if! {
     }
 }
 
-pub const F_ADD_SEALS: ::c_int = 19;
-pub const F_GET_SEALS: ::c_int = 20;
-pub const F_SEAL_SEAL: ::c_int = 0x0001;
-pub const F_SEAL_SHRINK: ::c_int = 0x0002;
-pub const F_SEAL_GROW: ::c_int = 0x0004;
-pub const F_SEAL_WRITE: ::c_int = 0x0008;
-
-pub const GRND_NONBLOCK: ::c_uint = 0x1;
-pub const GRND_RANDOM: ::c_uint = 0x2;
-
 pub const RAND_MAX: ::c_int = 0x7fff_ffff;
-
-pub const SO_DOMAIN: ::c_int = 0x1019;
-
-pub const EINTEGRITY: ::c_int = 97;
 pub const ELAST: ::c_int = 97;
-pub const GRND_INSECURE: ::c_uint = 0x4;
-
-pub const PROC_ASLR_CTL: ::c_int = 13;
-pub const PROC_ASLR_STATUS: ::c_int = 14;
-pub const PROC_PROTMAX_CTL: ::c_int = 15;
-pub const PROC_PROTMAX_STATUS: ::c_int = 16;
-pub const PROC_PROCCTL_MD_MIN: ::c_int = 0x10000000;
-
-pub const LOCAL_CREDS_PERSISTENT: ::c_int = 3;
-pub const SCM_CREDS2: ::c_int = 0x08;
 
 f! {
     pub fn SOCKCRED2SIZE(ngrps: usize) -> usize {

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -626,6 +626,7 @@ pub const ENOTCAPABLE: ::c_int = 93;
 pub const ECAPMODE: ::c_int = 94;
 pub const ENOTRECOVERABLE: ::c_int = 95;
 pub const EOWNERDEAD: ::c_int = 96;
+pub const EINTEGRITY: ::c_int = 97;
 pub const RLIMIT_NPTS: ::c_int = 11;
 pub const RLIMIT_SWAP: ::c_int = 12;
 pub const RLIMIT_KQUEUES: ::c_int = 13;
@@ -903,6 +904,8 @@ pub const MNT_UNION: ::c_int = 0x00000020;
 pub const MNT_EXPUBLIC: ::c_int = 0x20000000;
 pub const MNT_NONBUSY: ::c_int = 0x04000000;
 
+pub const SCM_CREDS2: ::c_int = 0x08;
+
 pub const SO_BINTIME: ::c_int = 0x2000;
 pub const SO_NO_OFFLOAD: ::c_int = 0x4000;
 pub const SO_NO_DDP: ::c_int = 0x8000;
@@ -916,9 +919,11 @@ pub const SO_SETFIB: ::c_int = 0x1014;
 pub const SO_USER_COOKIE: ::c_int = 0x1015;
 pub const SO_PROTOCOL: ::c_int = 0x1016;
 pub const SO_PROTOTYPE: ::c_int = SO_PROTOCOL;
+pub const SO_DOMAIN: ::c_int = 0x1019;
 pub const SO_VENDOR: ::c_int = 0x80000000;
 
 pub const LOCAL_CREDS: ::c_int = 2;
+pub const LOCAL_CREDS_PERSISTENT: ::c_int = 3;
 pub const LOCAL_CONNWAIT: ::c_int = 4;
 pub const LOCAL_VENDOR: ::c_int = SO_VENDOR;
 
@@ -967,8 +972,13 @@ pub const PROC_TRAPCAP_CTL: ::c_int = 9;
 pub const PROC_TRAPCAP_STATUS: ::c_int = 10;
 pub const PROC_PDEATHSIG_CTL: ::c_int = 11;
 pub const PROC_PDEATHSIG_STATUS: ::c_int = 12;
+pub const PROC_ASLR_CTL: ::c_int = 13;
+pub const PROC_ASLR_STATUS: ::c_int = 14;
+pub const PROC_PROTMAX_CTL: ::c_int = 15;
+pub const PROC_PROTMAX_STATUS: ::c_int = 16;
 pub const PROC_STACKGAP_CTL: ::c_int = 17;
 pub const PROC_STACKGAP_STATUS: ::c_int = 18;
+pub const PROC_PROCCTL_MD_MIN: ::c_int = 0x10000000;
 
 pub const AF_SLOW: ::c_int = 33;
 pub const AF_SCLUSTER: ::c_int = 34;
@@ -1435,14 +1445,28 @@ pub const UF_READONLY: ::c_ulong = 0x00001000;
 pub const UF_HIDDEN: ::c_ulong = 0x00008000;
 pub const SF_SNAPSHOT: ::c_ulong = 0x00200000;
 
+// fcntl commands
+pub const F_ADD_SEALS: ::c_int = 19;
+pub const F_DUP2FD: ::c_int = 10;
+pub const F_DUP2FD_CLOEXEC: ::c_int = 18;
+pub const F_GET_SEALS: ::c_int = 20;
 pub const F_OGETLK: ::c_int = 7;
 pub const F_OSETLK: ::c_int = 8;
 pub const F_OSETLKW: ::c_int = 9;
-pub const F_DUP2FD: ::c_int = 10;
-pub const F_SETLK_REMOTE: ::c_int = 14;
-pub const F_READAHEAD: ::c_int = 15;
 pub const F_RDAHEAD: ::c_int = 16;
-pub const F_DUP2FD_CLOEXEC: ::c_int = 18;
+pub const F_READAHEAD: ::c_int = 15;
+pub const F_SETLK_REMOTE: ::c_int = 14;
+
+// for use with F_ADD_SEALS
+pub const F_SEAL_GROW: ::c_int = 4;
+pub const F_SEAL_SEAL: ::c_int = 1;
+pub const F_SEAL_SHRINK: ::c_int = 2;
+pub const F_SEAL_WRITE: ::c_int = 8;
+
+// For getrandom()
+pub const GRND_NONBLOCK: ::c_uint = 0x1;
+pub const GRND_RANDOM: ::c_uint = 0x2;
+pub const GRND_INSECURE: ::c_uint = 0x4;
 
 // For realhostname* api
 pub const HOSTNAME_FOUND: ::c_int = 0;


### PR DESCRIPTION
The freebsd12 and freebsd13 modules should only be used for symbols that
_change_ in those versions, not for newly added symbols.  Mostly they
should be used for versioned ELF symbols.  It does no harm to publish
ordinary constants in the base FreeBSD module even if they weren't
defined in the lowest supported version of FreeBSD, but it does make it
much easier for consumers to use them.