### PR TITLE
Add fexecve() to DragonFly

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1336,7 +1336,7 @@ fn test_dragonflybsd(target: &str) {
         // skip those that are manually verified
         match name {
             // FIXME: https://github.com/rust-lang/libc/issues/1272
-            "execv" | "execve" | "execvp" => true,
+            "execv" | "execve" | "execvp" | "fexecve" => true,
 
             "getrlimit" | "getrlimit64" |    // non-int in 1st arg
             "setrlimit" | "setrlimit64" |    // non-int in 1st arg

--- a/libc-test/semver/dragonfly.txt
+++ b/libc-test/semver/dragonfly.txt
@@ -1227,6 +1227,7 @@ faccessat
 fchdir
 fchflags
 fdopendir
+fexecve
 fmemopen
 forkpty
 fparseln

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1702,11 +1702,6 @@ extern "C" {
         msgflg: ::c_int,
     ) -> ::c_int;
     pub fn cfmakesane(termios: *mut ::termios);
-    pub fn fexecve(
-        fd: ::c_int,
-        argv: *const *const ::c_char,
-        envp: *const *const ::c_char,
-    ) -> ::c_int;
 
     pub fn pdfork(fdp: *mut ::c_int, flags: ::c_int) -> ::pid_t;
     pub fn pdgetpid(fd: ::c_int, pidp: *mut ::pid_t) -> ::c_int;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1441,6 +1441,11 @@ extern "C" {
     pub fn duplocale(base: ::locale_t) -> ::locale_t;
     pub fn endutxent();
     pub fn fchflags(fd: ::c_int, flags: ::c_ulong) -> ::c_int;
+    pub fn fexecve(
+        fd: ::c_int,
+        argv: *const *const ::c_char,
+        envp: *const *const ::c_char,
+    ) -> ::c_int;
     pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
     pub fn getdomainname(name: *mut ::c_char, len: ::c_int) -> ::c_int;
     pub fn getgrent_r(


### PR DESCRIPTION
DragonFly 6.0 added support for `fexecve(2)`.

Implementing it with a mismatched signature from what C exposes, as outlined in #1272, for consistency with other platforms.

Tested with https://github.com/nix-rust/nix/pull/1577