### PR TITLE
Define ip_mreqn on OpenBSD

### DIFF
--- a/libc-test/semver/openbsd.txt
+++ b/libc-test/semver/openbsd.txt
@@ -999,6 +999,7 @@ if_nameindex
 ifaddrs
 in6_pktinfo
 initgroups
+ip_mreqn
 ipc_perm
 iso_args
 kevent

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -48,6 +48,12 @@ cfg_if! {
 }
 
 s! {
+    pub struct ip_mreqn {
+        pub imr_multiaddr: in_addr,
+        pub imr_address: in_addr,
+        pub imr_ifindex: ::c_int,
+    }
+
     pub struct glob_t {
         pub gl_pathc:   ::size_t,
         pub gl_matchc:  ::size_t,


### PR DESCRIPTION
Essentially an extension of https://github.com/rust-lang/libc/pull/2625

Reference: https://man.openbsd.org/ip.4