### PR TITLE
add major/minor/makedev on apple OSes

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -4976,6 +4976,18 @@ f! {
     pub {const} fn VM_MAKE_TAG(id: u8) -> u32 {
         (id as u32) << 24u32
     }
+
+    pub fn major(dev: dev_t) -> i32 {
+        (dev >> 24) & 0xff
+    }
+
+    pub fn minor(dev: dev_t) -> i32 {
+        dev & 0xffffff
+    }
+
+    pub fn makedev(major: i32, minor: i32) -> dev_t {
+        (major << 24) | minor
+    }
 }
 
 safe_f! {


### PR DESCRIPTION
This impl corresponds to the macros in [`sys/types.h`](https://opensource.apple.com/source/xnu/xnu-7195.81.3/bsd/sys/types.h.auto.html):

```c
#define major(x)        ((int32_t)(((u_int32_t)(x) >> 24) & 0xff))
#define minor(x)        ((int32_t)((x) & 0xffffff))
#define makedev(x, y)    ((dev_t)(((x) << 24) | (y)))
```