### PR TITLE
uclibc: Don't specialize PTRACE_O_MASK for uclibc

### DIFF
--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -166,7 +166,6 @@ pub const PTRACE_SETREGSET: ::c_int = 0x4205;
 pub const PTRACE_SEIZE: ::c_int = 0x4206;
 pub const PTRACE_INTERRUPT: ::c_int = 0x4207;
 pub const PTRACE_LISTEN: ::c_int = 0x4208;
-pub const PTRACE_O_MASK: ::c_int = 0x000000ff;
 
 pub const POSIX_FADV_DONTNEED: ::c_int = 4;
 pub const POSIX_FADV_NOREUSE: ::c_int = 5;

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1163,6 +1163,7 @@ pub const PTRACE_O_TRACEEXIT: ::c_int = 0x00000040;
 pub const PTRACE_O_TRACESECCOMP: ::c_int = 0x00000080;
 pub const PTRACE_O_SUSPEND_SECCOMP: ::c_int = 0x00200000;
 pub const PTRACE_O_EXITKILL: ::c_int = 0x00100000;
+pub const PTRACE_O_MASK: ::c_int = 0x003000ff;
 
 // Wait extended result codes for the above trace options.
 pub const PTRACE_EVENT_FORK: ::c_int = 1;
@@ -1363,12 +1364,6 @@ pub const ARPHRD_IEEE802154: u16 = 804;
 
 pub const ARPHRD_VOID: u16 = 0xFFFF;
 pub const ARPHRD_NONE: u16 = 0xFFFE;
-
-cfg_if! {
-    if #[cfg(not(target_env = "uclibc"))] {
-        pub const PTRACE_O_MASK: ::c_int = 0x003000ff;
-    }
-}
 
 const_fn! {
     {const} fn CMSG_ALIGN(len: usize) -> usize {


### PR DESCRIPTION
This constant comes from the kernel headers, so its value should not depend on the libc type.

To test: see instructions in https://github.com/rust-lang/libc/pull/2566