### PR TITLE
Revert "Auto merge of #3018 - ehuss:highfive-triagebot, r=JohnTitor"

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -3,23 +3,4 @@ allow-unauthenticated = [
     "C-*", "O-*", "S-*"
 ]
 
-[autolabel."S-waiting-on-review"]
-new_pr = true
-
 [assign]
-contributing_url = "https://github.com/rust-lang/libc/blob/master/CONTRIBUTING.md"
-
-[assign.owners]
-"*" = ["@JohnTitor"]
-
-[mentions."src/unix/bsd/netbsdlike/openbsd"]
-message = "Some changes occurred in OpenBSD module"
-cc = ["@semarie"]
-
-[mentions."src/unix/bsd/netbsdlike/mod.rs"]
-message = "Some changes occurred in OpenBSD module"
-cc = ["@semarie"]
-
-[mentions."src/unix/solarish"]
-message = "Some changes occurred in solarish module"
-cc = ["@jclulow", "@pfmooney"]


### PR DESCRIPTION
This reverts commit 605f6c3e4db18e278c9642932b268a36701db845, reversing changes made to dafa56706542c9f890afe8c10f820ef99df1db3c.

Ref. https://github.com/rust-lang/libc/pull/3018#issuecomment-1328154387
