### PR TITLE
Release 0.2.115 to crates.io.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.114"
+version = "0.2.115"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-test"
-version = "0.2.114"
+version = "0.2.115"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.114"
+version = "0.2.115"
 default-features = false
 
 [build-dependencies]


### PR DESCRIPTION
Needed by https://github.com/rust-lang/rust/pull/93351.

Should have included this in my prior PR but hadn't finished reading CONTRIBUTING.md. Sorry for the extra traffic!