### PR TITLE
Socket constants necessary for ESP-IDF support in socket2

### DIFF
--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -83,6 +83,9 @@ pub const MSG_DONTROUTE: ::c_int = 0x4;
 pub const MSG_WAITALL: ::c_int = 0x02;
 pub const MSG_MORE: ::c_int = 0x10;
 pub const MSG_NOSIGNAL: ::c_int = 0x20;
+pub const MSG_TRUNC: ::c_int = 0x04;
+pub const MSG_CTRUNC: ::c_int = 0x08;
+pub const MSG_EOR: c_int = 0x08;
 
 pub const PTHREAD_STACK_MIN: ::size_t = 768;
 
@@ -100,6 +103,8 @@ extern "C" {
     pub fn sendmsg(s: ::c_int, msg: *const ::msghdr, flags: ::c_int) -> ::ssize_t;
     #[link_name = "lwip_recvmsg"]
     pub fn recvmsg(s: ::c_int, msg: *mut ::msghdr, flags: ::c_int) -> ::ssize_t;
+
+    pub fn eventfd(initval: ::c_uint, flags: ::c_int) -> ::c_int;
 }
 
 pub use crate::unix::newlib::generic::{sigset_t, stat};


### PR DESCRIPTION
I would like to upstream the support for [ESP-IDF](https://github.com/espressif/esp-idf) in the [socket2 crate](https://github.com/esp-rs-compat/socket2). (Which in turn is necessary for Rust async networking support on top of ESP-IDF.)

To tidy up the patch and remove [this](https://github.com/rust-lang/socket2/compare/master...esp-rs-compat:socket2:master#diff-bbdb7821e30b05ce3afbaa9fbc1526c18d6670d65479baaca3beaf4ea6174891R80) and [this](https://github.com/rust-lang/socket2/compare/master...esp-rs-compat:socket2:master#diff-bbdb7821e30b05ce3afbaa9fbc1526c18d6670d65479baaca3beaf4ea6174891R413) TODOs I need these constants defined in the `libc` crate