### PR TITLE
Bump up to v0.2.129

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.128"
+version = "0.2.129"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-test"
-version = "0.2.128"
+version = "0.2.129"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.128"
+version = "0.2.129"
 default-features = false
 
 [build-dependencies]


### PR DESCRIPTION
... because v0.2.128 has a Cargo bug: https://github.com/rust-lang/libc/issues/2866

Signed-off-by: Yuki Okushi <jtitor@2k36.org>