### PR TITLE
Disable broken CI jobs

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -274,6 +274,7 @@ jobs:
         shell: bash
 
   semver_linux:
+    if: ${{ false }} # This is currently broken
     name: Semver Linux
     runs-on: ubuntu-20.04
     continue-on-error: true
@@ -286,6 +287,7 @@ jobs:
         run: sh ci/semver.sh linux
 
   semver_macos:
+    if: ${{ false }} # This is currently broken
     name: Semver macOS
     runs-on: macos-11
     continue-on-error: true

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -154,6 +154,7 @@ jobs:
   # These targets are tier 3 or otherwise need to have CI build std via -Zbuild-std.
   # Because of this, only the nightly compiler can be used on these targets.
   docker_linux_build_std:
+    if: ${{ false }} # This is currently broken
     name: Docker Linux Build-Std Targets
     needs: [docker_linux_tier1, style_check]
     runs-on: ubuntu-20.04
@@ -326,7 +327,7 @@ jobs:
     needs: [
       docker_linux_tier1,
       docker_linux_tier2,
-      docker_linux_build_std,
+      #docker_linux_build_std,
       macos,
       windows,
       style_check,
@@ -348,7 +349,7 @@ jobs:
     needs: [
       docker_linux_tier1,
       docker_linux_tier2,
-      docker_linux_build_std,
+      #docker_linux_build_std,
       macos,
       windows,
       style_check,

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -226,7 +226,6 @@ aarch64-unknown-openbsd \
 aarch64-wrs-vxworks \
 armebv7r-none-eabi \
 armebv7r-none-eabihf \
-armv7-unknown-linux-uclibceabihf \
 armv7-wrs-vxworks-eabihf \
 armv7r-none-eabi \
 armv7r-none-eabihf \
@@ -237,9 +236,7 @@ i686-unknown-haiku \
 i686-unknown-netbsd \
 i686-unknown-openbsd \
 i686-wrs-vxworks \
-mips-unknown-linux-uclibc \
 mipsel-sony-psp \
-mipsel-unknown-linux-uclibc \
 mips64-unknown-linux-muslabi64 \
 mips64el-unknown-linux-muslabi64 \
 nvptx64-nvidia-cuda \


### PR DESCRIPTION
These are temporarily removed until someone comes to fix them.

The semver jobs have been broken for over a year now, but are ignored by bors. Now we just disable them completely since they cause confusion when reading the build logs.

The uclibc targets were recently broken by https://github.com/rust-lang/rust/pull/95688. They are missing a `si_addr()` function on `struct siginfo`.