### PR TITLE
Update FreeBSD 12 CI image to 12.3.  12.2 is EoL.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ task:
 task:
   name: nightly x86_64-unknown-freebsd-12
   freebsd_instance:
-    image: freebsd-12-2-release-amd64
+    image: freebsd-12-3-release-amd64
   setup_script:
     - pkg install -y curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh


### PR DESCRIPTION
11.4 is also EoL, but we need to keep testing on FreeBSD 11 since we
expose a FreeBSD 11 ABI.