### PR TITLE
Bump version to 0.2.119

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.118"
+version = "0.2.119"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-test"
-version = "0.2.118"
+version = "0.2.119"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.118"
+version = "0.2.119"
 default-features = false
 
 [build-dependencies]


### PR DESCRIPTION
I'd like a new release because https://github.com/rust-lang/rust/pull/94100 requires the merged PR: https://github.com/rust-lang/libc/pull/2689 