### PR TITLE
memfd_create is a glibc API, which is not present on uclibc

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -139,6 +139,7 @@ RUST_NIGHTLY_LINUX_TARGETS="\
 aarch64-fuchsia \
 armv5te-unknown-linux-gnueabi \
 armv5te-unknown-linux-musleabi \
+armv7-unknown-linux-uclibceabihf \
 i686-pc-windows-gnu \
 riscv64gc-unknown-linux-gnu \
 wasm32-wasi \

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -139,7 +139,6 @@ RUST_NIGHTLY_LINUX_TARGETS="\
 aarch64-fuchsia \
 armv5te-unknown-linux-gnueabi \
 armv5te-unknown-linux-musleabi \
-armv7-unknown-linux-uclibceabihf \
 i686-pc-windows-gnu \
 riscv64gc-unknown-linux-gnu \
 wasm32-wasi \
@@ -217,6 +216,7 @@ for TARGET in $TARGETS; do
     fi
 done
 
+# Targets which are not available via rustup and must be built with -Zbuild-std
 RUST_LINUX_NO_CORE_TARGETS="\
 aarch64-pc-windows-msvc \
 aarch64-unknown-freebsd \
@@ -226,6 +226,7 @@ aarch64-unknown-openbsd \
 aarch64-wrs-vxworks \
 armebv7r-none-eabi \
 armebv7r-none-eabihf \
+armv7-unknown-linux-uclibceabihf \
 armv7-wrs-vxworks-eabihf \
 armv7r-none-eabi \
 armv7r-none-eabihf \

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1333,6 +1333,8 @@ extern "C" {
     pub fn pthread_setname_np(thread: ::pthread_t, name: *const ::c_char) -> ::c_int;
 
     pub fn sethostid(hostid: ::c_long) -> ::c_int;
+
+    pub fn memfd_create(name: *const ::c_char, flags: ::c_uint) -> ::c_int;
 }
 
 extern "C" {

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -3923,8 +3923,6 @@ extern "C" {
         needlelen: ::size_t,
     ) -> *mut ::c_void;
     pub fn sched_getcpu() -> ::c_int;
-
-    pub fn memfd_create(name: *const ::c_char, flags: ::c_uint) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -770,6 +770,8 @@ extern "C" {
     pub fn clock_adjtime(clk_id: ::clockid_t, buf: *mut ::timex) -> ::c_int;
 
     pub fn ctermid(s: *mut ::c_char) -> *mut ::c_char;
+
+    pub fn memfd_create(name: *const ::c_char, flags: ::c_uint) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
I think the title says it all!  The `armv7-unknown-linux-uclibceabihf` tier-3 target does not build without this change, and I suspect all other uclibc builds are broken as well.

It's a good reminder to try to add some CI validation of the uclibc build, which I will try to do in a followup PR.

To test this, get and unpack https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs/armv7-eabihf--uclibc--bleeding-edge-2020.08-1.tar.bz2

Note instances of `PATH_HERE` below which you'll have to customize for your system.

config.toml:
```
[target.armv7-unknown-linux-uclibceabihf]
linker = "/PATH_HERE/buildroot-armv7/output/host/usr/bin/arm-buildroot-linux-uclibcgnueabihf-gcc"
runner = "qemu-arm -L /PATH_HERE/armv7-eabihf--uclibc--bleeding-edge-2020.08-1/arm-buildroot-linux-uclibcgnueabihf/sysroot/"
```

Then run:
```
cd libc-test
CC_armv7_unknown_linux_uclibceabihf=/PATH_HERE/armv7-eabihf--uclibc--bleeding-edge-2020.08-1/bin/arm-buildroot-linux-uclibcgnueabihf-gcc cargo +nightly test -Zbuild-std --target armv7-unknown-linux-uclibceabihf
```

(if there's a way to include that `CC_armv7_etc` cross CC in the config.toml, I'm all ears!)
