### PR TITLE
Enable clock_gettime on wasi

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -72,6 +72,10 @@ fn main() {
         println!("cargo:rustc-cfg=libc_cfg_target_vendor");
     }
 
+    if rustc_minor_ver >= 51 || rustc_dep_of_std {
+        println!("cargo:rustc-cfg=libc_ptr_addr_of");
+    }
+
     // #[thread_local] is currently unstable
     if rustc_dep_of_std {
         println!("cargo:rustc-cfg=libc_thread_local");

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -341,3 +341,19 @@ macro_rules! deprecated_mach {
         )*
     }
 }
+
+#[allow(unused_macros)]
+#[cfg(not(libc_ptr_addr_of))]
+macro_rules! ptr_addr_of {
+    ($place:expr) => {
+        &$place
+    };
+}
+
+#[allow(unused_macros)]
+#[cfg(libc_ptr_addr_of)]
+macro_rules! ptr_addr_of {
+    ($place:expr) => {
+        ::core::ptr::addr_of!($place)
+    };
+}

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -51,6 +51,16 @@ pub enum __locale_struct {}
 
 pub type locale_t = *mut __locale_struct;
 
+s_paren! {
+    // in wasi-libc clockid_t is const struct __clockid* (where __clockid is an opaque struct),
+    // but that's an implementation detail that we don't want to have to deal with
+    #[repr(transparent)]
+    pub struct clockid_t(*const u8);
+}
+
+unsafe impl Send for clockid_t {}
+unsafe impl Sync for clockid_t {}
+
 s! {
     #[repr(align(8))]
     pub struct fpos_t {
@@ -342,6 +352,11 @@ pub const _SC_PAGE_SIZE: ::c_int = _SC_PAGESIZE;
 pub const _SC_IOV_MAX: c_int = 60;
 pub const _SC_SYMLOOP_MAX: c_int = 173;
 
+pub static CLOCK_MONOTONIC: clockid_t = unsafe { clockid_t(&_CLOCK_MONOTONIC) };
+pub static CLOCK_PROCESS_CPUTIME_ID: clockid_t = unsafe { clockid_t(&_CLOCK_PROCESS_CPUTIME_ID) };
+pub static CLOCK_REALTIME: clockid_t = unsafe { clockid_t(&_CLOCK_REALTIME) };
+pub static CLOCK_THREAD_CPUTIME_ID: clockid_t = unsafe { clockid_t(&_CLOCK_THREAD_CPUTIME_ID) };
+
 #[cfg_attr(
     feature = "rustc-dep-of-std",
     link(name = "c", kind = "static", cfg(target_feature = "crt-static"))
@@ -417,15 +432,14 @@ extern "C" {
     pub fn asctime_r(a: *const tm, b: *mut c_char) -> *mut c_char;
     pub fn ctime_r(a: *const time_t, b: *mut c_char) -> *mut c_char;
 
+    static _CLOCK_MONOTONIC: u8;
+    static _CLOCK_PROCESS_CPUTIME_ID: u8;
+    static _CLOCK_REALTIME: u8;
+    static _CLOCK_THREAD_CPUTIME_ID: u8;
     pub fn nanosleep(a: *const timespec, b: *mut timespec) -> c_int;
-    // pub fn clock_getres(a: clockid_t, b: *mut timespec) -> c_int;
-    // pub fn clock_gettime(a: clockid_t, b: *mut timespec) -> c_int;
-    // pub fn clock_nanosleep(
-    //     a: clockid_t,
-    //     a2: c_int,
-    //     b: *const timespec,
-    //     c: *mut timespec,
-    // ) -> c_int;
+    pub fn clock_getres(a: clockid_t, b: *mut timespec) -> c_int;
+    pub fn clock_gettime(a: clockid_t, b: *mut timespec) -> c_int;
+    pub fn clock_nanosleep(a: clockid_t, a2: c_int, b: *const timespec, c: *mut timespec) -> c_int;
 
     pub fn isalnum(c: c_int) -> c_int;
     pub fn isalpha(c: c_int) -> c_int;

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -352,10 +352,12 @@ pub const _SC_PAGE_SIZE: ::c_int = _SC_PAGESIZE;
 pub const _SC_IOV_MAX: c_int = 60;
 pub const _SC_SYMLOOP_MAX: c_int = 173;
 
-pub static CLOCK_MONOTONIC: clockid_t = unsafe { clockid_t(&_CLOCK_MONOTONIC) };
-pub static CLOCK_PROCESS_CPUTIME_ID: clockid_t = unsafe { clockid_t(&_CLOCK_PROCESS_CPUTIME_ID) };
-pub static CLOCK_REALTIME: clockid_t = unsafe { clockid_t(&_CLOCK_REALTIME) };
-pub static CLOCK_THREAD_CPUTIME_ID: clockid_t = unsafe { clockid_t(&_CLOCK_THREAD_CPUTIME_ID) };
+pub static CLOCK_MONOTONIC: clockid_t = unsafe { clockid_t(ptr_addr_of!(_CLOCK_MONOTONIC)) };
+pub static CLOCK_PROCESS_CPUTIME_ID: clockid_t =
+    unsafe { clockid_t(ptr_addr_of!(_CLOCK_PROCESS_CPUTIME_ID)) };
+pub static CLOCK_REALTIME: clockid_t = unsafe { clockid_t(ptr_addr_of!(_CLOCK_REALTIME)) };
+pub static CLOCK_THREAD_CPUTIME_ID: clockid_t =
+    unsafe { clockid_t(ptr_addr_of!(_CLOCK_THREAD_CPUTIME_ID)) };
 
 #[cfg_attr(
     feature = "rustc-dep-of-std",


### PR DESCRIPTION
I think this mostly addresses the issues that were brought up in #1307 regarding clock ids; I made clockid_t a wrapper struct because it needs to be Send and Sync to be used in a constant, and I figured it was opaque in wasi-libc anyway. Instead of static ZSTs, I just made them `u8`s, since I figured it's very unlikely that wasi-libc would change them from `struct __clockid { __wasi_clockid_t id; }` to `struct __clockid {}`, and it'll always be valid to treat a static as a `/(u8)+/`. One thing I was wondering about, should I add a cfg check to `build.rs` checking for `core::ptr::addr_of`? Since I *think*(?) using that would fix any issue of __clockid becoming a "zst" struct in the future.