### PR TITLE
Fix invalid freebsd version selection

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,13 +25,11 @@ fn main() {
     // On CI, we detect the actual FreeBSD version and match its ABI exactly,
     // running tests to ensure that the ABI is correct.
     match which_freebsd() {
-        Some(10) if libc_ci || rustc_dep_of_std => {
-            println!("cargo:rustc-cfg=freebsd10")
-        }
-        Some(11) if libc_ci => println!("cargo:rustc-cfg=freebsd11"),
-        Some(12) if libc_ci => println!("cargo:rustc-cfg=freebsd12"),
-        Some(13) if libc_ci => println!("cargo:rustc-cfg=freebsd13"),
-        Some(14) if libc_ci => println!("cargo:rustc-cfg=freebsd14"),
+        Some(10) => println!("cargo:rustc-cfg=freebsd10"),
+        Some(11) => println!("cargo:rustc-cfg=freebsd11"),
+        Some(12) => println!("cargo:rustc-cfg=freebsd12"),
+        Some(13) => println!("cargo:rustc-cfg=freebsd13"),
+        Some(14) => println!("cargo:rustc-cfg=freebsd14"),
         Some(_) | None => println!("cargo:rustc-cfg=freebsd11"),
     }
 


### PR DESCRIPTION
Just realized when working on sysinfo that my `stafs` struct filled by `getmntinfo` was missing **a lot** of information. After trying to find out from my size what I missed, I simply check the `size_of` the rust struct vs the C struct and found `484 != 2384`. After looking a bit more, I discovered that only the CI was using the right freebsd version, which is quite problematic.

r? @Amanieu 