### PR TITLE
style: Format errors so that editors can jump to file/line

### DIFF
--- a/ci/style.rs
+++ b/ci/style.rs
@@ -196,6 +196,6 @@ impl State {
 impl Errors {
     fn error(&mut self, path: &Path, line: usize, msg: &str) {
         self.errs = true;
-        println!("{}:{} - {}", path.display(), line + 1, msg);
+        println!("{}:{}: {}", path.display(), line + 1, msg);
     }
 }


### PR DESCRIPTION
With this change, it's now possible to do:
```
./style src > e
vim -q e
```
