### PR TITLE
mips32: fix missing __s64 type definition

### DIFF
--- a/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
@@ -13,6 +13,7 @@ pub type nlink_t = u32;
 pub type fsblkcnt_t = ::c_ulong;
 pub type fsfilcnt_t = ::c_ulong;
 pub type __u64 = ::c_ulonglong;
+pub type __s64 = ::c_longlong;
 pub type fsblkcnt64_t = u64;
 pub type fsfilcnt64_t = u64;
 


### PR DESCRIPTION
The compilation error message:

```shell
$ cargo build hello --target mipsel-unknown-linux-uclibc
...
error[E0412]: cannot find type `__s64` in the crate root
   --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.137/src/unix/linux_like/linux/mod.rs:601:23
    |
601 |         pub src_fd: ::__s64,
    |                       ^^^^^ help: a type alias with a similar name exists: `__u64`
    |
   ::: /root/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.137/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs:15:1
    |
15  | pub type __u64 = ::c_ulonglong;
    | ------------------------------- similarly named type alias `__u64` defined here

For more information about this error, try `rustc --explain E0412`.
```

Signed-off-by: Xiaobo Liu <cppcoffee@gmail.com>

