### PR TITLE
unix: setreuid/setregid

### DIFF
--- a/libc-test/semver/fuchsia.txt
+++ b/libc-test/semver/fuchsia.txt
@@ -1333,10 +1333,8 @@ setfsuid
 setgroups
 sethostname
 setpwent
-setregid
 setresgid
 setresuid
-setreuid
 settimeofday
 shmat
 shmatt_t

--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -3041,10 +3041,8 @@ setmntent
 setns
 setpriority
 setpwent
-setregid
 setresgid
 setresuid
-setreuid
 setrlimit
 setrlimit64
 setservent

--- a/libc-test/semver/unix.txt
+++ b/libc-test/semver/unix.txt
@@ -761,6 +761,8 @@ setpgid
 setsid
 setsockopt
 setuid
+setreuid
+setregid
 setvbuf
 shm_open
 shm_unlink

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -1768,8 +1768,6 @@ extern "C" {
     pub fn endgrent();
     pub fn getgrent() -> *mut ::group;
     pub fn setgrent();
-    pub fn setreuid(ruid: ::uid_t, euid: ::uid_t) -> ::c_int;
-    pub fn setregid(rgid: ::gid_t, egid: ::gid_t) -> ::c_int;
     pub fn sigwait(set: *const sigset_t, sig: *mut ::c_int) -> ::c_int;
     pub fn pthread_atfork(
         prepare: ::Option<unsafe extern "C" fn()>,

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1726,8 +1726,6 @@ extern "C" {
     pub fn clearenv() -> ::c_int;
     pub fn waitid(idtype: idtype_t, id: id_t, infop: *mut ::siginfo_t, options: ::c_int)
         -> ::c_int;
-    pub fn setreuid(ruid: ::uid_t, euid: ::uid_t) -> ::c_int;
-    pub fn setregid(rgid: ::gid_t, egid: ::gid_t) -> ::c_int;
     pub fn getresuid(ruid: *mut ::uid_t, euid: *mut ::uid_t, suid: *mut ::uid_t) -> ::c_int;
     pub fn getresgid(rgid: *mut ::gid_t, egid: *mut ::gid_t, sgid: *mut ::gid_t) -> ::c_int;
     pub fn acct(filename: *const ::c_char) -> ::c_int;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -901,6 +901,8 @@ extern "C" {
     pub fn setpgid(pid: pid_t, pgid: pid_t) -> ::c_int;
     pub fn setsid() -> pid_t;
     pub fn setuid(uid: uid_t) -> ::c_int;
+    pub fn setreuid(ruid: uid_t, euid: uid_t) -> ::c_int;
+    pub fn setregid(rgid: gid_t, egid: gid_t) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "sleep$UNIX2003"


### PR DESCRIPTION
This adds [`setreuid()`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/setreuid.html) and [`setregid()`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/setregid.html) on `unix`.