### PR TITLE
illumos: Remove obsolete (and private) a.out define

### DIFF
--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -56,8 +56,6 @@ pub const SOL_FILTER: ::c_int = 0xfffc;
 
 pub const MADV_PURGE: ::c_int = 9;
 
-pub const MR_HDR_AOUT: ::c_uint = 0x3;
-
 pub const B1000000: ::speed_t = 24;
 pub const B1152000: ::speed_t = 25;
 pub const B1500000: ::speed_t = 26;


### PR DESCRIPTION
This cleans up an obsolete definition which [has been removed](https://github.com/illumos/illumos-gate/commit/fec047081731fd77caf46ec0471c501b2cb33894#diff-33b9ac79706b16f65c95e909fde32771b388f896bee74a006d13fefdf877fe91L163) in upstream illumos, and thus is causing libc-test to fail on up-to-date machines.