### PR TITLE
memmem and task_set_info are available on iOS

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -5545,6 +5545,12 @@ cfg_if! {
     if #[cfg(target_os = "macos")] {
         extern "C" {
             pub fn clock_settime(clock_id: ::clockid_t, tp: *const ::timespec) -> ::c_int;
+        }
+    }
+}
+cfg_if! {
+    if #[cfg(any(target_os = "macos", target_os = "ios"))] {
+        extern "C" {
             pub fn memmem(
                 haystack: *const ::c_void,
                 haystacklen: ::size_t,


### PR DESCRIPTION
memmem:  __OSX_AVAILABLE_STARTING(__MAC_10_7, __IPHONE_4_3)
task_set_info: __TVOS_PROHIBITED __WATCHOS_PROHIBITED