### PR TITLE
Two improvements of the latest i128 numbers change

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -87,9 +87,9 @@ fn main() {
         println!("cargo:rustc-cfg=libc_ptr_addr_of");
     }
 
-    // Rust >= 1.57.0 allows assert! (and panics in general) in constants.
-    if rustc_minor_ver >= 57 || rustc_dep_of_std {
-        println!("cargo:rustc-cfg=libc_const_assert");
+    // Rust >= 1.37.0 allows underscores as anonymous constant names.
+    if rustc_minor_ver >= 37 || rustc_dep_of_std {
+        println!("cargo:rustc-cfg=libc_underscore_const_names");
     }
 
     // #[thread_local] is currently unstable

--- a/src/fixed_width_ints.rs
+++ b/src/fixed_width_ints.rs
@@ -44,7 +44,7 @@ cfg_if! {
         // until the upstream rust issue is resolved, but this at least lets us make
         // progress on platforms where this type is important.
         //
-        // The supported architectures and OSes is intentionally very restricted,
+        // The list of supported architectures and OSes is intentionally very restricted,
         // as careful work needs to be done to verify that a particular platform
         // has a conformant ABI.
         //

--- a/src/fixed_width_ints.rs
+++ b/src/fixed_width_ints.rs
@@ -60,35 +60,39 @@ cfg_if! {
         pub type __uint128_t = u128;
 
         cfg_if! {
-            if #[cfg(libc_const_assert)] {
+            if #[cfg(libc_underscore_const_names)] {
+                macro_rules! static_assert_eq {
+                    ($a:expr, $b:expr) => {
+                        const _: [(); $a] = [(); $b];
+                    };
+                }
+
                 // NOTE: if you add more platforms to here, you may need to cfg
                 // these consts. They should always match the platform's values
                 // for `sizeof(__int128)` and `_Alignof(__int128)`.
                 const _SIZE_128: usize = 16;
                 const _ALIGN_128: usize = 16;
 
-                /// Since Rust doesn't officially guarantee that these types
-                /// have compatible ABIs, we const assert that these values have the
-                /// known size/align of the target platform's libc. If rustc ever
-                /// tries to regress things, it will cause a compilation error.
-                ///
-                /// This isn't a bullet-proof solution because e.g. it doesn't
-                /// catch the fact that llvm and gcc disagree on how x64 __int128
-                /// is actually *passed* on the stack (clang underaligns it for
-                /// the same reason that rustc *never* properly aligns it).
-                const _ASSERT_128_COMPAT: () = {
-                    assert!(core::mem::size_of::<__int128>() == _SIZE_128);
-                    assert!(core::mem::align_of::<__int128>() == _ALIGN_128);
+                // Since Rust doesn't officially guarantee that these types
+                // have compatible ABIs, we const assert that these values have the
+                // known size/align of the target platform's libc. If rustc ever
+                // tries to regress things, it will cause a compilation error.
+                //
+                // This isn't a bullet-proof solution because e.g. it doesn't
+                // catch the fact that llvm and gcc disagree on how x64 __int128
+                // is actually *passed* on the stack (clang underaligns it for
+                // the same reason that rustc *never* properly aligns it).
+                static_assert_eq!(core::mem::size_of::<__int128>(), _SIZE_128);
+                static_assert_eq!(core::mem::align_of::<__int128>(), _ALIGN_128);
 
-                    assert!(core::mem::size_of::<__uint128>() == _SIZE_128);
-                    assert!(core::mem::align_of::<__uint128>() == _ALIGN_128);
+                static_assert_eq!(core::mem::size_of::<__uint128>(), _SIZE_128);
+                static_assert_eq!(core::mem::align_of::<__uint128>(), _ALIGN_128);
 
-                    assert!(core::mem::size_of::<__int128_t>() == _SIZE_128);
-                    assert!(core::mem::align_of::<__int128_t>() == _ALIGN_128);
+                static_assert_eq!(core::mem::size_of::<__int128_t>(), _SIZE_128);
+                static_assert_eq!(core::mem::align_of::<__int128_t>(), _ALIGN_128);
 
-                    assert!(core::mem::size_of::<__uint128_t>() == _SIZE_128);
-                    assert!(core::mem::align_of::<__uint128_t>() == _ALIGN_128);
-                };
+                static_assert_eq!(core::mem::size_of::<__uint128_t>(), _SIZE_128);
+                static_assert_eq!(core::mem::align_of::<__uint128_t>(), _ALIGN_128);
             }
         }
     }


### PR DESCRIPTION
Two improvements of #2719:

* First, a typo/grammar fix
* Second, a fix to avoid usage of the anti pattern of `==` inside an `assert` macro. Since a few releases, `assert` is usable inside `const` expressions, but for the purpose of `==`, superior alternatives exist that also work at compile time but print the two values at a mismatch. `assert_eq` is not yet usable in const contexts due to formatting.