### PR TITLE
Declare clock_settime for macOS.

### DIFF
--- a/libc-test/semver/macos.txt
+++ b/libc-test/semver/macos.txt
@@ -1,1 +1,2 @@
+clock_settime
 memmem

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -5372,6 +5372,7 @@ pub unsafe fn mach_task_self() -> ::mach_port_t {
 cfg_if! {
     if #[cfg(target_os = "macos")] {
         extern "C" {
+            pub fn clock_settime(clock_id: ::clockid_t, tp: *const ::timespec) -> ::c_int;
             pub fn memmem(
                 haystack: *const ::c_void,
                 haystacklen: ::size_t,


### PR DESCRIPTION
Looking at [time.h for macOS 11.5](https://opensource.apple.com/source/Libc/Libc-1439.141.1/include/time.h.auto.html) `clock_settime` still doesn't seem to be exported for iOS. Declaring it only for macOS (using #2208 as an example of how).