### PR TITLE
Skip CI on `sparc64-unknown-linux-gnu` for now

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -132,7 +132,8 @@ jobs:
           # See this comment for more details:
           # https://github.com/rust-lang/libc/pull/2225#issuecomment-880696737
           #wasm32-wasi,
-          sparc64-unknown-linux-gnu,
+          # FIXME: Recent nightly causes a segfault on libc-test
+          #sparc64-unknown-linux-gnu,
           wasm32-unknown-emscripten,
           x86_64-linux-android,
           x86_64-unknown-linux-gnux32,


### PR DESCRIPTION
cc #2502
r? @ghost