### PR TITLE
Add pthread_mutexattr_setprotocol and pthread_mutexattr_getprotocol on Linux

### DIFF
--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -1653,6 +1653,9 @@ PTHREAD_CREATE_DETACHED
 PTHREAD_CREATE_JOINABLE
 PTHREAD_MUTEX_DEFAULT
 PTHREAD_MUTEX_ERRORCHECK
+PTHREAD_PRIO_NONE
+PTHREAD_PRIO_INHERIT
+PTHREAD_PRIO_PROTECT
 PTHREAD_PROCESS_PRIVATE
 PTHREAD_PROCESS_SHARED
 PTHREAD_STACK_MIN
@@ -2951,7 +2954,9 @@ pthread_getschedparam
 pthread_kill
 pthread_mutex_consistent
 pthread_mutex_timedlock
+pthread_mutexattr_getprotocol
 pthread_mutexattr_getpshared
+pthread_mutexattr_setprotocol
 pthread_mutexattr_setpshared
 pthread_mutexattr_getrobust
 pthread_mutexattr_setrobust

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1519,6 +1519,9 @@ pub const PTHREAD_MUTEX_ERRORCHECK: ::c_int = 2;
 pub const PTHREAD_MUTEX_DEFAULT: ::c_int = PTHREAD_MUTEX_NORMAL;
 pub const PTHREAD_MUTEX_STALLED: ::c_int = 0;
 pub const PTHREAD_MUTEX_ROBUST: ::c_int = 1;
+pub const PTHREAD_PRIO_NONE: ::c_int = 0;
+pub const PTHREAD_PRIO_INHERIT: ::c_int = 1;
+pub const PTHREAD_PRIO_PROTECT: ::c_int = 2;
 pub const PTHREAD_PROCESS_PRIVATE: ::c_int = 0;
 pub const PTHREAD_PROCESS_SHARED: ::c_int = 1;
 pub const __SIZEOF_PTHREAD_COND_T: usize = 48;
@@ -3784,6 +3787,14 @@ extern "C" {
         nfds: nfds_t,
         timeout: *const ::timespec,
         sigmask: *const sigset_t,
+    ) -> ::c_int;
+    pub fn pthread_mutexattr_getprotocol(
+        attr: *const pthread_mutexattr_t,
+        protocol: *mut ::c_int,
+    ) -> ::c_int;
+    pub fn pthread_mutexattr_setprotocol(
+        attr: *mut pthread_mutexattr_t,
+        protocol: ::c_int,
     ) -> ::c_int;
     pub fn pthread_mutex_consistent(mutex: *mut pthread_mutex_t) -> ::c_int;
     pub fn pthread_mutex_timedlock(


### PR DESCRIPTION
Include the PTHREAD_PRIO_* constants. 