### PR TITLE
Define DT_UNKNOWN on Fuchsia.

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -1313,6 +1313,7 @@ pub const SIG_DFL: sighandler_t = 0 as sighandler_t;
 pub const SIG_IGN: sighandler_t = 1 as sighandler_t;
 pub const SIG_ERR: sighandler_t = !0 as sighandler_t;
 
+pub const DT_UNKNOWN: u8 = 0;
 pub const DT_FIFO: u8 = 1;
 pub const DT_CHR: u8 = 2;
 pub const DT_DIR: u8 = 4;


### PR DESCRIPTION
It looks like this constant is relied on in the new `remove_dir_all` logic and we need to reference it to be able to use the CVE fix correctly on Fuchsia.