### PR TITLE
Compatibility with ESP-IDF V5

### DIFF
--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -41,7 +41,7 @@ pub type tcflag_t = ::c_uint;
 pub type useconds_t = u32;
 
 cfg_if! {
-    if #[cfg(target_os = "horizon")] {
+    if #[cfg(any(target_os = "horizon", all(target_os = "espidf", espidf_time64)))] {
         pub type time_t = ::c_longlong;
     } else {
         pub type time_t = i32;


### PR DESCRIPTION
The new major release of the ESP-IDF (V5) has extended the `time_t` type from 32 to 64 bits. Unfortunately, this brings the challenge how to simultaneously support older ESP-IDF releases (current stable is V4.4.2) and the V5 one with the `libc` (and Rust STD) crates.

After dismissing the option to introduce 5 (or more) additional ESP-IDF targets, [we settled on the introduction of a `rustc` cfg flag, as the most lightweight option](https://github.com/esp-rs/rust/issues/110#issuecomment-1224550572): `espidf_time64`:
* This flag needs to be enabled by the user for ESP-IDF V5 (for example, by setting it in the `[build]` section of `.config/cargo.toml` or using one of the other methods to pass flags to the Rust compiler);
* This flag should not be set by the user for earlier ESP-IDF versions (we might reverse the logic once ESP-IDF V5 becomes more main-stream in future).

The good news in all that is that it is *impossible for the user to set the flag to the wrong value* as his/her build will simply fail. This is because compiling for the ESP-IDF framework, does require a hard dependency on the `esp-idf-sys` crate, which - besides exposing autogenerated (with bindgen) APIs which are a super-set of the `libc` APIs, also does the heavy-lifting of compiling the ESP-IDF framework itself and emitting the relevant Rust linker flags and a lot of other things. So when compiling `esp-idf-sys`, [we are checking the compatibility of the libc's `type_t` with the bindgen-ed one inside `esp-idf-sys`](https://github.com/esp-rs/esp-idf-sys/blob/master/src/lib.rs#L33) where the latter is the source of truth, so to say.


