### PR TITLE
Scope in Send, Sync for wasi

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ cfg_if! {
         use core::clone::Clone;
         #[doc(hidden)]
         #[allow(unused_imports)]
-        use core::marker::Copy;
+        use core::marker::{Copy, Send, Sync};
         #[doc(hidden)]
         #[allow(unused_imports)]
         use core::option::Option;
@@ -85,7 +85,7 @@ cfg_if! {
         pub use core::clone::Clone;
         #[doc(hidden)]
         #[allow(unused_imports)]
-        pub use core::marker::Copy;
+        pub use core::marker::{Copy, Send, Sync};
         #[doc(hidden)]
         #[allow(unused_imports)]
         pub use core::option::Option;

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -1,3 +1,5 @@
+use super::{Send, Sync};
+
 pub use ffi::c_void;
 
 pub type c_char = i8;


### PR DESCRIPTION
Without this, libc fails during the build of rustc. See https://github.com/rust-lang/rust/pull/90681
This dependency was introduced in rust-lang/libc#2499.
Alternative solution: It's not clear this is necessary for core to finish building,
so maybe we should `#[cfg]` it out in that case, instead?