### PR TITLE
riscv32: Define O_LARGEFILE

### DIFF
--- a/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
@@ -198,6 +198,7 @@ s! {
     }
 }
 
+pub const O_LARGEFILE: ::c_int = 0;
 pub const VEOF: usize = 4;
 pub const RTLD_DEEPBIND: ::c_int = 0x8;
 pub const RTLD_GLOBAL: ::c_int = 0x100;


### PR DESCRIPTION
Some applications (e.g. nix) use this define and expect it to come from libc

Signed-off-by: Khem Raj <raj.khem@gmail.com>