### PR TITLE
Use `::Option` and not `Option` for `pthread_jit_write_callback_t`

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -119,7 +119,7 @@ pub type thread_throughput_qos_policy_t = *mut thread_throughput_qos_policy;
 
 pub type pthread_introspection_hook_t =
     extern "C" fn(event: ::c_uint, thread: ::pthread_t, addr: *mut ::c_void, size: ::size_t);
-pub type pthread_jit_write_callback_t = Option<extern "C" fn(ctx: *mut ::c_void) -> ::c_int>;
+pub type pthread_jit_write_callback_t = ::Option<extern "C" fn(ctx: *mut ::c_void) -> ::c_int>;
 
 pub type vm_statistics_t = *mut vm_statistics;
 pub type vm_statistics_data_t = vm_statistics;


### PR DESCRIPTION
The `pthread_jit_write_callback_t` type alias (introduced by https://github.com/rust-lang/libc/pull/2896) uses `Option` rather than `::Option`, which causes problems when trying to update the `libc` dependency that `std` has.

(Please cut a release after merging this <3)