### PR TITLE
README.md: Clarify (lack of) MSRV policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ libc = "0.2"
 
 ## Rust version support
 
-The minimum supported Rust toolchain version is **Rust 1.13.0** . APIs requiring
+The minimum supported Rust toolchain version is currently **Rust 1.13.0**.
+(libc does not currently have any policy regarding changes to the minimum
+supported Rust version; such policy is a work in progress.) APIs requiring
 newer Rust features are only available on newer Rust toolchains:
 
 | Feature              | Version |


### PR DESCRIPTION
MSRV policy is still being discussed on an ongoing basis in
https://github.com/rust-lang/libs-team/issues/72 . In the interim,
clarify in README that libc doesn't currently have an MSRV policy.
