### PR TITLE
Document stat.st_blksize changes on DragonFly BSD

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -106,6 +106,11 @@ s! {
         pub f_uid_uuid: ::uuid_t,
     }
 
+    #[deprecated(
+        since = "0.2.107",
+        note = "stat.st_blksize is an i64 and stat.st_qspare1 is replaced with \
+                stat.st_blksize in DragonFly 5.8"
+    )]
     pub struct stat {
         pub st_ino: ::ino_t,
         pub st_nlink: ::nlink_t,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -699,6 +699,7 @@ extern "C" {
         all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "fstat@FBSD_1.0"
     )]
+    #[cfg_attr(target_os = "dragonfly", allow(deprecated))]
     pub fn fstat(fildes: ::c_int, buf: *mut stat) -> ::c_int;
 
     pub fn mkdir(path: *const c_char, mode: mode_t) -> ::c_int;
@@ -712,6 +713,7 @@ extern "C" {
         all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "stat@FBSD_1.0"
     )]
+    #[cfg_attr(target_os = "dragonfly", allow(deprecated))]
     pub fn stat(path: *const c_char, buf: *mut stat) -> ::c_int;
 
     pub fn pclose(stream: *mut ::FILE) -> ::c_int;
@@ -796,6 +798,7 @@ extern "C" {
         all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "fstatat@FBSD_1.1"
     )]
+    #[cfg_attr(target_os = "dragonfly", allow(deprecated))]
     pub fn fstatat(
         dirfd: ::c_int,
         pathname: *const ::c_char,
@@ -987,6 +990,7 @@ extern "C" {
         all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "lstat@FBSD_1.0"
     )]
+    #[cfg_attr(target_os = "dragonfly", allow(deprecated))]
     pub fn lstat(path: *const c_char, buf: *mut stat) -> ::c_int;
 
     #[cfg_attr(


### PR DESCRIPTION
The tests are currently failing on DragonFly BSD, due to [changes to `stat.st_blksize`](https://github.com/DragonFlyBSD/DragonFlyBSD/commit/34c6728ee290889398ff2f1305a91f08aa6b0b35) among other reasons.

`st_blksize` is now an `i64`, and has moved to take up a previously reserved struct member. Deprecate the struct, to indicate it will be modified in a subsequent release.