### PR TITLE
Ignore `res_init` test on macOS

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -332,6 +332,9 @@ fn test_apple(target: &str) {
             // close calls the close_nocancel system call
             "close" => true,
 
+            // FIXME: libstd removed libresolv support: https://github.com/rust-lang/rust/pull/102766
+            "res_init" => true,
+
             // FIXME: remove once the target in CI is updated
             "pthread_jit_write_freeze_callbacks_np" => true,
 


### PR DESCRIPTION
This addresses the below failure:

```
 = note: Undefined symbols for architecture x86_64:
            "_res_9_init", referenced from:
                main::fn_res_init::h8e336279ac8061c4 in main-00bd2ff8180a104c.3yxb2bpe56zwhp2u.rcgu.o
                ___test_fn_res_init in libmain.a(main.o)
          ld: symbol(s) not found for architecture x86_64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Signed-off-by: Yuki Okushi <jtitor@2k36.org>