### PR TITLE
Horizon (Nintendo 3DS) pthread functions and non-portable extensions

### DIFF
--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -208,14 +208,14 @@ extern "C" {
         param: *const sched_param,
     ) -> ::c_int;
 
-    pub fn pthread_attr_getidealprocessor_np(
+    pub fn pthread_attr_getprocessorid_np(
         attr: *const ::pthread_attr_t,
-        ideal_processor: *mut ::c_int,
+        processor_id: *mut ::c_int,
     ) -> ::c_int;
 
-    pub fn pthread_attr_setidealprocessor_np(
+    pub fn pthread_attr_setprocessorid_np(
         attr: *mut ::pthread_attr_t,
-        ideal_processor: ::c_int,
+        processor_id: ::c_int,
     ) -> ::c_int;
 
     pub fn pthread_getschedparam(
@@ -229,7 +229,7 @@ extern "C" {
         policy: ::c_int,
         param: *const ::sched_param,
     ) -> ::c_int;
-    
+
     pub fn pthread_getprocessorid_np() -> ::c_int;
 
     pub fn gethostid() -> ::c_long;

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -229,6 +229,8 @@ extern "C" {
         policy: ::c_int,
         param: *const ::sched_param,
     ) -> ::c_int;
+    
+    pub fn pthread_getprocessorid_np() -> ::c_int;
 
     pub fn gethostid() -> ::c_long;
 }

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -151,6 +151,10 @@ pub const FIONBIO: ::c_ulong = 1;
 
 pub const RTLD_DEFAULT: *mut ::c_void = 0 as *mut ::c_void;
 
+// For pthread get/setschedparam
+pub const SCHED_FIFO: ::c_int = 1;
+pub const SCHED_RR: ::c_int = 2;
+
 // Horizon OS works doesn't or can't hold any of this information
 safe_f! {
     pub {const} fn WIFSTOPPED(_status: ::c_int) -> bool {
@@ -214,7 +218,17 @@ extern "C" {
         ideal_processor: ::c_int,
     ) -> ::c_int;
 
-    pub fn pthread_getpriority() -> ::c_int;
+    pub fn pthread_getschedparam(
+        native: ::pthread_t,
+        policy: *mut ::c_int,
+        param: *mut ::sched_param,
+    ) -> ::c_int;
+
+    pub fn pthread_setschedparam(
+        native: ::pthread_t,
+        policy: ::c_int,
+        param: *const ::sched_param,
+    ) -> ::c_int;
 
     pub fn gethostid() -> ::c_long;
 }

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -51,6 +51,10 @@ s! {
         pub sun_family: ::sa_family_t,
         pub sun_path: [::c_char; 104usize],
     }
+
+    pub struct sched_param {
+        pub sched_priority: ::c_int,
+    }
 }
 
 pub const SIGEV_NONE: ::c_int = 1;
@@ -190,7 +194,15 @@ extern "C" {
         value: *mut ::c_void,
     ) -> ::c_int;
 
-    pub fn pthread_attr_setpriority(attr: *mut ::pthread_attr_t, priority: ::c_int) -> ::c_int;
+    pub fn pthread_attr_getschedparam(
+        attr: *const ::pthread_attr_t,
+        param: *mut sched_param,
+    ) -> ::c_int;
+
+    pub fn pthread_attr_setschedparam(
+        attr: *mut ::pthread_attr_t,
+        param: *const sched_param,
+    ) -> ::c_int;
 
     pub fn pthread_attr_setaffinity(attr: *mut ::pthread_attr_t, affinity: ::c_int) -> ::c_int;
 

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -190,5 +190,11 @@ extern "C" {
         value: *mut ::c_void,
     ) -> ::c_int;
 
+    pub fn pthread_attr_setpriority(attr: *mut ::pthread_attr_t, priority: ::c_int) -> ::c_int;
+
+    pub fn pthread_attr_setaffinity(attr: *mut ::pthread_attr_t, affinity: ::c_int) -> ::c_int;
+
+    pub fn pthread_getpriority() -> ::c_int;
+
     pub fn gethostid() -> ::c_long;
 }

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -204,7 +204,15 @@ extern "C" {
         param: *const sched_param,
     ) -> ::c_int;
 
-    pub fn pthread_attr_setaffinity(attr: *mut ::pthread_attr_t, affinity: ::c_int) -> ::c_int;
+    pub fn pthread_attr_getidealprocessor_np(
+        attr: *const ::pthread_attr_t,
+        ideal_processor: *mut ::c_int,
+    ) -> ::c_int;
+
+    pub fn pthread_attr_setidealprocessor_np(
+        attr: *mut ::pthread_attr_t,
+        ideal_processor: ::c_int,
+    ) -> ::c_int;
 
     pub fn pthread_getpriority() -> ::c_int;
 


### PR DESCRIPTION
This PR adds some standard and nonstandard pthread/threading functions to the horizon (Nintendo 3DS) operating system. This will allow us to open a PR to std for std threads support.

The Nintendo 3DS doesn't have a full libc implementation, so there are some user libraries which implement part of libc, such as libctru:
https://github.com/devkitPro/libctru
For some more context on this situation, see https://github.com/rust-random/getrandom/pull/248

But std doesn't want to interface directly with anything that could be seen as using the "internal" interfaces of the 3DS or consoles in general:
https://github.com/rust-lang/rust/pull/88529#issuecomment-919938396

So we work around this by implementing standard pthread interfaces, plus some nonstandard ones as necessary, and expose that interface to std:
https://github.com/Meziu/pthread-3ds

Here's the justifications for the nonstandard interfaces:
* `pthread_attr_setprocessorid_np` (and the `get` version):
  The 3DS requires the core a thread runs on to be specified at thread creation time. I'm pretty sure you can't migrate threads across cores. Additionally, the cores act differently (ex. one core is cooperatively scheduled). This means we need to have an API to set the core to use in the thread attributes struct. We didn't find any relevant standard API for this, so we added a nonstandard one.
* `pthread_getprocessorid_np`:
  The 3DS lets you get the core/processor ID of the executing thread. But it doesn't have a function to get the core ID of any arbitrary thread. We didn't find any standard APIs which would match these semantics, so we added a nonportable one. One place this API is used is to get the default core/processor ID when spawning a thread (i.e. spawn the thread on the current processor).

For more context, see:
* https://github.com/Meziu/rust-horizon/pull/10
  * Especially https://github.com/Meziu/rust-horizon/pull/10#issuecomment-1037026221
* https://github.com/rust-random/getrandom/pull/248

cc: @ian-h-chamberlain @Meziu