### PR TITLE
Add getresgid and getresuid to DragonFly, FreeBSD and OpenBSD

### DIFF
--- a/libc-test/semver/dragonfly.txt
+++ b/libc-test/semver/dragonfly.txt
@@ -1263,6 +1263,8 @@ getprogname
 getpwent
 getpwent_r
 getpwnam_r
+getresgid
+getresuid
 getrlimit
 getrusage
 getservbyport

--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -1501,6 +1501,8 @@ getprogname
 getpwent
 getpwent_r
 getpwnam_r
+getresgid
+getresuid
 getrlimit
 getrusage
 getservbyport

--- a/libc-test/semver/openbsd.txt
+++ b/libc-test/semver/openbsd.txt
@@ -963,6 +963,8 @@ getpriority
 getprogname
 getpwent
 getpwnam_r
+getresgid
+getresuid
 getrlimit
 getrusage
 getservbyport

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1477,6 +1477,8 @@ extern "C" {
         flags: ::c_int,
     ) -> ::c_int;
     pub fn getpriority(which: ::c_int, who: ::c_int) -> ::c_int;
+    pub fn getresgid(rgid: *mut ::gid_t, egid: *mut ::gid_t, sgid: *mut ::gid_t) -> ::c_int;
+    pub fn getresuid(ruid: *mut ::uid_t, euid: *mut ::uid_t, suid: *mut ::uid_t) -> ::c_int;
     pub fn getutxent() -> *mut utmpx;
     pub fn getutxid(ut: *const utmpx) -> *mut utmpx;
     pub fn getutxline(ut: *const utmpx) -> *mut utmpx;

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1527,6 +1527,8 @@ extern "C" {
         servlen: ::size_t,
         flags: ::c_int,
     ) -> ::c_int;
+    pub fn getresgid(rgid: *mut ::gid_t, egid: *mut ::gid_t, sgid: *mut ::gid_t) -> ::c_int;
+    pub fn getresuid(ruid: *mut ::uid_t, euid: *mut ::uid_t, suid: *mut ::uid_t) -> ::c_int;
     pub fn kevent(
         kq: ::c_int,
         changelist: *const ::kevent,


### PR DESCRIPTION
The functions have the same signatures as on Linux.