### PR TITLE
ci: Read test output from stderr

### DIFF
--- a/ci/runtest-android.rs
+++ b/ci/runtest-android.rs
@@ -22,7 +22,7 @@ fn main() {
         .arg(&test)
         .arg(&dst)
         .status()
-        .expect("failed to run: adb pushr");
+        .expect("failed to run: adb push");
     assert!(status.success());
 
     let output = Command::new("adb")
@@ -33,16 +33,17 @@ fn main() {
         .expect("failed to run: adb shell");
     assert!(status.success());
 
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
     println!("status: {}\nstdout ---\n{}\nstderr ---\n{}",
              output.status,
-             String::from_utf8_lossy(&output.stdout),
-             String::from_utf8_lossy(&output.stderr));
+             stdout,
+             stderr);
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    stdout.lines().find(|l|
-        (l.starts_with("PASSED ") && l.contains(" tests")) ||
-        l.starts_with("test result: ok")
-    ).unwrap_or_else(|| {
+    if !stderr.lines().any(|l| (l.starts_with("PASSED ") && l.contains(" tests")) || l.starts_with("test result: ok"))
+        && !stdout.lines().any(|l| (l.starts_with("PASSED ") && l.contains(" tests")) || l.starts_with("test result: ok"))
+    {
         panic!("failed to find successful test run");
-    });
+    };
 }


### PR DESCRIPTION
CI is currently failing because https://github.com/JohnTitor/ctest2/pull/37 changed the place to display the test results and `runtest-android.rs` cannot find it on stdout. This PR fixes it by reading lines from stderr instead.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>