### PR TITLE
Enable `libc_const_extern_fn` implicitly from Rust 1.62

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ libc = "0.2"
   This feature derives `Debug`, `Eq`, `Hash`, and `PartialEq`.
 
 * `const-extern-fn`: Changes some `extern fn`s into `const extern fn`s.
-   This feature requires a nightly rustc.
+  If you use Rust >= 1.62, this feature is implicitly enabled.
+  Otherwise it requires a nightly rustc.
 
 * **deprecated**: `use_std` is deprecated, and is equivalent to `std`.
 
@@ -53,6 +54,7 @@ newer Rust features are only available on newer Rust toolchains:
 | `core::ffi::c_void`  |  1.30.0 |
 | `repr(packed(N))`    |  1.33.0 |
 | `cfg(target_vendor)` |  1.33.0 |
+| `const-extern-fn`    |  1.62.0 |
 
 ## Platform support
 

--- a/build.rs
+++ b/build.rs
@@ -97,11 +97,18 @@ fn main() {
         println!("cargo:rustc-cfg=libc_thread_local");
     }
 
-    if const_extern_fn_cargo_feature {
-        if !is_nightly || rustc_minor_ver < 40 {
-            panic!("const-extern-fn requires a nightly compiler >= 1.40")
-        }
+    // Rust >= 1.62.0 allows to use `const_extern_fn` for "Rust" and "C".
+    if rustc_minor_ver >= 62 {
         println!("cargo:rustc-cfg=libc_const_extern_fn");
+    } else {
+        // Rust < 1.62.0 requires a crate feature and feature gate.
+        if const_extern_fn_cargo_feature {
+            if !is_nightly || rustc_minor_ver < 40 {
+                panic!("const-extern-fn requires a nightly compiler >= 1.40");
+            }
+            println!("cargo:rustc-cfg=libc_const_extern_fn_unstable");
+            println!("cargo:rustc-cfg=libc_const_extern_fn");
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
     feature = "rustc-dep-of-std",
     feature(native_link_modifiers, native_link_modifiers_bundle)
 )]
-#![cfg_attr(libc_const_extern_fn, feature(const_extern_fn))]
+#![cfg_attr(libc_const_extern_fn_unstable, feature(const_extern_fn))]
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
const_extern_fn for "C" has been stabilized since 1.62: https://github.com/rust-lang/rust/pull/95346
This enables the const-extern-fn feature implicitly from 1.62, but leaves the crate feature as-is for compatibility and old nightlies.