### PR TITLE
Update to the latest released wasi-libc and declare `getcwd`/`chdir`

### DIFF
--- a/ci/docker/wasm32-wasi/Dockerfile
+++ b/ci/docker/wasm32-wasi/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
 # those breaking changes on `libc`'s own CI
 RUN git clone https://github.com/WebAssembly/wasi-libc && \
   cd wasi-libc && \
-  git reset --hard f2e779e5f1ba4a539937cedeeaa762c1e0c162df
+  git reset --hard ad5133410f66b93a2381db5b542aad5e0964db96
 RUN apt-get install -y --no-install-recommends llvm
 RUN make -C wasi-libc install -j $(nproc) INSTALL_DIR=/wasi-libc
 

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -646,6 +646,8 @@ extern "C" {
     pub fn newlocale(mask: ::c_int, locale: *const ::c_char, base: ::locale_t) -> ::locale_t;
     pub fn uselocale(loc: ::locale_t) -> ::locale_t;
     pub fn sched_yield() -> ::c_int;
+    pub fn getcwd(buf: *mut c_char, size: ::size_t) -> *mut c_char;
+    pub fn chdir(dir: *const c_char) -> ::c_int;
 
     pub fn __wasilibc_register_preopened_fd(fd: c_int, path: *const c_char) -> c_int;
     pub fn __wasilibc_fd_renumber(fd: c_int, newfd: c_int) -> c_int;


### PR DESCRIPTION
Update to the latest version of wasi-libc which corresponds to the
version in the wasi-sdk 14.0 release.

And, add declarations for `getcwd` and `chdir`, which are now provided
by wasi-libc.