### PR TITLE
redox: long is 32-bits on 32-bit systems

### DIFF
--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -26,7 +26,7 @@ pub type ino_t = ::c_ulong;
 pub type mode_t = ::c_int;
 pub type nfds_t = ::c_ulong;
 pub type nlink_t = ::c_ulong;
-pub type off_t = ::c_long;
+pub type off_t = ::c_longlong;
 pub type pthread_t = *mut ::c_void;
 pub type pthread_attr_t = *mut ::c_void;
 pub type pthread_cond_t = *mut ::c_void;
@@ -46,7 +46,7 @@ pub type socklen_t = u32;
 pub type speed_t = u32;
 pub type suseconds_t = ::c_int;
 pub type tcflag_t = u32;
-pub type time_t = ::c_long;
+pub type time_t = ::c_longlong;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum timezone {}

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -1,7 +1,19 @@
 pub type c_char = i8;
-pub type c_long = i64;
-pub type c_ulong = u64;
 pub type wchar_t = i32;
+
+cfg_if! {
+    if #[cfg(target_pointer_width = "32")] {
+        pub type c_long = i32;
+        pub type c_ulong = u32;
+    }
+}
+
+cfg_if! {
+    if #[cfg(target_pointer_width = "64")] {
+        pub type c_long = i64;
+        pub type c_ulong = u64;
+    }
+}
 
 pub type blkcnt_t = ::c_ulong;
 pub type blksize_t = ::c_long;


### PR DESCRIPTION
This ensures that 32-bit systems use i32 for c_long and u32 for c_ulong.

I have also adjusted off_t and time_t to be `long long`, which is what they are in `relibc` now.