### PR TITLE
Add `procctl` data constants on freebsd

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2003,15 +2003,32 @@ fn test_freebsd(target: &str) {
             // Added in FreeBSD 13.0 (r356667)
             "GRND_INSECURE" if Some(13) > freebsd_ver => true,
 
-            // Added in FreeBSD 12.1 (r343964 and r345228)
-            "PROC_ASLR_CTL" | "PROC_ASLR_STATUS" | "PROC_PROCCTL_MD_MIN"
+            // Added in FreeBSD 12.1 (r343964)
+            "PROC_ASLR_CTL"
+            | "PROC_ASLR_STATUS"
+            | "PROC_ASLR_FORCE_ENABLE"
+            | "PROC_ASLR_FORCE_DISABLE"
+            | "PROC_ASLR_NOFORCE"
+            | "PROC_ASLR_ACTIVE"
                 if Some(11) == freebsd_ver =>
             {
                 true
             }
 
+            // Added in FreeBSD 12.1 (r345228)
+            "PROC_PROCCTL_MD_MIN" if Some(11) == freebsd_ver => true,
+
             // Added in FreeBSD 13.0 (r349609)
-            "PROC_PROTMAX_CTL" | "PROC_PROTMAX_STATUS" if Some(13) > freebsd_ver => true,
+            "PROC_PROTMAX_CTL"
+            | "PROC_PROTMAX_STATUS"
+            | "PROC_PROTMAX_FORCE_ENABLE"
+            | "PROC_PROTMAX_FORCE_DISABLE"
+            | "PROC_PROTMAX_NOFORCE"
+            | "PROC_PROTMAX_ACTIVE"
+                if Some(13) > freebsd_ver =>
+            {
+                true
+            }
 
             // Added in in FreeBSD 13.0 (r367776 and r367287)
             "SCM_CREDS2" | "LOCAL_CREDS_PERSISTENT" if Some(13) > freebsd_ver => true,

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1178,6 +1178,33 @@ pub const PROC_STACKGAP_CTL: ::c_int = 17;
 pub const PROC_STACKGAP_STATUS: ::c_int = 18;
 pub const PROC_PROCCTL_MD_MIN: ::c_int = 0x10000000;
 
+pub const PPROT_SET: ::c_int = 1;
+pub const PPROT_CLEAR: ::c_int = 2;
+pub const PPROT_DESCEND: ::c_int = 0x10;
+pub const PPROT_INHERIT: ::c_int = 0x20;
+
+pub const PROC_TRACE_CTL_ENABLE: ::c_int = 1;
+pub const PROC_TRACE_CTL_DISABLE: ::c_int = 2;
+pub const PROC_TRACE_CTL_DISABLE_EXEC: ::c_int = 3;
+
+pub const PROC_TRAPCAP_CTL_ENABLE: ::c_int = 1;
+pub const PROC_TRAPCAP_CTL_DISABLE: ::c_int = 2;
+
+pub const PROC_ASLR_FORCE_ENABLE: ::c_int = 1;
+pub const PROC_ASLR_FORCE_DISABLE: ::c_int = 2;
+pub const PROC_ASLR_NOFORCE: ::c_int = 3;
+pub const PROC_ASLR_ACTIVE: ::c_int = 0x80000000;
+
+pub const PROC_PROTMAX_FORCE_ENABLE: ::c_int = 1;
+pub const PROC_PROTMAX_FORCE_DISABLE: ::c_int = 2;
+pub const PROC_PROTMAX_NOFORCE: ::c_int = 3;
+pub const PROC_PROTMAX_ACTIVE: ::c_int = 0x80000000;
+
+pub const PROC_STACKGAP_ENABLE: ::c_int = 0x0001;
+pub const PROC_STACKGAP_DISABLE: ::c_int = 0x0002;
+pub const PROC_STACKGAP_ENABLE_EXEC: ::c_int = 0x0004;
+pub const PROC_STACKGAP_DISABLE_EXEC: ::c_int = 0x0008;
+
 pub const AF_SLOW: ::c_int = 33;
 pub const AF_SCLUSTER: ::c_int = 34;
 pub const AF_ARP: ::c_int = 35;


### PR DESCRIPTION
The constants to be passed in the `data` argument of `procctl` on freebsd.

Source for the constants: <https://github.com/freebsd/freebsd-src/blob/main/sys/sys/procctl.h>.