### PR TITLE
Enable copy_file_range on FreeBSD

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2304,6 +2304,7 @@ fn test_freebsd(target: &str) {
             "getlocalbase" if Some(13) > freebsd_ver => true,
             "aio_readv" if Some(13) > freebsd_ver => true,
             "aio_writev" if Some(13) > freebsd_ver => true,
+            "copy_file_range" if Some(13) > freebsd_ver => true,
 
             _ => false,
         }

--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -1517,6 +1517,7 @@ clearerr
 clock_getcpuclockid
 clock_getres
 clock_settime
+copy_file_range
 cmsgcred
 cmsghdr
 cpuset

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -527,15 +527,6 @@ extern "C" {
         policy: ::c_int,
     ) -> ::c_int;
 
-    pub fn copy_file_range(
-        infd: ::c_int,
-        inoffp: *mut ::off_t,
-        outfd: ::c_int,
-        outoffp: *mut ::off_t,
-        len: ::size_t,
-        flags: ::c_uint,
-    ) -> ::ssize_t;
-
     pub fn dirname(path: *mut ::c_char) -> *mut ::c_char;
     pub fn basename(path: *mut ::c_char) -> *mut ::c_char;
 }

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -527,15 +527,6 @@ extern "C" {
         policy: ::c_int,
     ) -> ::c_int;
 
-    pub fn copy_file_range(
-        infd: ::c_int,
-        inoffp: *mut ::off_t,
-        outfd: ::c_int,
-        outoffp: *mut ::off_t,
-        len: ::size_t,
-        flags: ::c_uint,
-    ) -> ::ssize_t;
-
     pub fn dirname(path: *mut ::c_char) -> *mut ::c_char;
     pub fn basename(path: *mut ::c_char) -> *mut ::c_char;
 }

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -3954,6 +3954,15 @@ extern "C" {
     pub fn aio_write(aiocbp: *mut aiocb) -> ::c_int;
     pub fn aio_writev(aiocbp: *mut ::aiocb) -> ::c_int;
 
+    pub fn copy_file_range(
+        infd: ::c_int,
+        inoffp: *mut ::off_t,
+        outfd: ::c_int,
+        outoffp: *mut ::off_t,
+        len: ::size_t,
+        flags: ::c_uint,
+    ) -> ::ssize_t;
+
     pub fn devname_r(
         dev: ::dev_t,
         mode: ::mode_t,


### PR DESCRIPTION
PR #2479 did this, but only in the freebsd13 and freebsd14 modules, which was incorrect.  Those modules should only be used for functions that change across FreeBSD versions, and therefore need different ELF symbol versions.  Functions that were newly added since FreeBSD 11 can still go in the base freebsd module.  It will cause no problems for them to be there, and users will see an error at link time if they try to use such a function in an environment that is too old to support it.
