### PR TITLE
Fix _CMSG_ALIGN on DragonFly

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1348,7 +1348,7 @@ pub const MINCORE_SUPER: ::c_int = 0x20;
 
 const_fn! {
     {const} fn _CMSG_ALIGN(n: usize) -> usize {
-        (n + 3) & !3
+        (n + ::mem::size_of::<::c_long>()) & !::mem::size_of::<::c_long>()
     }
 }
 


### PR DESCRIPTION
Based on the following DragonFly source:
- https://github.com/DragonFlyBSD/DragonFlyBSD/blob/f6a040333742c20fd088944a507721fda481fe08/sys/sys/socket.h#L480
- https://github.com/DragonFlyBSD/DragonFlyBSD/blob/f6a040333742c20fd088944a507721fda481fe08/sys/cpu/x86_64/include/alignbytes.h#L35

This fixes nix's failing scm tests on DragonFly.