### PR TITLE
Correct the size of certain types on espidf platform

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -23,8 +23,15 @@ pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
 pub type pid_t = i32;
-pub type uid_t = u32;
-pub type gid_t = u32;
+cfg_if! {
+    if #[cfg(target_os = "espidf")] {
+        pub type uid_t = ::c_ushort;
+        pub type gid_t = ::c_ushort;
+    } else {
+        pub type uid_t = u32;
+        pub type gid_t = u32;
+    }
+}
 pub type in_addr_t = u32;
 pub type in_port_t = u16;
 pub type sighandler_t = ::size_t;

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -1,17 +1,27 @@
 pub type blkcnt_t = i32;
 pub type blksize_t = i32;
 pub type clockid_t = ::c_ulong;
-pub type dev_t = u32;
+
+cfg_if! {
+    if #[cfg(target_os = "espidf")] {
+        pub type dev_t = ::c_short;
+        pub type ino_t = ::c_ushort;
+        pub type off_t = ::c_long;
+    } else {
+        pub type dev_t = u32;
+        pub type ino_t = u32;
+        pub type off_t = i64;
+    }
+}
+
 pub type fsblkcnt_t = u64;
 pub type fsfilcnt_t = u32;
 pub type id_t = u32;
-pub type ino_t = u32;
 pub type key_t = ::c_int;
 pub type loff_t = ::c_longlong;
 pub type mode_t = ::c_uint;
 pub type nfds_t = u32;
 pub type nlink_t = ::c_ushort;
-pub type off_t = i64;
 pub type pthread_t = ::c_ulong;
 pub type pthread_key_t = ::c_uint;
 pub type rlim_t = u32;


### PR DESCRIPTION
This was initially discovered in https://github.com/esp-rs/rust/issues/92, the reason stat fails on the esp-idf platform is because the `stat` struct has a different layout on the Rust side compared to the C side.