### PR TITLE
mips64: add missing ENOTSUP const

### DIFF
--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -505,6 +505,7 @@ pub const ENOPROTOOPT: ::c_int = 99;
 pub const EPROTONOSUPPORT: ::c_int = 120;
 pub const ESOCKTNOSUPPORT: ::c_int = 121;
 pub const EOPNOTSUPP: ::c_int = 122;
+pub const ENOTSUP: ::c_int = EOPNOTSUPP;
 pub const EPFNOSUPPORT: ::c_int = 123;
 pub const EAFNOSUPPORT: ::c_int = 124;
 pub const EADDRINUSE: ::c_int = 125;


### PR DESCRIPTION
ENOTSUP was added to Mips but not Mips64.

Signed-off-by: Donald Hoskins <grommish@gmail.com>

Reference Issue https://github.com/rust-lang/rust/issues/91976