### PR TITLE
kmc-solid: `wchar_t` is `u32`

### DIFF
--- a/src/solid/aarch64.rs
+++ b/src/solid/aarch64.rs
@@ -1,4 +1,4 @@
 pub type c_char = i8;
-pub type wchar_t = i16;
+pub type wchar_t = u32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/solid/arm.rs
+++ b/src/solid/arm.rs
@@ -1,4 +1,4 @@
 pub type c_char = i8;
-pub type wchar_t = i16;
+pub type wchar_t = u32;
 pub type c_long = i32;
 pub type c_ulong = u32;


### PR DESCRIPTION
This PR fixes the definition of `wchar_t` for the [`*-kmc-solid_*`](https://doc.rust-lang.org/nightly/rustc/platform-support/kmc-solid.html) targets.
