### PR TITLE
Add ip_mreqn to Linux s390x

### DIFF
--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -139,6 +139,12 @@ s! {
         __unused5: ::c_ulong
     }
 
+    pub struct ip_mreqn {
+        pub imr_multiaddr: ::in_addr,
+        pub imr_address: ::in_addr,
+        pub imr_ifindex: ::c_int,
+    }
+
     pub struct statvfs {
         pub f_bsize: ::c_ulong,
         pub f_frsize: ::c_ulong,


### PR DESCRIPTION
I'm not 100% sure this layout is correct, however since it's the same on
all other existing (at the time out writing) architectures I hope it's
the same on s390x.