### PR TITLE
Fix definition of kevent.data on 32-bit FreeBSD 12+

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -22,7 +22,7 @@ s! {
         pub filter: ::c_short,
         pub flags: ::c_ushort,
         pub fflags: ::c_uint,
-        pub data: ::intptr_t,
+        pub data: i64,
         pub udata: *mut ::c_void,
         pub ext: [u64; 4],
     }

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -25,7 +25,7 @@ s! {
         pub filter: ::c_short,
         pub flags: ::c_ushort,
         pub fflags: ::c_uint,
-        pub data: ::intptr_t,
+        pub data: i64,
         pub udata: *mut ::c_void,
         pub ext: [u64; 4],
     }

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -25,7 +25,7 @@ s! {
         pub filter: ::c_short,
         pub flags: ::c_ushort,
         pub fflags: ::c_uint,
-        pub data: ::intptr_t,
+        pub data: i64,
         pub udata: *mut ::c_void,
         pub ext: [u64; 4],
     }


### PR DESCRIPTION
FreeBSD 12 changed this field from intptr_t to __int64_t