### PR TITLE
Make some freebsd private struct fields public and upgrade crate version to 0.2.112

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.111"
+version = "0.2.112"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-test"
-version = "0.2.111"
+version = "0.2.112"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.111"
+version = "0.2.112"
 default-features = false
 
 [build-dependencies]

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2302,6 +2302,9 @@ fn test_freebsd(target: &str) {
             ("kinfo_proc", "ki_tdaddr") => true,
             ("kinfo_proc", "ki_pd") => true,
 
+            // Anonymous type.
+            ("filestat", "next") => true,
+
             // We ignore this field because we needed to use a hack in order to make rust 1.19
             // happy...
             ("kinfo_proc", "ki_sparestrings") => true,

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -459,33 +459,37 @@ s! {
         pub kve_path: [[::c_char; 32]; 32],
     }
 
+    pub struct __c_anonymous_filestat {
+        pub stqe_next: *mut filestat,
+    }
+
     pub struct filestat {
-        fs_type: ::c_int,
-        fs_flags: ::c_int,
-        fs_fflags: ::c_int,
-        fs_uflags: ::c_int,
-        fs_fd: ::c_int,
-        fs_ref_count: ::c_int,
-        fs_offset: ::off_t,
-        fs_typedep: *mut ::c_void,
-        fs_path: *mut ::c_char,
-        next: *mut filestat,
-        fs_cap_rights: cap_rights_t,
+        pub fs_type: ::c_int,
+        pub fs_flags: ::c_int,
+        pub fs_fflags: ::c_int,
+        pub fs_uflags: ::c_int,
+        pub fs_fd: ::c_int,
+        pub fs_ref_count: ::c_int,
+        pub fs_offset: ::off_t,
+        pub fs_typedep: *mut ::c_void,
+        pub fs_path: *mut ::c_char,
+        pub next: __c_anonymous_filestat,
+        pub fs_cap_rights: cap_rights_t,
     }
 
     pub struct filestat_list {
-        stqh_first: *mut filestat,
-        stqh_last: *mut *mut filestat,
+        pub stqh_first: *mut filestat,
+        pub stqh_last: *mut *mut filestat,
     }
 
     pub struct procstat {
-        tpe: ::c_int,
-        kd: ::uintptr_t,
-        vmentries: *mut ::c_void,
-        files: *mut ::c_void,
-        argv: *mut ::c_void,
-        envv: *mut ::c_void,
-        core: ::uintptr_t,
+        pub tpe: ::c_int,
+        pub kd: ::uintptr_t,
+        pub vmentries: *mut ::c_void,
+        pub files: *mut ::c_void,
+        pub argv: *mut ::c_void,
+        pub envv: *mut ::c_void,
+        pub core: ::uintptr_t,
     }
 
     pub struct itimerspec {


### PR DESCRIPTION
Otherwise we can't use the structs at all...