### PR TITLE
DragonFly's devname_r takes a size_t len parameter

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1363,6 +1363,14 @@ extern "C" {
 
     pub fn aio_waitcomplete(iocbp: *mut *mut aiocb, timeout: *mut ::timespec) -> ::c_int;
 
+    #[deprecated(since = "0.2.107", note = "len should be of type size_t")]
+    pub fn devname_r(
+        dev: ::dev_t,
+        mode: ::mode_t,
+        buf: *mut ::c_char,
+        len: ::c_int,
+    ) -> *mut ::c_char;
+
     pub fn waitid(
         idtype: idtype_t,
         id: ::id_t,

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -2009,6 +2009,13 @@ extern "C" {
     ) -> ::c_int;
     pub fn aio_write(aiocbp: *mut aiocb) -> ::c_int;
 
+    pub fn devname_r(
+        dev: ::dev_t,
+        mode: ::mode_t,
+        buf: *mut ::c_char,
+        len: ::c_int,
+    ) -> *mut ::c_char;
+
     pub fn extattr_delete_fd(
         fd: ::c_int,
         attrnamespace: ::c_int,

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1417,12 +1417,6 @@ extern "C" {
     pub fn sem_init(sem: *mut sem_t, pshared: ::c_int, value: ::c_uint) -> ::c_int;
 
     pub fn daemon(nochdir: ::c_int, noclose: ::c_int) -> ::c_int;
-    pub fn devname_r(
-        dev: ::dev_t,
-        mode: ::mode_t,
-        buf: *mut ::c_char,
-        len: ::c_int,
-    ) -> *mut ::c_char;
     pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::timezone) -> ::c_int;
     pub fn accept4(
         s: ::c_int,


### PR DESCRIPTION
#2435 introduced this function on DragonFly BSD with FreeBSD's signature, which is incorrect. Deprecate it, to be fixed in a subsequent release.

https://github.com/DragonFlyBSD/DragonFlyBSD/blob/c163a4d7ee9c6857ee4e04a3a2cbb50c3de29da1/include/stdlib.h#L285