### PR TITLE
add major/minor on BSDs/illumos

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -821,6 +821,7 @@ fn test_solarish(target: &str) {
         "sys/ioctl.h",
         "sys/lgrp_user.h",
         "sys/loadavg.h",
+        "sys/mkdev.h",
         "sys/mman.h",
         "sys/mount.h",
         "sys/priv.h",

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1578,6 +1578,14 @@ f! {
         let (idx, offset) = ((cpu >> 6) & 3, cpu & 63);
         0 != cpuset.ary[idx] & (1 << offset)
     }
+
+    pub fn major(dev: ::dev_t) -> ::c_int {
+         ((dev >> 8) & 0xff) as ::c_int
+    }
+
+    pub fn minor(dev: ::dev_t) -> ::c_int {
+        (dev & 0xffff00ff) as ::c_int
+    }
 }
 
 safe_f! {

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
@@ -442,6 +442,16 @@ safe_f! {
     }
 }
 
+f! {
+    pub fn major(dev: ::dev_t) -> ::c_int {
+         ((dev >> 8) & 0xff) as ::c_int
+    }
+
+    pub fn minor(dev: ::dev_t) -> ::c_int {
+        (dev & 0xffff00ff) as ::c_int
+    }
+}
+
 extern "C" {
     // Return type ::c_int was removed in FreeBSD 12
     pub fn setgrent() -> ::c_int;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -462,6 +462,16 @@ safe_f! {
     }
 }
 
+f! {
+    pub fn major(dev: ::dev_t) -> ::c_int {
+        (((dev >> 32) & 0xffffff00) | ((dev >> 8) & 0xff)) as ::c_int
+    }
+
+    pub fn minor(dev: ::dev_t) -> ::c_int {
+        (((dev >> 24) & 0xff00) | (dev & 0xffff00ff)) as ::c_int
+    }
+}
+
 extern "C" {
     pub fn setgrent();
     pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -481,6 +481,16 @@ safe_f! {
     }
 }
 
+f! {
+    pub fn major(dev: ::dev_t) -> ::c_int {
+        (((dev >> 32) & 0xffffff00) | ((dev >> 8) & 0xff)) as ::c_int
+    }
+
+    pub fn minor(dev: ::dev_t) -> ::c_int {
+        (((dev >> 24) & 0xff00) | (dev & 0xffff00ff)) as ::c_int
+    }
+}
+
 extern "C" {
     pub fn setgrent();
     pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -481,6 +481,16 @@ safe_f! {
     }
 }
 
