### PR TITLE
Enforce order of any `s_*!` macro calls

### DIFF
--- a/ci/style.rs
+++ b/ci/style.rs
@@ -142,6 +142,12 @@ fn check_style(file: &str, path: &Path, err: &mut Errors) {
         } else if line.starts_with("s! {") {
             s_macros += 1;
             State::Structs
+        } else if line.starts_with("s_no_extra_traits! {") {
+            // multiple macros of this type are allowed
+            State::Structs
+        } else if line.starts_with("s_paren! {") {
+            // multiple macros of this type are allowed
+            State::Structs
         } else if line.starts_with("f! {") {
             f_macros += 1;
             State::FunctionDefinitions

--- a/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
@@ -6,17 +6,6 @@ pub type time_t = i64;
 pub type suseconds_t = i64;
 pub type register_t = i64;
 
-// should be pub(crate), but that requires Rust 1.18.0
-cfg_if! {
-    if #[cfg(libc_const_size_of)] {
-        #[doc(hidden)]
-        pub const _ALIGNBYTES: usize = ::mem::size_of::<::c_longlong>() - 1;
-    } else {
-        #[doc(hidden)]
-        pub const _ALIGNBYTES: usize = 8 - 1;
-    }
-}
-
 s_no_extra_traits! {
     pub struct gpregs {
         pub gp_x: [::register_t; 30],
@@ -41,6 +30,17 @@ s_no_extra_traits! {
         pub mc_flags: ::c_int,
         pub mc_pad: ::c_int,
         pub mc_spare: [u64; 8],
+    }
+}
+
+// should be pub(crate), but that requires Rust 1.18.0
+cfg_if! {
+    if #[cfg(libc_const_size_of)] {
+        #[doc(hidden)]
+        pub const _ALIGNBYTES: usize = ::mem::size_of::<::c_longlong>() - 1;
+    } else {
+        #[doc(hidden)]
+        pub const _ALIGNBYTES: usize = 8 - 1;
     }
 }
 

--- a/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
@@ -6,17 +6,6 @@ pub type time_t = i64;
 pub type suseconds_t = ::c_long;
 pub type register_t = i64;
 
-// should be pub(crate), but that requires Rust 1.18.0
-cfg_if! {
-    if #[cfg(libc_const_size_of)] {
-        #[doc(hidden)]
-        pub const _ALIGNBYTES: usize = ::mem::size_of::<::c_longlong>() - 1;
-    } else {
-        #[doc(hidden)]
-        pub const _ALIGNBYTES: usize = 8 - 1;
-    }
-}
-
 s_no_extra_traits! {
     pub struct gpregs {
         pub gp_ra: ::register_t,
@@ -43,6 +32,17 @@ s_no_extra_traits! {
         pub mc_flags: ::c_int,
         pub mc_pad: ::c_int,
         pub mc_spare: [u64; 8],
+    }
+}
+
+// should be pub(crate), but that requires Rust 1.18.0
+cfg_if! {
+    if #[cfg(libc_const_size_of)] {
+        #[doc(hidden)]
+        pub const _ALIGNBYTES: usize = ::mem::size_of::<::c_longlong>() - 1;
+    } else {
+        #[doc(hidden)]
+        pub const _ALIGNBYTES: usize = 8 - 1;
     }
 }
 

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -26,6 +26,30 @@ s! {
     }
 }
 
+s_no_extra_traits! {
+    #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
+    pub union door_desc_t__d_data {
+        pub d_desc: door_desc_t__d_data__d_desc,
+        d_resv: [::c_int; 5], /* Check out /usr/include/sys/door.h */
+    }
+
+    #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
+    pub struct door_desc_t {
+        pub d_attributes: door_attr_t,
+        pub d_data: door_desc_t__d_data,
+    }
+
+    #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
+    pub struct door_arg_t {
+        pub data_ptr: *const ::c_char,
+        pub data_size: ::size_t,
+        pub desc_ptr: *const door_desc_t,
+        pub dec_num: ::c_uint,
+        pub rbuf: *const ::c_char,
+        pub rsize: ::size_t,
+    }
+}
+
 pub const PORT_SOURCE_POSTWAIT: ::c_int = 8;
 pub const PORT_SOURCE_SIGNAL: ::c_int = 9;
 
@@ -74,28 +98,4 @@ extern "C" {
     pub fn pthread_getattr_np(thread: ::pthread_t, attr: *mut ::pthread_attr_t) -> ::c_int;
 
     pub fn euidaccess(path: *const ::c_char, amode: ::c_int) -> ::c_int;
-}
-
-s_no_extra_traits! {
-    #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
-    pub union door_desc_t__d_data {
-        pub d_desc: door_desc_t__d_data__d_desc,
-        d_resv: [::c_int; 5], /* Check out /usr/include/sys/door.h */
-    }
-
-    #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
-    pub struct door_desc_t {
-        pub d_attributes: door_attr_t,
-        pub d_data: door_desc_t__d_data,
-    }
-
-    #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
-    pub struct door_arg_t {
-        pub data_ptr: *const ::c_char,
-        pub data_size: ::size_t,
-        pub desc_ptr: *const door_desc_t,
-        pub dec_num: ::c_uint,
-        pub rbuf: *const ::c_char,
-        pub rsize: ::size_t,
-    }
 }

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -39,6 +39,7 @@ pub type blkcnt_t = i64;
 pub type nfds_t = c_ulong;
 pub type wchar_t = i32;
 pub type nl_item = c_int;
+pub type __wasi_rights_t = u64;
 
 s_no_extra_traits! {
     #[repr(align(16))]
@@ -47,8 +48,6 @@ s_no_extra_traits! {
         priv_: [f64; 4]
     }
 }
-
-pub type __wasi_rights_t = u64;
 
 #[allow(missing_copy_implementations)]
 #[cfg_attr(feature = "extra_traits", derive(Debug))]


### PR DESCRIPTION
Before this change, only the order of `s!` was checked. After, it also checks `s_no_extra_traits!` and `s_paren!`. Only the order is checked, not the number of calls. This is required because multiple calls have to be allowed.