### PR TITLE
Bump libc to 0.2.107

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.106"
+version = "0.2.107"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-test"
-version = "0.2.106"
+version = "0.2.107"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.105"
+version = "0.2.107"
 default-features = false
 
 [build-dependencies]


### PR DESCRIPTION
Primarily so as to fix building for aarch64-unknown-linux-musl,
as implemented in commit fd331f65f214ea75b6210b415b5fd8650be15c73

This may help resolve https://github.com/rust-lang/rust/pull/90044
I do not have release privileges for libc, so if anyone would be so kind as to tag it and publish to crates.io, that would be lovely.