### PR TITLE
openbsd: ignore ci error about unexistent KERN_NSELCOLL constant

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -491,6 +491,8 @@ fn test_openbsd(target: &str) {
         match name {
             // Removed in OpenBSD 6.0
             "KERN_USERMOUNT" | "KERN_ARND" => true,
+            // Removed in OpenBSD 7.2
+            "KERN_NSELCOLL" => true,
             // Good chance it's going to be wrong depending on the host release
             "KERN_MAXID" | "NET_RT_MAXID" => true,
             "EV_SYSFLAGS" => true,


### PR DESCRIPTION
This sysctl(2) constant has been removed.

https://github.com/openbsd/src/commit/9bf42e341afcf2dd868da323254a70b8eb9463cf