### PR TITLE
Add ENOTSUP constant for riscv64 musl

### DIFF
--- a/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
@@ -546,6 +546,7 @@ pub const ENOPROTOOPT: ::c_int = 92;
 pub const EPROTONOSUPPORT: ::c_int = 93;
 pub const ESOCKTNOSUPPORT: ::c_int = 94;
 pub const EOPNOTSUPP: ::c_int = 95;
+pub const ENOTSUP: ::c_int = EOPNOTSUPP;
 pub const EPFNOSUPPORT: ::c_int = 96;
 pub const EAFNOSUPPORT: ::c_int = 97;
 pub const EADDRINUSE: ::c_int = 98;


### PR DESCRIPTION
Previously:

* https://github.com/rust-lang/libc/pull/2595
* https://github.com/rust-lang/libc/pull/1971
* https://github.com/rust-lang/libc/pull/448

but not of these added the constant for riscv64 musl and rustc itself seems to use it nowadays.