### PR TITLE
Add `gnu_get_[version|release]` for glibc

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2675,7 +2675,7 @@ fn test_linux(target: &str) {
                "elf.h",
                "fcntl.h",
                "glob.h",
-               "gnu/libc-version.h",
+               [gnu]: "gnu/libc-version.h",
                "grp.h",
                "iconv.h",
                "ifaddrs.h",

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2675,6 +2675,7 @@ fn test_linux(target: &str) {
                "elf.h",
                "fcntl.h",
                "glob.h",
+               "gnu/libc-version.h",
                "grp.h",
                "iconv.h",
                "ifaddrs.h",

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1326,6 +1326,11 @@ extern "C" {
     pub fn malloc_trim(__pad: ::size_t) -> ::c_int;
 }
 
+extern "C" {
+    pub fn gnu_get_libc_release() -> *const ::c_char;
+    pub fn gnu_get_libc_version() -> *const ::c_char;
+}
+
 cfg_if! {
     if #[cfg(any(target_arch = "x86",
                  target_arch = "arm",


### PR DESCRIPTION
See <https://sourceware.org/git/?p=glibc.git;a=blob;f=csu/version.c;h=8c0ed79c01223e1f12b54d19f90b5e5b7dd78d27;hb=HEAD#l51> and <http://refspecs.linux-foundation.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/libc-gnu-get-libc-version-1.html>