+f! {
+    pub fn major(dev: ::dev_t) -> ::c_int {
+        (((dev >> 32) & 0xffffff00) | ((dev >> 8) & 0xff)) as ::c_int
+    }
+
+    pub fn minor(dev: ::dev_t) -> ::c_int {
+        (((dev >> 24) & 0xff00) | (dev & 0xffff00ff)) as ::c_int
+    }
+}
+
 extern "C" {
     pub fn setgrent();
     pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2464,6 +2464,17 @@ f! {
     pub fn PROT_MPROTECT_EXTRACT(x: ::c_int) -> ::c_int {
         (x >> 3) & 0x7
     }
+
+    pub fn major(dev: ::dev_t) -> ::c_int {
+        (((dev as u32) & 0x000fff00) >>  8) as ::c_int
+    }
+
+    pub fn minor(dev: ::dev_t) -> ::c_int {
+        let mut res = 0;
+        res |= ((dev as u32) & 0xfff00000) >> 12;
+        res |= (dev as u32) & 0x000000ff;
+        res as ::c_int
+    }
 }
 
 safe_f! {

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1729,6 +1729,19 @@ f! {
         (_ALIGN(::mem::size_of::<::cmsghdr>()) + _ALIGN(length as usize))
             as ::c_uint
     }
+
+    pub fn major(dev: ::dev_t) -> ::c_uint{
+        ((dev as ::c_uint) >> 8) & 0xff
+    }
+
+    pub fn minor(dev: ::dev_t) -> ::c_uint {
+        let dev = dev as ::c_uint;
+        let mut res = 0;
+        res |= (dev) & 0xff;
+        res |= ((dev) & 0xffff0000) >> 8;
+
+        res
+    }
 }
 
 safe_f! {

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2584,6 +2584,8 @@ const _CMSG_HDR_ALIGNMENT: usize = 4;
 
 const _CMSG_DATA_ALIGNMENT: usize = ::mem::size_of::<::c_int>();
 
+const NEWDEV: ::c_int = 1;
+
 const_fn! {
     {const} fn _CMSG_HDR_ALIGN(p: usize) -> usize {
         (p + _CMSG_HDR_ALIGNMENT - 1) & !(_CMSG_HDR_ALIGNMENT - 1)
@@ -3198,6 +3200,10 @@ extern "C" {
     ) -> ::c_int;
 
     pub fn sync();
+
+    fn __major(version: ::c_int, devnum: ::dev_t) -> ::major_t;
+    fn __minor(version: ::c_int, devnum: ::dev_t) -> ::minor_t;
+    fn __makedev(version: ::c_int, majdev: ::major_t, mindev: ::minor_t) -> ::dev_t;
 }
 
 #[link(name = "sendfile")]
@@ -3252,6 +3258,18 @@ extern "C" {
         tpe: ::lgrp_rsrc_t,
     ) -> ::c_int;
     pub fn lgrp_root(cookie: ::lgrp_cookie_t) -> ::lgrp_id_t;
+}
+
+pub unsafe fn major(device: ::dev_t) -> ::major_t {
+    __major(NEWDEV, device)
+}
+
+pub unsafe fn minor(device: ::dev_t) -> ::minor_t {
+    __minor(NEWDEV, device)
+}
+
+pub unsafe fn makedev(maj: ::major_t, min: ::minor_t) -> ::dev_t {
+    __makedev(NEWDEV, maj, min)
 }
 
 mod compat;


### PR DESCRIPTION
This PR adds `major/minor` on BSDs and `major/minor/makedev` on illumos.

Ref:
* [FreeBSD 11](https://github.com/freebsd/freebsd-src/blob/3e9337c6b211e778829ed3af783cd41447a8721b/sys/sys/types.h#L372-L374)
   ```c
   #define	major(x)	((int)(((u_int)(x) >> 8)&0xff))	/* major number */
   #define	minor(x)	((int)((x)&0xffff00ff))		/* minor number */
   ```
* [FreeBSD 12/13/14](https://github.com/freebsd/freebsd-src/blob/3d98e253febf816e6e2aea7d3b1c013c421895de/sys/sys/types.h#L332-L341)
  ```c
  static __inline int
  __major(dev_t _d)
  {
      return (((_d >> 32) & 0xffffff00) | ((_d >> 8) & 0xff));
  }
  
  static __inline int
  __minor(dev_t _d)
  {
      return (((_d >> 24) & 0xff00) | (_d & 0xffff00ff));
  }
  ```
* [DragonFly](https://github.com/DragonFlyBSD/DragonFlyBSD/blob/d7a10f947f5344fc95e874ca3b83e9e8d0986b25/sys/sys/types.h#L170-L171)
  ```c
  #define	major(x)	((int)(((u_int)(x) >> 8)&0xff)) /* major number */
  #define	minor(x)	((int)((x)&0xffff00ff))         /* minor number */
  ```
* [NetBSD](https://github.com/NetBSD/src/blob/a25a6fec1b0a676fc5b36fa01b2990e775775d90/sys/sys/types.h#L264-L266)
   ```c
  #define	major(x)	((devmajor_t)(((uint32_t)(x) & 0x000fff00) >>  8))
  #define	minor(x)	((devminor_t)((((uint32_t)(x) & 0xfff00000) >> 12) | \
				                      (((uint32_t)(x) & 0x000000ff) >>  0)))
   ```
* [OpenBSD](https://github.com/openbsd/src/blob/05cbc9aa8d8372e83274c75e35add6b8073c26f5/sys/sys/types.h#L211-L212)
   ```c
   #define	major(x)	(((unsigned)(x) >> 8) & 0xff)
   #define	minor(x)	((unsigned)((x) & 0xff) | (((x) & 0xffff0000) >> 8))
   ```
* illumos:

  1. [mkdev.c](https://github.com/illumos/illumos-gate/blob/8b26092d555bd1deaacf79ea64da374602aefb65/usr/src/lib/libc/port/gen/mkdev.c#L40-L146)
  2. [mkdev.h](https://github.com/illumos/illumos-gate/blob/8b26092d555bd1deaacf79ea64da374602aefb65/usr/src/uts/common/sys/mkdev.h#L97-L99)

  