### PR TITLE
Ignore `TIOCREMOTE` on macOS

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -300,6 +300,9 @@ fn test_apple(target: &str) {
             "KERN_KDENABLE_BG_TRACE" | "KERN_KDDISABLE_BG_TRACE" => true,
             // FIXME: the value has been changed since Catalina (0xffff0000 -> 0x3fff0000).
             "SF_SETTABLE" => true,
+
+            // FIXME: XCode 13.1 doesn't have it.
+            "TIOCREMOTE" => true,
             _ => false,
         }
     });


### PR DESCRIPTION
r? @ghost
GHA macOS image updated to 20211114.1 which changed the default version of XCode to 13.1 thus we've encountered #2507.