### PR TITLE
Fix FreeBSD CPU_ macros

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -3781,21 +3781,21 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpuset_t) -> () {
-        let bitset_bits = ::mem::size_of::<::c_long>();
+        let bitset_bits = 8 * ::mem::size_of::<::c_long>();
         let (idx, offset) = (cpu / bitset_bits, cpu % bitset_bits);
         cpuset.__bits[idx] |= 1 << offset;
         ()
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpuset_t) -> () {
-        let bitset_bits = ::mem::size_of::<::c_long>();
+        let bitset_bits = 8 * ::mem::size_of::<::c_long>();
         let (idx, offset) = (cpu / bitset_bits, cpu % bitset_bits);
         cpuset.__bits[idx] &= !(1 << offset);
         ()
     }
 
     pub fn CPU_ISSET(cpu: usize, cpuset: &cpuset_t) -> bool {
-        let bitset_bits = ::mem::size_of::<::c_long>();
+        let bitset_bits = 8 * ::mem::size_of::<::c_long>();
         let (idx, offset) = (cpu / bitset_bits, cpu % bitset_bits);
         0 != cpuset.__bits[idx] & (1 << offset)
     }
@@ -3803,9 +3803,9 @@ f! {
     pub fn CPU_COUNT(cpuset: &cpuset_t) -> ::c_int {
         let mut s: u32 = 0;
         let cpuset_size = ::mem::size_of::<cpuset_t>();
-        let bitset_bits = ::mem::size_of::<::c_long>();
+        let bitset_size = ::mem::size_of::<::c_long>();
 
-        for i in cpuset.__bits[..(cpuset_size / bitset_bits)].iter() {
+        for i in cpuset.__bits[..(cpuset_size / bitset_size)].iter() {
             s += i.count_ones();
         };
         s as ::c_int


### PR DESCRIPTION
The current definitions conflate bits and bytes, leading to panics.

Found while trying to add support for `nix::sched::sched_setaffinity` to FreeBSD. 