### PR TITLE
Use libc specific type for architecture specific ioctl defines on Linux.

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2740,6 +2740,9 @@ fn test_linux(target: &str) {
             | "Elf64_Shdr" | "Elf32_Sym" | "Elf64_Sym" | "Elf32_Ehdr" | "Elf64_Ehdr"
             | "Elf32_Chdr" | "Elf64_Chdr" => ty.to_string(),
 
+            "Ioctl" if gnu => "unsigned long".to_string(),
+            "Ioctl" => "int".to_string(),
+
             t if is_union => format!("union {}", t),
 
             t if t.ends_with("_t") => t.to_string(),
@@ -2796,6 +2799,9 @@ fn test_linux(target: &str) {
             "__rlimit_resource_t" => true,
             // on Linux, this is a volatile int
             "pthread_spinlock_t" => true,
+
+            // For internal use only, to define architecture specific ioctl constants with a libc specific type.
+            "Ioctl" => true,
 
             _ => false,
         }
@@ -3227,6 +3233,7 @@ fn test_linux(target: &str) {
 // This function tests APIs that are incompatible to test when other APIs
 // are included (e.g. because including both sets of headers clashes)
 fn test_linux_like_apis(target: &str) {
+    let gnu = target.contains("gnu");
     let musl = target.contains("musl");
     let linux = target.contains("linux");
     let emscripten = target.contains("emscripten");
@@ -3293,6 +3300,8 @@ fn test_linux_like_apis(target: &str) {
             })
             .skip_struct(|s| s != "termios2")
             .type_name(move |ty, is_struct, is_union| match ty {
+                "Ioctl" if gnu => "unsigned long".to_string(),
+                "Ioctl" => "int".to_string(),
                 t if is_struct => format!("struct {}", t),
                 t if is_union => format!("union {}", t),
                 t => t.to_string(),

--- a/src/unix/linux_like/linux/arch/generic/mod.rs
+++ b/src/unix/linux_like/linux/arch/generic/mod.rs
@@ -112,14 +112,14 @@ cfg_if! {
 pub const SCM_TIMESTAMPNS: ::c_int = SO_TIMESTAMPNS;
 pub const SCM_TIMESTAMPING: ::c_int = SO_TIMESTAMPING;
 
-pub const TIOCMGET: ::c_ulong = 0x5415;
-pub const TIOCMBIS: ::c_ulong = 0x5416;
-pub const TIOCMBIC: ::c_ulong = 0x5417;
-pub const TIOCMSET: ::c_ulong = 0x5418;
-pub const TCGETS2: ::c_ulong = 0x802c542a;
-pub const TCSETS2: ::c_ulong = 0x402c542b;
-pub const TCSETSW2: ::c_ulong = 0x402c542c;
-pub const TCSETSF2: ::c_ulong = 0x402c542d;
+pub const TIOCMGET: ::Ioctl = 0x5415;
+pub const TIOCMBIS: ::Ioctl = 0x5416;
+pub const TIOCMBIC: ::Ioctl = 0x5417;
+pub const TIOCMSET: ::Ioctl = 0x5418;
+pub const TCGETS2: ::Ioctl = 0x802c542a;
+pub const TCSETS2: ::Ioctl = 0x402c542b;
+pub const TCSETSW2: ::Ioctl = 0x402c542c;
+pub const TCSETSF2: ::Ioctl = 0x402c542d;
 
 pub const TIOCM_LE: ::c_int = 0x001;
 pub const TIOCM_DTR: ::c_int = 0x002;

--- a/src/unix/linux_like/linux/arch/mips/mod.rs
+++ b/src/unix/linux_like/linux/arch/mips/mod.rs
@@ -108,14 +108,14 @@ pub const SO_TIMESTAMPING: ::c_int = 37;
 pub const SCM_TIMESTAMPNS: ::c_int = SO_TIMESTAMPNS;
 pub const SCM_TIMESTAMPING: ::c_int = SO_TIMESTAMPING;
 
-pub const TIOCMGET: ::c_ulong = 0x741d;
-pub const TIOCMBIS: ::c_ulong = 0x741b;
-pub const TIOCMBIC: ::c_ulong = 0x741c;
-pub const TIOCMSET: ::c_ulong = 0x741a;
-pub const TCGETS2: ::c_ulong = 0x4030542a;
-pub const TCSETS2: ::c_ulong = 0x8030542b;
-pub const TCSETSW2: ::c_ulong = 0x8030542c;
-pub const TCSETSF2: ::c_ulong = 0x8030542d;
+pub const TIOCMGET: ::Ioctl = 0x741d;
+pub const TIOCMBIS: ::Ioctl = 0x741b;
+pub const TIOCMBIC: ::Ioctl = 0x741c;
+pub const TIOCMSET: ::Ioctl = 0x741a;
+pub const TCGETS2: ::Ioctl = 0x4030542a;
+pub const TCSETS2: ::Ioctl = 0x8030542b;
+pub const TCSETSW2: ::Ioctl = 0x8030542c;
+pub const TCSETSF2: ::Ioctl = 0x8030542d;
 
 pub const TIOCM_LE: ::c_int = 0x001;
 pub const TIOCM_DTR: ::c_int = 0x002;

--- a/src/unix/linux_like/linux/arch/powerpc/mod.rs
+++ b/src/unix/linux_like/linux/arch/powerpc/mod.rs
@@ -90,10 +90,10 @@ pub const SO_BINDTOIFINDEX: ::c_int = 62;
 pub const SCM_TIMESTAMPNS: ::c_int = SO_TIMESTAMPNS;
 pub const SCM_TIMESTAMPING: ::c_int = SO_TIMESTAMPING;
 
-pub const TIOCMGET: ::c_int = 0x5415;
-pub const TIOCMBIS: ::c_int = 0x5416;
-pub const TIOCMBIC: ::c_int = 0x5417;
-pub const TIOCMSET: ::c_int = 0x5418;
+pub const TIOCMGET: ::Ioctl = 0x5415;
+pub const TIOCMBIS: ::Ioctl = 0x5416;
+pub const TIOCMBIC: ::Ioctl = 0x5417;
+pub const TIOCMSET: ::Ioctl = 0x5418;
 
 pub const TIOCM_LE: ::c_int = 0x001;
 pub const TIOCM_DTR: ::c_int = 0x002;

--- a/src/unix/linux_like/linux/arch/sparc/mod.rs
+++ b/src/unix/linux_like/linux/arch/sparc/mod.rs
@@ -100,14 +100,14 @@ pub const SO_TIMESTAMPING: ::c_int = 0x0023;
 pub const SCM_TIMESTAMPNS: ::c_int = SO_TIMESTAMPNS;
 pub const SCM_TIMESTAMPING: ::c_int = SO_TIMESTAMPING;
 
-pub const TIOCMGET: ::c_ulong = 0x4004746a;
-pub const TIOCMBIS: ::c_ulong = 0x8004746c;
-pub const TIOCMBIC: ::c_ulong = 0x8004746b;
-pub const TIOCMSET: ::c_ulong = 0x8004746d;
-pub const TCGETS2: ::c_ulong = 0x402c540c;
-pub const TCSETS2: ::c_ulong = 0x802c540d;
-pub const TCSETSW2: ::c_ulong = 0x802c540e;
-pub const TCSETSF2: ::c_ulong = 0x802c540f;
+pub const TIOCMGET: ::Ioctl = 0x4004746a;
+pub const TIOCMBIS: ::Ioctl = 0x8004746c;
+pub const TIOCMBIC: ::Ioctl = 0x8004746b;
+pub const TIOCMSET: ::Ioctl = 0x8004746d;
+pub const TCGETS2: ::Ioctl = 0x402c540c;
+pub const TCSETS2: ::Ioctl = 0x802c540d;
+pub const TCSETSW2: ::Ioctl = 0x802c540e;
+pub const TCSETSF2: ::Ioctl = 0x802c540f;
 
 pub const TIOCM_LE: ::c_int = 0x001;
 pub const TIOCM_DTR: ::c_int = 0x002;

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -4,6 +4,16 @@ pub type __rlimit_resource_t = ::c_uint;
 pub type Lmid_t = ::c_long;
 pub type regoff_t = ::c_int;
 
+cfg_if! {
+    if #[cfg(doc)] {
+        // Used in `linux::arch` to define ioctl constants.
+        pub(crate) type Ioctl = ::c_ulong;
+    } else {
+        #[doc(hidden)]
+        pub type Ioctl = ::c_ulong;
+    }
+}
+
 s! {
     pub struct statx {
         pub stx_mask: u32,

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -24,6 +24,16 @@ pub type rlim_t = ::c_ulonglong;
 
 pub type flock64 = flock;
 
+cfg_if! {
+    if #[cfg(doc)] {
+        // Used in `linux::arch` to define ioctl constants.
+        pub(crate) type Ioctl = ::c_int;
+    } else {
+        #[doc(hidden)]
+        pub type Ioctl = ::c_int;
+    }
+}
+
 impl siginfo_t {
     pub unsafe fn si_addr(&self) -> *mut ::c_void {
         #[repr(C)]

--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -5,6 +5,16 @@ pub type regoff_t = ::c_int;
 pub type __rlimit_resource_t = ::c_uint;
 pub type __priority_which_t = ::c_uint;
 
+cfg_if! {
+    if #[cfg(doc)] {
+        // Used in `linux::arch` to define ioctl constants.
+        pub(crate) type Ioctl = ::c_int;
+    } else {
+        #[doc(hidden)]
+        pub type Ioctl = ::c_int;
+    }
+}
+
 s! {
     pub struct statvfs {  // Different than GNU!
         pub f_bsize: ::c_ulong,


### PR DESCRIPTION
This PR should fix the type change of some ioctl constants on Linux introduced by #2530.

It does this by adding a `#[doc(hidden)]` type called `Ioctl`, which is defined in libc specific modules and used in arch specific modules.

However, when doing this I noticed that when I added `TCGETS2`, `TCSETS2`, ... in #2508, I unconditionally used `c_ulong`. This is inconsistent with the other ioctl constants for `musl` and `uclibc`. This PR also changes those to use the libc specific types. However, PR #2508 has already been released in 0.2.107, so technically that is also a semver incompatible change. The impact is limited to new constants introduced in the last release, and only on `musl` and `uclibc` targets.

So what is more important here? Consistency in the type of ioctl constants, or being very strict with backwards compatibility? If it is the latter, I'll revert `TCGETS2` etc to `c_ulong`  for this PR.