### PR TITLE
EV_SYSFLAGS changed value on upcoming OpenBSD 7.1

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -486,6 +486,7 @@ fn test_openbsd(target: &str) {
             "KERN_USERMOUNT" | "KERN_ARND" => true,
             // Good chance it's going to be wrong depending on the host release
             "KERN_MAXID" | "NET_RT_MAXID" => true,
+            "EV_SYSFLAGS" => true,
             _ => false,
         }
     });

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1173,7 +1173,9 @@ pub const EV_DISPATCH: u16 = 0x80;
 pub const EV_FLAG1: u16 = 0x2000;
 pub const EV_ERROR: u16 = 0x4000;
 pub const EV_EOF: u16 = 0x8000;
-pub const EV_SYSFLAGS: u16 = 0xf000;
+
+#[deprecated(since = "0.2.113", note = "Not stable across OS versions")]
+pub const EV_SYSFLAGS: u16 = 0xf800;
 
 pub const NOTE_LOWAT: u32 = 0x00000001;
 pub const NOTE_EOF: u32 = 0x00000002;


### PR DESCRIPTION
Mark `EV_SYSFLAGS` deprecated and ignore it on tests.

The value changed on upcoming OpenBSD 7.1.

Note I don't find [any real usage](https://codesearch.debian.net/search?q=EV_SYSFLAGS&literal=1) of the value in code (outside libc copying/redefinition in Rust, Go or Python code).