### PR TITLE
Fix the definition of sigevent

### DIFF
--- a/ci/style.rs
+++ b/ci/style.rs
@@ -177,7 +177,15 @@ fn check_style(file: &str, path: &Path, err: &mut Errors) {
         }
         if s_macros == 2 {
             s_macros += 1;
-            err.error(path, i, "multiple s! macros in one module");
+            // Can't enforce this rule until after raising the MSRV to 1.19.0 or
+            // later.  It seems that earlier Rust versions ignore #[cfg()]
+            // attributes within the macro.  As a result, it's sometimes
+            // necessary to have multiple s!{} macros in a single file.  It's
+            // hard to debug, because cargo-expand doesn't work with such
+            // old versions.
+            // See also https://github.com/rust-lang/libc/pull/2813
+
+            // err.error(path, i, "multiple s! macros in one module");
         }
 
         state = line_state;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1355,6 +1355,10 @@ s! {
     // structure exists for backwards-compatibility with consumers that still
     // try to access that one member.
     #[doc(hidden)]
+    #[deprecated(
+        since = "0.2.127",
+        note = "Use sigevent instead"
+    )]
     pub struct sigevent_0_2_126 {
         pub sigev_notify: ::c_int,
         pub sigev_signo: ::c_int,
@@ -1664,6 +1668,7 @@ s_no_extra_traits! {
     }
 }
 
+#[allow(deprecated)]
 impl ::core::ops::Deref for sigevent {
     type Target = sigevent_0_2_126;
 
@@ -1672,6 +1677,7 @@ impl ::core::ops::Deref for sigevent {
     }
 }
 
+#[allow(deprecated)]
 impl ::core::ops::DerefMut for sigevent {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { &mut *(self as *mut Self as *mut sigevent_0_2_126) }

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1434,6 +1434,12 @@ s_no_extra_traits! {
         pub sigev_signo: ::c_int,
         pub sigev_value: ::sigval,
         pub _sigev_un: __c_anonymous_sigev_un,
+        /// Exists just to prevent the struct from being safely constructed,
+        /// because the Debug, Hash, PartialImpl, and
+        /// Deref<Target=sigevent_0_2_0126> trait impls might read uninitialized
+        /// fields of _sigev_un.  This field may be removed once those trait
+        /// impls are.
+        _private: ()
     }
 
     pub struct ptsstat {

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -275,7 +275,7 @@ s! {
 }
 
 #[cfg(libc_union)]
-s_no_extra_traits!{
+s_no_extra_traits! {
     // Can't correctly impl Debug for unions
     #[allow(missing_debug_implementations)]
     #[cfg(libc_union)]
@@ -303,7 +303,7 @@ s_no_extra_traits!{
 }
 
 #[cfg(not(libc_union))]
-s_no_extra_traits!{
+s_no_extra_traits! {
     pub struct sigevent {
         pub sigev_value: ::sigval,
         pub sigev_signo: ::c_int,

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -216,6 +216,10 @@ s! {
     // structure exists for backwards-compatibility with consumers that still
     // try to access that one member.
     #[doc(hidden)]
+    #[deprecated(
+        since = "0.2.127",
+        note = "Use sigevent instead"
+    )]
     pub struct sigevent_0_2_126 {
         pub sigev_value: ::sigval,
         pub sigev_signo: ::c_int,
@@ -286,6 +290,7 @@ s_no_extra_traits! {
     }
 }
 
+#[allow(deprecated)]
 impl ::core::ops::Deref for sigevent {
     type Target = sigevent_0_2_126;
 
@@ -294,6 +299,7 @@ impl ::core::ops::Deref for sigevent {
     }
 }
 
+#[allow(deprecated)]
 impl ::core::ops::DerefMut for sigevent {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { &mut *(self as *mut Self as *mut sigevent_0_2_126) }

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -287,6 +287,12 @@ s_no_extra_traits! {
         pub sigev_signo: ::c_int,
         pub sigev_notify: ::c_int,
         pub _sigev_un: __c_anonymous_sigev_un,
+        /// Exists just to prevent the struct from being safely constructed,
+        /// because the Debug, Hash, PartialImpl, and
+        /// Deref<Target=sigevent_0_2_0126> trait impls might read uninitialized
+        /// fields of _sigev_un.  This field may be removed once those trait
+        /// impls are.
+        _private: ()
     }
 }
 


### PR DESCRIPTION
It was originally defined back before rust could represent C unions.  So
instead of defining the union field correctly, it simply defined that
union's most useful field.  Define it correctly now.

Include a backwards-compatibility mechanism: Rename sigevent's old
definition and hide it.  Implement Deref and DerefMut from sigevent to
the old definition, so consumers will still be able to use the old field
name.