### PR TITLE
Upgrade macOS image to 12

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -29,7 +29,7 @@ jobs:
 
   macos:
     name: macOS
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       fail-fast: true
       matrix:
@@ -223,7 +223,7 @@ jobs:
   build_channels_macos:
     name: Build Channels macOS
     needs: macos
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       OS: macos
     strategy:
@@ -290,7 +290,7 @@ jobs:
   semver_macos:
     if: ${{ false }} # This is currently broken
     name: Semver macOS
-    runs-on: macos-11
+    runs-on: macos-12
     continue-on-error: true
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
 
   macos:
     name: macOS
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       fail-fast: true
       matrix:

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -321,9 +321,6 @@ fn test_apple(target: &str) {
             // close calls the close_nocancel system call
             "close" => true,
 
-            // macOs 12 minimum
-            "backtrace_async" => true,
-
             _ => false,
         }
     });


### PR DESCRIPTION
macOS 12 on GHA is now GA: https://github.blog/changelog/2022-06-13-github-actions-macos-12-for-github-hosted-runners-is-now-generally-available/

Signed-off-by: Yuki Okushi <jtitor@2k36.org>