### PR TITLE
Revert "Fix invalid freebsd version selection"

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,11 +25,13 @@ fn main() {
     // On CI, we detect the actual FreeBSD version and match its ABI exactly,
     // running tests to ensure that the ABI is correct.
     match which_freebsd() {
-        Some(10) => println!("cargo:rustc-cfg=freebsd10"),
-        Some(11) => println!("cargo:rustc-cfg=freebsd11"),
-        Some(12) => println!("cargo:rustc-cfg=freebsd12"),
-        Some(13) => println!("cargo:rustc-cfg=freebsd13"),
-        Some(14) => println!("cargo:rustc-cfg=freebsd14"),
+        Some(10) if libc_ci || rustc_dep_of_std => {
+            println!("cargo:rustc-cfg=freebsd10")
+        }
+        Some(11) if libc_ci => println!("cargo:rustc-cfg=freebsd11"),
+        Some(12) if libc_ci => println!("cargo:rustc-cfg=freebsd12"),
+        Some(13) if libc_ci => println!("cargo:rustc-cfg=freebsd13"),
+        Some(14) if libc_ci => println!("cargo:rustc-cfg=freebsd14"),
         Some(_) | None => println!("cargo:rustc-cfg=freebsd11"),
     }
 


### PR DESCRIPTION
This reverts commit 53e79b886bf4e4d3682ae6669e3585b3586e5255.

PR #2581 unintentionally changed libc's bindings from the FreeBSD 11 ABI
to the native ABI of the build host.  This is causing breakage for many
downstream crates.