### PR TITLE
Add kexec_file_load system call for arm64 linux

### DIFF
--- a/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
@@ -866,6 +866,7 @@ pub const SYS_pkey_alloc: ::c_long = 289;
 pub const SYS_pkey_free: ::c_long = 290;
 pub const SYS_statx: ::c_long = 291;
 pub const SYS_rseq: ::c_long = 293;
+pub const SYS_kexec_file_load: ::c_long = 294;
 pub const SYS_pidfd_send_signal: ::c_long = 424;
 pub const SYS_io_uring_setup: ::c_long = 425;
 pub const SYS_io_uring_enter: ::c_long = 426;


### PR DESCRIPTION
This syscall was introduced in Linux 5.0. References:

- https://patchwork.kernel.org/project/linux-arm-kernel/list/?series=43329&state=%2A&archive=both
- https://github.com/torvalds/linux/commit/4e21565b7fd4d9045765f697887e74a704135fe2
- https://github.com/sunfishcode/linux-raw-sys/blob/v0.1.2/src/aarch64/general.rs#L2118
- https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/aarch64/arch-syscall.h#l110