### PR TITLE
haiku: improve platform compatibility

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3680,6 +3680,7 @@ fn test_haiku(target: &str) {
     cfg.flag("-Wno-deprecated-declarations");
     cfg.define("__USE_GNU", Some("1"));
     cfg.define("_GNU_SOURCE", None);
+    cfg.language(ctest::Lang::CXX);
 
     // POSIX API
     headers! { cfg:
@@ -3723,7 +3724,6 @@ fn test_haiku(target: &str) {
                "net/if_types.h",
                "net/route.h",
                "netdb.h",
-               "netinet/icmp6.h",
                "netinet/in.h",
                "netinet/ip.h",
                "netinet/ip6.h",
@@ -3881,6 +3881,9 @@ fn test_haiku(target: &str) {
 
             "get_cpuid" => true,
 
+            // uses varargs parameter
+            "ioctl" => true,
+
             _ => false,
         }
     });
@@ -3954,6 +3957,9 @@ fn test_haiku(target: &str) {
             | "team_usage_info" | "thread_info" | "cpu_info" | "system_info"
             | "object_wait_info" | "image_info" | "attr_info" | "index_info" | "fs_info"
             | "FILE" | "DIR" | "Dl_info" => ty.to_string(),
+
+            // enums don't need a prefix
+            "directory_which" | "path_base_directory" => ty.to_string(),
 
             // is actually a union
             "sigval" => format!("union sigval"),

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -28,8 +28,12 @@ pub type fsfilcnt_t = i64;
 pub type pthread_attr_t = *mut ::c_void;
 pub type nl_item = ::c_int;
 pub type id_t = i32;
-pub type idtype_t = ::c_uint;
+pub type idtype_t = ::c_int;
 pub type fd_mask = u32;
+pub type regoff_t = ::c_int;
+pub type key_t = i32;
+pub type msgqnum_t = u32;
+pub type msglen_t = u32;
 
 pub type Elf32_Addr = u32;
 pub type Elf32_Half = u16;
@@ -44,6 +48,9 @@ pub type Elf64_Sword = i32;
 pub type Elf64_Sxword = i64;
 pub type Elf64_Word = u32;
 pub type Elf64_Xword = u64;
+
+pub type ENTRY = entry;
+pub type ACTION = ::c_int;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum timezone {}
@@ -362,17 +369,6 @@ s! {
         pub sdl_data: [u8; 46],
     }
 
-    pub struct dl_phdr_info {
-        pub dlpi_addr: Elf_Addr,
-        pub dlpi_name: *const ::c_char,
-        pub dlpi_phdr: *const Elf_Phdr,
-        pub dlpi_phnum: Elf_Half,
-        pub dlpi_adds: ::c_ulonglong,
-        pub dlpi_subs: ::c_ulonglong,
-        pub dlpi_tls_modid: usize,
-        pub dlpi_tls_data: *mut ::c_void,
-    }
-
     pub struct spwd {
         pub sp_namp: *mut ::c_char,
         pub sp_pwdp: *mut ::c_char,
@@ -383,6 +379,53 @@ s! {
         pub sp_inact: ::c_int,
         pub sp_expire: ::c_int,
         pub sp_flag: ::c_int,
+    }
+
+    pub struct regex_t {
+        __buffer: *mut ::c_void,
+        __allocated: ::size_t,
+        __used: ::size_t,
+        __syntax: ::c_ulong,
+        __fastmap: *mut ::c_char,
+        __translate: *mut ::c_char,
+        __re_nsub: ::size_t,
+        __bitfield: u8,
+    }
+
+    pub struct regmatch_t {
+        pub rm_so: regoff_t,
+        pub rm_eo: regoff_t,
+    }
+
+    pub struct msqid_ds {
+        pub msg_perm: ::ipc_perm,
+        pub msg_qnum: ::msgqnum_t,
+        pub msg_qbytes: ::msglen_t,
+        pub msg_lspid: ::pid_t,
+        pub msg_lrpid: ::pid_t,
+        pub msg_stime: ::time_t,
+        pub msg_rtime: ::time_t,
+        pub msg_ctime: ::time_t,
+    }
+
+    pub struct ipc_perm {
+        pub key: ::key_t,
+        pub uid: ::uid_t,
+        pub gid: ::gid_t,
+        pub cuid: ::uid_t,
+        pub cgid: ::gid_t,
+        pub mode: ::mode_t,
+    }
+
+    pub struct sembuf {
+        pub sem_num: ::c_ushort,
+        pub sem_op: ::c_short,
+        pub sem_flg: ::c_short,
+    }
+
+    pub struct entry {
+        pub key: *mut ::c_char,
+        pub data: *mut ::c_void,
     }
 }
 
@@ -657,6 +700,8 @@ pub const PTHREAD_CREATE_DETACHED: ::c_int = 1;
 
 pub const CLOCK_REALTIME: ::c_int = -1;
 pub const CLOCK_MONOTONIC: ::c_int = 0;
+pub const CLOCK_PROCESS_CPUTIME_ID: ::c_int = -2;
+pub const CLOCK_THREAD_CPUTIME_ID: ::c_int = -3;
 
 pub const RLIMIT_CORE: ::c_int = 0;
 pub const RLIMIT_CPU: ::c_int = 1;
@@ -665,7 +710,7 @@ pub const RLIMIT_FSIZE: ::c_int = 3;
 pub const RLIMIT_NOFILE: ::c_int = 4;
 pub const RLIMIT_STACK: ::c_int = 5;
 pub const RLIMIT_AS: ::c_int = 6;
-pub const RLIM_INFINITY: ::c_ulong = 0xffffffff;
+pub const RLIM_INFINITY: ::rlim_t = 0xffffffff;
 // Haiku specific
 pub const RLIMIT_NOVMON: ::c_int = 7;
 pub const RLIM_NLIMITS: ::c_int = 8;
@@ -1564,15 +1609,20 @@ extern "C" {
         bufferSize: ::size_t,
         res: *mut *mut spwd,
     ) -> ::c_int;
-}
-
-#[link(name = "bsd")]
-extern "C" {
+    pub fn mkfifoat(dirfd: ::c_int, pathname: *const ::c_char, mode: ::mode_t) -> ::c_int;
+    pub fn mknodat(
+        dirfd: ::c_int,
+        pathname: *const ::c_char,
+        mode: ::mode_t,
+        dev: dev_t,
+    ) -> ::c_int;
     pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
     pub fn sem_init(sem: *mut sem_t, pshared: ::c_int, value: ::c_uint) -> ::c_int;
 
-    pub fn clock_gettime(clk_id: ::c_int, tp: *mut ::timespec) -> ::c_int;
-    pub fn clock_settime(clk_id: ::c_int, tp: *const ::timespec) -> ::c_int;
+    pub fn clock_getres(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
+    pub fn clock_gettime(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
+    pub fn clock_settime(clk_id: ::clockid_t, tp: *const ::timespec) -> ::c_int;
+    pub fn clock_getcpuclockid(pid: ::pid_t, clk_id: *mut ::clockid_t) -> ::c_int;
     pub fn pthread_create(
         thread: *mut ::pthread_t,
         attr: *const ::pthread_attr_t,
@@ -1600,6 +1650,7 @@ extern "C" {
     pub fn malloc_usable_size(ptr: *mut ::c_void) -> ::size_t;
     pub fn memalign(align: ::size_t, size: ::size_t) -> *mut ::c_void;
     pub fn setgroups(ngroups: ::c_int, ptr: *const ::gid_t) -> ::c_int;
+    pub fn initgroups(name: *const ::c_char, basegid: ::gid_t) -> ::c_int;
     pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
     pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
     pub fn dirfd(dirp: *mut ::DIR) -> ::c_int;
@@ -1655,7 +1706,6 @@ extern "C" {
         addrlen: *mut ::socklen_t,
     ) -> ::ssize_t;
     pub fn mkstemps(template: *mut ::c_char, suffixlen: ::c_int) -> ::c_int;
-    pub fn lutimes(file: *const ::c_char, times: *const ::timeval) -> ::c_int;
     pub fn nl_langinfo(item: ::nl_item) -> *mut ::c_char;
 
     pub fn bind(socket: ::c_int, address: *const ::sockaddr, address_len: ::socklen_t) -> ::c_int;
@@ -1698,7 +1748,6 @@ extern "C" {
     pub fn getgrnam(name: *const ::c_char) -> *mut ::group;
     pub fn pthread_kill(thread: ::pthread_t, sig: ::c_int) -> ::c_int;
     pub fn sem_unlink(name: *const ::c_char) -> ::c_int;
-    pub fn daemon(nochdir: ::c_int, noclose: ::c_int) -> ::c_int;
     pub fn getpwnam_r(
         name: *const ::c_char,
         pwd: *mut passwd,
@@ -1713,6 +1762,14 @@ extern "C" {
         buflen: ::size_t,
         result: *mut *mut passwd,
     ) -> ::c_int;
+    pub fn getpwent() -> *mut passwd;
+    pub fn setpwent();
+    pub fn endpwent();
+    pub fn endgrent();
+    pub fn getgrent() -> *mut ::group;
+    pub fn setgrent();
+    pub fn setreuid(ruid: ::uid_t, euid: ::uid_t) -> ::c_int;
+    pub fn setregid(rgid: ::gid_t, egid: ::gid_t) -> ::c_int;
     pub fn sigwait(set: *const sigset_t, sig: *mut ::c_int) -> ::c_int;
     pub fn pthread_atfork(
         prepare: ::Option<unsafe extern "C" fn()>,
@@ -1721,19 +1778,6 @@ extern "C" {
     ) -> ::c_int;
     pub fn getgrgid(gid: ::gid_t) -> *mut ::group;
     pub fn popen(command: *const c_char, mode: *const c_char) -> *mut ::FILE;
-    pub fn openpty(
-        amaster: *mut ::c_int,
-        aslave: *mut ::c_int,
-        name: *mut ::c_char,
-        termp: *mut termios,
-        winp: *mut ::winsize,
-    ) -> ::c_int;
-    pub fn forkpty(
-        amaster: *mut ::c_int,
-        name: *mut ::c_char,
-        termp: *mut termios,
-        winp: *mut ::winsize,
-    ) -> ::pid_t;
     pub fn sethostname(name: *const ::c_char, len: ::size_t) -> ::c_int;
     pub fn uname(buf: *mut ::utsname) -> ::c_int;
     pub fn getutxent() -> *mut utmpx;
@@ -1742,31 +1786,126 @@ extern "C" {
     pub fn pututxline(ut: *const utmpx) -> *mut utmpx;
     pub fn setutxent();
     pub fn endutxent();
-
-    pub fn dl_iterate_phdr(
-        callback: ::Option<
-            unsafe extern "C" fn(
-                info: *mut dl_phdr_info,
-                size: usize,
-                data: *mut ::c_void,
-            ) -> ::c_int,
-        >,
-        data: *mut ::c_void,
+    pub fn faccessat(
+        dirfd: ::c_int,
+        pathname: *const ::c_char,
+        mode: ::c_int,
+        flags: ::c_int,
     ) -> ::c_int;
 
+    pub fn sigtimedwait(
+        set: *const sigset_t,
+        info: *mut siginfo_t,
+        timeout: *const ::timespec,
+    ) -> ::c_int;
+    pub fn sigwaitinfo(set: *const sigset_t, info: *mut siginfo_t) -> ::c_int;
+
+    pub fn getitimer(which: ::c_int, curr_value: *mut ::itimerval) -> ::c_int;
+    pub fn setitimer(
+        which: ::c_int,
+        new_value: *const ::itimerval,
+        old_value: *mut ::itimerval,
+    ) -> ::c_int;
+
+    pub fn regcomp(preg: *mut regex_t, pattern: *const ::c_char, cflags: ::c_int) -> ::c_int;
+
+    pub fn regexec(
+        preg: *const regex_t,
+        input: *const ::c_char,
+        nmatch: ::size_t,
+        pmatch: *mut regmatch_t,
+        eflags: ::c_int,
+    ) -> ::c_int;
+
+    pub fn regerror(
+        errcode: ::c_int,
+        preg: *const regex_t,
+        errbuf: *mut ::c_char,
+        errbuf_size: ::size_t,
+    ) -> ::size_t;
+
+    pub fn regfree(preg: *mut regex_t);
+
+    pub fn msgctl(msqid: ::c_int, cmd: ::c_int, buf: *mut msqid_ds) -> ::c_int;
+    pub fn msgget(key: ::key_t, msgflg: ::c_int) -> ::c_int;
+    pub fn msgrcv(
+        msqid: ::c_int,
+        msgp: *mut ::c_void,
+        msgsz: ::size_t,
+        msgtype: ::c_long,
+        msgflg: ::c_int,
+    ) -> ::ssize_t;
+    pub fn msgsnd(
+        msqid: ::c_int,
+        msgp: *const ::c_void,
+        msgsz: ::size_t,
+        msgflg: ::c_int,
+    ) -> ::c_int;
+    pub fn semget(key: ::key_t, nsems: ::c_int, semflg: ::c_int) -> ::c_int;
+    pub fn semctl(semid: ::c_int, semnum: ::c_int, cmd: ::c_int, ...) -> ::c_int;
+    pub fn semop(semid: ::c_int, sops: *mut sembuf, nsops: ::size_t) -> ::c_int;
+    pub fn ftok(pathname: *const ::c_char, proj_id: ::c_int) -> ::key_t;
+
+    pub fn memrchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
+
+    pub fn lsearch(
+        key: *const ::c_void,
+        base: *mut ::c_void,
+        nelp: *mut ::size_t,
+        width: ::size_t,
+        compar: ::Option<unsafe extern "C" fn(*const ::c_void, *const ::c_void) -> ::c_int>,
+    ) -> *mut ::c_void;
+    pub fn lfind(
+        key: *const ::c_void,
+        base: *const ::c_void,
+        nelp: *mut ::size_t,
+        width: ::size_t,
+        compar: ::Option<unsafe extern "C" fn(*const ::c_void, *const ::c_void) -> ::c_int>,
+    ) -> *mut ::c_void;
+    pub fn hcreate(nelt: ::size_t) -> ::c_int;
+    pub fn hdestroy();
+    pub fn hsearch(entry: ::ENTRY, action: ::ACTION) -> *mut ::ENTRY;
+
+    pub fn drand48() -> ::c_double;
+    pub fn erand48(xseed: *mut ::c_ushort) -> ::c_double;
+    pub fn lrand48() -> ::c_long;
+    pub fn nrand48(xseed: *mut ::c_ushort) -> ::c_long;
+    pub fn mrand48() -> ::c_long;
+    pub fn jrand48(xseed: *mut ::c_ushort) -> ::c_long;
+    pub fn srand48(seed: ::c_long);
+    pub fn seed48(xseed: *mut ::c_ushort) -> *mut ::c_ushort;
+    pub fn lcong48(p: *mut ::c_ushort);
+
+    pub fn clearenv() -> ::c_int;
+    pub fn ctermid(s: *mut ::c_char) -> *mut ::c_char;
+
+    pub fn sync();
+    pub fn getpagesize() -> ::c_int;
+
+    pub fn brk(addr: *mut ::c_void) -> ::c_int;
+    pub fn sbrk(increment: ::intptr_t) -> *mut ::c_void;
+}
+
+#[link(name = "bsd")]
+extern "C" {
+    pub fn lutimes(file: *const ::c_char, times: *const ::timeval) -> ::c_int;
+    pub fn daemon(nochdir: ::c_int, noclose: ::c_int) -> ::c_int;
+    pub fn forkpty(
+        amaster: *mut ::c_int,
+        name: *mut ::c_char,
+        termp: *mut termios,
+        winp: *mut ::winsize,
+    ) -> ::pid_t;
+    pub fn openpty(
+        amaster: *mut ::c_int,
+        aslave: *mut ::c_int,
+        name: *mut ::c_char,
+        termp: *mut termios,
+        winp: *mut ::winsize,
+    ) -> ::c_int;
     pub fn strsep(string: *mut *mut ::c_char, delimiters: *const ::c_char) -> *mut ::c_char;
     pub fn explicit_bzero(buf: *mut ::c_void, len: ::size_t);
-
     pub fn login_tty(_fd: ::c_int) -> ::c_int;
-    pub fn fgetln(stream: *mut ::FILE, _length: *mut ::size_t) -> *mut ::c_char;
-
-    pub fn realhostname(host: *mut ::c_char, hsize: ::size_t, ip: *const in_addr) -> ::c_int;
-    pub fn realhostname_sa(
-        host: *mut ::c_char,
-        hsize: ::size_t,
-        addr: *mut sockaddr,
-        addrlen: ::c_int,
-    ) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/haiku/native.rs
+++ b/src/unix/haiku/native.rs
@@ -272,7 +272,8 @@ s! {
 
     pub struct cpu_info {
         pub active_time: bigtime_t,
-        pub enabled: bool
+        pub enabled: bool,
+        pub current_frequency: u64
     }
 
     pub struct system_info {
@@ -667,7 +668,6 @@ pub const B_SHUTTING_DOWN: status_t = B_APP_ERROR_BASE + 18;
 
 // Storage kit errors
 pub const B_FILE_ERROR: status_t = B_STORAGE_ERROR_BASE + 0;
-pub const B_FILE_NOT_FOUND: status_t = B_STORAGE_ERROR_BASE + 1;
 pub const B_FILE_EXISTS: status_t = B_STORAGE_ERROR_BASE + 2;
 pub const B_ENTRY_NOT_FOUND: status_t = B_STORAGE_ERROR_BASE + 3;
 pub const B_NAME_TOO_LONG: status_t = B_STORAGE_ERROR_BASE + 4;
@@ -1020,7 +1020,12 @@ extern "C" {
     pub fn disable_debugger(state: ::c_int) -> ::c_int;
 
     pub fn get_system_info(info: *mut system_info) -> status_t;
-    pub fn get_cpu_info(firstCPU: u32, cpuCount: u32, info: *mut cpu_info) -> status_t;
+    pub fn _get_cpu_info_etc(
+        firstCPU: u32,
+        cpuCount: u32,
+        info: *mut cpu_info,
+        size: ::size_t,
+    ) -> status_t;
     pub fn is_computer_on() -> i32;
     pub fn is_computer_on_fire() -> ::c_double;
     pub fn send_signal(threadID: thread_id, signal: ::c_uint) -> ::c_int;
@@ -1200,6 +1205,7 @@ extern "C" {
         architecture: *const ::c_char,
         baseDirectory: path_base_directory,
         subPath: *const ::c_char,
+        flags: u32,
         _paths: *mut *mut *mut ::c_char,
         pathCount: *mut ::size_t,
     ) -> status_t;
@@ -1221,10 +1227,22 @@ cfg_if! {
 }
 
 // The following functions are defined as macros in C/C++
+#[inline]
+pub unsafe fn get_cpu_info(firstCPU: u32, cpuCount: u32, info: *mut cpu_info) -> status_t {
+    _get_cpu_info_etc(
+        firstCPU,
+        cpuCount,
+        info,
+        core::mem::size_of::<cpu_info>() as ::size_t,
+    )
+}
+
+#[inline]
 pub unsafe fn get_area_info(id: area_id, info: *mut area_info) -> status_t {
     _get_area_info(id, info, core::mem::size_of::<area_info>() as usize)
 }
 
+#[inline]
 pub unsafe fn get_next_area_info(
     team: team_id,
     cookie: *mut isize,
@@ -1238,10 +1256,12 @@ pub unsafe fn get_next_area_info(
     )
 }
 
+#[inline]
 pub unsafe fn get_port_info(port: port_id, buf: *mut port_info) -> status_t {
     _get_port_info(port, buf, core::mem::size_of::<port_info>() as ::size_t)
 }
 
+#[inline]
 pub unsafe fn get_next_port_info(
     port: port_id,
     cookie: *mut i32,
@@ -1255,6 +1275,7 @@ pub unsafe fn get_next_port_info(
     )
 }
 
+#[inline]
 pub unsafe fn get_port_message_info_etc(
     port: port_id,
     info: *mut port_message_info,
@@ -1270,10 +1291,12 @@ pub unsafe fn get_port_message_info_etc(
     )
 }
 
+#[inline]
 pub unsafe fn get_sem_info(id: sem_id, info: *mut sem_info) -> status_t {
     _get_sem_info(id, info, core::mem::size_of::<sem_info>() as ::size_t)
 }
 
+#[inline]
 pub unsafe fn get_next_sem_info(team: team_id, cookie: *mut i32, info: *mut sem_info) -> status_t {
     _get_next_sem_info(
         team,
@@ -1283,14 +1306,17 @@ pub unsafe fn get_next_sem_info(team: team_id, cookie: *mut i32, info: *mut sem_
     )
 }
 
+#[inline]
 pub unsafe fn get_team_info(team: team_id, info: *mut team_info) -> status_t {
     _get_team_info(team, info, core::mem::size_of::<team_info>() as ::size_t)
 }
 
+#[inline]
 pub unsafe fn get_next_team_info(cookie: *mut i32, info: *mut team_info) -> status_t {
     _get_next_team_info(cookie, info, core::mem::size_of::<team_info>() as ::size_t)
 }
 
+#[inline]
 pub unsafe fn get_team_usage_info(team: team_id, who: i32, info: *mut team_usage_info) -> status_t {
     _get_team_usage_info(
         team,
@@ -1300,10 +1326,12 @@ pub unsafe fn get_team_usage_info(team: team_id, who: i32, info: *mut team_usage
     )
 }
 
+#[inline]
 pub unsafe fn get_thread_info(id: thread_id, info: *mut thread_info) -> status_t {
     _get_thread_info(id, info, core::mem::size_of::<thread_info>() as ::size_t)
 }
 
+#[inline]
 pub unsafe fn get_next_thread_info(
     team: team_id,
     cookie: *mut i32,
@@ -1318,10 +1346,12 @@ pub unsafe fn get_next_thread_info(
 }
 
 // kernel/image.h
+#[inline]
 pub unsafe fn get_image_info(image: image_id, info: *mut image_info) -> status_t {
     _get_image_info(image, info, core::mem::size_of::<image_info>() as ::size_t)
 }
 
+#[inline]
 pub unsafe fn get_next_image_info(
     team: team_id,
     cookie: *mut i32,


### PR DESCRIPTION
* Also moves a number functions out of the `libbsd` module, as these are actually in `libroot`, so don't require linking against `libbsd`.
* `dl_iterate_phdr` is not implemented.
* `B_FILE_NOT_FOUND` has been deprecated, and removed from the
  public headers