### PR TITLE
add faccessat on illumos/solaris and euidaccess on solaris

### DIFF
--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -3145,6 +3145,8 @@ extern "C" {
     pub fn setpflags(flags: ::c_uint, value: ::c_uint) -> ::c_int;
 
     pub fn sysinfo(command: ::c_int, buf: *mut ::c_char, count: ::c_long) -> ::c_int;
+
+    pub fn faccessat(fd: ::c_int, path: *const ::c_char, amode: ::c_int, flag: ::c_int) -> ::c_int;
 }
 
 #[link(name = "sendfile")]

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -72,6 +72,8 @@ extern "C" {
     pub fn fattach(fildes: ::c_int, path: *const ::c_char) -> ::c_int;
 
     pub fn pthread_getattr_np(thread: ::pthread_t, attr: *mut ::pthread_attr_t) -> ::c_int;
+
+    pub fn euidaccess(path: *const ::c_char, amode: ::c_int) -> ::c_int;
 }
 
 s_no_extra_traits! {


### PR DESCRIPTION
[`faccessat` man page of illumos](https://illumos.org/man/2/faccessat)

[`faccessat` and `euidaccess` man page of solaris](https://docs.oracle.com/cd/E88353_01/html/E37841/access-2.html)