### PR TITLE
Don't link against iconv on apple targets when used by `std`

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -5873,7 +5873,10 @@ cfg_if! {
     }
 }
 
-#[link(name = "iconv")]
+// These require a dependency on `libiconv`, and including this when built as
+// part of `std` means every Rust program gets it. Ideally we would have a link
+// modifier to only include these if they are used, but we do not.
+#[cfg_attr(not(feature = "rustc-dep-of-std"), link(name = "iconv"))]
 extern "C" {
     pub fn iconv_open(tocode: *const ::c_char, fromcode: *const ::c_char) -> iconv_t;
     pub fn iconv(


### PR DESCRIPTION
See https://github.com/rust-lang/libc/issues/2870 (and specifically my, erm, rant in https://github.com/rust-lang/libc/issues/2870#issuecomment-1271104762). I think we should probably remove it outright, but we definitely shouldn't have it in every Rust program by giving it to `std`.

FIxes https://github.com/rust-lang/libc/issues/2870