### PR TITLE
Rearrange `sockaddr_storage` padding/alignment fields on Linux and Fuchsia

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -909,8 +909,8 @@ s_no_extra_traits! {
 
     pub struct sockaddr_storage {
         pub ss_family: sa_family_t,
+        __ss_pad2: [u8; 128 - 2 - 8],
         __ss_align: ::size_t,
-        __ss_pad2: [u8; 128 - 2 * 8],
     }
 
     pub struct utsname {

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -231,11 +231,11 @@ s_no_extra_traits! {
 
     pub struct sockaddr_storage {
         pub ss_family: sa_family_t,
-        __ss_align: ::size_t,
         #[cfg(target_pointer_width = "32")]
-        __ss_pad2: [u8; 128 - 2 * 4],
+        __ss_pad2: [u8; 128 - 2 - 4],
         #[cfg(target_pointer_width = "64")]
-        __ss_pad2: [u8; 128 - 2 * 8],
+        __ss_pad2: [u8; 128 - 2 - 8],
+        __ss_align: ::size_t,
     }
 
     pub struct utsname {


### PR DESCRIPTION
Part of #3004.

Previously on Linux, the `sockaddr_storage` structure had padding bytes between the `ss_family` and `__ss_align` fields. The `__ss_align` field has now been moved to the end of the structure to eliminate these padding bytes, matching recent glibc versions: https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/bits/socket.h;h=4f1f810ea1d9bf00ff428e4e7c49a52c71620775;hb=c804cd1c00adde061ca51711f63068c103e94eef#l190

After the PR on Linux x86-64:

```
print-type-size type: `unix::linux_like::sockaddr_storage`: 128 bytes, alignment: 8 bytes
print-type-size     field `.ss_family`: 2 bytes
print-type-size     field `.__ss_pad2`: 118 bytes
print-type-size     field `.__ss_align`: 8 bytes
```

These moved fields are private but they are used in the `sockaddr_storage`s `PartialEq`, `Debug`, and `Hash` implementations, so the exact behaviour may change slightly, but I don't think anyone should be depending on this.

~(It looks like [Fuchsia](https://github.com/rust-lang/libc/blob/73c25f4e9d66054d1496c693b72d60caea00c4a9/src/fuchsia/mod.rs#L910) has the same issue, but I didn't modify its structure because I don't know much about it, or how to test it.)~