### PR TITLE
add dirname and basename

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -204,6 +204,7 @@ fn test_apple(target: &str) {
         "iconv.h",
         "ifaddrs.h",
         "langinfo.h",
+        "libgen.h",
         "libproc.h",
         "limits.h",
         "locale.h",
@@ -417,6 +418,7 @@ fn test_openbsd(target: &str) {
         "errno.h",
         "execinfo.h",
         "fcntl.h",
+        "libgen.h",
         "limits.h",
         "link.h",
         "locale.h",
@@ -992,6 +994,7 @@ fn test_netbsd(target: &str) {
         "elf.h",
         "errno.h",
         "fcntl.h",
+        "libgen.h",
         "limits.h",
         "link.h",
         "locale.h",
@@ -1206,6 +1209,7 @@ fn test_dragonflybsd(target: &str) {
         "ifaddrs.h",
         "kvm.h",
         "langinfo.h",
+        "libgen.h",
         "limits.h",
         "link.h",
         "locale.h",
@@ -1505,6 +1509,7 @@ fn test_android(target: &str) {
                "fcntl.h",
                "grp.h",
                "ifaddrs.h",
+               "libgen.h",
                "limits.h",
                "link.h",
                "locale.h",
@@ -1866,6 +1871,7 @@ fn test_freebsd(target: &str) {
                 "iconv.h",
                 "ifaddrs.h",
                 "langinfo.h",
+                "libgen.h",
                 "libutil.h",
                 "limits.h",
                 "link.h",
@@ -2771,6 +2777,7 @@ fn test_linux(target: &str) {
                "iconv.h",
                "ifaddrs.h",
                "langinfo.h",
+               "libgen.h",
                "limits.h",
                "link.h",
                "locale.h",
@@ -3409,6 +3416,22 @@ fn test_linux(target: &str) {
             // to the issues described here: https://github.com/rust-lang/libc/issues/2816
             // it can't be changed from struct.
             "pthread_sigqueue" => true,
+
+            // There are two versions of basename(3) on Linux with glibc, see
+            //
+            // https://man7.org/linux/man-pages/man3/basename.3.html
+            //
+            // If libgen.h is included, then the POSIX version will be available;
+            // If _GNU_SOURCE is defined and string.h is included, then the GNU one
+            // will be used.
+            //
+            // libc exposes both of them, providing a prefix to differentiate between
+            // them.
+            //
+            // Because the name with prefix is not a valid symbol in C, we have to
+            // skip the tests.
+            "posix_basename" if gnu => true,
+            "gnu_basename" if gnu => true,
 
             _ => false,
         }

--- a/libc-test/semver/android.txt
+++ b/libc-test/semver/android.txt
@@ -3548,3 +3548,5 @@ winsize
 wmemchr
 write
 writev
+dirname
+basename

--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -2227,3 +2227,5 @@ wait4
 waitid
 xsw_usage
 xucred
+dirname
+basename

--- a/libc-test/semver/dragonfly.txt
+++ b/libc-test/semver/dragonfly.txt
@@ -1546,3 +1546,5 @@ wait4
 waitid
 xucred
 eaccess
+dirname
+basename

--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -1926,3 +1926,5 @@ waitid
 xallocx
 xucred
 eaccess
+dirname
+basename

--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -658,3 +658,6 @@ asctime_r
 ctime_r
 strftime
 strptime
+dirname
+posix_basename
+gnu_basename

--- a/libc-test/semver/linux-musl.txt
+++ b/libc-test/semver/linux-musl.txt
@@ -53,3 +53,5 @@ eaccess
 asctime_r
 strftime
 strptime
+dirname
+basename

--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -1533,3 +1533,5 @@ uucred
 vm_size_t
 wait4
 waitid
+dirname
+basename

--- a/libc-test/semver/openbsd.txt
+++ b/libc-test/semver/openbsd.txt
@@ -1231,3 +1231,5 @@ utmp
 utrace
 wait4
 xucred
+dirname
+basename

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -5870,6 +5870,9 @@ extern "C" {
 
     pub fn malloc_size(ptr: *const ::c_void) -> ::size_t;
     pub fn malloc_good_size(size: ::size_t) -> ::size_t;
+
+    pub fn dirname(path: *mut ::c_char) -> *mut ::c_char;
+    pub fn basename(path: *mut ::c_char) -> *mut ::c_char;
 }
 
 pub unsafe fn mach_task_self() -> ::mach_port_t {

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1663,6 +1663,9 @@ extern "C" {
 
     pub fn umtx_sleep(ptr: *const ::c_int, value: ::c_int, timeout: ::c_int) -> ::c_int;
     pub fn umtx_wakeup(ptr: *const ::c_int, count: ::c_int) -> ::c_int;
+
+    pub fn dirname(path: *mut ::c_char) -> *mut ::c_char;
+    pub fn basename(path: *mut ::c_char) -> *mut ::c_char;
 }
 
 #[link(name = "rt")]

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
@@ -463,6 +463,9 @@ extern "C" {
     ) -> ::c_int;
 
     pub fn fdatasync(fd: ::c_int) -> ::c_int;
+
+    pub fn dirname(path: *const ::c_char) -> *mut ::c_char;
+    pub fn basename(path: *const ::c_char) -> *mut ::c_char;
 }
 
 cfg_if! {

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -487,6 +487,9 @@ extern "C" {
     pub fn setproctitle_fast(fmt: *const ::c_char, ...);
     pub fn timingsafe_bcmp(a: *const ::c_void, b: *const ::c_void, len: ::size_t) -> ::c_int;
     pub fn timingsafe_memcmp(a: *const ::c_void, b: *const ::c_void, len: ::size_t) -> ::c_int;
+
+    pub fn dirname(path: *mut ::c_char) -> *mut ::c_char;
+    pub fn basename(path: *mut ::c_char) -> *mut ::c_char;
 }
 
 cfg_if! {

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -535,6 +535,9 @@ extern "C" {
         len: ::size_t,
         flags: ::c_uint,
     ) -> ::ssize_t;
+
+    pub fn dirname(path: *mut ::c_char) -> *mut ::c_char;
+    pub fn basename(path: *mut ::c_char) -> *mut ::c_char;
 }
 
 #[link(name = "kvm")]

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -535,6 +535,9 @@ extern "C" {
         len: ::size_t,
         flags: ::c_uint,
     ) -> ::ssize_t;
+
+    pub fn dirname(path: *mut ::c_char) -> *mut ::c_char;
+    pub fn basename(path: *mut ::c_char) -> *mut ::c_char;
 }
 
 #[link(name = "kvm")]

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -743,6 +743,9 @@ extern "C" {
     pub fn gethostid() -> ::c_long;
     pub fn sethostid(hostid: ::c_long) -> ::c_int;
     pub fn ftok(path: *const ::c_char, id: ::c_int) -> ::key_t;
+
+    pub fn dirname(path: *mut ::c_char) -> *mut ::c_char;
+    pub fn basename(path: *mut ::c_char) -> *mut ::c_char;
 }
 
 cfg_if! {

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -3227,6 +3227,9 @@ extern "C" {
     pub fn reallocarray(ptr: *mut ::c_void, nmemb: ::size_t, size: ::size_t) -> *mut ::c_void;
 
     pub fn pthread_getcpuclockid(thread: ::pthread_t, clk_id: *mut ::clockid_t) -> ::c_int;
+
+    pub fn dirname(path: *const ::c_char) -> *mut ::c_char;
+    pub fn basename(path: *const ::c_char) -> *mut ::c_char;
 }
 
 cfg_if! {

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1346,6 +1346,14 @@ extern "C" {
         tm: *const ::tm,
     ) -> ::size_t;
     pub fn strptime(s: *const ::c_char, format: *const ::c_char, tm: *mut ::tm) -> *mut ::c_char;
+
+    pub fn dirname(path: *mut ::c_char) -> *mut ::c_char;
+    /// POSIX version of `basename(3)`, defined in `libgen.h`.
+    #[link_name = "__xpg_basename"]
+    pub fn posix_basename(path: *mut ::c_char) -> *mut ::c_char;
+    /// GNU version of `basename(3)`, defined in `string.h`.
+    #[link_name = "basename"]
+    pub fn gnu_basename(path: *const ::c_char) -> *mut ::c_char;
 }
 
 extern "C" {

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -767,6 +767,9 @@ extern "C" {
         tm: *const ::tm,
     ) -> ::size_t;
     pub fn strptime(s: *const ::c_char, format: *const ::c_char, tm: *mut ::tm) -> *mut ::c_char;
+
+    pub fn dirname(path: *mut ::c_char) -> *mut ::c_char;
+    pub fn basename(path: *mut ::c_char) -> *mut ::c_char;
 }
 
 cfg_if! {


### PR DESCRIPTION
This PR adds `dirname(3)` and `basename(3)` on the following platforms:
* Linux with glibc
* Linux with musl
* Android
* FreeBSD
* DragonFlyBSD
* NetBSD
* OpenBSD
* Apple platforms

I tested this PR on my host machine (Linux with glibc), and got the following error:
```
RUNNING ALL TESTS
bad basename function pointer: rust: 140093945892128 (0x7f6a29e14d20) != c 140093945544944 (0x7f6a29dc00f0)
thread 'main' panicked at 'some tests failed', /home/steve/Documents/workspace/libc/target/debug/build/libc-test-592f01d15ee93e7a/out/main.rs:12:21
stack backtrace:
   0: std::panicking::begin_panic
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/panicking.rs:616:12
   1: main::main
             at /home/steve/Documents/workspace/libc/target/debug/build/libc-test-592f01d15ee93e7a/out/main.rs:12:21
   2: core::ops::function::FnOnce::call_once
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/ops/function.rs:248:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
error: test failed, to rerun pass '--test main'
```
The reason for this error probably is that there are two `basename(3)` on Linux with glibc, the  POSIX version and the GNU version, and they clash with each other. In C, if one `#include <libgen.h>`, then the POSIX version will be available; If one ` #define _GNU_SOURCE` and `#include <string.h>`, then the GNU one will be used.

Can we distinguish them in `libc`?