### PR TITLE
Exposed malloc_size on MacOSX

### DIFF
--- a/src/unix/bsd/apple/b64/aarch64/mod.rs
+++ b/src/unix/bsd/apple/b64/aarch64/mod.rs
@@ -8,6 +8,10 @@ s! {
 
 pub const CLOCK_UPTIME_RAW: ::clockid_t = 8;
 
+extern "C" {
+    pub fn malloc_size(ptr: *mut ::c_void) -> ::size_t;
+}
+
 cfg_if! {
     if #[cfg(libc_align)] {
         mod align;

--- a/src/unix/bsd/apple/b64/x86_64/mod.rs
+++ b/src/unix/bsd/apple/b64/x86_64/mod.rs
@@ -1,6 +1,10 @@
 pub type boolean_t = ::c_uint;
 pub type mcontext_t = *mut __darwin_mcontext64;
 
+extern "C" {
+    pub fn malloc_size(ptr: *mut ::c_void) -> ::size_t;
+}
+
 s! {
     pub struct ucontext_t {
         pub uc_onstack: ::c_int,


### PR DESCRIPTION
`malloc_size` is available in the OSX libc, but not exposed by rust libc. This change exposed it.

This is my first PR to libc, or to any rust library. So please be liberal with feedback.