### PR TITLE
add fgetpwent_r and fgetgrent_r on GNU/Linux

### DIFF
--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -589,9 +589,11 @@ futimes
 getauxval
 getentropy
 getgrent_r
+fgetgrent_r
 getloadavg
 getpt
 getpwent_r
+fgetpwent_r
 getpwnam_r
 getspent_r
 getutxent

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1310,6 +1310,20 @@ extern "C" {
         buflen: ::size_t,
         result: *mut *mut ::group,
     ) -> ::c_int;
+    pub fn fgetpwent_r(
+        stream: *mut ::FILE,
+        pwd: *mut ::passwd,
+        buf: *mut ::c_char,
+        buflen: ::size_t,
+        result: *mut *mut ::passwd,
+    ) -> ::c_int;
+    pub fn fgetgrent_r(
+        stream: *mut ::FILE,
+        grp: *mut ::group,
+        buf: *mut ::c_char,
+        buflen: ::size_t,
+        result: *mut *mut ::group,
+    ) -> ::c_int;
 
     pub fn sethostid(hostid: ::c_long) -> ::c_int;
 


### PR DESCRIPTION
[man page for `fgetpwent_r()`](https://man7.org/linux/man-pages/man3/getpwent_r.3.html)

[man page for `fgetgrent_r()`](https://man7.org/linux/man-pages/man3/getgrent_r.3.html)