### PR TITLE
Fix the loongarch64 kernel ABI

### DIFF
--- a/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
@@ -325,8 +325,6 @@ pub const SYS_vmsplice: ::c_long = 75;
 pub const SYS_splice: ::c_long = 76;
 pub const SYS_tee: ::c_long = 77;
 pub const SYS_readlinkat: ::c_long = 78;
-pub const SYS_newfstatat: ::c_long = 79;
-pub const SYS_fstat: ::c_long = 80;
 pub const SYS_sync: ::c_long = 81;
 pub const SYS_fsync: ::c_long = 82;
 pub const SYS_fdatasync: ::c_long = 83;
@@ -409,8 +407,6 @@ pub const SYS_setgroups: ::c_long = 159;
 pub const SYS_uname: ::c_long = 160;
 pub const SYS_sethostname: ::c_long = 161;
 pub const SYS_setdomainname: ::c_long = 162;
-pub const SYS_getrlimit: ::c_long = 163;
-pub const SYS_setrlimit: ::c_long = 164;
 pub const SYS_getrusage: ::c_long = 165;
 pub const SYS_umask: ::c_long = 166;
 pub const SYS_prctl: ::c_long = 167;
@@ -772,8 +768,8 @@ pub const EXTPROC: ::tcflag_t = 0x00010000;
 pub const TCSANOW: ::c_int = 0;
 pub const TCSADRAIN: ::c_int = 1;
 pub const TCSAFLUSH: ::c_int = 2;
-pub const SIGSTKSZ: ::size_t = 8192;
-pub const MINSIGSTKSZ: ::size_t = 2048;
+pub const SIGSTKSZ: ::size_t = 16384;
+pub const MINSIGSTKSZ: ::size_t = 4096;
 pub const CBAUD: ::tcflag_t = 0o0010017;
 pub const CSIZE: ::tcflag_t = 0x00000030;
 pub const CS6: ::tcflag_t = 0x00000010;
@@ -857,17 +853,6 @@ pub const EPOLL_CLOEXEC: ::c_int = 0x80000;
 
 pub const EFD_CLOEXEC: ::c_int = 0x80000;
 pub const EFD_NONBLOCK: ::c_int = 0x800;
-
-extern "C" {
-    pub fn sysctl(
-        name: *mut ::c_int,
-        namelen: ::c_int,
-        oldp: *mut ::c_void,
-        oldlenp: *mut ::size_t,
-        newp: *mut ::c_void,
-        newlen: ::size_t,
-    ) -> ::c_int;
-}
 
 cfg_if! {
     if #[cfg(libc_align)] {


### PR DESCRIPTION
The initial loongarch64 support code went in too early, even before the upstream kernel ABI has finalized, and was not adjusted since then. No one with enough knowledge of LoongArch was involved in the initial review, so we have been shipping broken LoongArch support, but luckily the rustc port is not merged yet so no real damage has been done.

Fix the following discrepancies:

- There is no longer {g,s}etrlimit, only prlimit64.
- There is no longer fstat and newfstatat, only statx.
- MINSIGSTKSZ and SIGSTKSZ now have different values.
- The binary sysctl syscall was removed from Linux long before the existence of upstream Linux/LoongArch port (5.5 vs 5.19) so even a wrapper does not make sense.

There might be more but these are the most obvious.

cc @xry111 @zhaixiaojuan