### PR TITLE
Release v0.2.113

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.112"
+version = "0.2.113"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-test"
-version = "0.2.112"
+version = "0.2.113"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.112"
+version = "0.2.113"
 default-features = false
 
 [build-dependencies]


### PR DESCRIPTION
To include https://github.com/rust-lang/libc/pull/2625.

Unblocks https://github.com/rust-lang/socket2/pull/284