### PR TITLE
Add musl's lib folder to library search path

### DIFF
--- a/ci/docker/aarch64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-musl/Dockerfile
@@ -10,6 +10,6 @@ RUN sh /install-musl.sh aarch64
 # FIXME: shouldn't need the `-lgcc` here, shouldn't that be in libstd?
 ENV PATH=$PATH:/musl-aarch64/bin:/rust/bin \
     CC_aarch64_unknown_linux_musl=musl-gcc \
-    RUSTFLAGS='-Clink-args=-lgcc' \
+    RUSTFLAGS='-Clink-args=-lgcc -L /musl-aarch64/lib' \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER="qemu-aarch64 -L /musl-aarch64"

--- a/ci/docker/arm-unknown-linux-musleabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-musleabihf/Dockerfile
@@ -10,4 +10,5 @@ RUN sh /install-musl.sh arm
 ENV PATH=$PATH:/musl-arm/bin:/rust/bin \
     CC_arm_unknown_linux_musleabihf=musl-gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_LINKER=musl-gcc \
-    CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_RUNNER="qemu-arm -L /musl-arm"
+    CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_RUNNER="qemu-arm -L /musl-arm" \
+    RUSTFLAGS="-L /musl-arm/lib"

--- a/ci/docker/i686-unknown-linux-musl/Dockerfile
+++ b/ci/docker/i686-unknown-linux-musl/Dockerfile
@@ -9,4 +9,5 @@ COPY install-musl.sh /
 RUN sh /install-musl.sh i686
 
 ENV PATH=$PATH:/musl-i686/bin:/rust/bin \
-    CC_i686_unknown_linux_musl=musl-gcc
+    CC_i686_unknown_linux_musl=musl-gcc \
+    RUSTFLAGS="-L /musl-i686/lib"

--- a/ci/docker/mips-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mips-unknown-linux-musl/Dockerfile
@@ -21,4 +21,5 @@ ENV PATH=$PATH:/rust/bin:/toolchain/staging_dir/toolchain-mips_24kc_gcc-8.4.0_mu
     STAGING_DIR=/toolchain/staging_dir \
     CC_mips_unknown_linux_musl=mips-openwrt-linux-musl-gcc \
     CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_LINKER=mips-openwrt-linux-musl-gcc \
-    CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_RUNNER="qemu-mips -L /toolchain/staging_dir/toolchain-mips_24kc_gcc-8.4.0_musl"
+    CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_RUNNER="qemu-mips -L /toolchain/staging_dir/toolchain-mips_24kc_gcc-8.4.0_musl" \
+    RUSTFLAGS="-L /toolchain/staging_dir/toolchain-mips_24kc_gcc-8.4.0_musl/lib"

--- a/ci/docker/mips64-unknown-linux-muslabi64/Dockerfile
+++ b/ci/docker/mips64-unknown-linux-muslabi64/Dockerfile
@@ -10,6 +10,6 @@ RUN sh /install-musl.sh mips64
 # FIXME: shouldn't need the `-lgcc` here, shouldn't that be in libstd?
 ENV PATH=$PATH:/musl-mips64/bin:/rust/bin \
     CC_mips64_unknown_linux_muslabi64=musl-gcc \
-    RUSTFLAGS='-Clink-args=-lgcc' \
+    RUSTFLAGS='-Clink-args=-lgcc -L /musl-mips64/lib' \
     CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_LINKER=musl-gcc \
     CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_RUNNER="qemu-mips64 -L /musl-mips64"

--- a/ci/docker/mips64el-unknown-linux-muslabi64/Dockerfile
+++ b/ci/docker/mips64el-unknown-linux-muslabi64/Dockerfile
@@ -10,6 +10,6 @@ RUN sh /install-musl.sh mips64el
 # FIXME: shouldn't need the `-lgcc` here, shouldn't that be in libstd?
 ENV PATH=$PATH:/musl-mips64el/bin:/rust/bin \
     CC_mips64el_unknown_linux_muslabi64=musl-gcc \
-    RUSTFLAGS='-Clink-args=-lgcc' \
+    RUSTFLAGS='-Clink-args=-lgcc -L /musl-mips64el/lib' \
     CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_MUSLABI64_LINKER=musl-gcc \
     CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_MUSLABI64_RUNNER="qemu-mips64el -L /musl-mips64el"

--- a/ci/docker/mipsel-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mipsel-unknown-linux-musl/Dockerfile
@@ -21,4 +21,5 @@ ENV PATH=$PATH:/rust/bin:/toolchain/staging_dir/toolchain-mipsel_mips32_gcc-8.4.
     STAGING_DIR=/toolchain/staging_dir \
     CC_mipsel_unknown_linux_musl=mipsel-openwrt-linux-musl-gcc \
     CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_LINKER=mipsel-openwrt-linux-musl-gcc \
-    CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_RUNNER="qemu-mipsel -L /toolchain/staging_dir/toolchain-mipsel_mips32_gcc-8.4.0_musl"
+    CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_RUNNER="qemu-mipsel -L /toolchain/staging_dir/toolchain-mipsel_mips32_gcc-8.4.0_musl" \
+    RUSTFLAGS="-L /toolchain/staging_dir/toolchain-mipsel_mips32_gcc-8.4.0_musl/lib"

--- a/ci/docker/s390x-unknown-linux-musl/Dockerfile
+++ b/ci/docker/s390x-unknown-linux-musl/Dockerfile
@@ -13,5 +13,5 @@ RUN sh /install-musl.sh s390x
 ENV CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-linux-gnu-gcc \
     CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_RUNNER="qemu-s390x -L /musl-s390x" \
     CC_s390x_unknown_linux_gnu=musl-gcc \
-    RUSTFLAGS='-Clink-args=-lgcc' \
+    RUSTFLAGS='-Clink-args=-lgcc -L /musl-s390x/lib' \
     PATH=$PATH:/musl-s390x/bin:/rust/bin

--- a/ci/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -7,4 +7,5 @@ RUN apt-get install -y --no-install-recommends \
 COPY install-musl.sh /
 RUN sh /install-musl.sh x86_64
 
-ENV PATH=$PATH:/musl-x86_64/bin:/rust/bin
+ENV PATH=$PATH:/musl-x86_64/bin:/rust/bin \
+    RUSTFLAGS="-L /musl-x86_64/lib"


### PR DESCRIPTION
Prior to this change, `libc.a` was being found in rustc's self-contained
musl target folder instead of the `libc.a` that we've built or
downloaded. This doesn't seem to have caused any noticeable issues as the
versions of musl we built/installed and the version shipped in rustc's
target matched exactly.

To resolve this, we pass the path to our version of musl's lib folder
directly as a `RUSTFLAG` which causes it to be found first.