### PR TITLE
Add `confstr` and guaranteed `_CS_*` constants on apple

### DIFF
--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -1507,6 +1507,10 @@ XATTR_SHOWCOMPRESSION
 XUCRED_VERSION
 YESEXPR
 YESSTR
+_CS_PATH
+_CS_DARWIN_USER_DIR
+_CS_DARWIN_USER_TEMP_DIR
+_CS_DARWIN_USER_CACHE_DIR
 _IOFBF
 _IOLBF
 _IONBF
@@ -1681,6 +1685,7 @@ clock_getres
 clonefile
 clonefileat
 cmsghdr
+confstr
 connectx
 copyfile
 copyfile_flags_t

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -3796,6 +3796,11 @@ pub const _SC_TRACE_NAME_MAX: ::c_int = 128;
 pub const _SC_TRACE_SYS_MAX: ::c_int = 129;
 pub const _SC_TRACE_USER_EVENT_MAX: ::c_int = 130;
 pub const _SC_PASS_MAX: ::c_int = 131;
+// `confstr` keys (only the values guaranteed by `man confstr`).
+pub const _CS_PATH: ::c_int = 1;
+pub const _CS_DARWIN_USER_DIR: ::c_int = 65536;
+pub const _CS_DARWIN_USER_TEMP_DIR: ::c_int = 65537;
+pub const _CS_DARWIN_USER_CACHE_DIR: ::c_int = 65538;
 
 pub const PTHREAD_MUTEX_NORMAL: ::c_int = 0;
 pub const PTHREAD_MUTEX_ERRORCHECK: ::c_int = 1;
@@ -4846,6 +4851,11 @@ extern "C" {
     pub fn fchflags(fd: ::c_int, flags: ::c_uint) -> ::c_int;
     pub fn clock_getres(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
     pub fn clock_gettime(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
+    #[cfg_attr(
+        all(target_os = "macos", target_arch = "x86"),
+        link_name = "confstr$UNIX2003"
+    )]
+    pub fn confstr(name: ::c_int, buf: *mut ::c_char, len: ::size_t) -> ::size_t;
     pub fn lio_listio(
         mode: ::c_int,
         aiocb_list: *const *mut aiocb,


### PR DESCRIPTION
I actually just want `_CS_DARWIN_USER_TEMP_DIR`, and the `confstr` function, but I also have added the other "guaranteed" `_CS_*` values (e.g. present in the [output of `man confstr`](https://gist.github.com/thomcc/12a27c7998019b6da9fa4b539bdbca44)).

This is apparently a [POSIX API](https://pubs.opengroup.org/onlinepubs/9699919799/functions/confstr.html) but I have no idea which other platforms support it, nor what values should be provided. It's somewhat important on Darwin (the only way to access the user temp dir), but I'm not sure what other use it has, so I've only provided it on Darwin.

There are a few other constants in Darwin `unistd.h`, but they're omitted since they're only conditionally present, and they provide values that... don't actually work[^1]. As a result, I've only provided the ones documented by `confstr` documentation.

[^1]: For example, `_CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS` nominally provides values that can be passed to a c compiler, but it gives `-W 64` for me, which does not seem to work with `clang`.