### PR TITLE
Define the `MFD_HUGE_*` macros for Linux and Android.

### DIFF
--- a/ci/docker/mips-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mips-unknown-linux-musl/Dockerfile
@@ -6,11 +6,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN mkdir /toolchain
 
-# Linux kernel version: 4.14.151
-# See build_dir/target-mips_24kc_musl/linux-ar71xx_generic/linux-4.14.151
+# Linux kernel version: 5.4.154
+# See build_dir/target-mips_24kc_musl/linux-ath79_generic/linux-5.4.154
 # Musl version: 1.1.24
-# See staging_dir/toolchain-mips_24kc_gcc-7.4.0_musl/info.mk
-RUN curl --retry 5 -L https://downloads.openwrt.org/releases/19.07.0-rc1/targets/ar71xx/generic/openwrt-sdk-19.07.0-rc1-ar71xx-generic_gcc-7.4.0_musl.Linux-x86_64.tar.xz | \
+# See staging_dir/toolchain-mips_24kc_gcc-8.4.0_musl/info.mk
+RUN curl --retry 5 -L https://downloads.openwrt.org/releases/21.02.1/targets/ath79/generic/openwrt-sdk-21.02.1-ath79-generic_gcc-8.4.0_musl.Linux-x86_64.tar.xz | \
     tar xJf - -C /toolchain --strip-components=1
 
 # See https://lkml.org/lkml/2014/3/14/269

--- a/ci/docker/mips-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mips-unknown-linux-musl/Dockerfile
@@ -15,10 +15,10 @@ RUN curl --retry 5 -L https://downloads.openwrt.org/releases/21.02.1/targets/ath
 
 # See https://lkml.org/lkml/2014/3/14/269
 COPY sysinfo_guard.patch /toolchain
-RUN patch /toolchain/staging_dir/toolchain-mips_24kc_gcc-7.4.0_musl/include/linux/kernel.h </toolchain/sysinfo_guard.patch
+RUN patch /toolchain/staging_dir/toolchain-mips_24kc_gcc-8.4.0_musl/include/linux/kernel.h </toolchain/sysinfo_guard.patch
 
-ENV PATH=$PATH:/rust/bin:/toolchain/staging_dir/toolchain-mips_24kc_gcc-7.4.0_musl/bin \
+ENV PATH=$PATH:/rust/bin:/toolchain/staging_dir/toolchain-mips_24kc_gcc-8.4.0_musl/bin \
     STAGING_DIR=/toolchain/staging_dir \
     CC_mips_unknown_linux_musl=mips-openwrt-linux-musl-gcc \
     CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_LINKER=mips-openwrt-linux-musl-gcc \
-    CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_RUNNER="qemu-mips -L /toolchain/staging_dir/toolchain-mips_24kc_gcc-7.4.0_musl"
+    CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_RUNNER="qemu-mips -L /toolchain/staging_dir/toolchain-mips_24kc_gcc-8.4.0_musl"

--- a/ci/docker/mipsel-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mipsel-unknown-linux-musl/Dockerfile
@@ -6,19 +6,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN mkdir /toolchain
 
-# Linux kernel version: 4.14.151
-# See build_dir/target-mipsel_mips32_musl/linux-brcm47xx_generic/linux-4.14.151
+# Linux kernel version: 5.4.154
+# See build_dir/target-mipsel_mips32_musl/linux-brcm47xx_generic/linux-5.4.154
 # Musl version: 1.1.24
-# See staging_dir/toolchain-mipsel_mips32_gcc-7.4.0_musl/info.mk
-RUN curl --retry 5 -L https://downloads.openwrt.org/releases/19.07.0-rc1/targets/brcm47xx/generic/openwrt-sdk-19.07.0-rc1-brcm47xx-generic_gcc-7.4.0_musl.Linux-x86_64.tar.xz | \
+# See staging_dir/toolchain-mipsel_mips32_gcc-8.4.0_musl/info.mk
+RUN curl --retry 5 -L https://downloads.openwrt.org/releases/21.02.1/targets/bcm47xx/generic/openwrt-sdk-21.02.1-bcm47xx-generic_gcc-8.4.0_musl.Linux-x86_64.tar.xz | \
     tar xJf - -C /toolchain --strip-components=1
 
 # See https://lkml.org/lkml/2014/3/14/269
 COPY sysinfo_guard.patch /toolchain
-RUN patch /toolchain/staging_dir/toolchain-mipsel_mips32_gcc-7.4.0_musl/include/linux/kernel.h </toolchain/sysinfo_guard.patch
+RUN patch /toolchain/staging_dir/toolchain-mipsel_mips32_gcc-8.4.0_musl/include/linux/kernel.h </toolchain/sysinfo_guard.patch
 
