### PR TITLE
handle c circular dependence (linux gnu)

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -329,6 +329,8 @@ cfg_if! {
             cfg(target_feature = "crt-static"))]
         #[link(name = "gcc", kind = "static", modifiers = "-bundle",
             cfg(target_feature = "crt-static"))]
+        #[link(name = "c", kind = "static", modifiers = "-bundle",
+            cfg(target_feature = "crt-static"))]
         #[link(name = "util", cfg(not(target_feature = "crt-static")))]
         #[link(name = "rt", cfg(not(target_feature = "crt-static")))]
         #[link(name = "pthread", cfg(not(target_feature = "crt-static")))]


### PR DESCRIPTION
Repeating libc allows solve [this fixme](https://github.com/rust-lang/rust/blob/master/compiler/rustc_codegen_ssa/src/back/link.rs#:~:text=//%20HACK/FIXME%3A%20Fixup,the%20libc%20crate.) in rust compiler.