### PR TITLE
Fix linux ioctl BLKSSZGET and BLKPBSZGET constants types.

### DIFF
--- a/src/unix/linux_like/linux/arch/generic/mod.rs
+++ b/src/unix/linux_like/linux/arch/generic/mod.rs
@@ -230,5 +230,5 @@ pub const TIOCM_DSR: ::c_int = 0x100;
 pub const BOTHER: ::speed_t = 0o010000;
 pub const IBSHIFT: ::tcflag_t = 16;
 
-pub const BLKSSZGET: ::c_int = 0x1268;
-pub const BLKPBSZGET: ::c_int = 0x127B;
+pub const BLKSSZGET: ::Ioctl = 0x1268;
+pub const BLKPBSZGET: ::Ioctl = 0x127B;

--- a/src/unix/linux_like/linux/arch/mips/mod.rs
+++ b/src/unix/linux_like/linux/arch/mips/mod.rs
@@ -208,5 +208,5 @@ pub const TIOCM_DSR: ::c_int = 0x400;
 pub const BOTHER: ::speed_t = 0o010000;
 pub const IBSHIFT: ::tcflag_t = 16;
 
-pub const BLKSSZGET: ::c_int = 0x20001268;
-pub const BLKPBSZGET: ::c_int = 0x2000127B;
+pub const BLKSSZGET: ::Ioctl = 0x20001268;
+pub const BLKPBSZGET: ::Ioctl = 0x2000127B;

--- a/src/unix/linux_like/linux/arch/powerpc/mod.rs
+++ b/src/unix/linux_like/linux/arch/powerpc/mod.rs
@@ -187,5 +187,5 @@ pub const TIOCM_DSR: ::c_int = 0x100;
 pub const BOTHER: ::speed_t = 0o0037;
 pub const IBSHIFT: ::tcflag_t = 16;
 
-pub const BLKSSZGET: ::c_int = 0x20001268;
-pub const BLKPBSZGET: ::c_int = 0x2000127B;
+pub const BLKSSZGET: ::Ioctl = 0x20001268;
+pub const BLKPBSZGET: ::Ioctl = 0x2000127B;

--- a/src/unix/linux_like/linux/arch/sparc/mod.rs
+++ b/src/unix/linux_like/linux/arch/sparc/mod.rs
@@ -194,5 +194,5 @@ pub const TIOCM_DSR: ::c_int = 0x100;
 pub const BOTHER: ::speed_t = 0x1000;
 pub const IBSHIFT: ::tcflag_t = 16;
 
-pub const BLKSSZGET: ::c_int = 0x20001268;
-pub const BLKPBSZGET: ::c_int = 0x2000127B;
+pub const BLKSSZGET: ::Ioctl = 0x20001268;
+pub const BLKPBSZGET: ::Ioctl = 0x2000127B;


### PR DESCRIPTION
The BLKSSZGET and BLKPBSZGET constants weren't arch dependent as they should have.