### PR TITLE
Fix _CMSG_ALIGN on DragonFly

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1348,7 +1348,7 @@ pub const MINCORE_SUPER: ::c_int = 0x20;
 
 const_fn! {
     {const} fn _CMSG_ALIGN(n: usize) -> usize {
-        (n + ::mem::size_of::<::c_long>()) & !::mem::size_of::<::c_long>()
+        (n + (::mem::size_of::<::c_long>() - 1)) & !(::mem::size_of::<::c_long>() - 1)
     }
 }
 


### PR DESCRIPTION
The attempted fix in #2610 originally had `7` hard coded, but it was suggested I replace this with a size_of call. Unfortunately the suggestion omitted a subtraction from the size_of call, and I didn't catch it.

Tested by running the failing `nix` tests on DragonFly (and didn't change the code again after running the tests).