### PR TITLE
redox: fix compilation on stable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 #![cfg_attr(not(feature = "rustc-dep-of-std"), no_std)]
 #![cfg_attr(feature = "rustc-dep-of-std", no_core)]
 #![cfg_attr(
-    any(feature = "rustc-dep-of-std", target_os = "redox"),
+    feature = "rustc-dep-of-std",
     feature(static_nobundle, native_link_modifiers, native_link_modifiers_bundle)
 )]
 #![cfg_attr(libc_const_extern_fn, feature(const_extern_fn))]


### PR DESCRIPTION
These features are no longer required by default on Redox