### PR TITLE
Add pthread_set/get schedparam functions to FreeBSD.

### DIFF
--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -1724,6 +1724,8 @@ pthread_rwlockattr_getpshared
 pthread_rwlockattr_setpshared
 pthread_setaffinity_np
 pthread_set_name_np
+pthread_getschedparam
+pthread_setschedparam
 pthread_spin_destroy
 pthread_spin_init
 pthread_spin_lock

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1594,6 +1594,16 @@ extern "C" {
     pub fn pthread_barrier_wait(barrier: *mut pthread_barrier_t) -> ::c_int;
     pub fn pthread_get_name_np(tid: ::pthread_t, name: *mut ::c_char, len: ::size_t);
     pub fn pthread_set_name_np(tid: ::pthread_t, name: *const ::c_char);
+    pub fn pthread_setschedparam(
+        native: ::pthread_t,
+        policy: ::c_int,
+        param: *const sched_param,
+    ) -> ::c_int;
+    pub fn pthread_getschedparam(
+        native: ::pthread_t,
+        policy: *mut ::c_int,
+        param: *mut sched_param,
+    ) -> ::c_int;
     pub fn ptrace(request: ::c_int, pid: ::pid_t, addr: *mut ::c_char, data: ::c_int) -> ::c_int;
     pub fn utrace(addr: *const ::c_void, len: ::size_t) -> ::c_int;
     pub fn pututxline(ut: *const utmpx) -> *mut utmpx;


### PR DESCRIPTION
FreeBSD has these functions and this provides an interface to use them.

In particular, the [`thread-priority`](https://github.com/vityafx/thread-priority/runs/5881232298) crate can't be built without those.