### PR TITLE
Add sys/ucontext.h signatures for linux aarch64 glibc

### DIFF
--- a/src/unix/linux_like/linux/gnu/b64/aarch64/align.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64/align.rs
@@ -49,3 +49,10 @@ s! {
         pub cgroup: ::c_ulonglong,
     }
 }
+
+extern "C" {
+    pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;
+    pub fn setcontext(ucp: *const ucontext_t) -> ::c_int;
+    pub fn makecontext(ucp: *mut ucontext_t, func: extern "C" fn(), argc: ::c_int, ...);
+    pub fn swapcontext(uocp: *mut ucontext_t, ucp: *const ucontext_t) -> ::c_int;
+}


### PR DESCRIPTION
### `getcontext`, `setcontext`, `makecontext`, `swapcontext`

From \<sys/ucontext.h\>. The specification for these was removed from POSIX.1-2008 in favor of POSIX threads, but glibc continues to ship an implementation for aarch64 just as it does for x86_64.

Libc crate's existing x86_64 binding with the same signatures added in this PR:

https://github.com/rust-lang/libc/blob/bbf929d2c8355fa19384b3551c5874c866be465f/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs#L810-L813

Glibc implementation:

- https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/aarch64/getcontext.S
- https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/aarch64/setcontext.S
- https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/aarch64/makecontext.c
- https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/aarch64/swapcontext.S

<br>

### ~~`iopl`, `ioperm`~~

~~From \<sys/io.h\>. These are functions for accessing x86 I/O ports. ARM has no such I/O ports in the architecture. Linux's `man 2` for both functions contains: _"This call is mostly for the i386 architecture.  On many other architectures it does not exist or will always return an error."_ Glibc ships one of these "always return an error" implementation of both functions for aarch64.~~

~~Matching signatures from x86_64:~~

https://github.com/rust-lang/libc/blob/bbf929d2c8355fa19384b3551c5874c866be465f/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs#L814-L815

~~Glibc implementation:~~

- ~~https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/arm/ioperm.c~~

~~The implementation has `unsigned int` for the argument of `iopl` but I've used int in the PR to match the Linux docs, which seems more authoritative. Unclear why glibc diverges from this but it doesn't make a difference in the ABI.~~