-ENV PATH=$PATH:/rust/bin:/toolchain/staging_dir/toolchain-mipsel_mips32_gcc-7.4.0_musl/bin \
+ENV PATH=$PATH:/rust/bin:/toolchain/staging_dir/toolchain-mipsel_mips32_gcc-8.4.0_musl/bin \
     STAGING_DIR=/toolchain/staging_dir \
     CC_mipsel_unknown_linux_musl=mipsel-openwrt-linux-musl-gcc \
     CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_LINKER=mipsel-openwrt-linux-musl-gcc \
-    CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_RUNNER="qemu-mipsel -L /toolchain/staging_dir/toolchain-mipsel_mips32_gcc-7.4.0_musl"
+    CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_RUNNER="qemu-mipsel -L /toolchain/staging_dir/toolchain-mipsel_mips32_gcc-8.4.0_musl"

--- a/ci/sysinfo_guard.patch
+++ b/ci/sysinfo_guard.patch
@@ -5,6 +5,6 @@
 +#ifdef __GLIBC__
  #include <linux/sysinfo.h>
 +#endif
+ #include <linux/const.h>
  
- /*
-  * 'kernel.h' contains some often-used function prototypes etc
+ #endif /* _LINUX_KERNEL_H */

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -1893,6 +1893,20 @@ pub const O_TMPFILE: ::c_int = 0o20000000 | O_DIRECTORY;
 pub const MFD_CLOEXEC: ::c_uint = 0x0001;
 pub const MFD_ALLOW_SEALING: ::c_uint = 0x0002;
 pub const MFD_HUGETLB: ::c_uint = 0x0004;
+pub const MFD_HUGE_64KB: ::c_uint = 0x40000000;
+pub const MFD_HUGE_512KB: ::c_uint = 0x4c000000;
+pub const MFD_HUGE_1MB: ::c_uint = 0x50000000;
+pub const MFD_HUGE_2MB: ::c_uint = 0x54000000;
+pub const MFD_HUGE_8MB: ::c_uint = 0x5c000000;
+pub const MFD_HUGE_16MB: ::c_uint = 0x60000000;
+pub const MFD_HUGE_32MB: ::c_uint = 0x64000000;
+pub const MFD_HUGE_256MB: ::c_uint = 0x70000000;
+pub const MFD_HUGE_512MB: ::c_uint = 0x74000000;
+pub const MFD_HUGE_1GB: ::c_uint = 0x78000000;
+pub const MFD_HUGE_2GB: ::c_uint = 0x7c000000;
+pub const MFD_HUGE_16GB: ::c_uint = 0x88000000;
+pub const MFD_HUGE_MASK: ::c_uint = 63;
+pub const MFD_HUGE_SHIFT: ::c_uint = 26;
 
 // these are used in the p_type field of Elf32_Phdr and Elf64_Phdr, which has
 // the type Elf32Word and Elf64Word respectively. Luckily, both of those are u32

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1820,6 +1820,20 @@ pub const CMSPAR: ::tcflag_t = 0o10000000000;
 pub const MFD_CLOEXEC: ::c_uint = 0x0001;
 pub const MFD_ALLOW_SEALING: ::c_uint = 0x0002;
 pub const MFD_HUGETLB: ::c_uint = 0x0004;
+pub const MFD_HUGE_64KB: ::c_uint = 0x40000000;
+pub const MFD_HUGE_512KB: ::c_uint = 0x4c000000;
+pub const MFD_HUGE_1MB: ::c_uint = 0x50000000;
+pub const MFD_HUGE_2MB: ::c_uint = 0x54000000;
+pub const MFD_HUGE_8MB: ::c_uint = 0x5c000000;
+pub const MFD_HUGE_16MB: ::c_uint = 0x60000000;
+pub const MFD_HUGE_32MB: ::c_uint = 0x64000000;
+pub const MFD_HUGE_256MB: ::c_uint = 0x70000000;
+pub const MFD_HUGE_512MB: ::c_uint = 0x74000000;
+pub const MFD_HUGE_1GB: ::c_uint = 0x78000000;
+pub const MFD_HUGE_2GB: ::c_uint = 0x7c000000;
+pub const MFD_HUGE_16GB: ::c_uint = 0x88000000;
+pub const MFD_HUGE_MASK: ::c_uint = 63;
+pub const MFD_HUGE_SHIFT: ::c_uint = 26;
 
 // linux/close_range.h
 pub const CLOSE_RANGE_UNSHARE: ::c_uint = 1 << 1;


### PR DESCRIPTION
This defines the `MFD_HUGE_*` flags which can accompany the `MEMFD_HUGETLB`
flag in Linux's [`memfd_create`] call.

[`memfd_create`]: https://man7.org/linux/man-pages/man2/memfd_create.2.html