### PR TITLE
Macos aarch64 clock uptime const

### DIFF
--- a/libc-test/semver/macos-aarch64.txt
+++ b/libc-test/semver/macos-aarch64.txt
@@ -1,3 +1,4 @@
 __darwin_arm_exception_state64
 __darwin_arm_neon_state64
 __darwin_arm_thread_state64
+CLOCK_UPTIME_RAW

--- a/src/unix/bsd/apple/b64/aarch64/mod.rs
+++ b/src/unix/bsd/apple/b64/aarch64/mod.rs
@@ -1,5 +1,8 @@
 pub type boolean_t = ::c_int;
 
+pub const CLOCK_UPTIME_RAW: ::clockid_t = 8;
+
+
 s! {
     pub struct malloc_zone_t {
         __private: [::uintptr_t; 18], // FIXME: needs arm64 auth pointers support

--- a/src/unix/bsd/apple/b64/aarch64/mod.rs
+++ b/src/unix/bsd/apple/b64/aarch64/mod.rs
@@ -2,7 +2,6 @@ pub type boolean_t = ::c_int;
 
 pub const CLOCK_UPTIME_RAW: ::clockid_t = 8;
 
-
 s! {
     pub struct malloc_zone_t {
         __private: [::uintptr_t; 18], // FIXME: needs arm64 auth pointers support


### PR DESCRIPTION
This will add the constant `CLOCK_UPTIME_RAW` from `time.h` on macos apple silicon. I don't know if the same constant also exists for other systems, so I put it into the most specific file. Background is this issue: https://github.com/rust-lang/rust/issues/91417 which might need the constant.

On my machine, it is defined as:

```C
typedef enum {
_CLOCK_REALTIME __CLOCK_AVAILABILITY = 0,
#define CLOCK_REALTIME _CLOCK_REALTIME
_CLOCK_MONOTONIC __CLOCK_AVAILABILITY = 6,
#define CLOCK_MONOTONIC _CLOCK_MONOTONIC
#if !defined(_POSIX_C_SOURCE) || defined(_DARWIN_C_SOURCE)
_CLOCK_MONOTONIC_RAW __CLOCK_AVAILABILITY = 4,
#define CLOCK_MONOTONIC_RAW _CLOCK_MONOTONIC_RAW
_CLOCK_MONOTONIC_RAW_APPROX __CLOCK_AVAILABILITY = 5,
#define CLOCK_MONOTONIC_RAW_APPROX _CLOCK_MONOTONIC_RAW_APPROX
_CLOCK_UPTIME_RAW __CLOCK_AVAILABILITY = 8,
#define CLOCK_UPTIME_RAW _CLOCK_UPTIME_RAW
_CLOCK_UPTIME_RAW_APPROX __CLOCK_AVAILABILITY = 9,
#define CLOCK_UPTIME_RAW_APPROX _CLOCK_UPTIME_RAW_APPROX
#endif
_CLOCK_PROCESS_CPUTIME_ID __CLOCK_AVAILABILITY = 12,
#define CLOCK_PROCESS_CPUTIME_ID _CLOCK_PROCESS_CPUTIME_ID
_CLOCK_THREAD_CPUTIME_ID __CLOCK_AVAILABILITY = 16
#define CLOCK_THREAD_CPUTIME_ID _CLOCK_THREAD_CPUTIME_ID
} clockid_t;
```

I ran the tests in `libc-test` :
```
% cargo test
   Compiling libc v0.2.118 (/Users/backes/dev/libc)
   Compiling libc-test v0.2.118 (/Users/backes/dev/libc/libc-test)
    Finished test [unoptimized + debuginfo] target(s) in 10.40s
     Running test/cmsg.rs (/Users/backes/dev/libc/target/debug/deps/cmsg-1a9cf9acb3bfd606)

running 5 tests
test t::test_cmsg_firsthdr ... ok
test t::test_cmsg_data ... ok
test t::test_cmsg_space ... ok
test t::test_cmsg_len ... ok
test t::test_cmsg_nxthdr ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s

     Running test/errqueue.rs (/Users/backes/dev/libc/target/debug/deps/errqueue-34a57aa145f73969)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running test/linux_elf.rs (/Users/backes/dev/libc/target/debug/deps/linux_elf-0d81190c35086f0f)
PASSED 0 tests
     Running test/linux_fcntl.rs (/Users/backes/dev/libc/target/debug/deps/linux_fcntl-35043d47b0ba1ab8)
PASSED 0 tests
     Running test/linux_if_arp.rs (/Users/backes/dev/libc/target/debug/deps/linux_if_arp-7d13a47b02694998)
PASSED 0 tests
     Running test/linux_ipv6.rs (/Users/backes/dev/libc/target/debug/deps/linux_ipv6-019e5b7c295e467b)
PASSED 0 tests
     Running test/linux_strerror_r.rs (/Users/backes/dev/libc/target/debug/deps/linux_strerror_r-177f4ad6f4f31457)
PASSED 0 tests
     Running test/linux_termios.rs (/Users/backes/dev/libc/target/debug/deps/linux_termios-0ef27e1d55afb4db)
PASSED 0 tests
     Running test/main.rs (/Users/backes/dev/libc/target/debug/deps/main-112b28ce12de7d4b)
RUNNING ALL TESTS
PASSED 13288 tests
     Running test/semver.rs (/Users/backes/dev/libc/target/debug/deps/semver-e9e1e170582c8b37)
PASSED 1 tests
     Running test/sigrt.rs (/Users/backes/dev/libc/target/debug/deps/sigrt-13dc29f6aa83ea4c)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```
