### PR TITLE
Drop support for Rumprun

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,10 @@ after a certain period. The steps are:
     If you're using it, please comment on #XXX").
 2. If we don't see any concerns for a while, do the change actually.
 
+## Supported target policy
+
+When Rust removes a support for a target, the libc crate also may remove the support anytime.
+
 ## Releasing your change to crates.io
 
 Now that you've done the amazing job of landing your new API or your new

--- a/ci/README.md
+++ b/ci/README.md
@@ -39,9 +39,6 @@ The remaining architectures look like:
   then otherwise runs tests normally.
 * iOS builds need an extra linker flag currently, but beyond that they're built
   as standard as everything else.
-* The rumprun target builds an entire kernel from the test suite and then runs
-  it inside QEMU using the serial console to test whether it succeeded or
-  failed.
 * The BSD builds, currently OpenBSD and FreeBSD, use QEMU to boot up a system
   and compile/run tests. More information on that below.
 
@@ -61,10 +58,6 @@ We provide it the runtime path for the dynamically loaded system libraries,
 however. This strategy is used for all Linux architectures that aren't intel.
 Note that one downside of this QEMU system is that threads are barely
 implemented, so we're careful to not spawn many threads.
-
-For the rumprun target the only output is a kernel image, so we just use that
-plus the `rumpbake` command to create a full kernel image which is then run from
-within QEMU.
 
 Finally, the fun part, the BSDs. Quite a few hoops are jumped through to get CI
 working for these platforms, but the gist of it looks like:

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -969,7 +969,6 @@ fn test_solarish(target: &str) {
 
 fn test_netbsd(target: &str) {
     assert!(target.contains("netbsd"));
-    let rumprun = target.contains("rumprun");
     let mut cfg = ctest_cfg();
 
     cfg.flag("-Wno-deprecated-declarations");
@@ -1145,26 +1144,6 @@ fn test_netbsd(target: &str) {
             "getrlimit" | "getrlimit64" |    // non-int in 1st arg
             "setrlimit" | "setrlimit64" |    // non-int in 1st arg
             "prlimit" | "prlimit64" |        // non-int in 2nd arg
-
-            // These functions presumably exist on netbsd but don't look like
-            // they're implemented on rumprun yet, just let them slide for now.
-            // Some of them look like they have headers but then don't have
-            // corresponding actual definitions either...
-            "shm_open" |
-            "shm_unlink" |
-            "syscall" |
-            "mq_open" |
-            "mq_close" |
-            "mq_getattr" |
-            "mq_notify" |
-            "mq_receive" |
-            "mq_send" |
-            "mq_setattr" |
-            "mq_timedreceive" |
-            "mq_timedsend" |
-            "mq_unlink" |
-            "ptrace" |
-            "sigaltstack" if rumprun => true,
 
             _ => false,
         }

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1568,10 +1568,7 @@ pub const IPPROTO_VRRP: ::c_int = 112;
 /// Common Address Resolution Protocol
 pub const IPPROTO_CARP: ::c_int = 112;
 /// L2TPv3
-// TEMP: Disabled for now; this constant was added to NetBSD on 2017-02-16,
-// but isn't yet supported by the NetBSD rumprun kernel image used for
-// libc testing.
-//pub const IPPROTO_L2TP: ::c_int = 115;
+pub const IPPROTO_L2TP: ::c_int = 115;
 /// SCTP
 pub const IPPROTO_SCTP: ::c_int = 132;
 /// PFSYNC

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -346,14 +346,6 @@ cfg_if! {
     } else if #[cfg(target_os = "emscripten")] {
         #[link(name = "c")]
         extern {}
-    } else if #[cfg(all(target_os = "netbsd",
-                        feature = "rustc-dep-of-std",
-                        target_vendor = "rumprun"))] {
-        // Since we don't use -nodefaultlibs on Rumprun, libc is always pulled
-        // in automatically by the linker. We avoid passing it explicitly, as it
-        // causes some versions of binutils to crash with an assertion failure.
-        #[link(name = "m")]
-        extern {}
     } else if #[cfg(any(target_os = "macos",
                         target_os = "ios",
                         target_os = "watchos",


### PR DESCRIPTION
Closes #2091

Also, document "Supported target policy" on the contributing.md. I'm not sure what we should say other than "Rust removes it, we also may remove it", so put only that for now. Any suggestion is appreciated.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>