### PR TITLE
Bump version to 0.2.120

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.119"
+version = "0.2.120"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-test"
-version = "0.2.119"
+version = "0.2.120"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.119"
+version = "0.2.120"
 default-features = false
 
 [build-dependencies]


### PR DESCRIPTION
I'd like a new release because an upcoming PR to `rust-lang/rust` requires the merged PR: #2720