### PR TITLE
fix wrong xattr syscalls on NetBSD

### DIFF
--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2977,12 +2977,14 @@ extern "C" {
         name: *const ::c_char,
         value: *const ::c_void,
         size: ::size_t,
+        flags: ::c_int,
     ) -> ::c_int;
     pub fn lsetxattr(
         path: *const ::c_char,
         name: *const ::c_char,
         value: *const ::c_void,
         size: ::size_t,
+        flags: ::c_int,
     ) -> ::c_int;
     pub fn fsetxattr(
         filedes: ::c_int,
@@ -2996,7 +2998,7 @@ extern "C" {
     pub fn flistxattr(filedes: ::c_int, list: *mut ::c_char, size: ::size_t) -> ::ssize_t;
     pub fn removexattr(path: *const ::c_char, name: *const ::c_char) -> ::c_int;
     pub fn lremovexattr(path: *const ::c_char, name: *const ::c_char) -> ::c_int;
-    pub fn fremovexattr(fd: ::c_int, path: *const ::c_char, name: *const ::c_char) -> ::c_int;
+    pub fn fremovexattr(fd: ::c_int, name: *const ::c_char) -> ::c_int;
 
     pub fn string_to_flags(
         string_p: *mut *mut ::c_char,


### PR DESCRIPTION
I am not 100% sure that these bindings are wrong because I can not find them in the [NetBSD manual](https://man.netbsd.org/lsetxattr).

But according to [sys/sys/xattr.h](https://github.com/NetBSD/src/blob/ac36f3f9fee8aff1c69d653503149faaa531f752/sys/sys/xattr.h#L62-L76), they seems to be wrong:

```c
int	setxattr(const char *, const char *, const void *, size_t, int);
int	lsetxattr(const char *, const char *, const void *, size_t, int);

int	fremovexattr(int, const char *);
```

```rust
// Current bindings in `libc`:

pub fn setxattr(
    path: *const ::c_char,
    name: *const ::c_char,
    value: *const ::c_void,
    size: ::size_t,
) -> ::c_int;
pub fn lsetxattr(
    path: *const ::c_char,
    name: *const ::c_char,
    value: *const ::c_void,
    size: ::size_t,
) -> ::c_int;
pub fn fremovexattr(
    fd: ::c_int, 
    path: *const ::c_char, 
    name: *const ::c_char
) -> ::c_int;
```

Friendly ping @devnexen who originally added them in #2514 .