### PR TITLE
add some time functions on glibc and musl

### DIFF
--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -654,3 +654,7 @@ utmpx
 utmpxname
 euidaccess
 eaccess
+asctime_r
+ctime_r
+strftime
+strptime

--- a/libc-test/semver/linux-musl.txt
+++ b/libc-test/semver/linux-musl.txt
@@ -50,3 +50,6 @@ reallocarray
 timex
 euidaccess
 eaccess
+asctime_r
+strftime
+strptime

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1335,6 +1335,17 @@ extern "C" {
 
     pub fn euidaccess(pathname: *const ::c_char, mode: ::c_int) -> ::c_int;
     pub fn eaccess(pathname: *const ::c_char, mode: ::c_int) -> ::c_int;
+
+    pub fn asctime_r(tm: *const ::tm, buf: *mut ::c_char) -> *mut ::c_char;
+    pub fn ctime_r(timep: *const time_t, buf: *mut ::c_char) -> *mut ::c_char;
+
+    pub fn strftime(
+        s: *mut ::c_char,
+        max: ::size_t,
+        format: *const ::c_char,
+        tm: *const ::tm,
+    ) -> ::size_t;
+    pub fn strptime(s: *const ::c_char, format: *const ::c_char, tm: *mut ::tm) -> *mut ::c_char;
 }
 
 extern "C" {

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -757,6 +757,16 @@ extern "C" {
 
     pub fn euidaccess(pathname: *const ::c_char, mode: ::c_int) -> ::c_int;
     pub fn eaccess(pathname: *const ::c_char, mode: ::c_int) -> ::c_int;
+
+    pub fn asctime_r(tm: *const ::tm, buf: *mut ::c_char) -> *mut ::c_char;
+
+    pub fn strftime(
+        s: *mut ::c_char,
+        max: ::size_t,
+        format: *const ::c_char,
+        tm: *const ::tm,
+    ) -> ::size_t;
+    pub fn strptime(s: *const ::c_char, format: *const ::c_char, tm: *mut ::tm) -> *mut ::c_char;
 }
 
 cfg_if! {


### PR DESCRIPTION
#### man pages

* [asctime/ctime man page](https://man7.org/linux/man-pages/man3/ctime.3.html)
* [strftime](https://man7.org/linux/man-pages/man3/strftime.3.html)
* [strptime](https://man7.org/linux/man-pages/man3/strptime.3.html)

I didn't add `ctime()/ctime_r()` on musl because they involve the `time_t` type, which elicits [a deprecation wraning](https://github.com/rust-lang/libc/pull/1956).

Is it fine to add these two functions on `musl`, they will have the same definitions  as the `glibc` ones:
```rust
pub fn ctime(timep: *const time_t) -> *mut ::c_char;
pub fn ctime_r(timep: *const time_t, buf: *mut ::c_char) -> *mut ::c_char;
```
If it's ok, I will add them:)