### PR TITLE
Make statx available for all Linux targets

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -41,12 +41,6 @@ s! {
         __statx_pad3: [u64; 12],
     }
 
-    pub struct statx_timestamp {
-        pub tv_sec: i64,
-        pub tv_nsec: u32,
-        pub __statx_timestamp_pad1: [i32; 1],
-    }
-
     pub struct aiocb {
         pub aio_fildes: ::c_int,
         pub aio_lio_opcode: ::c_int,
@@ -997,33 +991,6 @@ pub const M_CHECK_ACTION: ::c_int = -5;
 pub const M_PERTURB: ::c_int = -6;
 pub const M_ARENA_TEST: ::c_int = -7;
 pub const M_ARENA_MAX: ::c_int = -8;
-
-pub const AT_STATX_SYNC_TYPE: ::c_int = 0x6000;
-pub const AT_STATX_SYNC_AS_STAT: ::c_int = 0x0000;
-pub const AT_STATX_FORCE_SYNC: ::c_int = 0x2000;
-pub const AT_STATX_DONT_SYNC: ::c_int = 0x4000;
-pub const STATX_TYPE: ::c_uint = 0x0001;
-pub const STATX_MODE: ::c_uint = 0x0002;
-pub const STATX_NLINK: ::c_uint = 0x0004;
-pub const STATX_UID: ::c_uint = 0x0008;
-pub const STATX_GID: ::c_uint = 0x0010;
-pub const STATX_ATIME: ::c_uint = 0x0020;
-pub const STATX_MTIME: ::c_uint = 0x0040;
-pub const STATX_CTIME: ::c_uint = 0x0080;
-pub const STATX_INO: ::c_uint = 0x0100;
-pub const STATX_SIZE: ::c_uint = 0x0200;
-pub const STATX_BLOCKS: ::c_uint = 0x0400;
-pub const STATX_BASIC_STATS: ::c_uint = 0x07ff;
-pub const STATX_BTIME: ::c_uint = 0x0800;
-pub const STATX_MNT_ID: ::c_uint = 0x1000;
-pub const STATX_ALL: ::c_uint = 0x0fff;
-pub const STATX__RESERVED: ::c_int = 0x80000000;
-pub const STATX_ATTR_COMPRESSED: ::c_int = 0x0004;
-pub const STATX_ATTR_IMMUTABLE: ::c_int = 0x0010;
-pub const STATX_ATTR_APPEND: ::c_int = 0x0020;
-pub const STATX_ATTR_NODUMP: ::c_int = 0x0040;
-pub const STATX_ATTR_ENCRYPTED: ::c_int = 0x0800;
-pub const STATX_ATTR_AUTOMOUNT: ::c_int = 0x1000;
 
 pub const SOMAXCONN: ::c_int = 4096;
 

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -58,6 +58,38 @@ impl ::Clone for fpos64_t {
 }
 
 s! {
+    pub struct statx {
+        pub stx_mask: u32,
+        pub stx_blksize: u32,
+        pub stx_attributes: u64,
+        pub stx_nlink: u32,
+        pub stx_uid: u32,
+        pub stx_gid: u32,
+        pub stx_mode: u16,
+        __statx_pad1: [u16; 1],
+        pub stx_ino: u64,
+        pub stx_size: u64,
+        pub stx_blocks: u64,
+        pub stx_attributes_mask: u64,
+        pub stx_atime: ::statx_timestamp,
+        pub stx_btime: ::statx_timestamp,
+        pub stx_ctime: ::statx_timestamp,
+        pub stx_mtime: ::statx_timestamp,
+        pub stx_rdev_major: u32,
+        pub stx_rdev_minor: u32,
+        pub stx_dev_major: u32,
+        pub stx_dev_minor: u32,
+        pub stx_mnt_id: u64,
+        __statx_pad2: u64,
+        __statx_pad3: [u64; 12],
+    }
+
+    pub struct statx_timestamp {
+        pub tv_sec: i64,
+        pub tv_nsec: u32,
+        pub __statx_timestamp_pad1: [i32; 1],
+    }
+
     pub struct rlimit64 {
         pub rlim_cur: rlim64_t,
         pub rlim_max: rlim64_t,
@@ -1324,6 +1356,33 @@ pub const AT_RANDOM: ::c_ulong = 25;
 pub const AT_HWCAP2: ::c_ulong = 26;
 
 pub const AT_EXECFN: ::c_ulong = 31;
+
+pub const AT_STATX_SYNC_TYPE: ::c_int = 0x6000;
+pub const AT_STATX_SYNC_AS_STAT: ::c_int = 0x0000;
+pub const AT_STATX_FORCE_SYNC: ::c_int = 0x2000;
+pub const AT_STATX_DONT_SYNC: ::c_int = 0x4000;
+pub const STATX_TYPE: ::c_uint = 0x0001;
+pub const STATX_MODE: ::c_uint = 0x0002;
+pub const STATX_NLINK: ::c_uint = 0x0004;
+pub const STATX_UID: ::c_uint = 0x0008;
+pub const STATX_GID: ::c_uint = 0x0010;
+pub const STATX_ATIME: ::c_uint = 0x0020;
+pub const STATX_MTIME: ::c_uint = 0x0040;
+pub const STATX_CTIME: ::c_uint = 0x0080;
+pub const STATX_INO: ::c_uint = 0x0100;
+pub const STATX_SIZE: ::c_uint = 0x0200;
+pub const STATX_BLOCKS: ::c_uint = 0x0400;
+pub const STATX_BASIC_STATS: ::c_uint = 0x07ff;
+pub const STATX_BTIME: ::c_uint = 0x0800;
+pub const STATX_MNT_ID: ::c_uint = 0x1000;
+pub const STATX_ALL: ::c_uint = 0x0fff;
+pub const STATX__RESERVED: ::c_int = 0x80000000;
+pub const STATX_ATTR_COMPRESSED: ::c_int = 0x0004;
+pub const STATX_ATTR_IMMUTABLE: ::c_int = 0x0010;
+pub const STATX_ATTR_APPEND: ::c_int = 0x0020;
+pub const STATX_ATTR_NODUMP: ::c_int = 0x0040;
+pub const STATX_ATTR_ENCRYPTED: ::c_int = 0x0800;
+pub const STATX_ATTR_AUTOMOUNT: ::c_int = 0x1000;
 
 pub const GLOB_ERR: ::c_int = 1 << 0;
 pub const GLOB_MARK: ::c_int = 1 << 1;


### PR DESCRIPTION
I _think_ all this should be available on all Linux targets now, but I'm not very familiar with uClibc, so I'm not sure about it.
