### PR TITLE
Add pthread_[s,g]etschedparam to emscripten.

### DIFF
--- a/ci/emscripten-entry.sh
+++ b/ci/emscripten-entry.sh
@@ -7,6 +7,6 @@ source /emsdk-portable/emsdk_env.sh &> /dev/null
 
 # emsdk-portable provides a node binary, but we need version 8 to run wasm
 # NOTE: Do not forget to sync Node.js version with `emscripten.sh`!
-export PATH="/node-v14.17.0-linux-x64/bin:$PATH"
+export PATH="/node-v18.0.0-linux-x64/bin:$PATH"
 
 exec "$@"

--- a/ci/emscripten.sh
+++ b/ci/emscripten.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-EMSDK_VERSION=1.39.20
+EMSDK_VERSION=3.1.9
 
 hide_output() {
   set +x
@@ -39,5 +39,5 @@ chmod a+rxw -R /emsdk-portable
 # node 8 is required to run wasm
 # NOTE: Do not forget to sync Node.js version with `emscripten-entry.sh`!
 cd /
-curl --retry 5 -L https://nodejs.org/dist/v14.17.0/node-v14.17.0-linux-x64.tar.xz | \
+curl --retry 5 -L https://nodejs.org/dist/v18.0.0/node-v18.0.0-linux-x64.tar.xz | \
     tar -xJ

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -113,6 +113,8 @@ else
       # Rust uses -g4 by default what causes link issues.
       # This should disable the -g4 option.
       export RUSTFLAGS="-Cdebuginfo=0"
+      export EMCC_FLAGS="-s USE_PTHREADS=1 -s SHARED_MEMORY"
+      export EMCC_CFLAGS="-s USE_PTHREADS=1 -s SHARED_MEMORY"
   fi
   cargo test --no-default-features --manifest-path libc-test/Cargo.toml \
     --target "${TARGET}" ${LIBC_CI_ZBUILD_STD+"-Zbuild-std"}

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -111,7 +111,8 @@ if [ "$TARGET" = "s390x-unknown-linux-gnu" ]; then
 else
   if [ "$TARGET" = "asmjs-unknown-emscripten" ]; then
       # Rust uses -g4 by default what causes link issues.
-      export EMCC_CFLAGS="-g3"
+      # This should disable the -g4 option.
+      export RUSTFLAGS="-Cdebuginfo=0"
   fi
   cargo test --no-default-features --manifest-path libc-test/Cargo.toml \
     --target "${TARGET}" ${LIBC_CI_ZBUILD_STD+"-Zbuild-std"}

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -109,6 +109,10 @@ if [ "$TARGET" = "s390x-unknown-linux-gnu" ]; then
     sleep 1
   done
 else
+  if [ "$TARGET" = "asmjs-unknown-emscripten" ]; then
+      # Rust uses -g4 by default what causes link issues.
+      export EMCC_CFLAGS="-g3"
+  fi
   cargo test --no-default-features --manifest-path libc-test/Cargo.toml \
     --target "${TARGET}" ${LIBC_CI_ZBUILD_STD+"-Zbuild-std"}
 

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2454,7 +2454,10 @@ fn test_emscripten(target: &str) {
 
     let mut cfg = ctest_cfg();
     cfg.define("_GNU_SOURCE", None); // FIXME: ??
-    cfg.flag("-pthread"); // Enable POSIX threads support.
+    cfg.flag("-pthread");
+    cfg.flag("-mbulk-memory");
+    cfg.flag("-matomics");
+    cfg.flag("-Wl,--shared-memory");
 
     headers! { cfg:
                "aio.h",

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2511,7 +2511,6 @@ fn test_emscripten(target: &str) {
                "sys/reboot.h",
                "sys/resource.h",
                "sys/sem.h",
-               "sys/sendfile.h",
                "sys/shm.h",
                "sys/signalfd.h",
                "sys/socket.h",

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2454,10 +2454,6 @@ fn test_emscripten(target: &str) {
 
     let mut cfg = ctest_cfg();
     cfg.define("_GNU_SOURCE", None); // FIXME: ??
-    cfg.flag("-pthread");
-    cfg.flag("-mbulk-memory");
-    cfg.flag("-matomics");
-    cfg.flag("-Wl,--shared-memory");
 
     headers! { cfg:
                "aio.h",

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2454,6 +2454,7 @@ fn test_emscripten(target: &str) {
 
     let mut cfg = ctest_cfg();
     cfg.define("_GNU_SOURCE", None); // FIXME: ??
+    cfg.flag("-pthread"); // Enable POSIX threads support.
 
     headers! { cfg:
                "aio.h",

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1879,6 +1879,16 @@ extern "C" {
         f: extern "C" fn(*mut ::c_void) -> *mut ::c_void,
         value: *mut ::c_void,
     ) -> ::c_int;
+    pub fn pthread_setschedparam(
+        native: ::pthread_t,
+        policy: ::c_int,
+        param: *const ::sched_param,
+    ) -> ::c_int;
+    pub fn pthread_getschedparam(
+        native: ::pthread_t,
+        policy: *mut ::c_int,
+        param: *mut ::sched_param,
+    ) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -108,13 +108,13 @@ s! {
 
     pub struct sched_param {
         pub sched_priority: ::c_int,
-        #[cfg(any(target_env = "musl", target_os = "emscripten"))]
+        #[cfg(target_env = "musl")]
         pub sched_ss_low_priority: ::c_int,
-        #[cfg(any(target_env = "musl", target_os = "emscripten"))]
+        #[cfg(target_env = "musl")]
         pub sched_ss_repl_period: ::timespec,
-        #[cfg(any(target_env = "musl", target_os = "emscripten"))]
+        #[cfg(target_env = "musl")]
         pub sched_ss_init_budget: ::timespec,
-        #[cfg(any(target_env = "musl", target_os = "emscripten"))]
+        #[cfg(target_env = "musl")]
         pub sched_ss_max_repl: ::c_int,
     }
 


### PR DESCRIPTION
Closes https://github.com/rust-lang/libc/issues/2754

The functions are available in emscripten when built with the posix threads support.