### PR TITLE
kmc-solid: Mark `abort`, `exit`, and `_Exit` as diverging

### DIFF
--- a/src/solid/mod.rs
+++ b/src/solid/mod.rs
@@ -535,8 +535,8 @@ extern "C" {
     pub fn strtod_l(arg1: *const c_char, arg2: *mut *mut c_char, arg3: locale_t) -> f64;
     pub fn strtof_l(arg1: *const c_char, arg2: *mut *mut c_char, arg3: locale_t) -> f32;
     pub fn strtold_l(arg1: *const c_char, arg2: *mut *mut c_char, arg3: locale_t) -> f64;
-    pub fn _Exit(arg1: c_int);
-    pub fn abort();
+    pub fn _Exit(arg1: c_int) -> !;
+    pub fn abort() -> !;
     pub fn abs(arg1: c_int) -> c_int;
     pub fn atexit(arg1: ::Option<unsafe extern "C" fn()>) -> c_int;
     pub fn atoi(arg1: *const c_char) -> c_int;
@@ -553,7 +553,7 @@ extern "C" {
     ) -> *mut c_void;
     pub fn calloc(arg1: size_t, arg2: size_t) -> *mut c_void;
     pub fn div(arg1: c_int, arg2: c_int) -> div_t;
-    pub fn exit(arg1: c_int);
+    pub fn exit(arg1: c_int) -> !;
     pub fn free(arg1: *mut c_void);
     pub fn getenv(arg1: *const c_char) -> *mut c_char;
     pub fn labs(arg1: c_long) -> c_long;


### PR DESCRIPTION
This PR marks these functions as diverging (`fn (...) -> !`) for the [`*-kmc-solid_*`](https://doc.rust-lang.org/nightly/rustc/platform-support/kmc-solid.html) target, so that they are in line with the other targets (e.g., [`unix`](https://github.com/rust-lang/libc/blob/1708299c6b49e9fb7e7c34b9edd37c77e7af003c/src/unix/mod.rs#L496)).