### PR TITLE
Move Linux's `POLLRDHUP` into `linux_like` and fix its type.

### DIFF
--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -3088,19 +3088,6 @@ pub const CAN_RAW_RECV_OWN_MSGS: ::c_int = 4;
 pub const CAN_RAW_FD_FRAMES: ::c_int = 5;
 pub const CAN_RAW_JOIN_FILTERS: ::c_int = 6;
 
-#[deprecated(
-    since = "0.2.102",
-    note = "Errnoeously uses c_int; should use c_short."
-)]
-#[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))]
-pub const POLLRDHUP: ::c_int = 0x2000;
-#[deprecated(
-    since = "0.2.102",
-    note = "Errnoeously uses c_int; should use c_short."
-)]
-#[cfg(any(target_arch = "sparc", target_arch = "sparc64"))]
-pub const POLLRDHUP: ::c_int = 0x800;
-
 f! {
     pub fn NLA_ALIGN(len: ::c_int) -> ::c_int {
         return ((len) + NLA_ALIGNTO - 1) & !(NLA_ALIGNTO - 1)

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1237,6 +1237,10 @@ pub const POLLHUP: ::c_short = 0x10;
 pub const POLLNVAL: ::c_short = 0x20;
 pub const POLLRDNORM: ::c_short = 0x040;
 pub const POLLRDBAND: ::c_short = 0x080;
+#[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))]
+pub const POLLRDHUP: ::c_short = 0x2000;
+#[cfg(any(target_arch = "sparc", target_arch = "sparc64"))]
+pub const POLLRDHUP: ::c_short = 0x800;
 
 pub const IPTOS_LOWDELAY: u8 = 0x10;
 pub const IPTOS_THROUGHPUT: u8 = 0x08;


### PR DESCRIPTION
This was originally posted as #2390, but since it was a breaking change,
that PR instead just added `deprecated` warnings. There haven't been any
concerns for a while, so this is now a PR to do the change actually, per
the [breaking-change-policy].

This fixes two errors in #2247.

 - It moves the definitions of `POLLRDHUP` out of `linux_like/linux`
   and into `linux_like`, so that they're available on Android as well.

 - It changes the type from `c_int` to `c_short` to match the other
   `POLL*` flags.

[breaking-change-policy]: https://github.com/rust-lang/libc/blob/master/CONTRIBUTING.md#breaking-change-policy