### PR TITLE
freebsd: Correctly detect FreeBSD version

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,13 +25,13 @@ fn main() {
     // On CI, we detect the actual FreeBSD version and match its ABI exactly,
     // running tests to ensure that the ABI is correct.
     match which_freebsd() {
-        Some(10) if libc_ci || rustc_dep_of_std => {
+        Some(10) if rustc_dep_of_std => {
             println!("cargo:rustc-cfg=freebsd10")
         }
-        Some(11) if libc_ci => println!("cargo:rustc-cfg=freebsd11"),
-        Some(12) if libc_ci => println!("cargo:rustc-cfg=freebsd12"),
-        Some(13) if libc_ci => println!("cargo:rustc-cfg=freebsd13"),
-        Some(14) if libc_ci => println!("cargo:rustc-cfg=freebsd14"),
+        Some(11) => println!("cargo:rustc-cfg=freebsd11"),
+        Some(12) => println!("cargo:rustc-cfg=freebsd12"),
+        Some(13) => println!("cargo:rustc-cfg=freebsd13"),
+        Some(14) => println!("cargo:rustc-cfg=freebsd14"),
         Some(_) | None => println!("cargo:rustc-cfg=freebsd11"),
     }
 


### PR DESCRIPTION
This change removes the CI check that applies to freebsd version cfg. This is causing problems where the freebsd version defaults to 11 when CI is not enabled, some types may be incorrect on a > 11 system,
and compilation failures ensue.
A concrete example is libc::dev_t. This was defaulting to u32 on my FreeBSD 13-STABLE desktop, when it should have been u64. I couldn't compile anything that uses libc::devname_r as a result.