### PR TITLE
Add LIO_READV and LIO_WRITEV on FreeBSD

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2254,6 +2254,9 @@ fn test_freebsd(target: &str) {
                 true
             }
 
+            // Added in FreeBSD 14
+            "LIO_READV" | "LIO_WRITEV" | "LIO_VECTORED" if Some(14) > freebsd_ver => true,
+
             _ => false,
         }
     });

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1885,6 +1885,11 @@ impl ::Clone for dot3Vendors {
     }
 }
 
+// aio.h
+pub const LIO_VECTORED: ::c_int = 4;
+pub const LIO_WRITEV: ::c_int = 5;
+pub const LIO_READV: ::c_int = 6;
+
 // sys/devicestat.h
 pub const DEVSTAT_N_TRANS_FLAGS: ::c_int = 4;
 pub const DEVSTAT_NAME_LEN: ::c_int = 16;


### PR DESCRIPTION
They are used along with lio_listio for non-POSIX vectored operations.