### PR TITLE
add more archs definition for openbsd

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsd/arm.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/arm.rs
@@ -1,0 +1,16 @@
+pub type c_long = i64;
+pub type c_ulong = u64;
+pub type c_char = u8;
+
+// should be pub(crate), but that requires Rust 1.18.0
+cfg_if! {
+    if #[cfg(libc_const_size_of)] {
+        #[doc(hidden)]
+        pub const _ALIGNBYTES: usize = ::mem::size_of::<::c_double>() - 1;
+    } else {
+        #[doc(hidden)]
+        pub const _ALIGNBYTES: usize = 8 - 1;
+    }
+}
+
+pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/arm.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/arm.rs
@@ -1,5 +1,5 @@
-pub type c_long = i64;
-pub type c_ulong = u64;
+pub type c_long = i32;
+pub type c_ulong = u32;
 pub type c_char = u8;
 
 // should be pub(crate), but that requires Rust 1.18.0

--- a/src/unix/bsd/netbsdlike/openbsd/mips64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mips64.rs
@@ -1,0 +1,8 @@
+pub type c_long = i64;
+pub type c_ulong = u64;
+pub type c_char = i8;
+
+#[doc(hidden)]
+pub const _ALIGNBYTES: usize = 7;
+
+pub const _MAX_PAGE_SHIFT: u32 = 14;

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1648,18 +1648,33 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(target_arch = "x86")] {
+    if #[cfg(target_arch = "aarch64")] {
+        mod aarch64;
+        pub use self::aarch64::*;
+    } else if #[cfg(target_arch = "arm")] {
+        mod arm;
+        pub use self::arm::*;
+    } else if #[cfg(target_arch = "mips64")] {
+        mod mips64;
+        pub use self::mips64::*;
+    } else if #[cfg(target_arch = "powerpc")] {
+        mod powerpc;
+        pub use self::powerpc::*;
+    } else if #[cfg(target_arch = "powerpc64")] {
+        mod powerpc64;
+        pub use self::powerpc64::*;
+    } else if #[cfg(target_arch = "riscv64")] {
+        mod riscv64;
+        pub use self::riscv64::*;
+    } else if #[cfg(target_arch = "sparc64")] {
+        mod sparc64;
+        pub use self::sparc64::*;
+    } else if #[cfg(target_arch = "x86")] {
         mod x86;
         pub use self::x86::*;
     } else if #[cfg(target_arch = "x86_64")] {
         mod x86_64;
         pub use self::x86_64::*;
-    } else if #[cfg(target_arch = "aarch64")] {
-        mod aarch64;
-        pub use self::aarch64::*;
-    } else if #[cfg(target_arch = "sparc64")] {
-        mod sparc64;
-        pub use self::sparc64::*;
     } else {
         // Unknown target_arch
     }

--- a/src/unix/bsd/netbsdlike/openbsd/powerpc.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/powerpc.rs
@@ -1,0 +1,16 @@
+pub type c_long = i32;
+pub type c_ulong = u32;
+pub type c_char = u8;
+
+// should be pub(crate), but that requires Rust 1.18.0
+cfg_if! {
+    if #[cfg(libc_const_size_of)] {
+        #[doc(hidden)]
+        pub const _ALIGNBYTES: usize = ::mem::size_of::<::c_double>() - 1;
+    } else {
+        #[doc(hidden)]
+        pub const _ALIGNBYTES: usize = 8 - 1;
+    }
+}
+
+pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/powerpc64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/powerpc64.rs
@@ -1,0 +1,16 @@
+pub type c_long = i64;
+pub type c_ulong = u64;
+pub type c_char = u8;
+
+// should be pub(crate), but that requires Rust 1.18.0
+cfg_if! {
+    if #[cfg(libc_const_size_of)] {
+        #[doc(hidden)]
+        pub const _ALIGNBYTES: usize = ::mem::size_of::<::c_long>() - 1;
+    } else {
+        #[doc(hidden)]
+        pub const _ALIGNBYTES: usize = 8 - 1;
+    }
+}
+
+pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/riscv64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/riscv64.rs
@@ -1,0 +1,16 @@
+pub type c_long = i64;
+pub type c_ulong = u64;
+pub type c_char = u8;
+
+// should be pub(crate), but that requires Rust 1.18.0
+cfg_if! {
+    if #[cfg(libc_const_size_of)] {
+        #[doc(hidden)]
+        pub const _ALIGNBYTES: usize = ::mem::size_of::<::c_long>() - 1;
+    } else {
+        #[doc(hidden)]
+        pub const _ALIGNBYTES: usize = 8 - 1;
+    }
+}
+
+pub const _MAX_PAGE_SHIFT: u32 = 12;


### PR DESCRIPTION
it adds libc definitions for more archs for openbsd: arm, mips64, powerpc, powerpc64, and riscv64.

it is a first iteration on adding support for at least some of them in rustc. I manually created them from OpenBSD source code and from clang crosscompilation output to determine type size and constants values.