### PR TITLE
Bump version to 0.2.132

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.131"
+version = "0.2.132"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-test"
-version = "0.2.131"
+version = "0.2.132"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.131"
+version = "0.2.132"
 default-features = false
 
 [build-dependencies]


### PR DESCRIPTION
I want to make changes to nix and other crates, but those changes depend on f967994052b23f81589069838a438fb9d32c785b being released. 