### PR TITLE
Exposed malloc_size on Mac

### DIFF
--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -1951,7 +1951,9 @@ mach_vm_offset_t
 mach_vm_size_t
 madvise
 malloc_default_zone
+malloc_good_size
 malloc_printf
+malloc_size
 malloc_statistics_t
 malloc_zone_calloc
 malloc_zone_check

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -5789,6 +5789,8 @@ extern "C" {
         attrBufSize: ::size_t,
         options: u64,
     ) -> ::c_int;
+
+    pub fn malloc_size(ptr: *const ::c_void) -> ::size_t;
 }
 
 pub unsafe fn mach_task_self() -> ::mach_port_t {

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -5791,6 +5791,7 @@ extern "C" {
     ) -> ::c_int;
 
     pub fn malloc_size(ptr: *const ::c_void) -> ::size_t;
+    pub fn malloc_good_size(size: ::size_t) -> ::size_t;
 }
 
 pub unsafe fn mach_task_self() -> ::mach_port_t {


### PR DESCRIPTION
This change exposes malloc_size, which is available in libc on MacOSX. 