### PR TITLE
ESP-IDF - add missing double-colon

### DIFF
--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -85,7 +85,7 @@ pub const MSG_MORE: ::c_int = 0x10;
 pub const MSG_NOSIGNAL: ::c_int = 0x20;
 pub const MSG_TRUNC: ::c_int = 0x04;
 pub const MSG_CTRUNC: ::c_int = 0x08;
-pub const MSG_EOR: c_int = 0x08;
+pub const MSG_EOR: ::c_int = 0x08;
 
 pub const PTHREAD_STACK_MIN: ::size_t = 768;
 


### PR DESCRIPTION
The previous PR was having one of the new `const`s wrongly defined which broke the ESP-IDF build.