### PR TITLE
add CI for armv7-unknown-linux-uclibceabihf

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -151,6 +151,29 @@ jobs:
       - name: Execute run-docker.sh
         run: LIBC_CI=1 sh ./ci/run-docker.sh ${{ matrix.target }}
 
+  # These targets are tier 3 or otherwise need to have CI build std via -Zbuild-std.
+  # Because of this, only the nightly compiler can be used on these targets.
+  docker_linux_build_std:
+    name: Docker Linux Build-Std Targets
+    needs: [docker_linux_tier1, style_check]
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: true
+      max-parallel: 12
+      matrix:
+        target: [
+          armv7-unknown-linux-uclibceabihf
+        ]
+    steps:
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/checkout@v2
+      - name: Setup Rust toolchain
+        run: TOOLCHAIN=nightly INSTALL_RUST_SRC=1 sh ./ci/install-rust.sh
+      - name: Execute run-docker.sh
+        run: LIBC_CI=1 TOOLCHAIN=nightly LIBC_CI_ZBUILD_STD=1 sh ./ci/run-docker.sh ${{ matrix.target }}
+
   # devkitpro's pacman needs to be connected from Docker.
   docker_switch:
     name: Docker Switch
@@ -301,6 +324,7 @@ jobs:
     needs: [
       docker_linux_tier1,
       docker_linux_tier2,
+      docker_linux_build_std,
       macos,
       windows,
       style_check,
@@ -322,6 +346,7 @@ jobs:
     needs: [
       docker_linux_tier1,
       docker_linux_tier2,
+      docker_linux_build_std,
       macos,
       windows,
       style_check,

--- a/ci/docker/armv7-unknown-linux-uclibceabihf/Dockerfile
+++ b/ci/docker/armv7-unknown-linux-uclibceabihf/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates qemu-system-arm curl \
-        xz-utils patch
+        xz-utils patch file
 
 RUN mkdir /toolchain
 
@@ -12,6 +12,6 @@ RUN /toolchain/relocate-sdk.sh
 
 ENV PATH=$PATH:/rust/bin:/toolchain/bin \
     STAGING_DIR=/toolchain/armv7-buildroot-linux-uclibceabihf/sysroot \
-    CC_armv7_unknown_linux_uclibc=armv7-buildroot-linux-uclibc-gcc \
-    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_UCLIBCEABIHF_LINKER=armv7-buildroot-linux-uclibc-gcc \
+    CC_armv7_unknown_linux_uclibceabihf=arm-buildroot-linux-uclibcgnueabihf-gcc \
+    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_UCLIBCEABIHF_LINKER=arm-buildroot-linux-uclibcgnueabihf-gcc \
     CARGO_TARGET_ARMV7_UNKNOWN_LINUX_UCLIBCEABIHF_RUNNER="qemu-arm -L /toolchain/arm-buildroot-linux-uclibcgnueabihf/sysroot/"

--- a/ci/install-rust.sh
+++ b/ci/install-rust.sh
@@ -26,6 +26,11 @@ if [ -n "$TARGET" ]; then
   rustup target add "$TARGET"
 fi
 
+if [ -n "$INSTALL_RUST_SRC" ]; then
+  echo "Install rust-src"
+  rustup component add rust-src
+fi
+
 if [ "$OS" = "windows" ]; then
   if [ "$ARCH_BITS" = "i686" ]; then
     echo "Install MinGW32"

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -37,6 +37,7 @@ run() {
       --rm \
       --user "$(id -u)":"$(id -g)" \
       --env LIBC_CI \
+      --env LIBC_CI_ZBUILD_STD \
       --env CARGO_HOME=/cargo \
       --env CARGO_TARGET_DIR=/checkout/target \
       --volume "$CARGO_HOME":/cargo \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -53,7 +53,7 @@ if [ "$QEMU" != "" ]; then
   cargo build \
     --manifest-path libc-test/Cargo.toml \
     --target "${TARGET}" \
-    --test main
+    --test main ${LIBC_CI_ZBUILD_STD+"-Zbuild-std"}
   rm "${CARGO_TARGET_DIR}/${TARGET}"/debug/main-*.d
   cp "${CARGO_TARGET_DIR}/${TARGET}"/debug/main-* "${tmpdir}"/mount/libc-test
   # shellcheck disable=SC2016
@@ -91,17 +91,17 @@ if [ "$TARGET" = "s390x-unknown-linux-gnu" ]; then
   until [ $n -ge $N ]
   do
     if [ "$passed" = "0" ]; then
-      if cargo test --no-default-features --manifest-path libc-test/Cargo.toml --target "${TARGET}" ; then
+      if cargo test --no-default-features --manifest-path libc-test/Cargo.toml --target "${TARGET}" ${LIBC_CI_ZBUILD_STD+"-Zbuild-std"} ; then
         passed=$((passed+1))
         continue
       fi
     elif [ "$passed" = "1" ]; then
-      if cargo test --manifest-path libc-test/Cargo.toml --target "${TARGET}" ; then
+      if cargo test --manifest-path libc-test/Cargo.toml --target "${TARGET}" ${LIBC_CI_ZBUILD_STD+"-Zbuild-std"} ; then
         passed=$((passed+1))
         continue
       fi
     elif [ "$passed" = "2" ]; then
-      if cargo test --features extra_traits --manifest-path libc-test/Cargo.toml --target "${TARGET}"; then
+      if cargo test --features extra_traits --manifest-path libc-test/Cargo.toml --target "${TARGET}" ${LIBC_CI_ZBUILD_STD+"-Zbuild-std"}; then
         break
       fi
     fi
@@ -110,10 +110,10 @@ if [ "$TARGET" = "s390x-unknown-linux-gnu" ]; then
   done
 else
   cargo test --no-default-features --manifest-path libc-test/Cargo.toml \
-    --target "${TARGET}"
+    --target "${TARGET}" ${LIBC_CI_ZBUILD_STD+"-Zbuild-std"}
 
-  cargo test --manifest-path libc-test/Cargo.toml --target "${TARGET}"
+  cargo test --manifest-path libc-test/Cargo.toml --target "${TARGET}" ${LIBC_CI_ZBUILD_STD+"-Zbuild-std"}
 
   RUST_BACKTRACE=1 cargo test --features extra_traits --manifest-path libc-test/Cargo.toml \
-    --target "${TARGET}"
+    --target "${TARGET}" ${LIBC_CI_ZBUILD_STD+"-Zbuild-std"}
 fi


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/libc/pull/2636, this is a framework for CI on targets with no prebuilt std.  They will build via `nightly` and `-Zbuild-std`, and run the unit tests via qemu-user (or whatever else the dockerfile specifies).

It seems like I could write some more documentation about how to add more targets of this type, but perhaps I can get a round of feedback on the mechanism here before I go and write that.