### PR TITLE
Add Trusty platform support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,12 @@ cfg_if! {
 
         mod hermit;
         pub use hermit::*;
+    } else if #[cfg(target_os = "trusty")] {
+        mod fixed_width_ints;
+        pub use fixed_width_ints::*;
+
+        mod trusty;
+        pub use trusty::*;
     } else if #[cfg(all(target_env = "sgx", target_vendor = "fortanix"))] {
         mod fixed_width_ints;
         pub use fixed_width_ints::*;

--- a/src/trusty.rs
+++ b/src/trusty.rs
@@ -1,0 +1,66 @@
+pub use core::ffi::c_void;
+
+pub type size_t = usize;
+pub type ssize_t = isize;
+
+cfg_if! {
+    if #[cfg(any(target_arch = "aarch64", target_arch = "arm"))] {
+        pub type c_char = u8;
+    } else if #[cfg(target_arch = "x86_64")] {
+        pub type c_char = i8;
+    }
+}
+
+pub type c_schar = i8;
+pub type c_uchar = u8;
+pub type c_short = i16;
+pub type c_ushort = u16;
+pub type c_int = i32;
+pub type c_uint = u32;
+
+cfg_if! {
+    if #[cfg(target_pointer_width = "32")] {
+        pub type c_long = i32;
+        pub type c_ulong = u32;
+    } else if #[cfg(target_pointer_width = "64")] {
+        pub type c_long = i64;
+        pub type c_ulong = u64;
+    }
+}
+
+pub type c_longlong = i64;
+pub type c_ulonglong = u64;
+
+pub type c_uint8_t = u8;
+pub type c_uint16_t = u16;
+pub type c_uint32_t = u32;
+pub type c_uint64_t = u64;
+
+pub type c_int8_t = i8;
+pub type c_int16_t = i16;
+pub type c_int32_t = i32;
+pub type c_int64_t = i64;
+
+pub type time_t = c_long;
+
+s! {
+    pub struct iovec {
+        pub iov_base: *mut ::c_void,
+        pub iov_len: ::size_t,
+    }
+}
+
+pub const STDOUT_FILENO: ::c_int = 1;
+pub const STDERR_FILENO: ::c_int = 2;
+
+extern "C" {
+    pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;
+    pub fn malloc(size: size_t) -> *mut c_void;
+    pub fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
+    pub fn free(p: *mut c_void);
+    pub fn memalign(align: ::size_t, size: ::size_t) -> *mut ::c_void;
+    pub fn posix_memalign(memptr: *mut *mut ::c_void, align: ::size_t, size: ::size_t) -> ::c_int;
+    pub fn write(fd: ::c_int, buf: *const ::c_void, count: ::size_t) -> ::ssize_t;
+    pub fn writev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
+    pub fn strlen(cs: *const c_char) -> size_t;
+}


### PR DESCRIPTION
This PR adds support for the [Trusty secure operating system](https://source.android.com/docs/security/features/trusty). This upstreams [the patch that we have been using](https://cs.android.com/android/platform/superproject/+/master:external/rust/crates/libc/patches/trusty.patch;l=1;drc=122e586e93a534160230dc10ae3474cf31dd8f7f) internally, cleaned up to meet the project's style conventions.