### PR TITLE
Fix incorrect constant for O_LARGEFILE on mips64-linux-musl

### DIFF
--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -458,7 +458,7 @@ pub const O_SYNC: ::c_int = 0x4010;
 pub const O_RSYNC: ::c_int = 0x4010;
 pub const O_DSYNC: ::c_int = 0x10;
 pub const O_ASYNC: ::c_int = 0x1000;
-pub const O_LARGEFILE: ::c_int = 0;
+pub const O_LARGEFILE: ::c_int = 0x2000;
 
 pub const EDEADLK: ::c_int = 45;
 pub const ENAMETOOLONG: ::c_int = 78;


### PR DESCRIPTION
Changes `O_LARGEFILE` from `0` to `0x2000` 

Bash script used for ensuring constant is correct:

```sh
#!/bin/bash
echo "
#include <fcntl.h>
int largefile() {
    return O_LARGEFILE;
}
" | mips64-linux-musl-gcc -c -O2 musl_o_largefile.c -o temp.o
mips64-linux-musl-objdump -d temp.o | grep -A2 largefile
```

Output:

```asm
0000000000000000 <largefile>:
   0:	03e00008 	jr	ra
   4:	24022000 	li	v0,8192    ; 0x2000
```

Link to relevant portion of kernel source, shows that it should match mips32 musl (which currently has a value of 0x2000 as well).

I believe the reason #2738 had this value incorrect was because it's 0 for glibc on mips64 (to specify it's the default, I believe).