### PR TITLE
Add pthread_condattr_{set,get}clock on Horizon OS

### DIFF
--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -250,6 +250,16 @@ extern "C" {
         param: *const ::sched_param,
     ) -> ::c_int;
 
+    pub fn pthread_condattr_getclock(
+        attr: *const ::pthread_condattr_t,
+        clock_id: *mut ::clockid_t,
+    ) -> ::c_int;
+
+    pub fn pthread_condattr_setclock(
+        attr: *mut ::pthread_condattr_t,
+        clock_id: ::clockid_t,
+    ) -> ::c_int;
+
     pub fn pthread_getprocessorid_np() -> ::c_int;
 
     pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;


### PR DESCRIPTION
These are supported by this `pthread-3ds` PR: https://github.com/Meziu/pthread-3ds/pull/16 and are required to compile, notably, `parking_lot_core` for the `armv6k-nintendo-3ds` target.

cc: @Meziu @AzureMarker 