### PR TITLE
Enable aio_{read,write}v on FreeBSD

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2352,6 +2352,8 @@ fn test_freebsd(target: &str) {
 
             // Added in FreeBSD 13.
             "getlocalbase" if Some(13) > freebsd_ver => true,
+            "aio_readv" if Some(13) > freebsd_ver => true,
+            "aio_writev" if Some(13) > freebsd_ver => true,
 
             _ => false,
         }

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -469,8 +469,6 @@ pub const DOMAINSET_POLICY_INTERLEAVE: ::c_int = 4;
 pub const MINCORE_SUPER: ::c_int = 0x20;
 
 extern "C" {
-    pub fn aio_readv(aiocbp: *mut ::aiocb) -> ::c_int;
-    pub fn aio_writev(aiocbp: *mut ::aiocb) -> ::c_int;
     pub fn setgrent();
     pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
     pub fn freelocale(loc: ::locale_t);

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -469,8 +469,6 @@ pub const DOMAINSET_POLICY_INTERLEAVE: ::c_int = 4;
 pub const MINCORE_SUPER: ::c_int = 0x60;
 
 extern "C" {
-    pub fn aio_readv(aiocbp: *mut ::aiocb) -> ::c_int;
-    pub fn aio_writev(aiocbp: *mut ::aiocb) -> ::c_int;
     pub fn setgrent();
     pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
     pub fn freelocale(loc: ::locale_t);

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -3840,6 +3840,7 @@ extern "C" {
     pub fn aio_error(aiocbp: *const aiocb) -> ::c_int;
     pub fn aio_fsync(op: ::c_int, aiocbp: *mut aiocb) -> ::c_int;
     pub fn aio_read(aiocbp: *mut aiocb) -> ::c_int;
+    pub fn aio_readv(aiocbp: *mut ::aiocb) -> ::c_int;
     pub fn aio_return(aiocbp: *mut aiocb) -> ::ssize_t;
     pub fn aio_suspend(
         aiocb_list: *const *const aiocb,
@@ -3847,6 +3848,7 @@ extern "C" {
         timeout: *const ::timespec,
     ) -> ::c_int;
     pub fn aio_write(aiocbp: *mut aiocb) -> ::c_int;
+    pub fn aio_writev(aiocbp: *mut ::aiocb) -> ::c_int;
 
     pub fn devname_r(
         dev: ::dev_t,


### PR DESCRIPTION
When I originally added these symbols, I put them in the freebsd13
module.  But I needn't have, since they didn't change any existing
symbols.  Instead, as totally new symbols, they should've gone into the
freebsd module.  This way they can actually be used.