### PR TITLE
Bump to 0.2.130

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.129"
+version = "0.2.130"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-test"
-version = "0.2.129"
+version = "0.2.130"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.129"
+version = "0.2.130"
 default-features = false
 
 [build-dependencies]

--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -85,7 +85,7 @@ pub const MSG_MORE: ::c_int = 0x10;
 pub const MSG_NOSIGNAL: ::c_int = 0x20;
 pub const MSG_TRUNC: ::c_int = 0x04;
 pub const MSG_CTRUNC: ::c_int = 0x08;
-pub const MSG_EOR: c_int = 0x08;
+pub const MSG_EOR: ::c_int = 0x08;
 
 pub const PTHREAD_STACK_MIN: ::size_t = 768;
 


### PR DESCRIPTION
Quick fix for target `riscv32imc-esp-espidf`.