### PR TITLE
Bump version to 0.2.124

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.123"
+version = "0.2.124"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-test"
-version = "0.2.123"
+version = "0.2.124"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.123"
+version = "0.2.124"
 default-features = false
 
 [build-dependencies]


### PR DESCRIPTION
Closes #2755. Also adds SSM sockop bindings for more Apple, OpenBSD and Solaris.