### PR TITLE
refactor: use grep -E instead of egrep

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -79,7 +79,7 @@ if [ "$QEMU" != "" ]; then
     -net user \
     -nographic \
     -vga none 2>&1 | tee "${CARGO_TARGET_DIR}/out.log"
-  exec egrep "^(PASSED)|(test result: ok)" "${CARGO_TARGET_DIR}/out.log"
+  exec grep -E "^(PASSED)|(test result: ok)" "${CARGO_TARGET_DIR}/out.log"
 fi
 
 if [ "$TARGET" = "s390x-unknown-linux-gnu" ]; then

--- a/ci/test-runner-linux
+++ b/ci/test-runner-linux
@@ -20,6 +20,6 @@ timeout 30s qemu-system-$arch \
   -append init=/run_prog.sh > output || true
 
 # remove kernel messages
-tr -d '\r' < output | egrep -v '^\['
+tr -d '\r' < output | grep -Ev '^\['
 
-egrep "(PASSED)|(test result: ok)" output > /dev/null
+grep -E "(PASSED)|(test result: ok)" output > /dev/null


### PR DESCRIPTION
`egrep` and `fgrep` are obsolescent now. This PR updates  all `egrep` and `fgrep` commands to `grep -E` and `grep -F`.

Running egrep/fgrep command with grep v3.8 will output the following warning to stderr:

```
egrep: warning: egrep is obsolescent; using grep -E
```

see also:

- https://www.phoronix.com/news/GNU-Grep-3.8-Stop-egrep-fgrep
- https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html