### PR TITLE
Deploy GitHub Pages via GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,34 +1,35 @@
-name: Upload documentation
+name: Upload documentation to GitHub Pages
 
 on:
   push:
     branches:
       - master
 
-jobs:
-  upload_docs:
-    name: Upload documentation
-    runs-on: ubuntu-22.04
-    if: github.repository == 'rust-lang/libc'
+# Sets permissions of `GITHUB_TOKEN` to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Setup Rust toolchain
         run: TARGET=x86_64-unknown-linux-gnu sh ./ci/install-rust.sh
       - name: Generate documentation
         run: LIBC_CI=1 sh ci/dox.sh
-      - name: Deploy GitHub Pages
-        run: |
-          git worktree add gh-pages gh-pages
-          git config user.name "Deploy from CI"
-          git config user.email ""
-          cd gh-pages
-          # Delete the ref to avoid keeping history.
-          git update-ref -d refs/heads/gh-pages
-          rm -rf *
-          mv ../target/doc/* .
-          git add .
-          git commit -m "Deploy $GITHUB_SHA to gh-pages"
-          git push --force
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'target/doc'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This simplifies the deployment workflow. Tested it works fine on https://github.com/JohnTitor/libc/actions/runs/3151392197, you can also see https://johntitor.github.io/libc/.
r? @ghost

Signed-off-by: Yuki Okushi <jtitor@2k36.org>