### PR TITLE
Upgrade Ubuntu image on GHA to 22.04

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   docker_linux_tier1:
     name: Docker Linux Tier1
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:
@@ -84,7 +84,7 @@ jobs:
 
   style_check:
     name: Style check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
         with:
@@ -98,7 +98,7 @@ jobs:
   docker_linux_tier2:
     name: Docker Linux Tier2
     needs: [docker_linux_tier1, style_check]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       max-parallel: 12
@@ -157,7 +157,7 @@ jobs:
     if: ${{ false }} # This is currently broken
     name: Docker Linux Build-Std Targets
     needs: [docker_linux_tier1, style_check]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       max-parallel: 12
@@ -179,7 +179,7 @@ jobs:
   docker_switch:
     name: Docker Switch
     needs: [docker_linux_tier1, style_check]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
         with:
@@ -193,7 +193,7 @@ jobs:
   build_channels_linux:
     name: Build Channels Linux
     needs: docker_linux_tier2
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       OS: linux
     strategy:
@@ -277,7 +277,7 @@ jobs:
   semver_linux:
     if: ${{ false }} # This is currently broken
     name: Semver Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
       - uses: actions/checkout@v3
@@ -302,7 +302,7 @@ jobs:
 
   docs:
     name: Generate documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: docker_linux_tier2
     steps:
       - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
@@ -323,7 +323,7 @@ jobs:
   end_success:
     name: bors build finished
     if: github.event.pusher.name == 'bors' && success()
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [
       docker_linux_tier1,
       docker_linux_tier2,
@@ -345,7 +345,7 @@ jobs:
   end_failure:
     name: bors build finished
     if: github.event.pusher.name == 'bors' && (failure() || cancelled())
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [
       docker_linux_tier1,
       docker_linux_tier2,

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   upload_docs:
     name: Upload documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'rust-lang/libc'
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   docker_linux_tier1:
     name: Docker Linux Tier1
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:
@@ -76,7 +76,7 @@ jobs:
 
   style_check:
     name: Style check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Setup Rust toolchain

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env sh
 
+# Disable SC2086 as it confuses the docker command.
+# shellcheck disable=SC2086
+
 # Small script to run tests for a target (or all targets) inside all the
 # respective docker images.
 


### PR DESCRIPTION
This updates Ubuntu image on GHA to 22.04.
Note that this doesn't update images on Docker so I expect the effect is relatively small.

r? @ghost
Signed-off-by: Yuki Okushi <jtitor@2k36.org>