### PR TITLE
Horizon OS Nintendo 3DS - Fixed size of sockaddr_in

### DIFF
--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -35,7 +35,6 @@ s! {
         pub sin_family: ::sa_family_t,
         pub sin_port: ::in_port_t,
         pub sin_addr: ::in_addr,
-        pub sin_zero: [::c_uchar; 8],
     }
 
     pub struct sockaddr_in6 {


### PR DESCRIPTION
The original API for the platform included these zeroed bytes at the end of the `sockaddr_in` struct, but the socket address calls (like `getsockname`) only write 8 bytes inside `sockaddr_storage`, making checks like the one in https://github.com/rust-lang/rust/blob/95561b336cf82a8250176eb3c61ea61c90e75d47/library/std/src/sys_common/net.rs#L109 faulty.

Since `sockaddr_in` is a struct *not* used in internal functionality, it shouldn't be a problem to just get rid of them.