### PR TITLE
Add OpenBSD's futex.h.

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -506,7 +506,7 @@ fn test_openbsd(target: &str) {
             // https://marc.info/?l=openbsd-cvs&m=154723400730318
             "mincore" => true,
 
-            // futex() has volative arguments, but that doesn't exist in Rust.
+            // futex() has volatile arguments, but that doesn't exist in Rust.
             "futex" => true,
 
             _ => false,

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -434,6 +434,7 @@ fn test_openbsd(target: &str) {
         "signal.h",
         "string.h",
         "sys/file.h",
+        "sys/futex.h",
         "sys/ioctl.h",
         "sys/ipc.h",
         "sys/mman.h",

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -506,6 +506,9 @@ fn test_openbsd(target: &str) {
             // https://marc.info/?l=openbsd-cvs&m=154723400730318
             "mincore" => true,
 
+            // futex() has volative arguments, but that doesn't exist in Rust.
+            "futex" => true,
+
             _ => false,
         }
     });

--- a/libc-test/semver/openbsd.txt
+++ b/libc-test/semver/openbsd.txt
@@ -215,6 +215,10 @@ FIONREAD
 FIOSETOWN
 FLUSHO
 FOPEN_MAX
+FUTEX_WAIT
+FUTEX_WAKE
+FUTEX_REQUEUE
+FUTEX_PRIVATE_FLAG
 F_GETOWN
 F_LOCK
 F_RDLCK
@@ -987,6 +991,7 @@ fsid_t
 fstatfs
 ftok
 fusefs_args
+futex
 futimes
 getdomainname
 getdtablesize

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1519,6 +1519,12 @@ pub const WCONTINUED: ::c_int = 8;
 pub const FIND: ::ACTION = 0;
 pub const ENTER: ::ACTION = 1;
 
+// futex.h
+pub const FUTEX_WAIT: ::c_int = 1;
+pub const FUTEX_WAKE: ::c_int = 2;
+pub const FUTEX_REQUEUE: ::c_int = 3;
+pub const FUTEX_PRIVATE_FLAG: ::c_int = 128;
+
 const_fn! {
     {const} fn _ALIGN(p: usize) -> usize {
         (p + _ALIGNBYTES) & !_ALIGNBYTES
@@ -1703,6 +1709,15 @@ extern "C" {
     pub fn hcreate(nelt: ::size_t) -> ::c_int;
     pub fn hdestroy();
     pub fn hsearch(entry: ::ENTRY, action: ::ACTION) -> *mut ::ENTRY;
+
+    // futex.h
+    pub fn futex(
+        uaddr: *mut u32,
+        op: ::c_int,
+        val: ::c_int,
+        timeout: *const ::timespec,
+        uaddr2: *mut u32,
+    ) -> ::c_int;
 }
 
 #[link(name = "execinfo")]


### PR DESCRIPTION
This adds OpenBSD's [src/sys/sys/futex.h](https://cvsweb.openbsd.org/src/sys/sys/futex.h?rev=1.2&content-type=text/x-cvsweb-markup).