### PR TITLE
Add DragonFlyBSD kinfo_proc and kinfo_lwp structs

### DIFF
--- a/libc-test/semver/dragonfly.txt
+++ b/libc-test/semver/dragonfly.txt
@@ -1315,6 +1315,8 @@ kevent
 killpg
 kinfo_cputime
 kinfo_file
+kinfo_lwp
+kinfo_proc
 kqueue
 labs
 lastlog

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -32,12 +32,32 @@ pub type pthread_barrierattr_t = ::c_int;
 pub type pthread_barrier_t = ::uintptr_t;
 pub type pthread_spinlock_t = ::uintptr_t;
 
+pub type segsz_t = usize;
+
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum sem {}
 impl ::Copy for sem {}
 impl ::Clone for sem {
     fn clone(&self) -> sem {
         *self
+    }
+}
+
+e! {
+    #[repr(u32)]
+    pub enum lwpstat {
+        LSRUN = 1,
+        LSSTOP = 2,
+        LSSLEEP = 3,
+    }
+
+    #[repr(u32)]
+    pub enum procstat {
+        SIDL = 1,
+        SACTIVE = 2,
+        SSTOP = 3,
+        SZOMB = 4,
+        SCORE = 5,
     }
 }
 
@@ -236,6 +256,84 @@ s! {
         pub cp_sample_pc: u64,
         pub cp_sample_sp: u64,
         pub cp_msg: [::c_char; 32],
+    }
+
+    pub struct kinfo_lwp {
+        pub kl_pid: ::pid_t,
+        pub kl_tid: ::lwpid_t,
+        pub kl_flags: ::c_int,
+        pub kl_stat: ::lwpstat,
+        pub kl_lock: ::c_int,
+        pub kl_tdflags: ::c_int,
+        pub kl_mpcount: ::c_int,
+        pub kl_prio: ::c_int,
+        pub kl_tdprio: ::c_int,
+        pub kl_rtprio: ::rtprio,
+        pub kl_uticks: u64,
+        pub kl_sticks: u64,
+        pub kl_iticks: u64,
+        pub kl_cpticks: u64,
+        pub kl_pctcpu: ::c_uint,
+        pub kl_slptime: ::c_uint,
+        pub kl_origcpu: ::c_int,
+        pub kl_estcpu: ::c_int,
+        pub kl_cpuid: ::c_int,
+        pub kl_ru: ::rusage,
+        pub kl_siglist: ::sigset_t,
+        pub kl_sigmask: ::sigset_t,
+        pub kl_wchan: ::uintptr_t,
+        pub kl_wmesg: [::c_char; 9],
+        pub kl_comm: [::c_char; MAXCOMLEN+1],
+    }
+
+    pub struct kinfo_proc {
+        pub kp_paddr: ::uintptr_t,
+        pub kp_flags: ::c_int,
+        pub kp_stat: ::procstat,
+        pub kp_lock: ::c_int,
+        pub kp_acflag: ::c_int,
+        pub kp_traceflag: ::c_int,
+        pub kp_fd: ::uintptr_t,
+        pub kp_siglist: ::sigset_t,
+        pub kp_sigignore: ::sigset_t,
+        pub kp_sigcatch: ::sigset_t,
+        pub kp_sigflag: ::c_int,
+        pub kp_start: ::timeval,
+        pub kp_comm: [::c_char; MAXCOMLEN+1],
+        pub kp_uid: ::uid_t,
+        pub kp_ngroups: ::c_short,
+        pub kp_groups: [::gid_t; NGROUPS],
+        pub kp_ruid: ::uid_t,
+        pub kp_svuid: ::uid_t,
+        pub kp_rgid: ::gid_t,
+        pub kp_svgid: ::gid_t,
+        pub kp_pid: ::pid_t,
+        pub kp_ppid: ::pid_t,
+        pub kp_pgid: ::pid_t,
+        pub kp_jobc: ::c_int,
+        pub kp_sid: ::pid_t,
+        pub kp_login: [::c_char; 40], // MAXNAMELEN rounded up to the nearest sizeof(long)
+        pub kp_tdev: ::dev_t,
+        pub kp_tpgid: ::pid_t,
+        pub kp_tsid: ::pid_t,
+        pub kp_exitstat: ::c_ushort,
+        pub kp_nthreads: ::c_int,
+        pub kp_nice: ::c_int,
+        pub kp_swtime: ::c_uint,
+        pub kp_vm_map_size: ::size_t,
+        pub kp_vm_rssize: ::segsz_t,
+        pub kp_vm_swrss: ::segsz_t,
+        pub kp_vm_tsize: ::segsz_t,
+        pub kp_vm_dsize: ::segsz_t,
+        pub kp_vm_ssize: ::segsz_t,
+        pub kp_vm_prssize: ::c_uint,
+        pub kp_jailid: ::c_int,
+        pub kp_ru: ::rusage,
+        pub kp_cru: ::rusage,
+        pub kp_auxflags: ::c_int,
+        pub kp_lwp: ::kinfo_lwp,
+        pub kp_ktaddr: ::uintptr_t,
+        kp_spare: [::c_int; 2],
     }
 
     pub struct cpuctl_msr_args_t {
@@ -1347,6 +1445,11 @@ pub const UTIME_OMIT: c_long = -2;
 pub const UTIME_NOW: c_long = -1;
 
 pub const MINCORE_SUPER: ::c_int = 0x20;
+
+// kinfo_proc constants
+pub const MAXCOMLEN: usize = 16;
+pub const MAXLOGNAME: usize = 33;
+pub const NGROUPS: usize = 16;
 
 const_fn! {
     {const} fn _CMSG_ALIGN(n: usize) -> usize {


### PR DESCRIPTION
This adds the aforementioned structs and a few supporting enums and constants.

I added the structs to semvar - contribution guidelines also say to add constants (and presumably enums) but I don't see this done for similar values to the ones I added so I'm unclear if there's some subtlety to this I'm missing.

One field is also expected to be rounded up to the nearest sizeof(long).  Rather than worry about cfg() or whether I can use const size_of, I just assumed 8 bytes, as DragonFly's last 32-bit release was nearly 8 years ago.