### PR TITLE
Derive Default for structs

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -71,7 +71,7 @@ macro_rules! s {
     (it: $(#[$attr:meta])* pub struct $i:ident { $($field:tt)* }) => (
         __item! {
             #[repr(C)]
-            #[cfg_attr(feature = "extra_traits", derive(Debug, Eq, Hash, PartialEq))]
+            #[cfg_attr(feature = "extra_traits", derive(Debug, Eq, Hash, PartialEq, Default))]
             #[allow(deprecated)]
             $(#[$attr])*
             pub struct $i { $($field)* }


### PR DESCRIPTION
A large number of structs are passed by-reference to functions which write them, and in this case, it's particularly useful to be able to easily construct a zeroed-out version of the struct instead of writing it by hand. At least in my particular case, I was interested in doing this for the [`passwd`](https://docs.rs/libc/latest/libc/struct.passwd.html) struct, but since I know it's not the only one, I decided to try a blanket-impl approach.

This is _only_ done when you have the `extra-traits` feature enabled, so, it shouldn't affect build time without this feature enabled.

You could argue that doing `MaybeUninit::zeroed().assume_init()` is okay even though it's unsafe code, since users of this library are already likely using a lot of unsafe code. I don't like this argument, since `Default` feels a lot more idiomatic, and reducing the number of unsafe blocks is still good imho.