### PR TITLE
Remove use of `feature(static_nobundle)`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 #![cfg_attr(feature = "rustc-dep-of-std", no_core)]
 #![cfg_attr(
     feature = "rustc-dep-of-std",
-    feature(static_nobundle, native_link_modifiers, native_link_modifiers_bundle)
+    feature(native_link_modifiers, native_link_modifiers_bundle)
 )]
 #![cfg_attr(libc_const_extern_fn, feature(const_extern_fn))]
 


### PR DESCRIPTION
It's used in "rustc-dep-of-std" mode and prevents removal of this feature from rustc.

(No need to publish a new libc version right now, the rustc PR is still waiting on some other work being finished.)