### PR TITLE
Deprecate FIODGNAME on DragonFly, add FIODNAME

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -882,6 +882,13 @@ pub const EV_ERROR: u16 = 0x4000;
 pub const EV_EOF: u16 = 0x8000;
 pub const EV_SYSFLAGS: u16 = 0xf000;
 
+pub const FIODNAME: ::c_ulong = 0x80106678;
+#[deprecated(
+    since = "0.2.106",
+    note = "FIODGNAME is not defined on DragonFly BSD. See FIODNAME."
+)]
+pub const FIODGNAME: ::c_ulong = 0x80106678;
+
 pub const NOTE_TRIGGER: u32 = 0x01000000;
 pub const NOTE_FFNOP: u32 = 0x00000000;
 pub const NOTE_FFAND: u32 = 0x40000000;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1047,6 +1047,7 @@ pub const H4DISC: ::c_int = 0x7;
 
 pub const BIOCSETFNR: ::c_ulong = 0x80104282;
 
+pub const FIODGNAME: ::c_ulong = 0x80106678;
 pub const FIONWRITE: ::c_ulong = 0x40046677;
 pub const FIONSPACE: ::c_ulong = 0x40046676;
 pub const FIOSEEKDATA: ::c_ulong = 0xc0086661;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1260,7 +1260,6 @@ pub const BIOCGRTIMEOUT: ::c_ulong = 0x4010426e;
 
 pub const FIODTYPE: ::c_ulong = 0x4004667a;
 pub const FIOGETLBA: ::c_ulong = 0x40046679;
-pub const FIODGNAME: ::c_ulong = 0x80106678;
 
 pub const B0: speed_t = 0;
 pub const B50: speed_t = 50;


### PR DESCRIPTION
`FIODGNAME` is FreeBSD specific, but `FIODNAME` exists on DragonFly which appears to provide similar functionality.

[FreeBSD definition](https://github.com/freebsd/freebsd-src/blob/dc6dd769de63c4eceb8899205a5d780d9f278fd2/sys/sys/filio.h#L60)
[DragonFly definition](https://github.com/DragonFlyBSD/DragonFlyBSD/blob/20f6ddd0df90767e1eba2d12dfa8e1769be7cec7/sys/sys/filio.h#L59)

`FIODGNAME` is appearing in the `libc-test` failures on DragonFly. Deprecate it, to be removed in a subsequent release.
