### PR TITLE
Promote pthread_getname_np and pthread_setname_np from glibc to linux

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3401,6 +3401,9 @@ fn test_linux(target: &str) {
             // Not defined in uclibc as of 1.0.34
             "gettid" if uclibc => true,
 
+            // Needs musl 1.2.3 or later.
+            "pthread_getname_np" if musl => true,
+
             _ => false,
         }
     });

--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -624,11 +624,9 @@ process_vm_readv
 process_vm_writev
 pthread_attr_getaffinity_np
 pthread_attr_setaffinity_np
-pthread_getname_np
 pthread_rwlockattr_getkind_np
 pthread_rwlockattr_getpshared
 pthread_rwlockattr_setkind_np
-pthread_setname_np
 ptrace_peeksiginfo_args
 ptrace_syscall_info
 pututxline

--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -2950,6 +2950,7 @@ pthread_condattr_setpshared
 pthread_getaffinity_np
 pthread_getattr_np
 pthread_getcpuclockid
+pthread_getname_np
 pthread_getschedparam
 pthread_kill
 pthread_mutex_consistent
@@ -2962,6 +2963,7 @@ pthread_mutexattr_getrobust
 pthread_mutexattr_setrobust
 pthread_rwlockattr_setpshared
 pthread_setaffinity_np
+pthread_setname_np
 pthread_setschedparam
 pthread_setschedprio
 pthread_spin_destroy

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1301,8 +1301,6 @@ extern "C" {
         buflen: ::size_t,
         result: *mut *mut ::group,
     ) -> ::c_int;
-    pub fn pthread_getname_np(thread: ::pthread_t, name: *mut ::c_char, len: ::size_t) -> ::c_int;
-    pub fn pthread_setname_np(thread: ::pthread_t, name: *const ::c_char) -> ::c_int;
 
     pub fn sethostid(hostid: ::c_long) -> ::c_int;
 

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -4097,6 +4097,9 @@ extern "C" {
         needlelen: ::size_t,
     ) -> *mut ::c_void;
     pub fn sched_getcpu() -> ::c_int;
+
+    pub fn pthread_getname_np(thread: ::pthread_t, name: *mut ::c_char, len: ::size_t) -> ::c_int;
+    pub fn pthread_setname_np(thread: ::pthread_t, name: *const ::c_char) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
musl libc added pthread_setname_np in 1.1.16 and pthread_getname_np
in 1.2.3, and uClibc has had them since v1.0.20.