### PR TITLE
Add support for QNX/Neutrino 7.1

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -32,6 +32,9 @@ cfg_if! {
     if #[cfg(any(target_os = "espidf", target_os = "horizon"))] {
         pub type uid_t = ::c_ushort;
         pub type gid_t = ::c_ushort;
+    } else if #[cfg(target_os = "nto")] {
+        pub type uid_t = i32;
+        pub type gid_t = i32;
     } else {
         pub type uid_t = u32;
         pub type gid_t = u32;
@@ -209,25 +212,31 @@ pub const INT_MAX: c_int = 2147483647;
 pub const SIG_DFL: sighandler_t = 0 as sighandler_t;
 pub const SIG_IGN: sighandler_t = 1 as sighandler_t;
 pub const SIG_ERR: sighandler_t = !0 as sighandler_t;
-
-pub const DT_UNKNOWN: u8 = 0;
-pub const DT_FIFO: u8 = 1;
-pub const DT_CHR: u8 = 2;
-pub const DT_DIR: u8 = 4;
-pub const DT_BLK: u8 = 6;
-pub const DT_REG: u8 = 8;
-pub const DT_LNK: u8 = 10;
-pub const DT_SOCK: u8 = 12;
-
+cfg_if! {
+    if #[cfg(not(target_os = "nto"))] {
+        pub const DT_UNKNOWN: u8 = 0;
+        pub const DT_FIFO: u8 = 1;
+        pub const DT_CHR: u8 = 2;
+        pub const DT_DIR: u8 = 4;
+        pub const DT_BLK: u8 = 6;
+        pub const DT_REG: u8 = 8;
+        pub const DT_LNK: u8 = 10;
+        pub const DT_SOCK: u8 = 12;
+    }
+}
 cfg_if! {
     if #[cfg(not(target_os = "redox"))] {
         pub const FD_CLOEXEC: ::c_int = 0x1;
     }
 }
 
-pub const USRQUOTA: ::c_int = 0;
-pub const GRPQUOTA: ::c_int = 1;
-
+cfg_if! {
+    if #[cfg(not(target_os = "nto"))]
+    {
+        pub const USRQUOTA: ::c_int = 0;
+        pub const GRPQUOTA: ::c_int = 1;
+    }
+}
 pub const SIGIOT: ::c_int = 6;
 
 pub const S_ISUID: ::mode_t = 0x800;
@@ -281,9 +290,13 @@ cfg_if! {
 pub const LOG_PRIMASK: ::c_int = 7;
 pub const LOG_FACMASK: ::c_int = 0x3f8;
 
-pub const PRIO_MIN: ::c_int = -20;
-pub const PRIO_MAX: ::c_int = 20;
-
+cfg_if! {
+    if #[cfg(not(target_os = "nto"))]
+    {
+        pub const PRIO_MIN: ::c_int = -20;
+        pub const PRIO_MAX: ::c_int = 20;
+    }
+}
 pub const IPPROTO_ICMP: ::c_int = 1;
 pub const IPPROTO_ICMPV6: ::c_int = 58;
 pub const IPPROTO_TCP: ::c_int = 6;
@@ -361,7 +374,9 @@ cfg_if! {
                         target_os = "tvos",
                         target_os = "watchos",
                         target_os = "android",
-                        target_os = "openbsd"))] {
+                        target_os = "openbsd",
+                        target_os = "nto",
+                    ))] {
         #[link(name = "c")]
         #[link(name = "m")]
         extern {}
@@ -453,8 +468,6 @@ extern "C" {
         link_name = "freopen$UNIX2003"
     )]
     pub fn freopen(filename: *const c_char, mode: *const c_char, file: *mut FILE) -> *mut FILE;
-    pub fn fmemopen(buf: *mut c_void, size: size_t, mode: *const c_char) -> *mut FILE;
-    pub fn open_memstream(ptr: *mut *mut c_char, sizeloc: *mut size_t) -> *mut FILE;
 
     pub fn fflush(file: *mut FILE) -> c_int;
     pub fn fclose(file: *mut FILE) -> c_int;
@@ -508,7 +521,6 @@ extern "C" {
     pub fn abort() -> !;
     pub fn exit(status: c_int) -> !;
     pub fn _exit(status: c_int) -> !;
-    pub fn atexit(cb: extern "C" fn()) -> c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "system$UNIX2003"
@@ -1162,8 +1174,6 @@ extern "C" {
         optlen: *mut ::socklen_t,
     ) -> ::c_int;
     pub fn raise(signum: ::c_int) -> ::c_int;
-    #[cfg_attr(target_os = "netbsd", link_name = "__sigaction14")]
-    pub fn sigaction(signum: ::c_int, act: *const sigaction, oldact: *mut sigaction) -> ::c_int;
 
     #[cfg_attr(target_os = "netbsd", link_name = "__utimes50")]
     pub fn utimes(filename: *const ::c_char, times: *const ::timeval) -> ::c_int;
@@ -1325,8 +1335,6 @@ extern "C" {
     pub fn statvfs(path: *const c_char, buf: *mut statvfs) -> ::c_int;
     pub fn fstatvfs(fd: ::c_int, buf: *mut statvfs) -> ::c_int;
 
-    pub fn readlink(path: *const c_char, buf: *mut c_char, bufsz: ::size_t) -> ::ssize_t;
-
     #[cfg_attr(target_os = "netbsd", link_name = "__sigemptyset14")]
     pub fn sigemptyset(set: *mut sigset_t) -> ::c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__sigaddset14")]
@@ -1347,23 +1355,6 @@ extern "C" {
 
     pub fn mkfifo(path: *const c_char, mode: mode_t) -> ::c_int;
 
-    #[cfg_attr(
-        all(target_os = "macos", target_arch = "x86_64"),
-        link_name = "pselect$1050"
-    )]
-    #[cfg_attr(
-        all(target_os = "macos", target_arch = "x86"),
-        link_name = "pselect$UNIX2003"
-    )]
-    #[cfg_attr(target_os = "netbsd", link_name = "__pselect50")]
-    pub fn pselect(
-        nfds: ::c_int,
-        readfds: *mut fd_set,
-        writefds: *mut fd_set,
-        errorfds: *mut fd_set,
-        timeout: *const timespec,
-        sigmask: *const sigset_t,
-    ) -> ::c_int;
     pub fn fseeko(stream: *mut ::FILE, offset: ::off_t, whence: ::c_int) -> ::c_int;
     pub fn ftello(stream: *mut ::FILE) -> ::off_t;
     #[cfg_attr(
@@ -1411,7 +1402,8 @@ extern "C" {
 cfg_if! {
     if #[cfg(not(any(target_os = "emscripten",
                      target_os = "android",
-                     target_os = "haiku")))] {
+                     target_os = "haiku",
+                     target_os = "nto")))] {
         extern "C" {
             pub fn adjtime(delta: *const timeval, olddelta: *mut timeval) -> ::c_int;
             pub fn stpncpy(dst: *mut c_char, src: *const c_char, n: size_t) -> *mut c_char;
@@ -1420,7 +1412,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(not(target_env = "uclibc"))] {
+    if #[cfg(not(any(target_env = "uclibc", target_os = "nto")))] {
         extern "C" {
             pub fn open_wmemstream(
                 ptr: *mut *mut wchar_t,
@@ -1439,12 +1431,8 @@ cfg_if! {
                        link_name = "pause$UNIX2003")]
             pub fn pause() -> ::c_int;
 
-            pub fn readlinkat(dirfd: ::c_int,
-                              pathname: *const ::c_char,
-                              buf: *mut ::c_char,
-                              bufsiz: ::size_t) -> ::ssize_t;
             pub fn mkdirat(dirfd: ::c_int, pathname: *const ::c_char,
-                           mode: ::mode_t) -> ::c_int;
+                          mode: ::mode_t) -> ::c_int;
             pub fn openat(dirfd: ::c_int, pathname: *const ::c_char,
                           flags: ::c_int, ...) -> ::c_int;
 
@@ -1475,7 +1463,64 @@ cfg_if! {
 }
 
 cfg_if! {
-   if #[cfg(not(any(target_os = "solaris", target_os = "illumos")))] {
+    if #[cfg(target_os = "nto")] {
+        extern {
+            pub fn readlinkat(dirfd: ::c_int,
+                pathname: *const ::c_char,
+                buf: *mut ::c_char,
+                bufsiz: ::size_t) -> ::c_int;
+            pub fn readlink(path: *const c_char, buf: *mut c_char, bufsz: ::size_t) -> ::c_int;
+            pub fn pselect(
+                nfds: ::c_int,
+                readfds: *mut fd_set,
+                writefds: *mut fd_set,
+                errorfds: *mut fd_set,
+                timeout: *mut timespec,
+                sigmask: *const sigset_t,
+            ) -> ::c_int;
+        }
+    } else {
+        extern {
+            pub fn readlinkat(dirfd: ::c_int,
+                pathname: *const ::c_char,
+                buf: *mut ::c_char,
+                bufsiz: ::size_t) -> ::ssize_t;
+            pub fn fmemopen(buf: *mut c_void, size: size_t, mode: *const c_char) -> *mut FILE;
+            pub fn open_memstream(ptr: *mut *mut c_char, sizeloc: *mut size_t) -> *mut FILE;
+            pub fn atexit(cb: extern "C" fn()) -> c_int;
+            #[cfg_attr(target_os = "netbsd", link_name = "__sigaction14")]
+            pub fn sigaction(
+                signum: ::c_int,
+                act: *const sigaction,
+                oldact: *mut sigaction
+            ) -> ::c_int;
+            pub fn readlink(path: *const c_char, buf: *mut c_char, bufsz: ::size_t) -> ::ssize_t;
+            #[cfg_attr(
+                all(target_os = "macos", target_arch = "x86_64"),
+                link_name = "pselect$1050"
+            )]
+            #[cfg_attr(
+                all(target_os = "macos", target_arch = "x86"),
+                link_name = "pselect$UNIX2003"
+            )]
+            #[cfg_attr(target_os = "netbsd", link_name = "__pselect50")]
+            pub fn pselect(
+                nfds: ::c_int,
+                readfds: *mut fd_set,
+                writefds: *mut fd_set,
+                errorfds: *mut fd_set,
+                timeout: *const timespec,
+                sigmask: *const sigset_t,
+            ) -> ::c_int;
+        }
+    }
+}
+
+cfg_if! {
+   if #[cfg(not(any(target_os = "solaris",
+                    target_os = "illumos",
+                    target_os = "nto",
+                )))] {
         extern {
             pub fn cfmakeraw(termios: *mut ::termios);
             pub fn cfsetspeed(termios: *mut ::termios,
@@ -1517,6 +1562,9 @@ cfg_if! {
     } else if #[cfg(target_os = "redox")] {
         mod redox;
         pub use self::redox::*;
+    } else if #[cfg(target_os = "nto")] {
+        mod nto;
+        pub use self::nto::*;
     } else {
         // Unknown target_os
     }

--- a/src/unix/nto/aarch64.rs
+++ b/src/unix/nto/aarch64.rs
@@ -1,0 +1,36 @@
+pub type c_char = u8;
+pub type wchar_t = u32;
+pub type c_long = i64;
+pub type c_ulong = u64;
+pub type time_t = i64;
+
+s! {
+    pub struct aarch64_qreg_t {
+        pub qlo: u64,
+        pub qhi: u64,
+    }
+
+    pub struct aarch64_fpu_registers {
+        pub reg: [::aarch64_qreg_t; 32],
+        pub fpsr: u32,
+        pub fpcr: u32,
+    }
+
+    pub struct aarch64_cpu_registers {
+        pub gpr: [u64; 32],
+        pub elr: u64,
+        pub pstate: u64,
+    }
+
+    #[repr(align(16))]
+    pub struct mcontext_t {
+        pub cpu: ::aarch64_cpu_registers,
+        pub fpu: ::aarch64_fpu_registers,
+    }
+
+    pub struct stack_t {
+        pub ss_sp: *mut ::c_void,
+        pub ss_size: ::size_t,
+        pub ss_flags: ::c_int,
+    }
+}

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -1,0 +1,3286 @@
+pub type clock_t = u32;
+
+pub type sa_family_t = u8;
+pub type speed_t = ::c_uint;
+pub type tcflag_t = ::c_uint;
+pub type clockid_t = ::c_int;
+pub type timer_t = ::c_int;
+pub type key_t = ::c_uint;
+pub type id_t = ::c_int;
+
+pub type useconds_t = u32;
+pub type dev_t = u32;
+pub type socklen_t = u32;
+pub type mode_t = u32;
+pub type rlim64_t = u64;
+pub type mqd_t = ::c_int;
+pub type nfds_t = ::c_uint;
+pub type idtype_t = ::c_uint;
+pub type errno_t = ::c_int;
+pub type rsize_t = c_ulong;
+
+pub type Elf32_Half = u16;
+pub type Elf32_Word = u32;
+pub type Elf32_Off = u32;
+pub type Elf32_Addr = u32;
+pub type Elf32_Lword = u64;
+pub type Elf32_Sword = i32;
+
+pub type Elf64_Half = u16;
+pub type Elf64_Word = u32;
+pub type Elf64_Off = u64;
+pub type Elf64_Addr = u64;
+pub type Elf64_Xword = u64;
+pub type Elf64_Sxword = i64;
+pub type Elf64_Lword = u64;
+pub type Elf64_Sword = i32;
+
+pub type Elf32_Section = u16;
+pub type Elf64_Section = u16;
+
+pub type _Time32t = u32;
+
+pub type pthread_t = ::c_int;
+pub type regoff_t = ::ssize_t;
+
+pub type nlink_t = u32;
+pub type blksize_t = u32;
+pub type suseconds_t = i32;
+
+pub type ino_t = u64;
+pub type off_t = i64;
+pub type blkcnt_t = u64;
+pub type msgqnum_t = u64;
+pub type msglen_t = u64;
+pub type fsblkcnt_t = u64;
+pub type fsfilcnt_t = u64;
+pub type rlim_t = u64;
+pub type posix_spawn_file_actions_t = *mut ::c_void;
+pub type posix_spawnattr_t = ::uintptr_t;
+
+pub type pthread_mutex_t = ::sync_t;
+pub type pthread_mutexattr_t = ::_sync_attr;
+pub type pthread_cond_t = ::sync_t;
+pub type pthread_condattr_t = ::_sync_attr;
+pub type pthread_rwlockattr_t = ::_sync_attr;
+pub type pthread_key_t = ::c_int;
+pub type pthread_spinlock_t = sync_t;
+pub type pthread_barrierattr_t = _sync_attr;
+pub type sem_t = sync_t;
+
+pub type nl_item = ::c_int;
+
+#[cfg_attr(feature = "extra_traits", derive(Debug))]
+pub enum timezone {}
+impl ::Copy for timezone {}
+impl ::Clone for timezone {
+    fn clone(&self) -> timezone {
+        *self
+    }
+}
+
+s! {
+    pub struct ip_mreq {
+        pub imr_multiaddr: in_addr,
+        pub imr_interface: in_addr,
+    }
+
+    #[repr(packed)]
+    pub struct in_addr {
+        pub s_addr: ::in_addr_t,
+    }
+
+    pub struct sockaddr {
+        pub sa_len: u8,
+        pub sa_family: sa_family_t,
+        pub sa_data: [::c_char; 14],
+    }
+
+    pub struct sockaddr_in {
+        pub sin_len: u8,
+        pub sin_family: sa_family_t,
+        pub sin_port: ::in_port_t,
+        pub sin_addr: ::in_addr,
+        pub sin_zero: [i8; 8],
+    }
+
+    pub struct sockaddr_in6 {
+        pub sin6_len: u8,
+        pub sin6_family: sa_family_t,
+        pub sin6_port: ::in_port_t,
+        pub sin6_flowinfo: u32,
+        pub sin6_addr: ::in6_addr,
+        pub sin6_scope_id: u32,
+    }
+
+    // The order of the `ai_addr` field in this struct is crucial
+    // for converting between the Rust and C types.
+    pub struct addrinfo {
+        pub ai_flags: ::c_int,
+        pub ai_family: ::c_int,
+        pub ai_socktype: ::c_int,
+        pub ai_protocol: ::c_int,
+        pub ai_addrlen: socklen_t,
+        pub ai_canonname: *mut c_char,
+        pub ai_addr: *mut ::sockaddr,
+        pub ai_next: *mut addrinfo,
+    }
+
+    pub struct fd_set {
+        fds_bits: [::c_uint; 2 * FD_SETSIZE / ULONG_SIZE],
+    }
+
+    pub struct tm {
+        pub tm_sec: ::c_int,
+        pub tm_min: ::c_int,
+        pub tm_hour: ::c_int,
+        pub tm_mday: ::c_int,
+        pub tm_mon: ::c_int,
+        pub tm_year: ::c_int,
+        pub tm_wday: ::c_int,
+        pub tm_yday: ::c_int,
+        pub tm_isdst: ::c_int,
+        pub tm_gmtoff: ::c_long,
+        pub tm_zone: *const ::c_char,
+    }
+
+    #[repr(align(8))]
+    pub struct sched_param {
+        pub sched_priority: ::c_int,
+        pub sched_curpriority: ::c_int,
+        pub reserved: [::c_int; 10],
+    }
+
+    #[repr(align(8))]
+    pub struct __sched_param {
+        pub __sched_priority: ::c_int,
+        pub __sched_curpriority: ::c_int,
+        pub reserved: [::c_int; 10],
+    }
+
+    pub struct Dl_info {
+        pub dli_fname: *const ::c_char,
+        pub dli_fbase: *mut ::c_void,
+        pub dli_sname: *const ::c_char,
+        pub dli_saddr: *mut ::c_void,
+    }
+
+    pub struct lconv {
+        pub currency_symbol: *mut ::c_char,
+        pub int_curr_symbol: *mut ::c_char,
+        pub mon_decimal_point: *mut ::c_char,
+        pub mon_grouping: *mut ::c_char,
+        pub mon_thousands_sep: *mut ::c_char,
+        pub negative_sign: *mut ::c_char,
+        pub positive_sign: *mut ::c_char,
+        pub frac_digits: ::c_char,
+        pub int_frac_digits: ::c_char,
+        pub n_cs_precedes: ::c_char,
+        pub n_sep_by_space: ::c_char,
+        pub n_sign_posn: ::c_char,
+        pub p_cs_precedes: ::c_char,
+        pub p_sep_by_space: ::c_char,
+        pub p_sign_posn: ::c_char,
+
+        pub int_n_cs_precedes: ::c_char,
+        pub int_n_sep_by_space: ::c_char,
+        pub int_n_sign_posn: ::c_char,
+        pub int_p_cs_precedes: ::c_char,
+        pub int_p_sep_by_space: ::c_char,
+        pub int_p_sign_posn: ::c_char,
+
+        pub decimal_point: *mut ::c_char,
+        pub grouping: *mut ::c_char,
+        pub thousands_sep: *mut ::c_char,
+
+        pub _Frac_grouping: *mut ::c_char,
+        pub _Frac_sep: *mut ::c_char,
+        pub _False: *mut ::c_char,
+        pub _True: *mut ::c_char,
+
+        pub _No: *mut ::c_char,
+        pub _Yes: *mut ::c_char,
+        pub _Nostr: *mut ::c_char,
+        pub _Yesstr: *mut ::c_char,
+        pub _Reserved: [*mut ::c_char; 8],
+        }
+
+    pub struct in_pktinfo {
+        pub ipi_addr: ::in_addr,
+        pub ipi_ifindex: ::c_uint,
+    }
+
+    pub struct ifaddrs {
+        pub ifa_next: *mut ifaddrs,
+        pub ifa_name: *mut c_char,
+        pub ifa_flags: ::c_uint,
+        pub ifa_addr: *mut ::sockaddr,
+        pub ifa_netmask: *mut ::sockaddr,
+        pub ifa_dstaddr: *mut ::sockaddr,
+        pub ifa_data: *mut ::c_void
+    }
+
+    pub struct arpreq {
+        pub arp_pa: ::sockaddr,
+        pub arp_ha: ::sockaddr,
+        pub arp_flags: ::c_int,
+    }
+
+    #[repr(packed)]
+    pub struct arphdr {
+        pub ar_hrd: u16,
+        pub ar_pro: u16,
+        pub ar_hln: u8,
+        pub ar_pln: u8,
+        pub ar_op: u16,
+    }
+
+    pub struct mmsghdr {
+        pub msg_hdr: ::msghdr,
+        pub msg_len: ::c_uint,
+    }
+
+    #[repr(align(8))]
+    pub struct siginfo_t {
+        pub si_signo: ::c_int,
+        pub si_code: ::c_int,
+        pub si_errno: ::c_int,
+        __data: [u8; 36], // union
+    }
+
+    pub struct sigaction {
+        pub sa_sigaction: ::sighandler_t,
+        pub sa_flags: ::c_int,
+        pub sa_mask: ::sigset_t,
+    }
+
+    pub struct _sync {
+        _union: ::c_uint,
+        __owner: ::c_uint,
+    }
+    pub struct rlimit64 {
+        pub rlim_cur: rlim64_t,
+        pub rlim_max: rlim64_t,
+    }
+
+    pub struct glob_t {
+        pub gl_pathc: ::size_t,
+        pub gl_matchc: ::c_int,
+        pub gl_pathv: *mut *mut c_char,
+        pub gl_offs: ::size_t,
+        pub gl_flags: ::c_int,
+        pub gl_errfunc: extern "C" fn(*const ::c_char, ::c_int) -> ::c_int,
+
+        __unused1: *mut ::c_void,
+        __unused2: *mut ::c_void,
+        __unused3: *mut ::c_void,
+        __unused4: *mut ::c_void,
+        __unused5: *mut ::c_void,
+    }
+
+    pub struct passwd {
+        pub pw_name: *mut ::c_char,
+        pub pw_passwd: *mut ::c_char,
+        pub pw_uid: ::uid_t,
+        pub pw_gid: ::gid_t,
+        pub pw_age: *mut ::c_char,
+        pub pw_comment: *mut ::c_char,
+        pub pw_gecos: *mut ::c_char,
+        pub pw_dir: *mut ::c_char,
+        pub pw_shell: *mut ::c_char,
+    }
+
+    pub struct if_nameindex {
+        pub if_index: ::c_uint,
+        pub if_name: *mut ::c_char,
+    }
+
+    pub struct sembuf {
+        pub sem_num: ::c_ushort,
+        pub sem_op: ::c_short,
+        pub sem_flg: ::c_short,
+    }
+
+    pub struct Elf32_Ehdr {
+        pub e_ident: [::c_uchar; 16],
+        pub e_type: Elf32_Half,
+        pub e_machine: Elf32_Half,
+        pub e_version: Elf32_Word,
+        pub e_entry: Elf32_Addr,
+        pub e_phoff: Elf32_Off,
+        pub e_shoff: Elf32_Off,
+        pub e_flags: Elf32_Word,
+        pub e_ehsize: Elf32_Half,
+        pub e_phentsize: Elf32_Half,
+        pub e_phnum: Elf32_Half,
+        pub e_shentsize: Elf32_Half,
+        pub e_shnum: Elf32_Half,
+        pub e_shstrndx: Elf32_Half,
+    }
+
+    pub struct Elf64_Ehdr {
+        pub e_ident: [::c_uchar; 16],
+        pub e_type: Elf64_Half,
+        pub e_machine: Elf64_Half,
+        pub e_version: Elf64_Word,
+        pub e_entry: Elf64_Addr,
+        pub e_phoff: Elf64_Off,
+        pub e_shoff: Elf64_Off,
+        pub e_flags: Elf64_Word,
+        pub e_ehsize: Elf64_Half,
+        pub e_phentsize: Elf64_Half,
+        pub e_phnum: Elf64_Half,
+        pub e_shentsize: Elf64_Half,
+        pub e_shnum: Elf64_Half,
+        pub e_shstrndx: Elf64_Half,
+    }
+
+    pub struct Elf32_Sym {
+        pub st_name: Elf32_Word,
+        pub st_value: Elf32_Addr,
+        pub st_size: Elf32_Word,
+        pub st_info: ::c_uchar,
+        pub st_other: ::c_uchar,
+        pub st_shndx: Elf32_Section,
+    }
+
+    pub struct Elf64_Sym {
+        pub st_name: Elf64_Word,
+        pub st_info: ::c_uchar,
+        pub st_other: ::c_uchar,
+        pub st_shndx: Elf64_Section,
+        pub st_value: Elf64_Addr,
+        pub st_size: Elf64_Xword,
+    }
+
+    pub struct Elf32_Phdr {
+        pub p_type: Elf32_Word,
+        pub p_offset: Elf32_Off,
+        pub p_vaddr: Elf32_Addr,
+        pub p_paddr: Elf32_Addr,
+        pub p_filesz: Elf32_Word,
+        pub p_memsz: Elf32_Word,
+        pub p_flags: Elf32_Word,
+        pub p_align: Elf32_Word,
+    }
+
+    pub struct Elf64_Phdr {
+        pub p_type: Elf64_Word,
+        pub p_flags: Elf64_Word,
+        pub p_offset: Elf64_Off,
+        pub p_vaddr: Elf64_Addr,
+        pub p_paddr: Elf64_Addr,
+        pub p_filesz: Elf64_Xword,
+        pub p_memsz: Elf64_Xword,
+        pub p_align: Elf64_Xword,
+    }
+
+    pub struct Elf32_Shdr {
+        pub sh_name: Elf32_Word,
+        pub sh_type: Elf32_Word,
+        pub sh_flags: Elf32_Word,
+        pub sh_addr: Elf32_Addr,
+        pub sh_offset: Elf32_Off,
+        pub sh_size: Elf32_Word,
+        pub sh_link: Elf32_Word,
+        pub sh_info: Elf32_Word,
+        pub sh_addralign: Elf32_Word,
+        pub sh_entsize: Elf32_Word,
+    }
+
+    pub struct Elf64_Shdr {
+        pub sh_name: Elf64_Word,
+        pub sh_type: Elf64_Word,
+        pub sh_flags: Elf64_Xword,
+        pub sh_addr: Elf64_Addr,
+        pub sh_offset: Elf64_Off,
+        pub sh_size: Elf64_Xword,
+        pub sh_link: Elf64_Word,
+        pub sh_info: Elf64_Word,
+        pub sh_addralign: Elf64_Xword,
+        pub sh_entsize: Elf64_Xword,
+    }
+
+    pub struct in6_pktinfo {
+        pub ipi6_addr: ::in6_addr,
+        pub ipi6_ifindex: ::c_uint,
+    }
+
+    pub struct inotify_event {
+        pub wd: ::c_int,
+        pub mask: u32,
+        pub cookie: u32,
+        pub len: u32
+    }
+
+    pub struct regmatch_t {
+        pub rm_so: regoff_t,
+        pub rm_eo: regoff_t,
+    }
+
+    pub struct msghdr {
+        pub msg_name: *mut ::c_void,
+        pub msg_namelen: ::socklen_t,
+        pub msg_iov: *mut ::iovec,
+        pub msg_iovlen: ::c_int,
+        pub msg_control: *mut ::c_void,
+        pub msg_controllen: ::socklen_t,
+        pub msg_flags: ::c_int,
+    }
+
+    pub struct cmsghdr {
+        pub cmsg_len: ::socklen_t,
+        pub cmsg_level: ::c_int,
+        pub cmsg_type: ::c_int,
+    }
+
+    pub struct termios {
+        pub c_iflag: ::tcflag_t,
+        pub c_oflag: ::tcflag_t,
+        pub c_cflag: ::tcflag_t,
+        pub c_lflag: ::tcflag_t,
+        pub c_cc: [::cc_t; ::NCCS],
+        __reserved: [::c_uint; 3],
+        pub c_ispeed: ::speed_t,
+        pub c_ospeed: ::speed_t,
+    }
+
+    pub struct mallinfo {
+        pub arena: ::c_int,
+        pub ordblks: ::c_int,
+        pub smblks: ::c_int,
+        pub hblks: ::c_int,
+        pub hblkhd: ::c_int,
+        pub usmblks: ::c_int,
+        pub fsmblks: ::c_int,
+        pub uordblks: ::c_int,
+        pub fordblks: ::c_int,
+        pub keepcost: ::c_int,
+    }
+
+    pub struct flock {
+        pub l_type: i16,
+        pub l_whence: i16,
+        pub l_zero1: i32,
+        pub l_start: ::off_t,
+        pub l_len: ::off_t,
+        pub l_pid: ::pid_t,
+        pub l_sysid: u32,
+    }
+
+    pub struct statvfs {
+        pub f_bsize: ::c_ulong,
+        pub f_frsize: ::c_ulong,
+        pub f_blocks: ::fsblkcnt_t,
+        pub f_bfree: ::fsblkcnt_t,
+        pub f_bavail: ::fsblkcnt_t,
+        pub f_files: ::fsfilcnt_t,
+        pub f_ffree: ::fsfilcnt_t,
+        pub f_favail: ::fsfilcnt_t,
+        pub f_fsid: ::c_ulong,
+        pub f_basetype: [::c_char; 16],
+        pub f_flag: ::c_ulong,
+        pub f_namemax: ::c_ulong,
+        f_filler: [::c_uint; 21],
+    }
+
+    pub struct aiocb {
+        pub aio_fildes: ::c_int,
+        pub aio_reqprio: ::c_int,
+        pub aio_offset: off_t,
+        pub aio_buf: *mut ::c_void,
+        pub aio_nbytes: ::size_t,
+        pub aio_sigevent: ::sigevent,
+        pub aio_lio_opcode: ::c_int,
+        pub _aio_lio_state: *mut ::c_void,
+        _aio_pad: [::c_int; 3],
+        pub _aio_next: *mut ::aiocb,
+        pub _aio_flag: ::c_uint,
+        pub _aio_iotype: ::c_uint,
+        pub _aio_result: ::ssize_t,
+        pub _aio_error: ::c_uint,
+        pub _aio_suspend: *mut ::c_void,
+        pub _aio_plist: *mut ::c_void,
+        pub _aio_policy: ::c_int,
+        pub _aio_param: ::__sched_param,
+    }
+
+    pub struct pthread_attr_t {
+        __data1: ::c_long,
+        __data2: [u8; 96]
+    }
+
+    pub struct ipc_perm {
+        pub uid: ::uid_t,
+        pub gid: ::gid_t,
+        pub cuid: ::uid_t,
+        pub cgid: ::gid_t,
+        pub mode: ::mode_t,
+        pub seq: ::c_uint,
+        pub key: ::key_t,
+        _reserved: [::c_int; 4],
+    }
+
+    pub struct regex_t {
+        re_magic: ::c_int,
+        re_nsub: ::size_t,
+        re_endp: *const ::c_char,
+        re_g: *mut ::c_void,
+    }
+
+    pub struct _thread_attr {
+        pub __flags: ::c_int,
+        pub __stacksize: ::size_t,
+        pub __stackaddr: *mut ::c_void,
+        pub __exitfunc: ::Option<unsafe extern "C" fn(_fake: *mut ::c_void)>,
+        pub __policy: ::c_int,
+        pub __param: ::__sched_param,
+        pub __guardsize: ::c_uint,
+        pub __prealloc: ::c_uint,
+        __spare: [::c_int; 2],
+    }
+
+    pub struct _sync_attr {
+        pub __protocol: ::c_int,
+        pub __flags: ::c_int,
+        pub __prioceiling: ::c_int,
+        pub __clockid: ::c_int,
+        pub __count: ::c_int,
+        __reserved: [::c_int; 3],
+    }
+
+    pub struct sockcred {
+        pub sc_uid: ::uid_t,
+        pub sc_euid: ::uid_t,
+        pub sc_gid: ::gid_t,
+        pub sc_egid: ::gid_t,
+        pub sc_ngroups: ::c_int,
+        pub sc_groups: [::gid_t; 1],
+    }
+
+    pub struct bpf_program {
+        pub bf_len: ::c_uint,
+        pub bf_insns: *mut ::bpf_insn,
+    }
+
+    pub struct bpf_stat {
+        pub bs_recv: u64,
+        pub bs_drop: u64,
+        pub bs_capt: u64,
+        bs_padding: [u64; 13],
+    }
+
+    pub struct bpf_version {
+        pub bv_major: ::c_ushort,
+        pub bv_minor: ::c_ushort,
+    }
+
+    pub struct bpf_hdr {
+        pub bh_tstamp: ::timeval,
+        pub bh_caplen: u32,
+        pub bh_datalen: u32,
+        pub bh_hdrlen: u16,
+    }
+
+    pub struct bpf_insn {
+        pub code: u16,
+        pub jt: ::c_uchar,
+        pub jf: ::c_uchar,
+        pub k: u32,
+    }
+
+    pub struct bpf_dltlist {
+        pub bfl_len: ::c_uint,
+        pub bfl_list: *mut ::c_uint,
+    }
+
+    pub struct unpcbid {
+        pub unp_pid: ::pid_t,
+        pub unp_euid: ::uid_t,
+        pub unp_egid: ::gid_t,
+    }
+
+    pub struct dl_phdr_info {
+        pub dlpi_addr: ::Elf64_Addr,
+        pub dlpi_name: *const ::c_char,
+        pub dlpi_phdr: *const ::Elf64_Phdr,
+        pub dlpi_phnum: ::Elf64_Half,
+    }
+
+    #[repr(align(8))]
+    pub struct ucontext_t {
+        pub uc_link: *mut ucontext_t,
+        pub uc_sigmask: ::sigset_t,
+        pub uc_stack: stack_t,
+        pub uc_mcontext: mcontext_t,
+    }
+}
+
+s_no_extra_traits! {
+    pub struct sockaddr_un {
+        pub sun_len: u8,
+        pub sun_family: sa_family_t,
+        pub sun_path: [::c_char; 104]
+    }
+
+    pub struct sockaddr_storage {
+        pub ss_len: u8,
+        pub ss_family: sa_family_t,
+        __ss_pad1: [::c_char; 6],
+        __ss_align: i64,
+        __ss_pad2: [::c_char; 112],
+    }
+
+    pub struct utsname {
+        pub sysname: [::c_char; _SYSNAME_SIZE],
+        pub nodename: [::c_char; _SYSNAME_SIZE],
+        pub release: [::c_char; _SYSNAME_SIZE],
+        pub version: [::c_char; _SYSNAME_SIZE],
+        pub machine: [::c_char; _SYSNAME_SIZE],
+    }
+
+    pub struct sigevent {
+        pub sigev_notify: ::c_int,
+        __sigev_un1: usize, // union
+        pub sigev_value: ::sigval,
+        __sigev_un2: usize, // union
+
+    }
+    pub struct dirent {
+        pub d_ino: ::ino_t,
+        pub d_offset: ::off_t,
+        pub d_reclen: ::c_short,
+        pub d_namelen: ::c_short,
+        pub d_name: [::c_char; 1], // flex array
+    }
+
+    pub struct dirent_extra {
+        pub d_datalen: u16,
+        pub d_type: u16,
+        pub d_reserved: u32,
+    }
+
+    pub struct stat {
+        pub st_ino: ::ino_t,
+        pub st_size: ::off_t,
+        pub st_dev: ::dev_t,
+        pub st_rdev: ::dev_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub __old_st_mtime: ::_Time32t,
+        pub __old_st_atime: ::_Time32t,
+        pub __old_st_ctime: ::_Time32t,
+        pub st_mode: ::mode_t,
+        pub st_nlink: ::nlink_t,
+        pub st_blocksize: ::blksize_t,
+        pub st_nblocks: i32,
+        pub st_blksize: ::blksize_t,
+        pub st_blocks: ::blkcnt_t,
+        pub st_mtim:    ::timespec,
+        pub st_atim:    ::timespec,
+        pub st_ctim:    ::timespec,
+    }
+
+    pub struct sigset_t {
+        __val: [u32; 2],
+    }
+
+    pub struct mq_attr {
+        pub mq_maxmsg: ::c_long,
+        pub mq_msgsize: ::c_long,
+        pub mq_flags: ::c_long,
+        pub mq_curmsgs: ::c_long,
+        pub mq_sendwait: ::c_long,
+        pub mq_recvwait: ::c_long,
+    }
+
+    pub struct msg {
+        pub msg_next: *mut ::msg,
+        pub msg_type: ::c_long,
+        pub msg_ts: ::c_ushort,
+        pub msg_spot: ::c_short,
+        _pad: [u8; 4],
+    }
+
+    pub struct msqid_ds {
+        pub msg_perm: ::ipc_perm,
+        pub msg_first: *mut ::msg,
+        pub msg_last: *mut ::msg,
+        pub msg_cbytes: ::msglen_t,
+        pub msg_qnum: ::msgqnum_t,
+        pub msg_qbytes: ::msglen_t,
+        pub msg_lspid: ::pid_t,
+        pub msg_lrpid: ::pid_t,
+        pub msg_stime: ::time_t,
+        msg_pad1: ::c_long,
+        pub msg_rtime: ::time_t,
+        msg_pad2: ::c_long,
+        pub msg_ctime: ::time_t,
+        msg_pad3: ::c_long,
+        msg_pad4: [::c_long; 4],
+    }
+
+    pub struct sockaddr_dl {
+        pub sdl_len: ::c_uchar,
+        pub sdl_family: ::sa_family_t,
+        pub sdl_index: u16,
+        pub sdl_type: ::c_uchar,
+        pub sdl_nlen: ::c_uchar,
+        pub sdl_alen: ::c_uchar,
+        pub sdl_slen: ::c_uchar,
+        pub sdl_data: [::c_char; 12],
+    }
+
+    pub struct sync_t {
+        __u: ::c_uint,                     // union
+        pub __owner: ::c_uint,
+    }
+
+    #[repr(align(4))]
+    pub struct pthread_barrier_t {         // union
+        __pad: [u8; 28],                   // union
+    }
+
+    pub struct pthread_rwlock_t {
+        pub __active: ::c_int,
+        pub __blockedwriters: ::c_int,
+        pub __blockedreaders: ::c_int,
+        pub __heavy: ::c_int,
+        pub __lock: ::pthread_mutex_t,     // union
+        pub __rcond: ::pthread_cond_t,     // union
+        pub __wcond: ::pthread_cond_t,     // union
+        pub __owner: ::c_uint,
+        pub __spare: ::c_uint,
+    }
+}
+
+cfg_if! {
+    if #[cfg(feature = "extra_traits")] {
+        impl PartialEq for sockaddr_un {
+            fn eq(&self, other: &sockaddr_un) -> bool {
+                self.sun_len == other.sun_len
+                    && self.sun_family == other.sun_family
+                    && self
+                    .sun_path
+                    .iter()
+                    .zip(other.sun_path.iter())
+                    .all(|(a,b)| a == b)
+            }
+        }
+
+        impl Eq for sockaddr_un {}
+
+        impl ::fmt::Debug for sockaddr_un {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("sockaddr_un")
+                    .field("sun_len", &self.sun_len)
+                    .field("sun_family", &self.sun_family)
+                    // FIXME: .field("sun_path", &self.sun_path)
+                    .finish()
+            }
+        }
+
+        impl ::hash::Hash for sockaddr_un {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                self.sun_len.hash(state);
+                self.sun_family.hash(state);
+                self.sun_path.hash(state);
+            }
+        }
+
+        impl PartialEq for utsname {
+            fn eq(&self, other: &utsname) -> bool {
+                self.sysname
+                    .iter()
+                    .zip(other.sysname.iter())
+                    .all(|(a,b)| a == b)
+                    && self
+                    .nodename
+                    .iter()
+                    .zip(other.nodename.iter())
+                    .all(|(a,b)| a == b)
+                    && self
+                    .release
+                    .iter()
+                    .zip(other.release.iter())
+                    .all(|(a,b)| a == b)
+                    && self
+                    .version
+                    .iter()
+                    .zip(other.version.iter())
+                    .all(|(a,b)| a == b)
+                    && self
+                    .machine
+                    .iter()
+                    .zip(other.machine.iter())
+                    .all(|(a,b)| a == b)
+            }
+        }
+
+        impl Eq for utsname {}
+
+        impl ::fmt::Debug for utsname {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("utsname")
+                // FIXME: .field("sysname", &self.sysname)
+                // FIXME: .field("nodename", &self.nodename)
+                // FIXME: .field("release", &self.release)
+                // FIXME: .field("version", &self.version)
+                // FIXME: .field("machine", &self.machine)
+                    .finish()
+            }
+        }
+
+        impl ::hash::Hash for utsname {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                self.sysname.hash(state);
+                self.nodename.hash(state);
+                self.release.hash(state);
+                self.version.hash(state);
+                self.machine.hash(state);
+            }
+        }
+
+        impl PartialEq for mq_attr {
+            fn eq(&self, other: &mq_attr) -> bool {
+                self.mq_maxmsg == other.mq_maxmsg &&
+                self.mq_msgsize == other.mq_msgsize &&
+                self.mq_flags == other.mq_flags &&
+                self.mq_curmsgs == other.mq_curmsgs &&
+                self.mq_msgsize == other.mq_msgsize &&
+                self.mq_sendwait == other.mq_sendwait &&
+                self.mq_recvwait == other.mq_recvwait
+            }
+        }
+
+        impl Eq for mq_attr {}
+
+        impl ::fmt::Debug for mq_attr {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("mq_attr")
+                    .field("mq_maxmsg", &self.mq_maxmsg)
+                    .field("mq_msgsize", &self.mq_msgsize)
+                    .field("mq_flags", &self.mq_flags)
+                    .field("mq_curmsgs", &self.mq_curmsgs)
+                    .field("mq_msgsize", &self.mq_msgsize)
+                    .field("mq_sendwait", &self.mq_sendwait)
+                    .field("mq_recvwait", &self.mq_recvwait)
+                    .finish()
+            }
+        }
+
+        impl PartialEq for sockaddr_storage {
+            fn eq(&self, other: &sockaddr_storage) -> bool {
+                self.ss_len == other.ss_len
+                    && self.ss_family == other.ss_family
+                    && self.__ss_pad1 == other.__ss_pad1
+                    && self.__ss_align == other.__ss_align
+                    && self
+                    .__ss_pad2
+                    .iter()
+                    .zip(other.__ss_pad2.iter())
+                    .all(|(a, b)| a == b)
+            }
+        }
+
+        impl Eq for sockaddr_storage {}
+
+        impl ::fmt::Debug for sockaddr_storage {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("sockaddr_storage")
+                    .field("ss_len", &self.ss_len)
+                    .field("ss_family", &self.ss_family)
+                    .field("__ss_pad1", &self.__ss_pad1)
+                    .field("__ss_align", &self.__ss_align)
+                    // FIXME: .field("__ss_pad2", &self.__ss_pad2)
+                    .finish()
+            }
+        }
+
+        impl ::hash::Hash for sockaddr_storage {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                self.ss_len.hash(state);
+                self.ss_family.hash(state);
+                self.__ss_pad1.hash(state);
+                self.__ss_align.hash(state);
+                self.__ss_pad2.hash(state);
+            }
+        }
+
+        impl PartialEq for dirent {
+            fn eq(&self, other: &dirent) -> bool {
+                self.d_ino == other.d_ino
+                    && self.d_offset == other.d_offset
+                    && self.d_reclen == other.d_reclen
+                    && self.d_namelen == other.d_namelen
+                    && self
+                    .d_name[..self.d_namelen as _]
+                    .iter()
+                    .zip(other.d_name.iter())
+                    .all(|(a,b)| a == b)
+            }
+        }
+
+        impl Eq for dirent {}
+
+        impl ::fmt::Debug for dirent {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("dirent")
+                    .field("d_ino", &self.d_ino)
+                    .field("d_offset", &self.d_offset)
+                    .field("d_reclen", &self.d_reclen)
+                    .field("d_namelen", &self.d_namelen)
+                    .field("d_name", &&self.d_name[..self.d_namelen as _])
+                    .finish()
+            }
+        }
+
+        impl ::hash::Hash for dirent {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                self.d_ino.hash(state);
+                self.d_offset.hash(state);
+                self.d_reclen.hash(state);
+                self.d_namelen.hash(state);
+                self.d_name[..self.d_namelen as _].hash(state);
+            }
+        }
+    }
+}
+
+pub const _SYSNAME_SIZE: usize = 256 + 1;
+pub const RLIM_INFINITY: ::rlim_t = 0xfffffffffffffffd;
+pub const O_LARGEFILE: ::c_int = 0o0100000;
+
+// intentionally not public, only used for fd_set
+cfg_if! {
+    if #[cfg(target_pointer_width = "32")] {
+        const ULONG_SIZE: usize = 32;
+    } else if #[cfg(target_pointer_width = "64")] {
+        const ULONG_SIZE: usize = 64;
+    } else {
+        // Unknown target_pointer_width
+    }
+}
+
+pub const EXIT_FAILURE: ::c_int = 1;
+pub const EXIT_SUCCESS: ::c_int = 0;
+pub const RAND_MAX: ::c_int = 32767;
+pub const EOF: ::c_int = -1;
+pub const SEEK_SET: ::c_int = 0;
+pub const SEEK_CUR: ::c_int = 1;
+pub const SEEK_END: ::c_int = 2;
+pub const _IOFBF: ::c_int = 0;
+pub const _IONBF: ::c_int = 2;
+pub const _IOLBF: ::c_int = 1;
+
+pub const F_DUPFD: ::c_int = 0;
+pub const F_GETFD: ::c_int = 1;
+pub const F_SETFD: ::c_int = 2;
+pub const F_GETFL: ::c_int = 3;
+pub const F_SETFL: ::c_int = 4;
+
+pub const F_DUPFD_CLOEXEC: ::c_int = 5;
+
+pub const SIGTRAP: ::c_int = 5;
+
+pub const CLOCK_REALTIME: ::clockid_t = 0;
+pub const CLOCK_MONOTONIC: ::clockid_t = 2;
+pub const CLOCK_PROCESS_CPUTIME_ID: ::clockid_t = 3;
+pub const CLOCK_THREAD_CPUTIME_ID: ::clockid_t = 4;
+pub const TIMER_ABSTIME: ::c_uint = 0x80000000;
+
+pub const RUSAGE_SELF: ::c_int = 0;
+
+pub const F_OK: ::c_int = 0;
+pub const X_OK: ::c_int = 1;
+pub const W_OK: ::c_int = 2;
+pub const R_OK: ::c_int = 4;
+
+pub const STDIN_FILENO: ::c_int = 0;
+pub const STDOUT_FILENO: ::c_int = 1;
+pub const STDERR_FILENO: ::c_int = 2;
+
+pub const SIGHUP: ::c_int = 1;
+pub const SIGINT: ::c_int = 2;
+pub const SIGQUIT: ::c_int = 3;
+pub const SIGILL: ::c_int = 4;
+pub const SIGABRT: ::c_int = 6;
+pub const SIGFPE: ::c_int = 8;
+pub const SIGKILL: ::c_int = 9;
+pub const SIGSEGV: ::c_int = 11;
+pub const SIGPIPE: ::c_int = 13;
+pub const SIGALRM: ::c_int = 14;
+pub const SIGTERM: ::c_int = 15;
+
+pub const PROT_NONE: ::c_int = 0x00000000;
+pub const PROT_READ: ::c_int = 0x00000100;
+pub const PROT_WRITE: ::c_int = 0x00000200;
+pub const PROT_EXEC: ::c_int = 0x00000400;
+
+pub const MAP_FILE: ::c_int = 0;
+pub const MAP_SHARED: ::c_int = 1;
+pub const MAP_PRIVATE: ::c_int = 2;
+pub const MAP_FIXED: ::c_int = 0x10;
+
+pub const MAP_FAILED: *mut ::c_void = !0 as *mut ::c_void;
+
+pub const MS_ASYNC: ::c_int = 1;
+pub const MS_INVALIDATE: ::c_int = 4;
+pub const MS_SYNC: ::c_int = 2;
+
+pub const SCM_RIGHTS: ::c_int = 0x01;
+pub const SCM_TIMESTAMP: ::c_int = 0x02;
+pub const SCM_CREDS: ::c_int = 0x04;
+
+pub const MAP_TYPE: ::c_int = 0x3;
+
+pub const IFF_UP: ::c_int = 0x00000001;
+pub const IFF_BROADCAST: ::c_int = 0x00000002;
+pub const IFF_DEBUG: ::c_int = 0x00000004;
+pub const IFF_LOOPBACK: ::c_int = 0x00000008;
+pub const IFF_POINTOPOINT: ::c_int = 0x00000010;
+pub const IFF_NOTRAILERS: ::c_int = 0x00000020;
+pub const IFF_RUNNING: ::c_int = 0x00000040;
+pub const IFF_NOARP: ::c_int = 0x00000080;
+pub const IFF_PROMISC: ::c_int = 0x00000100;
+pub const IFF_ALLMULTI: ::c_int = 0x00000200;
+pub const IFF_MULTICAST: ::c_int = 0x00008000;
+
+pub const AF_UNSPEC: ::c_int = 0;
+pub const AF_UNIX: ::c_int = AF_LOCAL;
+pub const AF_LOCAL: ::c_int = 1;
+pub const AF_INET: ::c_int = 2;
+pub const AF_IPX: ::c_int = 23;
+pub const AF_APPLETALK: ::c_int = 16;
+pub const AF_INET6: ::c_int = 24;
+pub const AF_ROUTE: ::c_int = 17;
+pub const AF_SNA: ::c_int = 11;
+pub const AF_BLUETOOTH: ::c_int = 31;
+pub const AF_ISDN: ::c_int = 26;
+
+pub const PF_UNSPEC: ::c_int = AF_UNSPEC;
+pub const PF_UNIX: ::c_int = PF_LOCAL;
+pub const PF_LOCAL: ::c_int = AF_LOCAL;
+pub const PF_INET: ::c_int = AF_INET;
+pub const PF_IPX: ::c_int = AF_IPX;
+pub const PF_APPLETALK: ::c_int = AF_APPLETALK;
+pub const PF_INET6: ::c_int = AF_INET6;
+pub const pseudo_AF_KEY: ::c_int = 29;
+pub const PF_KEY: ::c_int = pseudo_AF_KEY;
+pub const PF_ROUTE: ::c_int = AF_ROUTE;
+pub const PF_SNA: ::c_int = AF_SNA;
+
+pub const PF_BLUETOOTH: ::c_int = AF_BLUETOOTH;
+pub const PF_ISDN: ::c_int = AF_ISDN;
+
+pub const SOMAXCONN: ::c_int = 128;
+
+pub const MSG_OOB: ::c_int = 0x0001;
+pub const MSG_PEEK: ::c_int = 0x0002;
+pub const MSG_DONTROUTE: ::c_int = 0x0004;
+pub const MSG_CTRUNC: ::c_int = 0x0020;
+pub const MSG_TRUNC: ::c_int = 0x0010;
+pub const MSG_DONTWAIT: ::c_int = 0x0080;
+pub const MSG_EOR: ::c_int = 0x0008;
+pub const MSG_WAITALL: ::c_int = 0x0040;
+pub const MSG_NOSIGNAL: ::c_int = 0x0800;
+pub const MSG_WAITFORONE: ::c_int = 0x2000;
+
+pub const IP_TOS: ::c_int = 3;
+pub const IP_TTL: ::c_int = 4;
+pub const IP_HDRINCL: ::c_int = 2;
+pub const IP_OPTIONS: ::c_int = 1;
+pub const IP_RECVOPTS: ::c_int = 5;
+pub const IP_RETOPTS: ::c_int = 8;
+pub const IP_PKTINFO: ::c_int = 25;
+pub const IP_IPSEC_POLICY_COMPAT: ::c_int = 22;
+pub const IP_MULTICAST_IF: ::c_int = 9;
+pub const IP_MULTICAST_TTL: ::c_int = 10;
+pub const IP_MULTICAST_LOOP: ::c_int = 11;
+pub const IP_ADD_MEMBERSHIP: ::c_int = 12;
+pub const IP_DROP_MEMBERSHIP: ::c_int = 13;
+pub const IP_DEFAULT_MULTICAST_TTL: ::c_int = 1;
+pub const IP_DEFAULT_MULTICAST_LOOP: ::c_int = 1;
+
+pub const IPPROTO_HOPOPTS: ::c_int = 0;
+pub const IPPROTO_IGMP: ::c_int = 2;
+pub const IPPROTO_IPIP: ::c_int = 4;
+pub const IPPROTO_EGP: ::c_int = 8;
+pub const IPPROTO_PUP: ::c_int = 12;
+pub const IPPROTO_IDP: ::c_int = 22;
+pub const IPPROTO_TP: ::c_int = 29;
+pub const IPPROTO_ROUTING: ::c_int = 43;
+pub const IPPROTO_FRAGMENT: ::c_int = 44;
+pub const IPPROTO_RSVP: ::c_int = 46;
+pub const IPPROTO_GRE: ::c_int = 47;
+pub const IPPROTO_ESP: ::c_int = 50;
+pub const IPPROTO_AH: ::c_int = 51;
+pub const IPPROTO_NONE: ::c_int = 59;
+pub const IPPROTO_DSTOPTS: ::c_int = 60;
+pub const IPPROTO_ENCAP: ::c_int = 98;
+pub const IPPROTO_PIM: ::c_int = 103;
+pub const IPPROTO_SCTP: ::c_int = 132;
+pub const IPPROTO_RAW: ::c_int = 255;
+pub const IPPROTO_MAX: ::c_int = 256;
+pub const IPPROTO_CARP: ::c_int = 112;
+pub const IPPROTO_DIVERT: ::c_int = 259;
+pub const IPPROTO_DONE: ::c_int = 257;
+pub const IPPROTO_EON: ::c_int = 80;
+pub const IPPROTO_ETHERIP: ::c_int = 97;
+pub const IPPROTO_GGP: ::c_int = 3;
+pub const IPPROTO_IPCOMP: ::c_int = 108;
+pub const IPPROTO_MOBILE: ::c_int = 55;
+
+pub const IPV6_RTHDR_LOOSE: ::c_int = 0;
+pub const IPV6_RTHDR_STRICT: ::c_int = 1;
+pub const IPV6_UNICAST_HOPS: ::c_int = 4;
+pub const IPV6_MULTICAST_IF: ::c_int = 9;
+pub const IPV6_MULTICAST_HOPS: ::c_int = 10;
+pub const IPV6_MULTICAST_LOOP: ::c_int = 11;
+pub const IPV6_JOIN_GROUP: ::c_int = 12;
+pub const IPV6_LEAVE_GROUP: ::c_int = 13;
+pub const IPV6_CHECKSUM: ::c_int = 26;
+pub const IPV6_V6ONLY: ::c_int = 27;
+pub const IPV6_IPSEC_POLICY_COMPAT: ::c_int = 28;
+pub const IPV6_RTHDRDSTOPTS: ::c_int = 35;
+pub const IPV6_RECVPKTINFO: ::c_int = 36;
+pub const IPV6_RECVHOPLIMIT: ::c_int = 37;
+pub const IPV6_RECVRTHDR: ::c_int = 38;
+pub const IPV6_RECVHOPOPTS: ::c_int = 39;
+pub const IPV6_RECVDSTOPTS: ::c_int = 40;
+pub const IPV6_RECVPATHMTU: ::c_int = 43;
+pub const IPV6_PATHMTU: ::c_int = 44;
+pub const IPV6_PKTINFO: ::c_int = 46;
+pub const IPV6_HOPLIMIT: ::c_int = 47;
+pub const IPV6_NEXTHOP: ::c_int = 48;
+pub const IPV6_HOPOPTS: ::c_int = 49;
+pub const IPV6_DSTOPTS: ::c_int = 50;
+pub const IPV6_RECVTCLASS: ::c_int = 57;
+pub const IPV6_TCLASS: ::c_int = 61;
+pub const IPV6_DONTFRAG: ::c_int = 62;
+
+pub const TCP_NODELAY: ::c_int = 0x01;
+pub const TCP_MAXSEG: ::c_int = 0x02;
+pub const TCP_MD5SIG: ::c_int = 0x10;
+pub const TCP_KEEPALIVE: ::c_int = 0x04;
+
+pub const SHUT_RD: ::c_int = 0;
+pub const SHUT_WR: ::c_int = 1;
+pub const SHUT_RDWR: ::c_int = 2;
+
+pub const LOCK_SH: ::c_int = 0x1;
+pub const LOCK_EX: ::c_int = 0x2;
+pub const LOCK_NB: ::c_int = 0x4;
+pub const LOCK_UN: ::c_int = 0x8;
+
+pub const SS_ONSTACK: ::c_int = 1;
+pub const SS_DISABLE: ::c_int = 2;
+
+pub const PATH_MAX: ::c_int = 1024;
+
+pub const UIO_MAXIOV: ::c_int = 1024;
+
+pub const FD_SETSIZE: usize = 256;
+
+pub const TCIOFF: ::c_int = 0x0002;
+pub const TCION: ::c_int = 0x0003;
+pub const TCOOFF: ::c_int = 0x0000;
+pub const TCOON: ::c_int = 0x0001;
+pub const TCIFLUSH: ::c_int = 0;
+pub const TCOFLUSH: ::c_int = 1;
+pub const TCIOFLUSH: ::c_int = 2;
+pub const NL0: ::tcflag_t = 0x000;
+pub const NL1: ::tcflag_t = 0x100;
+pub const TAB0: ::tcflag_t = 0x0000;
+pub const CR0: ::tcflag_t = 0x000;
+pub const FF0: ::tcflag_t = 0x0000;
+pub const BS0: ::tcflag_t = 0x0000;
+pub const VT0: ::tcflag_t = 0x0000;
+pub const VERASE: usize = 2;
+pub const VKILL: usize = 3;
+pub const VINTR: usize = 0;
+pub const VQUIT: usize = 1;
+pub const VLNEXT: usize = 15;
+pub const IGNBRK: ::tcflag_t = 0x00000001;
+pub const BRKINT: ::tcflag_t = 0x00000002;
+pub const IGNPAR: ::tcflag_t = 0x00000004;
+pub const PARMRK: ::tcflag_t = 0x00000008;
+pub const INPCK: ::tcflag_t = 0x00000010;
+pub const ISTRIP: ::tcflag_t = 0x00000020;
+pub const INLCR: ::tcflag_t = 0x00000040;
+pub const IGNCR: ::tcflag_t = 0x00000080;
+pub const ICRNL: ::tcflag_t = 0x00000100;
+pub const IXANY: ::tcflag_t = 0x00000800;
+pub const IMAXBEL: ::tcflag_t = 0x00002000;
+pub const OPOST: ::tcflag_t = 0x00000001;
+pub const CS5: ::tcflag_t = 0x00;
+pub const ECHO: ::tcflag_t = 0x00000008;
+pub const OCRNL: ::tcflag_t = 0x00000008;
+pub const ONOCR: ::tcflag_t = 0x00000010;
+pub const ONLRET: ::tcflag_t = 0x00000020;
+pub const OFILL: ::tcflag_t = 0x00000040;
+pub const OFDEL: ::tcflag_t = 0x00000080;
+
+pub const WNOHANG: ::c_int = 0x0040;
+pub const WUNTRACED: ::c_int = 0x0004;
+pub const WSTOPPED: ::c_int = WUNTRACED;
+pub const WEXITED: ::c_int = 0x0001;
+pub const WCONTINUED: ::c_int = 0x0008;
+pub const WNOWAIT: ::c_int = 0x0080;
+pub const WTRAPPED: ::c_int = 0x0002;
+
+pub const RTLD_LOCAL: ::c_int = 0x0200;
+pub const RTLD_LAZY: ::c_int = 0x0001;
+
+pub const POSIX_FADV_NORMAL: ::c_int = 0;
+pub const POSIX_FADV_RANDOM: ::c_int = 2;
+pub const POSIX_FADV_SEQUENTIAL: ::c_int = 1;
+pub const POSIX_FADV_WILLNEED: ::c_int = 3;
+
+pub const AT_FDCWD: ::c_int = -100;
+pub const AT_EACCESS: ::c_int = 0x0001;
+pub const AT_SYMLINK_NOFOLLOW: ::c_int = 0x0002;
+pub const AT_SYMLINK_FOLLOW: ::c_int = 0x0004;
+pub const AT_REMOVEDIR: ::c_int = 0x0008;
+
+pub const LOG_CRON: ::c_int = 9 << 3;
+pub const LOG_AUTHPRIV: ::c_int = 10 << 3;
+pub const LOG_FTP: ::c_int = 11 << 3;
+pub const LOG_PERROR: ::c_int = 0x20;
+
+pub const PIPE_BUF: usize = 5120;
+
+pub const CLD_EXITED: ::c_int = 1;
+pub const CLD_KILLED: ::c_int = 2;
+pub const CLD_DUMPED: ::c_int = 3;
+pub const CLD_TRAPPED: ::c_int = 4;
+pub const CLD_STOPPED: ::c_int = 5;
+pub const CLD_CONTINUED: ::c_int = 6;
+
+pub const UTIME_OMIT: c_long = 0x40000002;
+pub const UTIME_NOW: c_long = 0x40000001;
+
+pub const POLLIN: ::c_short = POLLRDNORM | POLLRDBAND;
+pub const POLLPRI: ::c_short = 0x0008;
+pub const POLLOUT: ::c_short = 0x0002;
+pub const POLLERR: ::c_short = 0x0020;
+pub const POLLHUP: ::c_short = 0x0040;
+pub const POLLNVAL: ::c_short = 0x1000;
+pub const POLLRDNORM: ::c_short = 0x0001;
+pub const POLLRDBAND: ::c_short = 0x0004;
+
+pub const IPTOS_LOWDELAY: u8 = 0x10;
+pub const IPTOS_THROUGHPUT: u8 = 0x08;
+pub const IPTOS_RELIABILITY: u8 = 0x04;
+pub const IPTOS_MINCOST: u8 = 0x02;
+
+pub const IPTOS_PREC_NETCONTROL: u8 = 0xe0;
+pub const IPTOS_PREC_INTERNETCONTROL: u8 = 0xc0;
+pub const IPTOS_PREC_CRITIC_ECP: u8 = 0xa0;
+pub const IPTOS_PREC_FLASHOVERRIDE: u8 = 0x80;
+pub const IPTOS_PREC_FLASH: u8 = 0x60;
+pub const IPTOS_PREC_IMMEDIATE: u8 = 0x40;
+pub const IPTOS_PREC_PRIORITY: u8 = 0x20;
+pub const IPTOS_PREC_ROUTINE: u8 = 0x00;
+
+pub const IPTOS_ECN_MASK: u8 = 0x03;
+pub const IPTOS_ECN_ECT1: u8 = 0x01;
+pub const IPTOS_ECN_ECT0: u8 = 0x02;
+pub const IPTOS_ECN_CE: u8 = 0x03;
+
+pub const IPOPT_CONTROL: u8 = 0x00;
+pub const IPOPT_RESERVED1: u8 = 0x20;
+pub const IPOPT_RESERVED2: u8 = 0x60;
+pub const IPOPT_LSRR: u8 = 131;
+pub const IPOPT_RR: u8 = 7;
+pub const IPOPT_SSRR: u8 = 137;
+pub const IPDEFTTL: u8 = 64;
+pub const IPOPT_OPTVAL: u8 = 0;
+pub const IPOPT_OLEN: u8 = 1;
+pub const IPOPT_OFFSET: u8 = 2;
+pub const IPOPT_MINOFF: u8 = 4;
+pub const IPOPT_NOP: u8 = 1;
+pub const IPOPT_EOL: u8 = 0;
+pub const IPOPT_TS: u8 = 68;
+pub const IPOPT_TS_TSONLY: u8 = 0;
+pub const IPOPT_TS_TSANDADDR: u8 = 1;
+pub const IPOPT_TS_PRESPEC: u8 = 3;
+
+pub const MAX_IPOPTLEN: u8 = 40;
+pub const IPVERSION: u8 = 4;
+pub const MAXTTL: u8 = 255;
+
+pub const ARPHRD_ETHER: u16 = 1;
+pub const ARPHRD_IEEE802: u16 = 6;
+pub const ARPHRD_ARCNET: u16 = 7;
+pub const ARPHRD_IEEE1394: u16 = 24;
+
+pub const SOL_SOCKET: ::c_int = 0xffff;
+
+pub const SO_DEBUG: ::c_int = 0x0001;
+pub const SO_REUSEADDR: ::c_int = 0x0004;
+pub const SO_TYPE: ::c_int = 0x1008;
+pub const SO_ERROR: ::c_int = 0x1007;
+pub const SO_DONTROUTE: ::c_int = 0x0010;
+pub const SO_BROADCAST: ::c_int = 0x0020;
+pub const SO_SNDBUF: ::c_int = 0x1001;
+pub const SO_RCVBUF: ::c_int = 0x1002;
+pub const SO_KEEPALIVE: ::c_int = 0x0008;
+pub const SO_OOBINLINE: ::c_int = 0x0100;
+pub const SO_LINGER: ::c_int = 0x0080;
+pub const SO_REUSEPORT: ::c_int = 0x0200;
+pub const SO_RCVLOWAT: ::c_int = 0x1004;
+pub const SO_SNDLOWAT: ::c_int = 0x1003;
+pub const SO_RCVTIMEO: ::c_int = 0x1006;
+pub const SO_SNDTIMEO: ::c_int = 0x1005;
+pub const SO_BINDTODEVICE: ::c_int = 0x0800;
+pub const SO_TIMESTAMP: ::c_int = 0x0400;
+pub const SO_ACCEPTCONN: ::c_int = 0x0002;
+
+pub const TIOCM_LE: ::c_int = 0x0100;
+pub const TIOCM_DTR: ::c_int = 0x0001;
+pub const TIOCM_RTS: ::c_int = 0x0002;
+pub const TIOCM_ST: ::c_int = 0x0200;
+pub const TIOCM_SR: ::c_int = 0x0400;
+pub const TIOCM_CTS: ::c_int = 0x1000;
+pub const TIOCM_CAR: ::c_int = TIOCM_CD;
+pub const TIOCM_CD: ::c_int = 0x8000;
+pub const TIOCM_RNG: ::c_int = TIOCM_RI;
+pub const TIOCM_RI: ::c_int = 0x4000;
+pub const TIOCM_DSR: ::c_int = 0x2000;
+
+pub const SCHED_OTHER: ::c_int = 3;
+pub const SCHED_FIFO: ::c_int = 1;
+pub const SCHED_RR: ::c_int = 2;
+
+pub const IPC_PRIVATE: ::key_t = 0;
+
+pub const IPC_CREAT: ::c_int = 0o001000;
+pub const IPC_EXCL: ::c_int = 0o002000;
+pub const IPC_NOWAIT: ::c_int = 0o004000;
+
+pub const IPC_RMID: ::c_int = 0;
+pub const IPC_SET: ::c_int = 1;
+pub const IPC_STAT: ::c_int = 2;
+
+pub const MSG_NOERROR: ::c_int = 0o010000;
+
+pub const LOG_NFACILITIES: ::c_int = 24;
+
+pub const SEM_FAILED: *mut ::sem_t = 0xFFFFFFFFFFFFFFFF as *mut sem_t;
+
+pub const AI_PASSIVE: ::c_int = 0x00000001;
+pub const AI_CANONNAME: ::c_int = 0x00000002;
+pub const AI_NUMERICHOST: ::c_int = 0x00000004;
+
+pub const AI_NUMERICSERV: ::c_int = 0x00000008;
+
+pub const EAI_BADFLAGS: ::c_int = 3;
+pub const EAI_NONAME: ::c_int = 8;
+pub const EAI_AGAIN: ::c_int = 2;
+pub const EAI_FAIL: ::c_int = 4;
+pub const EAI_NODATA: ::c_int = 7;
+pub const EAI_FAMILY: ::c_int = 5;
+pub const EAI_SOCKTYPE: ::c_int = 10;
+pub const EAI_SERVICE: ::c_int = 9;
+pub const EAI_MEMORY: ::c_int = 6;
+pub const EAI_SYSTEM: ::c_int = 11;
+pub const EAI_OVERFLOW: ::c_int = 14;
+
+pub const NI_NUMERICHOST: ::c_int = 0x00000002;
+pub const NI_NUMERICSERV: ::c_int = 0x00000008;
+pub const NI_NOFQDN: ::c_int = 0x00000001;
+pub const NI_NAMEREQD: ::c_int = 0x00000004;
+pub const NI_DGRAM: ::c_int = 0x00000010;
+
+pub const AIO_CANCELED: ::c_int = 0;
+pub const AIO_NOTCANCELED: ::c_int = 2;
+pub const AIO_ALLDONE: ::c_int = 1;
+pub const LIO_READ: ::c_int = 1;
+pub const LIO_WRITE: ::c_int = 2;
+pub const LIO_NOP: ::c_int = 0;
+pub const LIO_WAIT: ::c_int = 1;
+pub const LIO_NOWAIT: ::c_int = 0;
+
+pub const ITIMER_REAL: ::c_int = 0;
+pub const ITIMER_VIRTUAL: ::c_int = 1;
+pub const ITIMER_PROF: ::c_int = 2;
+
+pub const POSIX_SPAWN_RESETIDS: ::c_int = 0x00000010;
+pub const POSIX_SPAWN_SETPGROUP: ::c_int = 0x00000001;
+pub const POSIX_SPAWN_SETSIGDEF: ::c_int = 0x00000004;
+pub const POSIX_SPAWN_SETSIGMASK: ::c_int = 0x00000002;
+pub const POSIX_SPAWN_SETSCHEDPARAM: ::c_int = 0x00000400;
+pub const POSIX_SPAWN_SETSCHEDULER: ::c_int = 0x00000040;
+
+pub const IPTOS_ECN_NOT_ECT: u8 = 0x00;
+
+pub const RTF_UP: ::c_ushort = 0x0001;
+pub const RTF_GATEWAY: ::c_ushort = 0x0002;
+
+pub const RTF_HOST: ::c_ushort = 0x0004;
+pub const RTF_DYNAMIC: ::c_ushort = 0x0010;
+pub const RTF_MODIFIED: ::c_ushort = 0x0020;
+pub const RTF_REJECT: ::c_ushort = 0x0008;
+pub const RTF_STATIC: ::c_ushort = 0x0800;
+pub const RTF_XRESOLVE: ::c_ushort = 0x0200;
+pub const RTF_BROADCAST: u32 = 0x80000;
+pub const RTM_NEWADDR: u16 = 0xc;
+pub const RTM_DELADDR: u16 = 0xd;
+pub const RTA_DST: ::c_ushort = 0x1;
+pub const RTA_GATEWAY: ::c_ushort = 0x2;
+
+pub const UDP_ENCAP: ::c_int = 100;
+
+pub const IN_ACCESS: u32 = 0x00000001;
+pub const IN_MODIFY: u32 = 0x00000002;
+pub const IN_ATTRIB: u32 = 0x00000004;
+pub const IN_CLOSE_WRITE: u32 = 0x00000008;
+pub const IN_CLOSE_NOWRITE: u32 = 0x00000010;
+pub const IN_CLOSE: u32 = IN_CLOSE_WRITE | IN_CLOSE_NOWRITE;
+pub const IN_OPEN: u32 = 0x00000020;
+pub const IN_MOVED_FROM: u32 = 0x00000040;
+pub const IN_MOVED_TO: u32 = 0x00000080;
+pub const IN_MOVE: u32 = IN_MOVED_FROM | IN_MOVED_TO;
+pub const IN_CREATE: u32 = 0x00000100;
+pub const IN_DELETE: u32 = 0x00000200;
+pub const IN_DELETE_SELF: u32 = 0x00000400;
+pub const IN_MOVE_SELF: u32 = 0x00000800;
+pub const IN_UNMOUNT: u32 = 0x00002000;
+pub const IN_Q_OVERFLOW: u32 = 0x00004000;
+pub const IN_IGNORED: u32 = 0x00008000;
+pub const IN_ONLYDIR: u32 = 0x01000000;
+pub const IN_DONT_FOLLOW: u32 = 0x02000000;
+
+pub const IN_ISDIR: u32 = 0x40000000;
+pub const IN_ONESHOT: u32 = 0x80000000;
+
+pub const REG_EXTENDED: ::c_int = 0o0001;
+pub const REG_ICASE: ::c_int = 0o0002;
+pub const REG_NEWLINE: ::c_int = 0o0010;
+pub const REG_NOSUB: ::c_int = 0o0004;
+
+pub const REG_NOTBOL: ::c_int = 0o00001;
+pub const REG_NOTEOL: ::c_int = 0o00002;
+
+pub const REG_ENOSYS: ::c_int = 17;
+pub const REG_NOMATCH: ::c_int = 1;
+pub const REG_BADPAT: ::c_int = 2;
+pub const REG_ECOLLATE: ::c_int = 3;
+pub const REG_ECTYPE: ::c_int = 4;
+pub const REG_EESCAPE: ::c_int = 5;
+pub const REG_ESUBREG: ::c_int = 6;
+pub const REG_EBRACK: ::c_int = 7;
+pub const REG_EPAREN: ::c_int = 8;
+pub const REG_EBRACE: ::c_int = 9;
+pub const REG_BADBR: ::c_int = 10;
+pub const REG_ERANGE: ::c_int = 11;
+pub const REG_ESPACE: ::c_int = 12;
+pub const REG_BADRPT: ::c_int = 13;
+
+// errno.h
+pub const EOK: ::c_int = 0;
+pub const EWOULDBLOCK: ::c_int = EAGAIN;
+pub const EPERM: ::c_int = 1;
+pub const ENOENT: ::c_int = 2;
+pub const ESRCH: ::c_int = 3;
+pub const EINTR: ::c_int = 4;
+pub const EIO: ::c_int = 5;
+pub const ENXIO: ::c_int = 6;
+pub const E2BIG: ::c_int = 7;
+pub const ENOEXEC: ::c_int = 8;
+pub const EBADF: ::c_int = 9;
+pub const ECHILD: ::c_int = 10;
+pub const EAGAIN: ::c_int = 11;
+pub const ENOMEM: ::c_int = 12;
+pub const EACCES: ::c_int = 13;
+pub const EFAULT: ::c_int = 14;
+pub const ENOTBLK: ::c_int = 15;
+pub const EBUSY: ::c_int = 16;
+pub const EEXIST: ::c_int = 17;
+pub const EXDEV: ::c_int = 18;
+pub const ENODEV: ::c_int = 19;
+pub const ENOTDIR: ::c_int = 20;
+pub const EISDIR: ::c_int = 21;
+pub const EINVAL: ::c_int = 22;
+pub const ENFILE: ::c_int = 23;
+pub const EMFILE: ::c_int = 24;
+pub const ENOTTY: ::c_int = 25;
+pub const ETXTBSY: ::c_int = 26;
+pub const EFBIG: ::c_int = 27;
+pub const ENOSPC: ::c_int = 28;
+pub const ESPIPE: ::c_int = 29;
+pub const EROFS: ::c_int = 30;
+pub const EMLINK: ::c_int = 31;
+pub const EPIPE: ::c_int = 32;
+pub const EDOM: ::c_int = 33;
+pub const ERANGE: ::c_int = 34;
+pub const ENOMSG: ::c_int = 35;
+pub const EIDRM: ::c_int = 36;
+pub const ECHRNG: ::c_int = 37;
+pub const EL2NSYNC: ::c_int = 38;
+pub const EL3HLT: ::c_int = 39;
+pub const EL3RST: ::c_int = 40;
+pub const ELNRNG: ::c_int = 41;
+pub const EUNATCH: ::c_int = 42;
+pub const ENOCSI: ::c_int = 43;
+pub const EL2HLT: ::c_int = 44;
+pub const EDEADLK: ::c_int = 45;
+pub const ENOLCK: ::c_int = 46;
+pub const ECANCELED: ::c_int = 47;
+pub const EDQUOT: ::c_int = 49;
+pub const EBADE: ::c_int = 50;
+pub const EBADR: ::c_int = 51;
+pub const EXFULL: ::c_int = 52;
+pub const ENOANO: ::c_int = 53;
+pub const EBADRQC: ::c_int = 54;
+pub const EBADSLT: ::c_int = 55;
+pub const EDEADLOCK: ::c_int = 56;
+pub const EBFONT: ::c_int = 57;
+pub const EOWNERDEAD: ::c_int = 58;
+pub const ENOSTR: ::c_int = 60;
+pub const ENODATA: ::c_int = 61;
+pub const ETIME: ::c_int = 62;
+pub const ENOSR: ::c_int = 63;
+pub const ENONET: ::c_int = 64;
+pub const ENOPKG: ::c_int = 65;
+pub const EREMOTE: ::c_int = 66;
+pub const ENOLINK: ::c_int = 67;
+pub const EADV: ::c_int = 68;
+pub const ESRMNT: ::c_int = 69;
+pub const ECOMM: ::c_int = 70;
+pub const EPROTO: ::c_int = 71;
+pub const EMULTIHOP: ::c_int = 74;
+pub const EBADMSG: ::c_int = 77;
+pub const ENAMETOOLONG: ::c_int = 78;
+pub const EOVERFLOW: ::c_int = 79;
+pub const ENOTUNIQ: ::c_int = 80;
+pub const EBADFD: ::c_int = 81;
+pub const EREMCHG: ::c_int = 82;
+pub const ELIBACC: ::c_int = 83;
+pub const ELIBBAD: ::c_int = 84;
+pub const ELIBSCN: ::c_int = 85;
+pub const ELIBMAX: ::c_int = 86;
+pub const ELIBEXEC: ::c_int = 87;
+pub const EILSEQ: ::c_int = 88;
+pub const ENOSYS: ::c_int = 89;
+pub const ELOOP: ::c_int = 90;
+pub const ERESTART: ::c_int = 91;
+pub const ESTRPIPE: ::c_int = 92;
+pub const ENOTEMPTY: ::c_int = 93;
+pub const EUSERS: ::c_int = 94;
+pub const ENOTRECOVERABLE: ::c_int = 95;
+pub const EOPNOTSUPP: ::c_int = 103;
+pub const EFPOS: ::c_int = 110;
+pub const ESTALE: ::c_int = 122;
+pub const EINPROGRESS: ::c_int = 236;
+pub const EALREADY: ::c_int = 237;
+pub const ENOTSOCK: ::c_int = 238;
+pub const EDESTADDRREQ: ::c_int = 239;
+pub const EMSGSIZE: ::c_int = 240;
+pub const EPROTOTYPE: ::c_int = 241;
+pub const ENOPROTOOPT: ::c_int = 242;
+pub const EPROTONOSUPPORT: ::c_int = 243;
+pub const ESOCKTNOSUPPORT: ::c_int = 244;
+pub const EPFNOSUPPORT: ::c_int = 246;
+pub const EAFNOSUPPORT: ::c_int = 247;
+pub const EADDRINUSE: ::c_int = 248;
+pub const EADDRNOTAVAIL: ::c_int = 249;
+pub const ENETDOWN: ::c_int = 250;
+pub const ENETUNREACH: ::c_int = 251;
+pub const ENETRESET: ::c_int = 252;
+pub const ECONNABORTED: ::c_int = 253;
+pub const ECONNRESET: ::c_int = 254;
+pub const ENOBUFS: ::c_int = 255;
+pub const EISCONN: ::c_int = 256;
+pub const ENOTCONN: ::c_int = 257;
+pub const ESHUTDOWN: ::c_int = 258;
+pub const ETOOMANYREFS: ::c_int = 259;
+pub const ETIMEDOUT: ::c_int = 260;
+pub const ECONNREFUSED: ::c_int = 261;
+pub const EHOSTDOWN: ::c_int = 264;
+pub const EHOSTUNREACH: ::c_int = 265;
+pub const EBADRPC: ::c_int = 272;
+pub const ERPCMISMATCH: ::c_int = 273;
+pub const EPROGUNAVAIL: ::c_int = 274;
+pub const EPROGMISMATCH: ::c_int = 275;
+pub const EPROCUNAVAIL: ::c_int = 276;
+pub const ENOREMOTE: ::c_int = 300;
+pub const ENONDP: ::c_int = 301;
+pub const EBADFSYS: ::c_int = 302;
+pub const EMORE: ::c_int = 309;
+pub const ECTRLTERM: ::c_int = 310;
+pub const ENOLIC: ::c_int = 311;
+pub const ESRVRFAULT: ::c_int = 312;
+pub const EENDIAN: ::c_int = 313;
+pub const ESECTYPEINVAL: ::c_int = 314;
+
+pub const RUSAGE_CHILDREN: ::c_int = -1;
+pub const L_tmpnam: ::c_uint = 255;
+
+pub const _PC_LINK_MAX: ::c_int = 1;
+pub const _PC_MAX_CANON: ::c_int = 2;
+pub const _PC_MAX_INPUT: ::c_int = 3;
+pub const _PC_NAME_MAX: ::c_int = 4;
+pub const _PC_PATH_MAX: ::c_int = 5;
+pub const _PC_PIPE_BUF: ::c_int = 6;
+pub const _PC_CHOWN_RESTRICTED: ::c_int = 9;
+pub const _PC_NO_TRUNC: ::c_int = 7;
+pub const _PC_VDISABLE: ::c_int = 8;
+pub const _PC_SYNC_IO: ::c_int = 14;
+pub const _PC_ASYNC_IO: ::c_int = 12;
+pub const _PC_PRIO_IO: ::c_int = 13;
+pub const _PC_SOCK_MAXBUF: ::c_int = 15;
+pub const _PC_FILESIZEBITS: ::c_int = 16;
+pub const _PC_REC_INCR_XFER_SIZE: ::c_int = 22;
+pub const _PC_REC_MAX_XFER_SIZE: ::c_int = 23;
+pub const _PC_REC_MIN_XFER_SIZE: ::c_int = 24;
+pub const _PC_REC_XFER_ALIGN: ::c_int = 25;
+pub const _PC_ALLOC_SIZE_MIN: ::c_int = 21;
+pub const _PC_SYMLINK_MAX: ::c_int = 17;
+pub const _PC_2_SYMLINKS: ::c_int = 20;
+
+pub const _SC_PAGE_SIZE: ::c_int = _SC_PAGESIZE;
+pub const _SC_ARG_MAX: ::c_int = 1;
+pub const _SC_CHILD_MAX: ::c_int = 2;
+pub const _SC_CLK_TCK: ::c_int = 3;
+pub const _SC_NGROUPS_MAX: ::c_int = 4;
+pub const _SC_OPEN_MAX: ::c_int = 5;
+pub const _SC_JOB_CONTROL: ::c_int = 6;
+pub const _SC_SAVED_IDS: ::c_int = 7;
+pub const _SC_VERSION: ::c_int = 8;
+pub const _SC_PASS_MAX: ::c_int = 9;
+pub const _SC_PAGESIZE: ::c_int = 11;
+pub const _SC_XOPEN_VERSION: ::c_int = 12;
+pub const _SC_STREAM_MAX: ::c_int = 13;
+pub const _SC_TZNAME_MAX: ::c_int = 14;
+pub const _SC_AIO_LISTIO_MAX: ::c_int = 15;
+pub const _SC_AIO_MAX: ::c_int = 16;
+pub const _SC_AIO_PRIO_DELTA_MAX: ::c_int = 17;
+pub const _SC_DELAYTIMER_MAX: ::c_int = 18;
+pub const _SC_MQ_OPEN_MAX: ::c_int = 19;
+pub const _SC_MQ_PRIO_MAX: ::c_int = 20;
+pub const _SC_RTSIG_MAX: ::c_int = 21;
+pub const _SC_SEM_NSEMS_MAX: ::c_int = 22;
+pub const _SC_SEM_VALUE_MAX: ::c_int = 23;
+pub const _SC_SIGQUEUE_MAX: ::c_int = 24;
+pub const _SC_TIMER_MAX: ::c_int = 25;
+pub const _SC_ASYNCHRONOUS_IO: ::c_int = 26;
+pub const _SC_FSYNC: ::c_int = 27;
+pub const _SC_MAPPED_FILES: ::c_int = 28;
+pub const _SC_MEMLOCK: ::c_int = 29;
+pub const _SC_MEMLOCK_RANGE: ::c_int = 30;
+pub const _SC_MEMORY_PROTECTION: ::c_int = 31;
+pub const _SC_MESSAGE_PASSING: ::c_int = 32;
+pub const _SC_PRIORITIZED_IO: ::c_int = 33;
+pub const _SC_PRIORITY_SCHEDULING: ::c_int = 34;
+pub const _SC_REALTIME_SIGNALS: ::c_int = 35;
+pub const _SC_SEMAPHORES: ::c_int = 36;
+pub const _SC_SHARED_MEMORY_OBJECTS: ::c_int = 37;
+pub const _SC_SYNCHRONIZED_IO: ::c_int = 38;
+pub const _SC_TIMERS: ::c_int = 39;
+pub const _SC_GETGR_R_SIZE_MAX: ::c_int = 40;
+pub const _SC_GETPW_R_SIZE_MAX: ::c_int = 41;
+pub const _SC_LOGIN_NAME_MAX: ::c_int = 42;
+pub const _SC_THREAD_DESTRUCTOR_ITERATIONS: ::c_int = 43;
+pub const _SC_THREAD_KEYS_MAX: ::c_int = 44;
+pub const _SC_THREAD_STACK_MIN: ::c_int = 45;
+pub const _SC_THREAD_THREADS_MAX: ::c_int = 46;
+pub const _SC_TTY_NAME_MAX: ::c_int = 47;
+pub const _SC_THREADS: ::c_int = 48;
+pub const _SC_THREAD_ATTR_STACKADDR: ::c_int = 49;
+pub const _SC_THREAD_ATTR_STACKSIZE: ::c_int = 50;
+pub const _SC_THREAD_PRIORITY_SCHEDULING: ::c_int = 51;
+pub const _SC_THREAD_PRIO_INHERIT: ::c_int = 52;
+pub const _SC_THREAD_PRIO_PROTECT: ::c_int = 53;
+pub const _SC_THREAD_PROCESS_SHARED: ::c_int = 54;
+pub const _SC_THREAD_SAFE_FUNCTIONS: ::c_int = 55;
+pub const _SC_2_CHAR_TERM: ::c_int = 56;
+pub const _SC_2_C_BIND: ::c_int = 57;
+pub const _SC_2_C_DEV: ::c_int = 58;
+pub const _SC_2_C_VERSION: ::c_int = 59;
+pub const _SC_2_FORT_DEV: ::c_int = 60;
+pub const _SC_2_FORT_RUN: ::c_int = 61;
+pub const _SC_2_LOCALEDEF: ::c_int = 62;
+pub const _SC_2_SW_DEV: ::c_int = 63;
+pub const _SC_2_UPE: ::c_int = 64;
+pub const _SC_2_VERSION: ::c_int = 65;
+pub const _SC_ATEXIT_MAX: ::c_int = 66;
+pub const _SC_AVPHYS_PAGES: ::c_int = 67;
+pub const _SC_BC_BASE_MAX: ::c_int = 68;
+pub const _SC_BC_DIM_MAX: ::c_int = 69;
+pub const _SC_BC_SCALE_MAX: ::c_int = 70;
+pub const _SC_BC_STRING_MAX: ::c_int = 71;
+pub const _SC_CHARCLASS_NAME_MAX: ::c_int = 72;
+pub const _SC_CHAR_BIT: ::c_int = 73;
+pub const _SC_CHAR_MAX: ::c_int = 74;
+pub const _SC_CHAR_MIN: ::c_int = 75;
+pub const _SC_COLL_WEIGHTS_MAX: ::c_int = 76;
+pub const _SC_EQUIV_CLASS_MAX: ::c_int = 77;
+pub const _SC_EXPR_NEST_MAX: ::c_int = 78;
+pub const _SC_INT_MAX: ::c_int = 79;
+pub const _SC_INT_MIN: ::c_int = 80;
+pub const _SC_LINE_MAX: ::c_int = 81;
+pub const _SC_LONG_BIT: ::c_int = 82;
+pub const _SC_MB_LEN_MAX: ::c_int = 83;
+pub const _SC_NL_ARGMAX: ::c_int = 84;
+pub const _SC_NL_LANGMAX: ::c_int = 85;
+pub const _SC_NL_MSGMAX: ::c_int = 86;
+pub const _SC_NL_NMAX: ::c_int = 87;
+pub const _SC_NL_SETMAX: ::c_int = 88;
+pub const _SC_NL_TEXTMAX: ::c_int = 89;
+pub const _SC_NPROCESSORS_CONF: ::c_int = 90;
+pub const _SC_NPROCESSORS_ONLN: ::c_int = 91;
+pub const _SC_NZERO: ::c_int = 92;
+pub const _SC_PHYS_PAGES: ::c_int = 93;
+pub const _SC_PII: ::c_int = 94;
+pub const _SC_PII_INTERNET: ::c_int = 95;
+pub const _SC_PII_INTERNET_DGRAM: ::c_int = 96;
+pub const _SC_PII_INTERNET_STREAM: ::c_int = 97;
+pub const _SC_PII_OSI: ::c_int = 98;
+pub const _SC_PII_OSI_CLTS: ::c_int = 99;
+pub const _SC_PII_OSI_COTS: ::c_int = 100;
+pub const _SC_PII_OSI_M: ::c_int = 101;
+pub const _SC_PII_SOCKET: ::c_int = 102;
+pub const _SC_PII_XTI: ::c_int = 103;
+pub const _SC_POLL: ::c_int = 104;
+pub const _SC_RE_DUP_MAX: ::c_int = 105;
+pub const _SC_SCHAR_MAX: ::c_int = 106;
+pub const _SC_SCHAR_MIN: ::c_int = 107;
+pub const _SC_SELECT: ::c_int = 108;
+pub const _SC_SHRT_MAX: ::c_int = 109;
+pub const _SC_SHRT_MIN: ::c_int = 110;
+pub const _SC_SSIZE_MAX: ::c_int = 111;
+pub const _SC_T_IOV_MAX: ::c_int = 112;
+pub const _SC_UCHAR_MAX: ::c_int = 113;
+pub const _SC_UINT_MAX: ::c_int = 114;
+pub const _SC_UIO_MAXIOV: ::c_int = 115;
+pub const _SC_ULONG_MAX: ::c_int = 116;
+pub const _SC_USHRT_MAX: ::c_int = 117;
+pub const _SC_WORD_BIT: ::c_int = 118;
+pub const _SC_XOPEN_CRYPT: ::c_int = 119;
+pub const _SC_XOPEN_ENH_I18N: ::c_int = 120;
+pub const _SC_XOPEN_SHM: ::c_int = 121;
+pub const _SC_XOPEN_UNIX: ::c_int = 122;
+pub const _SC_XOPEN_XCU_VERSION: ::c_int = 123;
+pub const _SC_XOPEN_XPG2: ::c_int = 124;
+pub const _SC_XOPEN_XPG3: ::c_int = 125;
+pub const _SC_XOPEN_XPG4: ::c_int = 126;
+pub const _SC_XBS5_ILP32_OFF32: ::c_int = 127;
+pub const _SC_XBS5_ILP32_OFFBIG: ::c_int = 128;
+pub const _SC_XBS5_LP64_OFF64: ::c_int = 129;
+pub const _SC_XBS5_LPBIG_OFFBIG: ::c_int = 130;
+pub const _SC_ADVISORY_INFO: ::c_int = 131;
+pub const _SC_CPUTIME: ::c_int = 132;
+pub const _SC_SPAWN: ::c_int = 133;
+pub const _SC_SPORADIC_SERVER: ::c_int = 134;
+pub const _SC_THREAD_CPUTIME: ::c_int = 135;
+pub const _SC_THREAD_SPORADIC_SERVER: ::c_int = 136;
+pub const _SC_TIMEOUTS: ::c_int = 137;
+pub const _SC_BARRIERS: ::c_int = 138;
+pub const _SC_CLOCK_SELECTION: ::c_int = 139;
+pub const _SC_MONOTONIC_CLOCK: ::c_int = 140;
+pub const _SC_READER_WRITER_LOCKS: ::c_int = 141;
+pub const _SC_SPIN_LOCKS: ::c_int = 142;
+pub const _SC_TYPED_MEMORY_OBJECTS: ::c_int = 143;
+pub const _SC_TRACE_EVENT_FILTER: ::c_int = 144;
+pub const _SC_TRACE: ::c_int = 145;
+pub const _SC_TRACE_INHERIT: ::c_int = 146;
+pub const _SC_TRACE_LOG: ::c_int = 147;
+pub const _SC_2_PBS: ::c_int = 148;
+pub const _SC_2_PBS_ACCOUNTING: ::c_int = 149;
+pub const _SC_2_PBS_CHECKPOINT: ::c_int = 150;
+pub const _SC_2_PBS_LOCATE: ::c_int = 151;
+pub const _SC_2_PBS_MESSAGE: ::c_int = 152;
+pub const _SC_2_PBS_TRACK: ::c_int = 153;
+pub const _SC_HOST_NAME_MAX: ::c_int = 154;
+pub const _SC_IOV_MAX: ::c_int = 155;
+pub const _SC_IPV6: ::c_int = 156;
+pub const _SC_RAW_SOCKETS: ::c_int = 157;
+pub const _SC_REGEXP: ::c_int = 158;
+pub const _SC_SHELL: ::c_int = 159;
+pub const _SC_SS_REPL_MAX: ::c_int = 160;
+pub const _SC_SYMLOOP_MAX: ::c_int = 161;
+pub const _SC_TRACE_EVENT_NAME_MAX: ::c_int = 162;
+pub const _SC_TRACE_NAME_MAX: ::c_int = 163;
+pub const _SC_TRACE_SYS_MAX: ::c_int = 164;
+pub const _SC_TRACE_USER_EVENT_MAX: ::c_int = 165;
+pub const _SC_V6_ILP32_OFF32: ::c_int = 166;
+pub const _SC_V6_ILP32_OFFBIG: ::c_int = 167;
+pub const _SC_V6_LP64_OFF64: ::c_int = 168;
+pub const _SC_V6_LPBIG_OFFBIG: ::c_int = 169;
+pub const _SC_XOPEN_REALTIME: ::c_int = 170;
+pub const _SC_XOPEN_REALTIME_THREADS: ::c_int = 171;
+pub const _SC_XOPEN_LEGACY: ::c_int = 172;
+pub const _SC_XOPEN_STREAMS: ::c_int = 173;
+pub const _SC_V7_ILP32_OFF32: ::c_int = 176;
+pub const _SC_V7_ILP32_OFFBIG: ::c_int = 177;
+pub const _SC_V7_LP64_OFF64: ::c_int = 178;
+pub const _SC_V7_LPBIG_OFFBIG: ::c_int = 179;
+
+pub const GLOB_ERR: ::c_int = 0x0001;
+pub const GLOB_MARK: ::c_int = 0x0002;
+pub const GLOB_NOSORT: ::c_int = 0x0004;
+pub const GLOB_DOOFFS: ::c_int = 0x0008;
+pub const GLOB_NOCHECK: ::c_int = 0x0010;
+pub const GLOB_APPEND: ::c_int = 0x0020;
+pub const GLOB_NOESCAPE: ::c_int = 0x0040;
+
+pub const GLOB_NOSPACE: ::c_int = 1;
+pub const GLOB_ABORTED: ::c_int = 2;
+pub const GLOB_NOMATCH: ::c_int = 3;
+
+pub const S_IEXEC: mode_t = ::S_IXUSR;
+pub const S_IWRITE: mode_t = ::S_IWUSR;
+pub const S_IREAD: mode_t = ::S_IRUSR;
+
+pub const S_IFIFO: ::mode_t = 0x1000;
+pub const S_IFCHR: ::mode_t = 0x2000;
+pub const S_IFDIR: ::mode_t = 0x4000;
+pub const S_IFBLK: ::mode_t = 0x6000;
+pub const S_IFREG: ::mode_t = 0x8000;
+pub const S_IFLNK: ::mode_t = 0xA000;
+pub const S_IFSOCK: ::mode_t = 0xC000;
+pub const S_IFMT: ::mode_t = 0xF000;
+
+pub const S_IXOTH: ::mode_t = 0o000001;
+pub const S_IWOTH: ::mode_t = 0o000002;
+pub const S_IROTH: ::mode_t = 0o000004;
+pub const S_IRWXO: ::mode_t = 0o000007;
+pub const S_IXGRP: ::mode_t = 0o000010;
+pub const S_IWGRP: ::mode_t = 0o000020;
+pub const S_IRGRP: ::mode_t = 0o000040;
+pub const S_IRWXG: ::mode_t = 0o000070;
+pub const S_IXUSR: ::mode_t = 0o000100;
+pub const S_IWUSR: ::mode_t = 0o000200;
+pub const S_IRUSR: ::mode_t = 0o000400;
+pub const S_IRWXU: ::mode_t = 0o000700;
+
+pub const F_LOCK: ::c_int = 1;
+pub const F_TEST: ::c_int = 3;
+pub const F_TLOCK: ::c_int = 2;
+pub const F_ULOCK: ::c_int = 0;
+
+pub const ST_RDONLY: ::c_ulong = 0x01;
+pub const ST_NOSUID: ::c_ulong = 0x04;
+pub const ST_NOEXEC: ::c_ulong = 0x02;
+pub const ST_NOATIME: ::c_ulong = 0x20;
+
+pub const RTLD_NEXT: *mut ::c_void = -3i64 as *mut ::c_void;
+pub const RTLD_DEFAULT: *mut ::c_void = -2i64 as *mut ::c_void;
+pub const RTLD_NODELETE: ::c_int = 0x1000;
+pub const RTLD_NOW: ::c_int = 0x0002;
+
+pub const EMPTY: ::c_short = 0;
+pub const RUN_LVL: ::c_short = 1;
+pub const BOOT_TIME: ::c_short = 2;
+pub const NEW_TIME: ::c_short = 4;
+pub const OLD_TIME: ::c_short = 3;
+pub const INIT_PROCESS: ::c_short = 5;
+pub const LOGIN_PROCESS: ::c_short = 6;
+pub const USER_PROCESS: ::c_short = 7;
+pub const DEAD_PROCESS: ::c_short = 8;
+pub const ACCOUNTING: ::c_short = 9;
+
+pub const ENOTSUP: ::c_int = 48;
+
+pub const BUFSIZ: ::c_uint = 1024;
+pub const TMP_MAX: ::c_uint = 26 * 26 * 26;
+pub const FOPEN_MAX: ::c_uint = 16;
+pub const FILENAME_MAX: ::c_uint = 255;
+
+pub const NI_MAXHOST: ::socklen_t = 1025;
+pub const M_KEEP: ::c_int = 4;
+pub const REG_STARTEND: ::c_int = 0o00004;
+pub const VEOF: usize = 4;
+
+pub const RTLD_GLOBAL: ::c_int = 0x0100;
+pub const RTLD_NOLOAD: ::c_int = 0x0004;
+
+pub const O_RDONLY: ::c_int = 0o000000;
+pub const O_WRONLY: ::c_int = 0o000001;
+pub const O_RDWR: ::c_int = 0o000002;
+
+pub const O_EXEC: ::c_int = 0o00003;
+pub const O_ASYNC: ::c_int = 0o0200000;
+pub const O_NDELAY: ::c_int = O_NONBLOCK;
+pub const O_TRUNC: ::c_int = 0o001000;
+pub const O_CLOEXEC: ::c_int = 0o020000;
+pub const O_DIRECTORY: ::c_int = 0o4000000;
+pub const O_ACCMODE: ::c_int = 0o000007;
+pub const O_APPEND: ::c_int = 0o000010;
+pub const O_CREAT: ::c_int = 0o000400;
+pub const O_EXCL: ::c_int = 0o002000;
+pub const O_NOCTTY: ::c_int = 0o004000;
+pub const O_NONBLOCK: ::c_int = 0o000200;
+pub const O_SYNC: ::c_int = 0o000040;
+pub const O_RSYNC: ::c_int = 0o000100;
+pub const O_DSYNC: ::c_int = 0o000020;
+pub const O_NOFOLLOW: ::c_int = 0o010000;
+
+pub const POSIX_FADV_DONTNEED: ::c_int = 4;
+pub const POSIX_FADV_NOREUSE: ::c_int = 5;
+
+pub const SOCK_SEQPACKET: ::c_int = 5;
+pub const SOCK_STREAM: ::c_int = 1;
+pub const SOCK_DGRAM: ::c_int = 2;
+pub const SOCK_RAW: ::c_int = 3;
+pub const SOCK_RDM: ::c_int = 4;
+pub const SOCK_CLOEXEC: ::c_int = 0x10000000;
+
+pub const SA_SIGINFO: ::c_int = 0x0002;
+pub const SA_NOCLDWAIT: ::c_int = 0x0020;
+pub const SA_NODEFER: ::c_int = 0x0010;
+pub const SA_RESETHAND: ::c_int = 0x0004;
+pub const SA_NOCLDSTOP: ::c_int = 0x0001;
+
+pub const SIGTTIN: ::c_int = 26;
+pub const SIGTTOU: ::c_int = 27;
+pub const SIGXCPU: ::c_int = 30;
+pub const SIGXFSZ: ::c_int = 31;
+pub const SIGVTALRM: ::c_int = 28;
+pub const SIGPROF: ::c_int = 29;
+pub const SIGWINCH: ::c_int = 20;
+pub const SIGCHLD: ::c_int = 18;
+pub const SIGBUS: ::c_int = 10;
+pub const SIGUSR1: ::c_int = 16;
+pub const SIGUSR2: ::c_int = 17;
+pub const SIGCONT: ::c_int = 25;
+pub const SIGSTOP: ::c_int = 23;
+pub const SIGTSTP: ::c_int = 24;
+pub const SIGURG: ::c_int = 21;
+pub const SIGIO: ::c_int = SIGPOLL;
+pub const SIGSYS: ::c_int = 12;
+pub const SIGPOLL: ::c_int = 22;
+pub const SIGPWR: ::c_int = 19;
+pub const SIG_SETMASK: ::c_int = 2;
+pub const SIG_BLOCK: ::c_int = 0;
+pub const SIG_UNBLOCK: ::c_int = 1;
+
+pub const POLLWRNORM: ::c_short = ::POLLOUT;
+pub const POLLWRBAND: ::c_short = 0x0010;
+
+pub const F_SETLK: ::c_int = 106;
+pub const F_SETLKW: ::c_int = 107;
+pub const F_ALLOCSP: ::c_int = 110;
+pub const F_FREESP: ::c_int = 111;
+pub const F_GETLK: ::c_int = 114;
+
+pub const F_RDLCK: ::c_int = 1;
+pub const F_WRLCK: ::c_int = 2;
+pub const F_UNLCK: ::c_int = 3;
+
+pub const NCCS: usize = 40;
+
+pub const MAP_ANON: ::c_int = MAP_ANONYMOUS;
+pub const MAP_ANONYMOUS: ::c_int = 0x00080000;
+
+pub const MCL_CURRENT: ::c_int = 0x000000001;
+pub const MCL_FUTURE: ::c_int = 0x000000002;
+
+pub const _TIO_CBAUD: ::tcflag_t = 15;
+pub const CBAUD: ::tcflag_t = _TIO_CBAUD;
+pub const TAB1: ::tcflag_t = 0x0800;
+pub const TAB2: ::tcflag_t = 0x1000;
+pub const TAB3: ::tcflag_t = 0x1800;
+pub const CR1: ::tcflag_t = 0x200;
+pub const CR2: ::tcflag_t = 0x400;
+pub const CR3: ::tcflag_t = 0x600;
+pub const FF1: ::tcflag_t = 0x8000;
+pub const BS1: ::tcflag_t = 0x2000;
+pub const VT1: ::tcflag_t = 0x4000;
+pub const VWERASE: usize = 14;
+pub const VREPRINT: usize = 12;
+pub const VSUSP: usize = 10;
+pub const VSTART: usize = 8;
+pub const VSTOP: usize = 9;
+pub const VDISCARD: usize = 13;
+pub const VTIME: usize = 17;
+pub const IXON: ::tcflag_t = 0x00000400;
+pub const IXOFF: ::tcflag_t = 0x00001000;
+pub const ONLCR: ::tcflag_t = 0x00000004;
+pub const CSIZE: ::tcflag_t = 0x00000030;
+pub const CS6: ::tcflag_t = 0x10;
+pub const CS7: ::tcflag_t = 0x20;
+pub const CS8: ::tcflag_t = 0x30;
+pub const CSTOPB: ::tcflag_t = 0x00000040;
+pub const CREAD: ::tcflag_t = 0x00000080;
+pub const PARENB: ::tcflag_t = 0x00000100;
+pub const PARODD: ::tcflag_t = 0x00000200;
+pub const HUPCL: ::tcflag_t = 0x00000400;
+pub const CLOCAL: ::tcflag_t = 0x00000800;
+pub const ECHOKE: ::tcflag_t = 0x00000800;
+pub const ECHOE: ::tcflag_t = 0x00000010;
+pub const ECHOK: ::tcflag_t = 0x00000020;
+pub const ECHONL: ::tcflag_t = 0x00000040;
+pub const ECHOCTL: ::tcflag_t = 0x00000200;
+pub const ISIG: ::tcflag_t = 0x00000001;
+pub const ICANON: ::tcflag_t = 0x00000002;
+pub const NOFLSH: ::tcflag_t = 0x00000080;
+pub const OLCUC: ::tcflag_t = 0x00000002;
+pub const NLDLY: ::tcflag_t = 0x00000100;
+pub const CRDLY: ::tcflag_t = 0x00000600;
+pub const TABDLY: ::tcflag_t = 0x00001800;
+pub const BSDLY: ::tcflag_t = 0x00002000;
+pub const FFDLY: ::tcflag_t = 0x00008000;
+pub const VTDLY: ::tcflag_t = 0x00004000;
+pub const XTABS: ::tcflag_t = 0x1800;
+
+pub const B0: ::speed_t = 0;
+pub const B50: ::speed_t = 1;
+pub const B75: ::speed_t = 2;
+pub const B110: ::speed_t = 3;
+pub const B134: ::speed_t = 4;
+pub const B150: ::speed_t = 5;
+pub const B200: ::speed_t = 6;
+pub const B300: ::speed_t = 7;
+pub const B600: ::speed_t = 8;
+pub const B1200: ::speed_t = 9;
+pub const B1800: ::speed_t = 10;
+pub const B2400: ::speed_t = 11;
+pub const B4800: ::speed_t = 12;
+pub const B9600: ::speed_t = 13;
+pub const B19200: ::speed_t = 14;
+pub const B38400: ::speed_t = 15;
+pub const EXTA: ::speed_t = 14;
+pub const EXTB: ::speed_t = 15;
+pub const B57600: ::speed_t = 57600;
+pub const B115200: ::speed_t = 115200;
+
+pub const VEOL: usize = 5;
+pub const VEOL2: usize = 6;
+pub const VMIN: usize = 16;
+pub const IEXTEN: ::tcflag_t = 0x00008000;
+pub const TOSTOP: ::tcflag_t = 0x00000100;
+
+pub const TCSANOW: ::c_int = 0x0001;
+pub const TCSADRAIN: ::c_int = 0x0002;
+pub const TCSAFLUSH: ::c_int = 0x0004;
+
+pub const HW_MACHINE: ::c_int = 1;
+pub const HW_MODEL: ::c_int = 2;
+pub const HW_NCPU: ::c_int = 3;
+pub const HW_BYTEORDER: ::c_int = 4;
+pub const HW_PHYSMEM: ::c_int = 5;
+pub const HW_USERMEM: ::c_int = 6;
+pub const HW_PAGESIZE: ::c_int = 7;
+pub const HW_DISKNAMES: ::c_int = 8;
+pub const HW_IOSTATS: ::c_int = 9;
+pub const HW_MACHINE_ARCH: ::c_int = 10;
+pub const HW_ALIGNBYTES: ::c_int = 11;
+pub const HW_CNMAGIC: ::c_int = 12;
+pub const HW_PHYSMEM64: ::c_int = 13;
+pub const HW_USERMEM64: ::c_int = 14;
+pub const HW_IOSTATNAMES: ::c_int = 15;
+pub const HW_MAXID: ::c_int = 15;
+
+pub const CTL_UNSPEC: ::c_int = 0;
+pub const CTL_KERN: ::c_int = 1;
+pub const CTL_VM: ::c_int = 2;
+pub const CTL_VFS: ::c_int = 3;
+pub const CTL_NET: ::c_int = 4;
+pub const CTL_DEBUG: ::c_int = 5;
+pub const CTL_HW: ::c_int = 6;
+pub const CTL_MACHDEP: ::c_int = 7;
+pub const CTL_USER: ::c_int = 8;
+pub const CTL_QNX: ::c_int = 9;
+pub const CTL_PROC: ::c_int = 10;
+pub const CTL_VENDOR: ::c_int = 11;
+pub const CTL_EMUL: ::c_int = 12;
+pub const CTL_SECURITY: ::c_int = 13;
+pub const CTL_MAXID: ::c_int = 14;
+
+pub const DAY_1: ::nl_item = 8;
+pub const DAY_2: ::nl_item = 9;
+pub const DAY_3: ::nl_item = 10;
+pub const DAY_4: ::nl_item = 11;
+pub const DAY_5: ::nl_item = 12;
+pub const DAY_6: ::nl_item = 13;
+pub const DAY_7: ::nl_item = 14;
+
+pub const MON_1: ::nl_item = 22;
+pub const MON_2: ::nl_item = 23;
+pub const MON_3: ::nl_item = 24;
+pub const MON_4: ::nl_item = 25;
+pub const MON_5: ::nl_item = 26;
+pub const MON_6: ::nl_item = 27;
+pub const MON_7: ::nl_item = 28;
+pub const MON_8: ::nl_item = 29;
+pub const MON_9: ::nl_item = 30;
+pub const MON_10: ::nl_item = 31;
+pub const MON_11: ::nl_item = 32;
+pub const MON_12: ::nl_item = 33;
+
+pub const ABDAY_1: ::nl_item = 15;
+pub const ABDAY_2: ::nl_item = 16;
+pub const ABDAY_3: ::nl_item = 17;
+pub const ABDAY_4: ::nl_item = 18;
+pub const ABDAY_5: ::nl_item = 19;
+pub const ABDAY_6: ::nl_item = 20;
+pub const ABDAY_7: ::nl_item = 21;
+
+pub const ABMON_1: ::nl_item = 34;
+pub const ABMON_2: ::nl_item = 35;
+pub const ABMON_3: ::nl_item = 36;
+pub const ABMON_4: ::nl_item = 37;
+pub const ABMON_5: ::nl_item = 38;
+pub const ABMON_6: ::nl_item = 39;
+pub const ABMON_7: ::nl_item = 40;
+pub const ABMON_8: ::nl_item = 41;
+pub const ABMON_9: ::nl_item = 42;
+pub const ABMON_10: ::nl_item = 43;
+pub const ABMON_11: ::nl_item = 44;
+pub const ABMON_12: ::nl_item = 45;
+
+pub const AF_ARP: ::c_int = 28;
+pub const AF_CCITT: ::c_int = 10;
+pub const AF_CHAOS: ::c_int = 5;
+pub const AF_CNT: ::c_int = 21;
+pub const AF_COIP: ::c_int = 20;
+pub const AF_DATAKIT: ::c_int = 9;
+pub const AF_DECnet: ::c_int = 12;
+pub const AF_DLI: ::c_int = 13;
+pub const AF_E164: ::c_int = 26;
+pub const AF_ECMA: ::c_int = 8;
+pub const AF_HYLINK: ::c_int = 15;
+pub const AF_IEEE80211: ::c_int = 32;
+pub const AF_IMPLINK: ::c_int = 3;
+pub const AF_ISO: ::c_int = 7;
+pub const AF_LAT: ::c_int = 14;
+pub const AF_LINK: ::c_int = 18;
+pub const AF_NATM: ::c_int = 27;
+pub const AF_NS: ::c_int = 6;
+pub const AF_OSI: ::c_int = 7;
+pub const AF_PUP: ::c_int = 4;
+pub const ALT_DIGITS: ::nl_item = 50;
+pub const AM_STR: ::nl_item = 6;
+pub const B76800: ::speed_t = 76800;
+
+pub const BIOCFLUSH: ::c_int = 17000;
+pub const BIOCGBLEN: ::c_int = 1074020966;
+pub const BIOCGDLT: ::c_int = 1074020970;
+pub const BIOCGDLTLIST: ::c_int = -1072676233;
+pub const BIOCGETIF: ::c_int = 1083196011;
+pub const BIOCGHDRCMPLT: ::c_int = 1074020980;
+pub const BIOCGRTIMEOUT: ::c_int = 1074807406;
+pub const BIOCGSEESENT: ::c_int = 1074020984;
+pub const BIOCGSTATS: ::c_int = 1082147439;
+pub const BIOCIMMEDIATE: ::c_int = -2147204496;
+pub const BIOCPROMISC: ::c_int = 17001;
+pub const BIOCSBLEN: ::c_int = -1073462682;
+pub const BIOCSDLT: ::c_int = -2147204490;
+pub const BIOCSETF: ::c_int = -2146418073;
+pub const BIOCSETIF: ::c_int = -2138029460;
+pub const BIOCSHDRCMPLT: ::c_int = -2147204491;
+pub const BIOCSRTIMEOUT: ::c_int = -2146418067;
+pub const BIOCSSEESENT: ::c_int = -2147204487;
+pub const BIOCVERSION: ::c_int = 1074020977;
+
+pub const BPF_ALIGNMENT: usize = ::mem::size_of::<::c_long>();
+pub const CHAR_BIT: usize = 8;
+pub const CODESET: ::nl_item = 1;
+pub const CRNCYSTR: ::nl_item = 55;
+
+pub const D_FLAG_FILTER: ::c_int = 0x00000001;
+pub const D_FLAG_STAT: ::c_int = 0x00000002;
+pub const D_FLAG_STAT_FORM_MASK: ::c_int = 0x000000f0;
+pub const D_FLAG_STAT_FORM_T32_2001: ::c_int = 0x00000010;
+pub const D_FLAG_STAT_FORM_T32_2008: ::c_int = 0x00000020;
+pub const D_FLAG_STAT_FORM_T64_2008: ::c_int = 0x00000030;
+pub const D_FLAG_STAT_FORM_UNSET: ::c_int = 0x00000000;
+
+pub const D_FMT: ::nl_item = 3;
+pub const D_GETFLAG: ::c_int = 1;
+pub const D_SETFLAG: ::c_int = 2;
+pub const D_T_FMT: ::nl_item = 2;
+pub const ERA: ::nl_item = 46;
+pub const ERA_D_FMT: ::nl_item = 47;
+pub const ERA_D_T_FMT: ::nl_item = 48;
+pub const ERA_T_FMT: ::nl_item = 49;
+pub const RADIXCHAR: ::nl_item = 51;
+pub const THOUSEP: ::nl_item = 52;
+pub const YESEXPR: ::nl_item = 53;
+pub const NOEXPR: ::nl_item = 54;
+pub const F_GETOWN: ::c_int = 35;
+
+pub const FIONBIO: ::c_int = -2147195266;
+pub const FIOASYNC: ::c_int = -2147195267;
+pub const FIOCLEX: ::c_int = 26113;
+pub const FIOGETOWN: ::c_int = 1074030203;
+pub const FIONCLEX: ::c_int = 26114;
+pub const FIONREAD: ::c_int = 1074030207;
+pub const FIONSPACE: ::c_int = 1074030200;
+pub const FIONWRITE: ::c_int = 1074030201;
+pub const FIOSETOWN: ::c_int = -2147195268;
+
+pub const F_SETOWN: ::c_int = 36;
+pub const IFF_ACCEPTRTADV: ::c_int = 0x40000000;
+pub const IFF_IP6FORWARDING: ::c_int = 0x20000000;
+pub const IFF_LINK0: ::c_int = 0x00001000;
+pub const IFF_LINK1: ::c_int = 0x00002000;
+pub const IFF_LINK2: ::c_int = 0x00004000;
+pub const IFF_OACTIVE: ::c_int = 0x00000400;
+pub const IFF_SHIM: ::c_int = 0x80000000;
+pub const IFF_SIMPLEX: ::c_int = 0x00000800;
+pub const IHFLOW: tcflag_t = 0x00000001;
+pub const IIDLE: tcflag_t = 0x00000008;
+pub const IP_RECVDSTADDR: ::c_int = 7;
+pub const IP_RECVIF: ::c_int = 20;
+pub const IPTOS_ECN_NOTECT: u8 = 0x00;
+pub const IUCLC: tcflag_t = 0x00000200;
+pub const IUTF8: tcflag_t = 0x0004000;
+
+pub const KERN_ARGMAX: ::c_int = 8;
+pub const KERN_ARND: ::c_int = 81;
+pub const KERN_BOOTTIME: ::c_int = 21;
+pub const KERN_CLOCKRATE: ::c_int = 12;
+pub const KERN_FILE: ::c_int = 15;
+pub const KERN_HOSTID: ::c_int = 11;
+pub const KERN_HOSTNAME: ::c_int = 10;
+pub const KERN_IOV_MAX: ::c_int = 38;
+pub const KERN_JOB_CONTROL: ::c_int = 19;
+pub const KERN_LOGSIGEXIT: ::c_int = 46;
+pub const KERN_MAXFILES: ::c_int = 7;
+pub const KERN_MAXID: ::c_int = 83;
+pub const KERN_MAXPROC: ::c_int = 6;
+pub const KERN_MAXVNODES: ::c_int = 5;
+pub const KERN_NGROUPS: ::c_int = 18;
+pub const KERN_OSRELEASE: ::c_int = 2;
+pub const KERN_OSREV: ::c_int = 3;
+pub const KERN_OSTYPE: ::c_int = 1;
+pub const KERN_POSIX1: ::c_int = 17;
+pub const KERN_PROC: ::c_int = 14;
+pub const KERN_PROC_ALL: ::c_int = 0;
+pub const KERN_PROC_ARGS: ::c_int = 48;
+pub const KERN_PROC_ENV: ::c_int = 3;
+pub const KERN_PROC_GID: ::c_int = 7;
+pub const KERN_PROC_PGRP: ::c_int = 2;
+pub const KERN_PROC_PID: ::c_int = 1;
+pub const KERN_PROC_RGID: ::c_int = 8;
+pub const KERN_PROC_RUID: ::c_int = 6;
+pub const KERN_PROC_SESSION: ::c_int = 3;
+pub const KERN_PROC_TTY: ::c_int = 4;
+pub const KERN_PROC_UID: ::c_int = 5;
+pub const KERN_PROF: ::c_int = 16;
+pub const KERN_SAVED_IDS: ::c_int = 20;
+pub const KERN_SECURELVL: ::c_int = 9;
+pub const KERN_VERSION: ::c_int = 4;
+pub const KERN_VNODE: ::c_int = 13;
+
+pub const LC_ALL: ::c_int = 63;
+pub const LC_COLLATE: ::c_int = 1;
+pub const LC_CTYPE: ::c_int = 2;
+pub const LC_MESSAGES: ::c_int = 32;
+pub const LC_MONETARY: ::c_int = 4;
+pub const LC_NUMERIC: ::c_int = 8;
+pub const LC_TIME: ::c_int = 16;
+
+pub const LOCAL_CONNWAIT: ::c_int = 0x0002;
+pub const LOCAL_CREDS: ::c_int = 0x0001;
+pub const LOCAL_PEEREID: ::c_int = 0x0003;
+
+pub const MAP_STACK: ::c_int = 0x00001000;
+pub const MNT_NOEXEC: ::c_int = 0x02;
+pub const MNT_NOSUID: ::c_int = 0x04;
+pub const MNT_RDONLY: ::c_int = 0x01;
+
+pub const MSG_NOTIFICATION: ::c_int = 0x0400;
+
+pub const NET_RT_DUMP: ::c_int = 1;
+pub const NET_RT_FLAGS: ::c_int = 2;
+pub const NET_RT_IFLIST: ::c_int = 4;
+pub const NI_NUMERICSCOPE: ::c_int = 0x00000040;
+pub const OHFLOW: tcflag_t = 0x00000002;
+pub const P_ALL: idtype_t = 0;
+pub const PARSTK: tcflag_t = 0x00000004;
+pub const PF_ARP: ::c_int = 28;
+pub const PF_CCITT: ::c_int = 10;
+pub const PF_CHAOS: ::c_int = 5;
+pub const PF_CNT: ::c_int = 21;
+pub const PF_COIP: ::c_int = 20;
+pub const PF_DATAKIT: ::c_int = 9;
+pub const PF_DECnet: ::c_int = 12;
+pub const PF_DLI: ::c_int = 13;
+pub const PF_ECMA: ::c_int = 8;
+pub const PF_HYLINK: ::c_int = 15;
+pub const PF_IMPLINK: ::c_int = 3;
+pub const PF_ISO: ::c_int = 7;
+pub const PF_LAT: ::c_int = 14;
+pub const PF_LINK: ::c_int = 18;
+pub const PF_NATM: ::c_int = 27;
+pub const PF_OSI: ::c_int = 7;
+pub const PF_PIP: ::c_int = 25;
+pub const PF_PUP: ::c_int = 4;
+pub const PF_RTIP: ::c_int = 22;
+pub const PF_XTP: ::c_int = 19;
+pub const PM_STR: ::nl_item = 7;
+pub const POSIX_MADV_DONTNEED: ::c_int = 4;
+pub const POSIX_MADV_NORMAL: ::c_int = 0;
+pub const POSIX_MADV_RANDOM: ::c_int = 2;
+pub const POSIX_MADV_SEQUENTIAL: ::c_int = 1;
+pub const POSIX_MADV_WILLNEED: ::c_int = 3;
+pub const _POSIX_VDISABLE: ::c_int = 0;
+pub const P_PGID: idtype_t = 2;
+pub const P_PID: idtype_t = 1;
+pub const PRIO_PGRP: ::c_int = 1;
+pub const PRIO_PROCESS: ::c_int = 0;
+pub const PRIO_USER: ::c_int = 2;
+pub const pseudo_AF_HDRCMPLT: ::c_int = 30;
+pub const pseudo_AF_PIP: ::c_int = 25;
+pub const pseudo_AF_RTIP: ::c_int = 22;
+pub const pseudo_AF_XTP: ::c_int = 19;
+pub const REG_ASSERT: ::c_int = 15;
+pub const REG_ATOI: ::c_int = 255;
+pub const REG_BACKR: ::c_int = 0x400;
+pub const REG_BASIC: ::c_int = 0x00;
+pub const REG_DUMP: ::c_int = 0x80;
+pub const REG_EMPTY: ::c_int = 14;
+pub const REG_INVARG: ::c_int = 16;
+pub const REG_ITOA: ::c_int = 0o400;
+pub const REG_LARGE: ::c_int = 0x200;
+pub const REG_NOSPEC: ::c_int = 0x10;
+pub const REG_OK: ::c_int = 0;
+pub const REG_PEND: ::c_int = 0x20;
+pub const REG_TRACE: ::c_int = 0x100;
+
+pub const RLIMIT_AS: ::c_int = 6;
+pub const RLIMIT_CORE: ::c_int = 4;
+pub const RLIMIT_CPU: ::c_int = 0;
+pub const RLIMIT_DATA: ::c_int = 2;
+pub const RLIMIT_FSIZE: ::c_int = 1;
+pub const RLIMIT_MEMLOCK: ::c_int = 7;
+pub const RLIMIT_NOFILE: ::c_int = 5;
+pub const RLIMIT_NPROC: ::c_int = 8;
+pub const RLIMIT_RSS: ::c_int = 6;
+pub const RLIMIT_STACK: ::c_int = 3;
+pub const RLIMIT_VMEM: ::c_int = 6;
+pub const RLIM_NLIMITS: ::c_int = 14;
+
+pub const SCHED_ADJTOHEAD: ::c_int = 5;
+pub const SCHED_ADJTOTAIL: ::c_int = 6;
+pub const SCHED_MAXPOLICY: ::c_int = 7;
+pub const SCHED_SETPRIO: ::c_int = 7;
+pub const SCHED_SPORADIC: ::c_int = 4;
+
+pub const SHM_ANON: *mut ::c_char = -1isize as *mut ::c_char;
+pub const SIGCLD: ::c_int = SIGCHLD;
+pub const SIGDEADLK: ::c_int = 7;
+pub const SIGEMT: ::c_int = 7;
+pub const SIGEV_NONE: ::c_int = 0;
+pub const SIGEV_SIGNAL: ::c_int = 129;
+pub const SIGEV_THREAD: ::c_int = 135;
+pub const SIOCGIFADDR: ::c_int = -1064277727;
+pub const SO_FIB: ::c_int = 0x100a;
+pub const SO_OVERFLOWED: ::c_int = 0x1009;
+pub const SO_SETFIB: ::c_int = 0x100a;
+pub const SO_TXPRIO: ::c_int = 0x100b;
+pub const SO_USELOOPBACK: ::c_int = 0x0040;
+pub const SO_VLANPRIO: ::c_int = 0x100c;
+pub const _SS_ALIGNSIZE: usize = ::mem::size_of::<i64>();
+pub const _SS_MAXSIZE: usize = 128;
+pub const _SS_PAD1SIZE: usize = _SS_ALIGNSIZE - 2;
+pub const _SS_PAD2SIZE: usize = _SS_MAXSIZE - 2 - _SS_PAD1SIZE - _SS_ALIGNSIZE;
+pub const TC_CPOSIX: tcflag_t = CLOCAL | CREAD | CSIZE | CSTOPB | HUPCL | PARENB | PARODD;
+pub const TCGETS: ::c_int = 0x404c540d;
+pub const TC_IPOSIX: tcflag_t =
+    BRKINT | ICRNL | IGNBRK | IGNPAR | INLCR | INPCK | ISTRIP | IXOFF | IXON | PARMRK;
+pub const TC_LPOSIX: tcflag_t =
+    ECHO | ECHOE | ECHOK | ECHONL | ICANON | IEXTEN | ISIG | NOFLSH | TOSTOP;
+pub const TC_OPOSIX: tcflag_t = OPOST;
+pub const T_FMT_AMPM: ::nl_item = 5;
+
+pub const TIOCCBRK: ::c_int = 29818;
+pub const TIOCCDTR: ::c_int = 29816;
+pub const TIOCDRAIN: ::c_int = 29790;
+pub const TIOCEXCL: ::c_int = 29709;
+pub const TIOCFLUSH: ::c_int = -2147191792;
+pub const TIOCGETA: ::c_int = 1078752275;
+pub const TIOCGPGRP: ::c_int = 1074033783;
+pub const TIOCGWINSZ: ::c_int = 1074295912;
+pub const TIOCMBIC: ::c_int = -2147191701;
+pub const TIOCMBIS: ::c_int = -2147191700;
+pub const TIOCMGET: ::c_int = 1074033770;
+pub const TIOCMSET: ::c_int = -2147191699;
+pub const TIOCNOTTY: ::c_int = 29809;
+pub const TIOCNXCL: ::c_int = 29710;
+pub const TIOCOUTQ: ::c_int = 1074033779;
+pub const TIOCPKT: ::c_int = -2147191696;
+pub const TIOCPKT_DATA: ::c_int = 0x00;
+pub const TIOCPKT_DOSTOP: ::c_int = 0x20;
+pub const TIOCPKT_FLUSHREAD: ::c_int = 0x01;
+pub const TIOCPKT_FLUSHWRITE: ::c_int = 0x02;
+pub const TIOCPKT_IOCTL: ::c_int = 0x40;
+pub const TIOCPKT_NOSTOP: ::c_int = 0x10;
+pub const TIOCPKT_START: ::c_int = 0x08;
+pub const TIOCPKT_STOP: ::c_int = 0x04;
+pub const TIOCSBRK: ::c_int = 29819;
+pub const TIOCSCTTY: ::c_int = 29793;
+pub const TIOCSDTR: ::c_int = 29817;
+pub const TIOCSETA: ::c_int = -2142473196;
+pub const TIOCSETAF: ::c_int = -2142473194;
+pub const TIOCSETAW: ::c_int = -2142473195;
+pub const TIOCSPGRP: ::c_int = -2147191690;
+pub const TIOCSTART: ::c_int = 29806;
+pub const TIOCSTI: ::c_int = -2147388302;
+pub const TIOCSTOP: ::c_int = 29807;
+pub const TIOCSWINSZ: ::c_int = -2146929561;
+
+pub const USER_CS_PATH: ::c_int = 1;
+pub const USER_BC_BASE_MAX: ::c_int = 2;
+pub const USER_BC_DIM_MAX: ::c_int = 3;
+pub const USER_BC_SCALE_MAX: ::c_int = 4;
+pub const USER_BC_STRING_MAX: ::c_int = 5;
+pub const USER_COLL_WEIGHTS_MAX: ::c_int = 6;
+pub const USER_EXPR_NEST_MAX: ::c_int = 7;
+pub const USER_LINE_MAX: ::c_int = 8;
+pub const USER_RE_DUP_MAX: ::c_int = 9;
+pub const USER_POSIX2_VERSION: ::c_int = 10;
+pub const USER_POSIX2_C_BIND: ::c_int = 11;
+pub const USER_POSIX2_C_DEV: ::c_int = 12;
+pub const USER_POSIX2_CHAR_TERM: ::c_int = 13;
+pub const USER_POSIX2_FORT_DEV: ::c_int = 14;
+pub const USER_POSIX2_FORT_RUN: ::c_int = 15;
+pub const USER_POSIX2_LOCALEDEF: ::c_int = 16;
+pub const USER_POSIX2_SW_DEV: ::c_int = 17;
+pub const USER_POSIX2_UPE: ::c_int = 18;
+pub const USER_STREAM_MAX: ::c_int = 19;
+pub const USER_TZNAME_MAX: ::c_int = 20;
+pub const USER_ATEXIT_MAX: ::c_int = 21;
+pub const USER_MAXID: ::c_int = 22;
+
+pub const VDOWN: usize = 31;
+pub const VINS: usize = 32;
+pub const VDEL: usize = 33;
+pub const VRUB: usize = 34;
+pub const VCAN: usize = 35;
+pub const VHOME: usize = 36;
+pub const VEND: usize = 37;
+pub const VSPARE3: usize = 38;
+pub const VSPARE4: usize = 39;
+pub const VSWTCH: usize = 7;
+pub const VDSUSP: usize = 11;
+pub const VFWD: usize = 18;
+pub const VLOGIN: usize = 19;
+pub const VPREFIX: usize = 20;
+pub const VSUFFIX: usize = 24;
+pub const VLEFT: usize = 28;
+pub const VRIGHT: usize = 29;
+pub const VUP: usize = 30;
+pub const XCASE: tcflag_t = 0x00000004;
+
+pub const PTHREAD_CREATE_JOINABLE: ::c_int = 0x00;
+pub const PTHREAD_CREATE_DETACHED: ::c_int = 0x01;
+
+pub const PTHREAD_MUTEX_ERRORCHECK: ::c_int = 1;
+pub const PTHREAD_MUTEX_RECURSIVE: ::c_int = 2;
+pub const PTHREAD_MUTEX_NORMAL: ::c_int = 3;
+pub const PTHREAD_STACK_MIN: ::size_t = 256;
+pub const PTHREAD_MUTEX_DEFAULT: ::c_int = 0;
+pub const PTHREAD_MUTEX_STALLED: ::c_int = 0x00;
+pub const PTHREAD_MUTEX_ROBUST: ::c_int = 0x10;
+pub const PTHREAD_PROCESS_PRIVATE: ::c_int = 0x00;
+pub const PTHREAD_PROCESS_SHARED: ::c_int = 0x01;
+
+pub const PTHREAD_KEYS_MAX: usize = 128;
+
+pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
+    __u: 0x80000000,
+    __owner: 0xffffffff,
+};
+pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = pthread_cond_t {
+    __u: CLOCK_REALTIME as u32,
+    __owner: 0xfffffffb,
+};
+pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
+    __active: 0,
+    __blockedwriters: 0,
+    __blockedreaders: 0,
+    __heavy: 0,
+    __lock: PTHREAD_MUTEX_INITIALIZER,
+    __rcond: PTHREAD_COND_INITIALIZER,
+    __wcond: PTHREAD_COND_INITIALIZER,
+    __owner: -2i32 as ::c_uint,
+    __spare: 0,
+};
+
+const_fn! {
+    {const} fn _CMSG_ALIGN(len: usize) -> usize {
+        len + ::mem::size_of::<usize>() - 1 & !(::mem::size_of::<usize>() - 1)
+    }
+
+    {const} fn _ALIGN(p: usize, b: usize) -> usize {
+        (p + b - 1) & !(b-1)
+    }
+}
+
+f! {
+    pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
+        if (*mhdr).msg_controllen as usize >= ::mem::size_of::<cmsghdr>() {
+            (*mhdr).msg_control as *mut cmsghdr
+        } else {
+            0 as *mut cmsghdr
+        }
+    }
+
+    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr, cmsg: *const ::cmsghdr)
+        -> *mut ::cmsghdr
+    {
+        let msg = _CMSG_ALIGN((*cmsg).cmsg_len as usize);
+        let next = cmsg as usize + msg + _CMSG_ALIGN(::mem::size_of::<::cmsghdr>());
+        if next > (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize {
+           0 as *mut ::cmsghdr
+        } else {
+            (cmsg as usize + msg) as *mut ::cmsghdr
+        }
+    }
+
+    pub fn CMSG_DATA(cmsg: *const ::cmsghdr) -> *mut ::c_uchar {
+        (cmsg as *mut ::c_uchar)
+            .offset(_CMSG_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
+    }
+
+    pub fn CMSG_LEN(length: ::c_uint) -> ::c_uint {
+        _CMSG_ALIGN(::mem::size_of::<::cmsghdr>()) as ::c_uint + length
+    }
+
+    pub {const} fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
+        (_CMSG_ALIGN(::mem::size_of::<cmsghdr>()) + _CMSG_ALIGN(length as usize) )
+            as ::c_uint
+    }
+
+    pub fn FD_CLR(fd: ::c_int, set: *mut fd_set) -> () {
+        let fd = fd as usize;
+        let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        (*set).fds_bits[fd / size] &= !(1 << (fd % size));
+        return
+    }
+
+    pub fn FD_ISSET(fd: ::c_int, set: *const fd_set) -> bool {
+        let fd = fd as usize;
+        let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0
+    }
+
+    pub fn FD_SET(fd: ::c_int, set: *mut fd_set) -> () {
+        let fd = fd as usize;
+        let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        (*set).fds_bits[fd / size] |= 1 << (fd % size);
+        return
+    }
+
+    pub fn FD_ZERO(set: *mut fd_set) -> () {
+        for slot in (*set).fds_bits.iter_mut() {
+            *slot = 0;
+        }
+    }
+
+    pub fn _DEXTRA_FIRST(_d: *const dirent) -> *mut ::dirent_extra {
+        let _f = &((*(_d)).d_name) as *const _;
+        let _s = _d as usize;
+
+        _ALIGN(_s + _f as usize - _s + (*_d).d_namelen as usize + 1, 8) as *mut ::dirent_extra
+    }
+
+    pub fn _DEXTRA_VALID(_x: *const ::dirent_extra, _d: *const dirent) -> bool {
+        let sz = _x as usize - _d as usize + ::mem::size_of::<::dirent_extra>();
+        let rsz = (*_d).d_reclen as usize;
+
+        if sz > rsz || sz + (*_x).d_datalen as usize > rsz {
+            false
+        } else {
+            true
+        }
+    }
+
+    pub fn _DEXTRA_NEXT(_x: *const ::dirent_extra) -> *mut ::dirent_extra {
+        _ALIGN(
+            _x as usize + ::mem::size_of::<::dirent_extra>() + (*_x).d_datalen as usize, 8
+        ) as *mut ::dirent_extra
+    }
+
+    pub fn SOCKCREDSIZE(ngrps: usize) -> usize {
+        let ngrps = if ngrps > 0 {
+            ngrps - 1
+        } else {
+            0
+        };
+        ::mem::size_of::<sockcred>() + ::mem::size_of::<::gid_t>() * ngrps
+    }
+}
+
+safe_f! {
+    pub {const} fn WIFSTOPPED(status: ::c_int) -> bool {
+        (status & 0xff) == 0x7f
+    }
+
+    pub {const} fn WSTOPSIG(status: ::c_int) -> ::c_int {
+        (status >> 8) & 0xff
+    }
+
+    pub {const} fn WIFCONTINUED(status: ::c_int) -> bool {
+        status == 0xffff
+    }
+
+    pub {const} fn WIFSIGNALED(status: ::c_int) -> bool {
+        ((status & 0x7f) + 1) as i8 >= 2
+    }
+
+    pub {const} fn WTERMSIG(status: ::c_int) -> ::c_int {
+        status & 0x7f
+    }
+
+    pub {const} fn WIFEXITED(status: ::c_int) -> bool {
+        (status & 0x7f) == 0
+    }
+
+    pub {const} fn WEXITSTATUS(status: ::c_int) -> ::c_int {
+        (status >> 8) & 0xff
+    }
+
+    pub {const} fn WCOREDUMP(status: ::c_int) -> bool {
+        (status & 0x80) != 0
+    }
+
+    pub {const} fn IPTOS_ECN(x: u8) -> u8 {
+        x & ::IPTOS_ECN_MASK
+    }
+}
+
+// Network related functions are provided by libsocket and regex
+// functions are provided by libregex.
+#[link(name = "socket")]
+#[link(name = "regex")]
+
+extern "C" {
+    pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
+    pub fn sem_init(sem: *mut sem_t, pshared: ::c_int, value: ::c_uint) -> ::c_int;
+    pub fn fdatasync(fd: ::c_int) -> ::c_int;
+    pub fn getpriority(which: ::c_int, who: ::id_t) -> ::c_int;
+    pub fn setpriority(which: ::c_int, who: ::id_t, prio: ::c_int) -> ::c_int;
+    pub fn mkfifoat(dirfd: ::c_int, pathname: *const ::c_char, mode: ::mode_t) -> ::c_int;
+
+    pub fn clock_getres(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
+    pub fn clock_gettime(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
+    pub fn clock_settime(clk_id: ::clockid_t, tp: *const ::timespec) -> ::c_int;
+    pub fn clock_getcpuclockid(pid: ::pid_t, clk_id: *mut ::clockid_t) -> ::c_int;
+
+    pub fn pthread_attr_getstack(
+        attr: *const ::pthread_attr_t,
+        stackaddr: *mut *mut ::c_void,
+        stacksize: *mut ::size_t,
+    ) -> ::c_int;
+    pub fn memalign(align: ::size_t, size: ::size_t) -> *mut ::c_void;
+    pub fn setgroups(ngroups: ::c_int, ptr: *const ::gid_t) -> ::c_int;
+
+    pub fn posix_fadvise(fd: ::c_int, offset: ::off_t, len: ::off_t, advise: ::c_int) -> ::c_int;
+    pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
+    pub fn nl_langinfo(item: ::nl_item) -> *mut ::c_char;
+
+    pub fn utimensat(
+        dirfd: ::c_int,
+        path: *const ::c_char,
+        times: *const ::timespec,
+        flag: ::c_int,
+    ) -> ::c_int;
+
+    pub fn pthread_condattr_getclock(
+        attr: *const pthread_condattr_t,
+        clock_id: *mut clockid_t,
+    ) -> ::c_int;
+    pub fn pthread_condattr_setclock(
+        attr: *mut pthread_condattr_t,
+        clock_id: ::clockid_t,
+    ) -> ::c_int;
+    pub fn pthread_condattr_setpshared(attr: *mut pthread_condattr_t, pshared: ::c_int) -> ::c_int;
+    pub fn pthread_mutexattr_setpshared(
+        attr: *mut pthread_mutexattr_t,
+        pshared: ::c_int,
+    ) -> ::c_int;
+    pub fn pthread_rwlockattr_getpshared(
+        attr: *const pthread_rwlockattr_t,
+        val: *mut ::c_int,
+    ) -> ::c_int;
+    pub fn pthread_rwlockattr_setpshared(attr: *mut pthread_rwlockattr_t, val: ::c_int) -> ::c_int;
+    pub fn ptsname_r(fd: ::c_int, buf: *mut ::c_char, buflen: ::size_t) -> *mut ::c_char;
+    pub fn clearenv() -> ::c_int;
+    pub fn waitid(idtype: idtype_t, id: id_t, infop: *mut ::siginfo_t, options: ::c_int)
+        -> ::c_int;
+    pub fn wait4(
+        pid: ::pid_t,
+        status: *mut ::c_int,
+        options: ::c_int,
+        rusage: *mut ::rusage,
+    ) -> ::pid_t;
+    pub fn execvpe(
+        file: *const ::c_char,
+        argv: *const *const ::c_char,
+        envp: *const *const ::c_char,
+    ) -> ::c_int;
+
+    pub fn getifaddrs(ifap: *mut *mut ::ifaddrs) -> ::c_int;
+    pub fn freeifaddrs(ifa: *mut ::ifaddrs);
+    pub fn bind(socket: ::c_int, address: *const ::sockaddr, address_len: ::socklen_t) -> ::c_int;
+
+    pub fn writev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
+    pub fn readv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
+
+    pub fn sendmsg(fd: ::c_int, msg: *const ::msghdr, flags: ::c_int) -> ::ssize_t;
+    pub fn recvmsg(fd: ::c_int, msg: *mut ::msghdr, flags: ::c_int) -> ::ssize_t;
+    pub fn openpty(
+        amaster: *mut ::c_int,
+        aslave: *mut ::c_int,
+        name: *mut ::c_char,
+        termp: *mut termios,
+        winp: *mut ::winsize,
+    ) -> ::c_int;
+    pub fn forkpty(
+        amaster: *mut ::c_int,
+        name: *mut ::c_char,
+        termp: *mut termios,
+        winp: *mut ::winsize,
+    ) -> ::pid_t;
+    pub fn login_tty(fd: ::c_int) -> ::c_int;
+
+    pub fn uname(buf: *mut ::utsname) -> ::c_int;
+
+    pub fn getpeereid(socket: ::c_int, euid: *mut ::uid_t, egid: *mut ::gid_t) -> ::c_int;
+
+    pub fn strerror_r(errnum: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
+
+    pub fn abs(i: ::c_int) -> ::c_int;
+    pub fn atof(s: *const ::c_char) -> ::c_double;
+    pub fn labs(i: ::c_long) -> ::c_long;
+    pub fn rand() -> ::c_int;
+    pub fn srand(seed: ::c_uint);
+
+    pub fn setpwent();
+    pub fn endpwent();
+    pub fn getpwent() -> *mut passwd;
+    pub fn setgrent();
+    pub fn endgrent();
+    pub fn getgrent() -> *mut ::group;
+    pub fn setspent();
+    pub fn endspent();
+
+    pub fn shm_open(name: *const c_char, oflag: ::c_int, mode: mode_t) -> ::c_int;
+
+    pub fn ftok(pathname: *const ::c_char, proj_id: ::c_int) -> ::key_t;
+    pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
+
+    pub fn posix_fallocate(fd: ::c_int, offset: ::off_t, len: ::off_t) -> ::c_int;
+    pub fn mkostemp(template: *mut ::c_char, flags: ::c_int) -> ::c_int;
+    pub fn mkostemps(template: *mut ::c_char, suffixlen: ::c_int, flags: ::c_int) -> ::c_int;
+    pub fn sigtimedwait(
+        set: *const sigset_t,
+        info: *mut siginfo_t,
+        timeout: *const ::timespec,
+    ) -> ::c_int;
+    pub fn sigwaitinfo(set: *const sigset_t, info: *mut siginfo_t) -> ::c_int;
+    pub fn pthread_setschedprio(native: ::pthread_t, priority: ::c_int) -> ::c_int;
+
+    pub fn if_nameindex() -> *mut if_nameindex;
+    pub fn if_freenameindex(ptr: *mut if_nameindex);
+
+    pub fn glob(
+        pattern: *const c_char,
+        flags: ::c_int,
+        errfunc: ::Option<extern "C" fn(epath: *const c_char, errno: ::c_int) -> ::c_int>,
+        pglob: *mut ::glob_t,
+    ) -> ::c_int;
+    pub fn globfree(pglob: *mut ::glob_t);
+
+    pub fn posix_madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
+
+    pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
+
+    pub fn seekdir(dirp: *mut ::DIR, loc: ::c_long);
+
+    pub fn telldir(dirp: *mut ::DIR) -> ::c_long;
+
+    pub fn msync(addr: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::c_int;
+
+    pub fn recvfrom(
+        socket: ::c_int,
+        buf: *mut ::c_void,
+        len: ::size_t,
+        flags: ::c_int,
+        addr: *mut ::sockaddr,
+        addrlen: *mut ::socklen_t,
+    ) -> ::ssize_t;
+    pub fn mkstemps(template: *mut ::c_char, suffixlen: ::c_int) -> ::c_int;
+
+    pub fn getdomainname(name: *mut ::c_char, len: ::size_t) -> ::c_int;
+    pub fn setdomainname(name: *const ::c_char, len: ::size_t) -> ::c_int;
+    pub fn sync();
+    pub fn pthread_getschedparam(
+        native: ::pthread_t,
+        policy: *mut ::c_int,
+        param: *mut ::sched_param,
+    ) -> ::c_int;
+    pub fn umount(target: *const ::c_char, flags: ::c_int) -> ::c_int;
+    pub fn sched_get_priority_max(policy: ::c_int) -> ::c_int;
+    pub fn settimeofday(tv: *const ::timeval, tz: *const ::c_void) -> ::c_int;
+    pub fn sched_rr_get_interval(pid: ::pid_t, tp: *mut ::timespec) -> ::c_int;
+    pub fn sem_timedwait(sem: *mut sem_t, abstime: *const ::timespec) -> ::c_int;
+    pub fn sem_getvalue(sem: *mut sem_t, sval: *mut ::c_int) -> ::c_int;
+    pub fn sched_setparam(pid: ::pid_t, param: *const ::sched_param) -> ::c_int;
+    pub fn mount(
+        special_device: *const ::c_char,
+        mount_directory: *const ::c_char,
+        flags: ::c_int,
+        mount_type: *const ::c_char,
+        mount_data: *const ::c_void,
+        mount_datalen: ::c_int,
+    ) -> ::c_int;
+    pub fn sched_getparam(pid: ::pid_t, param: *mut ::sched_param) -> ::c_int;
+    pub fn pthread_mutex_consistent(mutex: *mut pthread_mutex_t) -> ::c_int;
+    pub fn pthread_mutex_timedlock(
+        lock: *mut pthread_mutex_t,
+        abstime: *const ::timespec,
+    ) -> ::c_int;
+    pub fn pthread_spin_init(lock: *mut ::pthread_spinlock_t, pshared: ::c_int) -> ::c_int;
+    pub fn pthread_spin_destroy(lock: *mut ::pthread_spinlock_t) -> ::c_int;
+    pub fn pthread_spin_lock(lock: *mut ::pthread_spinlock_t) -> ::c_int;
+    pub fn pthread_spin_trylock(lock: *mut ::pthread_spinlock_t) -> ::c_int;
+    pub fn pthread_spin_unlock(lock: *mut ::pthread_spinlock_t) -> ::c_int;
+    pub fn pthread_barrierattr_init(__attr: *mut ::pthread_barrierattr_t) -> ::c_int;
+    pub fn pthread_barrierattr_destroy(__attr: *mut ::pthread_barrierattr_t) -> ::c_int;
+    pub fn pthread_barrierattr_getpshared(
+        __attr: *const ::pthread_barrierattr_t,
+        __pshared: *mut ::c_int,
+    ) -> ::c_int;
+    pub fn pthread_barrierattr_setpshared(
+        __attr: *mut ::pthread_barrierattr_t,
+        __pshared: ::c_int,
+    ) -> ::c_int;
+    pub fn pthread_barrier_init(
+        __barrier: *mut ::pthread_barrier_t,
+        __attr: *const ::pthread_barrierattr_t,
+        __count: ::c_uint,
+    ) -> ::c_int;
+    pub fn pthread_barrier_destroy(__barrier: *mut ::pthread_barrier_t) -> ::c_int;
+    pub fn pthread_barrier_wait(__barrier: *mut ::pthread_barrier_t) -> ::c_int;
+
+    pub fn sched_getscheduler(pid: ::pid_t) -> ::c_int;
+    pub fn clock_nanosleep(
+        clk_id: ::clockid_t,
+        flags: ::c_int,
+        rqtp: *const ::timespec,
+        rmtp: *mut ::timespec,
+    ) -> ::c_int;
+    pub fn pthread_attr_getguardsize(
+        attr: *const ::pthread_attr_t,
+        guardsize: *mut ::size_t,
+    ) -> ::c_int;
+    pub fn sethostname(name: *const ::c_char, len: ::size_t) -> ::c_int;
+    pub fn sched_get_priority_min(policy: ::c_int) -> ::c_int;
+    pub fn pthread_condattr_getpshared(
+        attr: *const pthread_condattr_t,
+        pshared: *mut ::c_int,
+    ) -> ::c_int;
+    pub fn pthread_setschedparam(
+        native: ::pthread_t,
+        policy: ::c_int,
+        param: *const ::sched_param,
+    ) -> ::c_int;
+    pub fn sched_setscheduler(
+        pid: ::pid_t,
+        policy: ::c_int,
+        param: *const ::sched_param,
+    ) -> ::c_int;
+    pub fn sigsuspend(mask: *const ::sigset_t) -> ::c_int;
+    pub fn getgrgid_r(
+        gid: ::gid_t,
+        grp: *mut ::group,
+        buf: *mut ::c_char,
+        buflen: ::size_t,
+        result: *mut *mut ::group,
+    ) -> ::c_int;
+    pub fn sem_close(sem: *mut sem_t) -> ::c_int;
+    pub fn getdtablesize() -> ::c_int;
+    pub fn getgrnam_r(
+        name: *const ::c_char,
+        grp: *mut ::group,
+        buf: *mut ::c_char,
+        buflen: ::size_t,
+        result: *mut *mut ::group,
+    ) -> ::c_int;
+    pub fn initgroups(user: *const ::c_char, group: ::gid_t) -> ::c_int;
+    pub fn pthread_sigmask(how: ::c_int, set: *const sigset_t, oldset: *mut sigset_t) -> ::c_int;
+    pub fn sem_open(name: *const ::c_char, oflag: ::c_int, ...) -> *mut sem_t;
+    pub fn getgrnam(name: *const ::c_char) -> *mut ::group;
+    pub fn pthread_cancel(thread: ::pthread_t) -> ::c_int;
+    pub fn pthread_kill(thread: ::pthread_t, sig: ::c_int) -> ::c_int;
+    pub fn sem_unlink(name: *const ::c_char) -> ::c_int;
+    pub fn daemon(nochdir: ::c_int, noclose: ::c_int) -> ::c_int;
+    pub fn getpwnam_r(
+        name: *const ::c_char,
+        pwd: *mut passwd,
+        buf: *mut ::c_char,
+        buflen: ::size_t,
+        result: *mut *mut passwd,
+    ) -> ::c_int;
+    pub fn getpwuid_r(
+        uid: ::uid_t,
+        pwd: *mut passwd,
+        buf: *mut ::c_char,
+        buflen: ::size_t,
+        result: *mut *mut passwd,
+    ) -> ::c_int;
+    pub fn sigwait(set: *const sigset_t, sig: *mut ::c_int) -> ::c_int;
+    pub fn pthread_atfork(
+        prepare: ::Option<unsafe extern "C" fn()>,
+        parent: ::Option<unsafe extern "C" fn()>,
+        child: ::Option<unsafe extern "C" fn()>,
+    ) -> ::c_int;
+    pub fn getgrgid(gid: ::gid_t) -> *mut ::group;
+    pub fn getgrouplist(
+        user: *const ::c_char,
+        group: ::gid_t,
+        groups: *mut ::gid_t,
+        ngroups: *mut ::c_int,
+    ) -> ::c_int;
+    pub fn pthread_mutexattr_getpshared(
+        attr: *const pthread_mutexattr_t,
+        pshared: *mut ::c_int,
+    ) -> ::c_int;
+    pub fn pthread_mutexattr_getrobust(
+        attr: *const pthread_mutexattr_t,
+        robustness: *mut ::c_int,
+    ) -> ::c_int;
+    pub fn pthread_mutexattr_setrobust(
+        attr: *mut pthread_mutexattr_t,
+        robustness: ::c_int,
+    ) -> ::c_int;
+    pub fn pthread_create(
+        native: *mut ::pthread_t,
+        attr: *const ::pthread_attr_t,
+        f: extern "C" fn(*mut ::c_void) -> *mut ::c_void,
+        value: *mut ::c_void,
+    ) -> ::c_int;
+    pub fn getitimer(which: ::c_int, curr_value: *mut ::itimerval) -> ::c_int;
+    pub fn setitimer(
+        which: ::c_int,
+        value: *const ::itimerval,
+        ovalue: *mut ::itimerval,
+    ) -> ::c_int;
+    pub fn posix_spawn(
+        pid: *mut ::pid_t,
+        path: *const ::c_char,
+        file_actions: *const ::posix_spawn_file_actions_t,
+        attrp: *const ::posix_spawnattr_t,
+        argv: *const *mut ::c_char,
+        envp: *const *mut ::c_char,
+    ) -> ::c_int;
+    pub fn posix_spawnp(
+        pid: *mut ::pid_t,
+        file: *const ::c_char,
+        file_actions: *const ::posix_spawn_file_actions_t,
+        attrp: *const ::posix_spawnattr_t,
+        argv: *const *mut ::c_char,
+        envp: *const *mut ::c_char,
+    ) -> ::c_int;
+    pub fn posix_spawnattr_init(attr: *mut posix_spawnattr_t) -> ::c_int;
+    pub fn posix_spawnattr_destroy(attr: *mut posix_spawnattr_t) -> ::c_int;
+    pub fn posix_spawnattr_getsigdefault(
+        attr: *const posix_spawnattr_t,
+        default: *mut ::sigset_t,
+    ) -> ::c_int;
+    pub fn posix_spawnattr_setsigdefault(
+        attr: *mut posix_spawnattr_t,
+        default: *const ::sigset_t,
+    ) -> ::c_int;
+    pub fn posix_spawnattr_getsigmask(
+        attr: *const posix_spawnattr_t,
+        default: *mut ::sigset_t,
+    ) -> ::c_int;
+    pub fn posix_spawnattr_setsigmask(
+        attr: *mut posix_spawnattr_t,
+        default: *const ::sigset_t,
+    ) -> ::c_int;
+    pub fn posix_spawnattr_getflags(
+        attr: *const posix_spawnattr_t,
+        flags: *mut ::c_short,
+    ) -> ::c_int;
+    pub fn posix_spawnattr_setflags(attr: *mut posix_spawnattr_t, flags: ::c_short) -> ::c_int;
+    pub fn posix_spawnattr_getpgroup(
+        attr: *const posix_spawnattr_t,
+        flags: *mut ::pid_t,
+    ) -> ::c_int;
+    pub fn posix_spawnattr_setpgroup(attr: *mut posix_spawnattr_t, flags: ::pid_t) -> ::c_int;
+    pub fn posix_spawnattr_getschedpolicy(
+        attr: *const posix_spawnattr_t,
+        flags: *mut ::c_int,
+    ) -> ::c_int;
+    pub fn posix_spawnattr_setschedpolicy(attr: *mut posix_spawnattr_t, flags: ::c_int) -> ::c_int;
+    pub fn posix_spawnattr_getschedparam(
+        attr: *const posix_spawnattr_t,
+        param: *mut ::sched_param,
+    ) -> ::c_int;
+    pub fn posix_spawnattr_setschedparam(
+        attr: *mut posix_spawnattr_t,
+        param: *const ::sched_param,
+    ) -> ::c_int;
+
+    pub fn posix_spawn_file_actions_init(actions: *mut posix_spawn_file_actions_t) -> ::c_int;
+    pub fn posix_spawn_file_actions_destroy(actions: *mut posix_spawn_file_actions_t) -> ::c_int;
+    pub fn posix_spawn_file_actions_addopen(
+        actions: *mut posix_spawn_file_actions_t,
+        fd: ::c_int,
+        path: *const ::c_char,
+        oflag: ::c_int,
+        mode: ::mode_t,
+    ) -> ::c_int;
+    pub fn posix_spawn_file_actions_addclose(
+        actions: *mut posix_spawn_file_actions_t,
+        fd: ::c_int,
+    ) -> ::c_int;
+    pub fn posix_spawn_file_actions_adddup2(
+        actions: *mut posix_spawn_file_actions_t,
+        fd: ::c_int,
+        newfd: ::c_int,
+    ) -> ::c_int;
+    pub fn popen(command: *const c_char, mode: *const c_char) -> *mut ::FILE;
+    pub fn faccessat(
+        dirfd: ::c_int,
+        pathname: *const ::c_char,
+        mode: ::c_int,
+        flags: ::c_int,
+    ) -> ::c_int;
+    pub fn inotify_rm_watch(fd: ::c_int, wd: ::c_int) -> ::c_int;
+    pub fn inotify_init() -> ::c_int;
+    pub fn inotify_add_watch(fd: ::c_int, path: *const ::c_char, mask: u32) -> ::c_int;
+
+    pub fn gettid() -> ::pid_t;
+
+    pub fn pthread_getcpuclockid(thread: ::pthread_t, clk_id: *mut ::clockid_t) -> ::c_int;
+
+    pub fn getnameinfo(
+        sa: *const ::sockaddr,
+        salen: ::socklen_t,
+        host: *mut ::c_char,
+        hostlen: ::socklen_t,
+        serv: *mut ::c_char,
+        sevlen: ::socklen_t,
+        flags: ::c_int,
+    ) -> ::c_int;
+
+    pub fn sendmmsg(
+        sockfd: ::c_int,
+        msgvec: *mut ::mmsghdr,
+        vlen: ::c_uint,
+        flags: ::c_uint,
+    ) -> ::c_int;
+    pub fn recvmmsg(
+        sockfd: ::c_int,
+        msgvec: *mut ::mmsghdr,
+        vlen: ::c_uint,
+        flags: ::c_uint,
+        timeout: *mut ::timespec,
+    ) -> ::c_int;
+
+    pub fn mallopt(param: ::c_int, value: i64) -> ::c_int;
+    pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::c_void) -> ::c_int;
+
+    pub fn ctermid(s: *mut ::c_char) -> *mut ::c_char;
+    pub fn ioctl(fd: ::c_int, request: ::c_int, ...) -> ::c_int;
+
+    pub fn mallinfo() -> ::mallinfo;
+    pub fn getpwent_r(
+        pwd: *mut ::passwd,
+        buf: *mut ::c_char,
+        __bufsize: ::c_int,
+        __result: *mut *mut ::passwd,
+    ) -> ::c_int;
+    pub fn pthread_getname_np(thread: ::pthread_t, name: *mut ::c_char, len: ::c_int) -> ::c_int;
+    pub fn pthread_setname_np(thread: ::pthread_t, name: *const ::c_char) -> ::c_int;
+
+    pub fn sysctl(
+        _: *const ::c_int,
+        _: ::c_uint,
+        _: *mut ::c_void,
+        _: *mut ::size_t,
+        _: *const ::c_void,
+        _: ::size_t,
+    ) -> ::c_int;
+
+    pub fn getrlimit(resource: ::c_int, rlim: *mut ::rlimit) -> ::c_int;
+    pub fn setrlimit(resource: ::c_int, rlp: *const ::rlimit) -> ::c_int;
+
+    pub fn lio_listio(
+        __mode: ::c_int,
+        __list: *const *mut aiocb,
+        __nent: ::c_int,
+        __sig: *mut sigevent,
+    ) -> ::c_int;
+
+    pub fn dl_iterate_phdr(
+        callback: ::Option<
+            unsafe extern "C" fn(
+                info: *const dl_phdr_info,
+                size: ::size_t,
+                data: *mut ::c_void,
+            ) -> ::c_int,
+        >,
+        data: *mut ::c_void,
+    ) -> ::c_int;
+
+    pub fn memset_s(s: *mut ::c_void, smax: ::size_t, c: ::c_int, n: ::size_t) -> ::c_int;
+
+    pub fn regcomp(
+        __preg: *mut ::regex_t,
+        __pattern: *const ::c_char,
+        __cflags: ::c_int,
+    ) -> ::c_int;
+    pub fn regexec(
+        __preg: *const ::regex_t,
+        __str: *const ::c_char,
+        __nmatch: ::size_t,
+        __pmatch: *mut ::regmatch_t,
+        __eflags: ::c_int,
+    ) -> ::c_int;
+    pub fn regerror(
+        __errcode: ::c_int,
+        __preg: *const ::regex_t,
+        __errbuf: *mut ::c_char,
+        __errbuf_size: ::size_t,
+    ) -> ::size_t;
+    pub fn regfree(__preg: *mut ::regex_t);
+    pub fn dirfd(__dirp: *mut ::DIR) -> ::c_int;
+    pub fn dircntl(dir: *mut ::DIR, cmd: ::c_int, ...) -> ::c_int;
+
+    pub fn aio_cancel(__fd: ::c_int, __aiocbp: *mut ::aiocb) -> ::c_int;
+    pub fn aio_error(__aiocbp: *const ::aiocb) -> ::c_int;
+    pub fn aio_fsync(__operation: ::c_int, __aiocbp: *mut ::aiocb) -> ::c_int;
+    pub fn aio_read(__aiocbp: *mut ::aiocb) -> ::c_int;
+    pub fn aio_return(__aiocpb: *mut ::aiocb) -> ::ssize_t;
+    pub fn aio_suspend(
+        __list: *const *const ::aiocb,
+        __nent: ::c_int,
+        __timeout: *const ::timespec,
+    ) -> ::c_int;
+    pub fn aio_write(__aiocpb: *mut ::aiocb) -> ::c_int;
+
+    pub fn mq_close(__mqdes: ::mqd_t) -> ::c_int;
+    pub fn mq_getattr(__mqdes: ::mqd_t, __mqstat: *mut ::mq_attr) -> ::c_int;
+    pub fn mq_notify(__mqdes: ::mqd_t, __notification: *const ::sigevent) -> ::c_int;
+    pub fn mq_open(__name: *const ::c_char, __oflag: ::c_int, ...) -> ::mqd_t;
+    pub fn mq_receive(
+        __mqdes: ::mqd_t,
+        __msg_ptr: *mut ::c_char,
+        __msg_len: ::size_t,
+        __msg_prio: *mut ::c_uint,
+    ) -> ::ssize_t;
+    pub fn mq_send(
+        __mqdes: ::mqd_t,
+        __msg_ptr: *const ::c_char,
+        __msg_len: ::size_t,
+        __msg_prio: ::c_uint,
+    ) -> ::c_int;
+    pub fn mq_setattr(
+        __mqdes: ::mqd_t,
+        __mqstat: *const mq_attr,
+        __omqstat: *mut mq_attr,
+    ) -> ::c_int;
+    pub fn mq_timedreceive(
+        __mqdes: ::mqd_t,
+        __msg_ptr: *mut ::c_char,
+        __msg_len: ::size_t,
+        __msg_prio: *mut ::c_uint,
+        __abs_timeout: *const ::timespec,
+    ) -> ::ssize_t;
+    pub fn mq_timedsend(
+        __mqdes: ::mqd_t,
+        __msg_ptr: *const ::c_char,
+        __msg_len: ::size_t,
+        __msg_prio: ::c_uint,
+        __abs_timeout: *const ::timespec,
+    ) -> ::c_int;
+    pub fn mq_unlink(__name: *const ::c_char) -> ::c_int;
+    pub fn __get_errno_ptr() -> *mut ::c_int;
+
+    // System page, see https://www.qnx.com/developers/docs/7.1#com.qnx.doc.neutrino.building/topic/syspage/syspage_about.html
+    pub static mut _syspage_ptr: *mut syspage_entry;
+
+    // Function on the stack after a call to pthread_create().  This is used
+    // as a sentinel to work around an infitnite loop in the unwinding code.
+    pub fn __my_thread_exit(value_ptr: *mut *const ::c_void);
+}
+
+// Models the implementation in stdlib.h.  Ctest will fail if trying to use the
+// default symbol from libc
+pub unsafe fn atexit(cb: extern "C" fn()) -> ::c_int {
+    extern "C" {
+        static __dso_handle: *mut ::c_void;
+        pub fn __cxa_atexit(
+            cb: extern "C" fn(),
+            __arg: *mut ::c_void,
+            __dso: *mut ::c_void,
+        ) -> ::c_int;
+    }
+    __cxa_atexit(cb, 0 as *mut ::c_void, __dso_handle)
+}
+
+impl siginfo_t {
+    pub unsafe fn si_addr(&self) -> *mut ::c_void {
+        #[repr(C)]
+        struct siginfo_si_addr {
+            _pad: [u8; 32],
+            si_addr: *mut ::c_void,
+        }
+        (*(self as *const siginfo_t as *const siginfo_si_addr)).si_addr
+    }
+
+    pub unsafe fn si_value(&self) -> ::sigval {
+        #[repr(C)]
+        struct siginfo_si_value {
+            _pad: [u8; 32],
+            si_value: ::sigval,
+        }
+        (*(self as *const siginfo_t as *const siginfo_si_value)).si_value
+    }
+
+    pub unsafe fn si_pid(&self) -> ::pid_t {
+        #[repr(C)]
+        struct siginfo_si_pid {
+            _pad: [u8; 16],
+            si_pid: ::pid_t,
+        }
+        (*(self as *const siginfo_t as *const siginfo_si_pid)).si_pid
+    }
+
+    pub unsafe fn si_uid(&self) -> ::uid_t {
+        #[repr(C)]
+        struct siginfo_si_uid {
+            _pad: [u8; 24],
+            si_uid: ::uid_t,
+        }
+        (*(self as *const siginfo_t as *const siginfo_si_uid)).si_uid
+    }
+
+    pub unsafe fn si_status(&self) -> ::c_int {
+        #[repr(C)]
+        struct siginfo_si_status {
+            _pad: [u8; 28],
+            si_status: ::c_int,
+        }
+        (*(self as *const siginfo_t as *const siginfo_si_status)).si_status
+    }
+}
+
+cfg_if! {
+    if #[cfg(target_arch = "x86_64")] {
+        mod x86_64;
+        pub use self::x86_64::*;
+    }
+    else if #[cfg(target_arch = "aarch64")] {
+        mod aarch64;
+        pub use self::aarch64::*;
+    }
+    else {
+        panic!("Unsupported arch");
+    }
+}
+
+mod neutrino;
+pub use self::neutrino::*;

--- a/src/unix/nto/neutrino.rs
+++ b/src/unix/nto/neutrino.rs
@@ -1,0 +1,1288 @@
+pub type nto_job_t = ::sync_t;
+
+s! {
+    pub struct intrspin {
+        pub value: ::c_uint, // volatile
+    }
+
+    pub struct iov_t {
+        pub iov_base: *mut ::c_void,  // union
+        pub iov_len: ::size_t,
+    }
+
+    pub struct _itimer {
+        pub nsec: u64,
+        pub interval_nsec: u64,
+    }
+
+    pub struct _msg_info64 {
+        pub nd: u32,
+        pub srcnd: u32,
+        pub pid: ::pid_t,
+        pub tid: i32,
+        pub chid: i32,
+        pub scoid: i32,
+        pub coid: i32,
+        pub priority: i16,
+        pub flags: i16,
+        pub msglen: isize,
+        pub srcmsglen: isize,
+        pub dstmsglen: isize,
+        pub type_id: u32,
+        reserved: u32,
+    }
+
+    pub struct _cred_info {
+        pub ruid: ::uid_t,
+        pub euid: ::uid_t,
+        pub suid: ::uid_t,
+        pub rgid: ::gid_t,
+        pub egid: ::gid_t,
+        pub sgid: ::gid_t,
+        pub ngroups: u32,
+        pub grouplist: [::gid_t; 8],
+    }
+
+    pub struct _client_info {
+        pub nd: u32,
+        pub pid: ::pid_t,
+        pub sid: ::pid_t,
+        pub flags: u32,
+        pub cred: ::_cred_info,
+    }
+
+    pub struct _client_able {
+        pub ability: u32,
+        pub flags: u32,
+        pub range_lo: u64,
+        pub range_hi: u64,
+    }
+
+    pub struct nto_channel_config {
+        pub event: ::sigevent,
+        pub num_pulses: ::c_uint,
+        pub rearm_threshold: ::c_uint,
+        pub options: ::c_uint,
+        reserved: [::c_uint; 3],
+    }
+
+    // TODO: The following structures are defined in a header file which doesn't
+    //       appear as part of the default headers found in a standard installation
+    //       of Neutrino 7.1 SDP.  Commented out for now.
+    //pub struct _asyncmsg_put_header {
+    //    pub err: ::c_int,
+    //    pub iov: *mut ::iov_t,
+    //    pub parts: ::c_int,
+    //    pub handle: ::c_uint,
+    //    pub cb: ::Option<
+    //        unsafe extern "C" fn(
+    //            err: ::c_int,
+    //            buf: *mut ::c_void,
+    //            handle: ::c_uint,
+    //        ) -> ::c_int>,
+    //    pub put_hdr_flags: ::c_uint,
+    //}
+
+    //pub struct _asyncmsg_connection_attr {
+    //    pub call_back: ::Option<
+    //        unsafe extern "C" fn(
+    //            err: ::c_int,
+    //            buff: *mut ::c_void,
+    //            handle: ::c_uint,
+    //        ) -> ::c_int>,
+    //    pub buffer_size: ::size_t,
+    //    pub max_num_buffer: ::c_uint,
+    //    pub trigger_num_msg: ::c_uint,
+    //    pub trigger_time: ::_itimer,
+    //    reserve: ::c_uint,
+    //}
+
+    //pub struct _asyncmsg_connection_descriptor {
+    //    pub flags: ::c_uint,
+    //    pub sendq_size: ::c_uint,
+    //    pub sendq_head: ::c_uint,
+    //    pub sendq_tail: ::c_uint,
+    //    pub sendq_free: ::c_uint,
+    //    pub err: ::c_int,
+    //    pub ev: ::sigevent,
+    //    pub num_curmsg: ::c_uint,
+    //    pub ttimer: ::timer_t,
+    //    pub block_con: ::pthread_cond_t,
+    //    pub mu: ::pthread_mutex_t,
+    //    reserved: ::c_uint,
+    //    pub attr: ::_asyncmsg_connection_attr,
+    //    pub reserves: [::c_uint; 3],
+    //    pub sendq: [::_asyncmsg_put_header; 1], // flexarray
+    //}
+
+    pub struct __c_anonymous_struct_ev {
+        pub event: ::sigevent,
+        pub coid: ::c_int,
+    }
+
+    pub struct _channel_connect_attr {  // union
+        pub ev: ::__c_anonymous_struct_ev,
+    }
+
+    pub struct _sighandler_info {
+        pub siginfo: ::siginfo_t,
+        pub handler: ::Option<unsafe extern "C" fn(value: ::c_int)>,
+        pub context: *mut ::c_void,
+    }
+
+    pub struct __c_anonymous_struct_time {
+        pub length: ::c_uint,
+        pub scale: ::c_uint,
+    }
+
+    pub struct _idle_hook {
+        pub hook_size: ::c_uint,
+        pub cmd: ::c_uint,
+        pub mode: ::c_uint,
+        pub latency: ::c_uint,
+        pub next_fire: u64,
+        pub curr_time: u64,
+        pub tod_adjust: u64,
+        pub resp: ::c_uint,
+        pub time: __c_anonymous_struct_time,
+        pub trigger: ::sigevent,
+        pub intrs: *mut ::c_uint,
+        pub block_stack_size: ::c_uint,
+    }
+
+    pub struct _clockadjust {
+        pub tick_count: u32,
+        pub tick_nsec_inc: i32,
+    }
+
+    pub struct qtime_entry {
+        pub cycles_per_sec: u64,
+        pub nsec_tod_adjust: u64, // volatile
+        pub nsec: u64,            // volatile
+        pub nsec_inc: u32,
+        pub boot_time: u32,
+        pub adjust: _clockadjust,
+        pub timer_rate: u32,
+        pub timer_scale: i32,
+        pub timer_load: u32,
+        pub intr: i32,
+        pub epoch: u32,
+        pub flags: u32,
+        pub rr_interval_mul: u32,
+        pub timer_load_hi: u32,
+        pub nsec_stable: u64,      // volatile
+        pub timer_load_max: u64,
+        pub timer_prog_time: u32,
+        spare: [u32; 7],
+    }
+
+    pub struct _sched_info {
+        pub priority_min: ::c_int,
+        pub priority_max: ::c_int,
+        pub interval: u64,
+        pub priority_priv: ::c_int,
+        reserved: [::c_int; 11],
+    }
+
+    pub struct _timer_info {
+        pub itime: ::_itimer,
+        pub otime: ::_itimer,
+        pub flags: u32,
+        pub tid: i32,
+        pub notify: i32,
+        pub clockid: ::clockid_t,
+        pub overruns: u32,
+        pub event: ::sigevent, // union
+    }
+
+    pub struct _clockperiod {
+        pub nsec: u32,
+        pub fract: i32,
+    }
+}
+
+s_no_extra_traits! {
+    pub struct syspage_entry_info {
+        pub entry_off: u16,
+        pub entry_size: u16,
+    }
+
+    pub struct syspage_array_info {
+        entry_off: u16,
+        entry_size: u16,
+        element_size: u16,
+    }
+
+    #[repr(align(8))]
+    pub struct syspage_entry {
+        pub size: u16,
+        pub total_size: u16,
+        pub type_: u16,
+        pub num_cpu: u16,
+        pub system_private: syspage_entry_info,
+        pub old_asinfo: syspage_entry_info,
+        pub __mangle_name_to_cause_compilation_errs_meminfo: syspage_entry_info,
+        pub hwinfo: syspage_entry_info,
+        pub old_cpuinfo: syspage_entry_info,
+        pub old_cacheattr: syspage_entry_info,
+        pub qtime: syspage_entry_info,
+        pub callout: syspage_entry_info,
+        pub callin: syspage_entry_info,
+        pub typed_strings: syspage_entry_info,
+        pub strings: syspage_entry_info,
+        pub old_intrinfo: syspage_entry_info,
+        pub smp: syspage_entry_info,
+        pub pminfo: syspage_entry_info,
+        pub old_mdriver: syspage_entry_info,
+        spare0: [u32; 1],
+        __reserved: [u8; 160], // anonymous union with architecture dependent structs
+        pub new_asinfo: syspage_array_info,
+        pub new_cpuinfo: syspage_array_info,
+        pub new_cacheattr: syspage_array_info,
+        pub new_intrinfo: syspage_array_info,
+        pub new_mdriver: syspage_array_info,
+    }
+}
+
+pub const SYSMGR_PID: u32 = 1;
+pub const SYSMGR_CHID: u32 = 1;
+pub const SYSMGR_COID: u32 = _NTO_SIDE_CHANNEL;
+pub const SYSMGR_HANDLE: u32 = 0;
+
+pub const STATE_DEAD: ::c_int = 0x00;
+pub const STATE_RUNNING: ::c_int = 0x01;
+pub const STATE_READY: ::c_int = 0x02;
+pub const STATE_STOPPED: ::c_int = 0x03;
+pub const STATE_SEND: ::c_int = 0x04;
+pub const STATE_RECEIVE: ::c_int = 0x05;
+pub const STATE_REPLY: ::c_int = 0x06;
+pub const STATE_STACK: ::c_int = 0x07;
+pub const STATE_WAITTHREAD: ::c_int = 0x08;
+pub const STATE_WAITPAGE: ::c_int = 0x09;
+pub const STATE_SIGSUSPEND: ::c_int = 0x0a;
+pub const STATE_SIGWAITINFO: ::c_int = 0x0b;
+pub const STATE_NANOSLEEP: ::c_int = 0x0c;
+pub const STATE_MUTEX: ::c_int = 0x0d;
+pub const STATE_CONDVAR: ::c_int = 0x0e;
+pub const STATE_JOIN: ::c_int = 0x0f;
+pub const STATE_INTR: ::c_int = 0x10;
+pub const STATE_SEM: ::c_int = 0x11;
+pub const STATE_WAITCTX: ::c_int = 0x12;
+pub const STATE_NET_SEND: ::c_int = 0x13;
+pub const STATE_NET_REPLY: ::c_int = 0x14;
+pub const STATE_MAX: ::c_int = 0x18;
+
+pub const _NTO_TIMEOUT_RECEIVE: i32 = 1 << STATE_RECEIVE;
+pub const _NTO_TIMEOUT_SEND: i32 = 1 << STATE_SEND;
+pub const _NTO_TIMEOUT_REPLY: i32 = 1 << STATE_REPLY;
+pub const _NTO_TIMEOUT_SIGSUSPEND: i32 = 1 << STATE_SIGSUSPEND;
+pub const _NTO_TIMEOUT_SIGWAITINFO: i32 = 1 << STATE_SIGWAITINFO;
+pub const _NTO_TIMEOUT_NANOSLEEP: i32 = 1 << STATE_NANOSLEEP;
+pub const _NTO_TIMEOUT_MUTEX: i32 = 1 << STATE_MUTEX;
+pub const _NTO_TIMEOUT_CONDVAR: i32 = 1 << STATE_CONDVAR;
+pub const _NTO_TIMEOUT_JOIN: i32 = 1 << STATE_JOIN;
+pub const _NTO_TIMEOUT_INTR: i32 = 1 << STATE_INTR;
+pub const _NTO_TIMEOUT_SEM: i32 = 1 << STATE_SEM;
+
+pub const _NTO_MI_ENDIAN_BIG: u32 = 1;
+pub const _NTO_MI_ENDIAN_DIFF: u32 = 2;
+pub const _NTO_MI_UNBLOCK_REQ: u32 = 256;
+pub const _NTO_MI_NET_CRED_DIRTY: u32 = 512;
+pub const _NTO_MI_CONSTRAINED: u32 = 1024;
+pub const _NTO_MI_CHROOT: u32 = 2048;
+pub const _NTO_MI_BITS_64: u32 = 4096;
+pub const _NTO_MI_BITS_DIFF: u32 = 8192;
+pub const _NTO_MI_SANDBOX: u32 = 16384;
+
+pub const _NTO_CI_ENDIAN_BIG: u32 = 1;
+pub const _NTO_CI_BKGND_PGRP: u32 = 4;
+pub const _NTO_CI_ORPHAN_PGRP: u32 = 8;
+pub const _NTO_CI_STOPPED: u32 = 128;
+pub const _NTO_CI_UNABLE: u32 = 256;
+pub const _NTO_CI_TYPE_ID: u32 = 512;
+pub const _NTO_CI_CHROOT: u32 = 2048;
+pub const _NTO_CI_BITS_64: u32 = 4096;
+pub const _NTO_CI_SANDBOX: u32 = 16384;
+pub const _NTO_CI_LOADER: u32 = 32768;
+pub const _NTO_CI_FULL_GROUPS: u32 = 2147483648;
+
+pub const _NTO_TI_ACTIVE: u32 = 1;
+pub const _NTO_TI_ABSOLUTE: u32 = 2;
+pub const _NTO_TI_EXPIRED: u32 = 4;
+pub const _NTO_TI_TOD_BASED: u32 = 8;
+pub const _NTO_TI_TARGET_PROCESS: u32 = 16;
+pub const _NTO_TI_REPORT_TOLERANCE: u32 = 32;
+pub const _NTO_TI_PRECISE: u32 = 64;
+pub const _NTO_TI_TOLERANT: u32 = 128;
+pub const _NTO_TI_WAKEUP: u32 = 256;
+pub const _NTO_TI_PROCESS_TOLERANT: u32 = 512;
+pub const _NTO_TI_HIGH_RESOLUTION: u32 = 1024;
+
+pub const _PULSE_TYPE: u32 = 0;
+pub const _PULSE_SUBTYPE: u32 = 0;
+pub const _PULSE_CODE_UNBLOCK: i32 = -32;
+pub const _PULSE_CODE_DISCONNECT: i32 = -33;
+pub const _PULSE_CODE_THREADDEATH: i32 = -34;
+pub const _PULSE_CODE_COIDDEATH: i32 = -35;
+pub const _PULSE_CODE_NET_ACK: i32 = -36;
+pub const _PULSE_CODE_NET_UNBLOCK: i32 = -37;
+pub const _PULSE_CODE_NET_DETACH: i32 = -38;
+pub const _PULSE_CODE_RESTART: i32 = -39;
+pub const _PULSE_CODE_NORESTART: i32 = -40;
+pub const _PULSE_CODE_UNBLOCK_RESTART: i32 = -41;
+pub const _PULSE_CODE_UNBLOCK_TIMER: i32 = -42;
+pub const _PULSE_CODE_MINAVAIL: u32 = 0;
+pub const _PULSE_CODE_MAXAVAIL: u32 = 127;
+
+pub const _NTO_HARD_FLAGS_END: u32 = 1;
+
+pub const _NTO_PULSE_IF_UNIQUE: u32 = 4096;
+pub const _NTO_PULSE_REPLACE: u32 = 8192;
+
+pub const _NTO_PF_NOCLDSTOP: u32 = 1;
+pub const _NTO_PF_LOADING: u32 = 2;
+pub const _NTO_PF_TERMING: u32 = 4;
+pub const _NTO_PF_ZOMBIE: u32 = 8;
+pub const _NTO_PF_NOZOMBIE: u32 = 16;
+pub const _NTO_PF_FORKED: u32 = 32;
+pub const _NTO_PF_ORPHAN_PGRP: u32 = 64;
+pub const _NTO_PF_STOPPED: u32 = 128;
+pub const _NTO_PF_DEBUG_STOPPED: u32 = 256;
+pub const _NTO_PF_BKGND_PGRP: u32 = 512;
+pub const _NTO_PF_NOISYNC: u32 = 1024;
+pub const _NTO_PF_CONTINUED: u32 = 2048;
+pub const _NTO_PF_CHECK_INTR: u32 = 4096;
+pub const _NTO_PF_COREDUMP: u32 = 8192;
+pub const _NTO_PF_RING0: u32 = 32768;
+pub const _NTO_PF_SLEADER: u32 = 65536;
+pub const _NTO_PF_WAITINFO: u32 = 131072;
+pub const _NTO_PF_DESTROYALL: u32 = 524288;
+pub const _NTO_PF_NOCOREDUMP: u32 = 1048576;
+pub const _NTO_PF_WAITDONE: u32 = 4194304;
+pub const _NTO_PF_TERM_WAITING: u32 = 8388608;
+pub const _NTO_PF_ASLR: u32 = 16777216;
+pub const _NTO_PF_EXECED: u32 = 33554432;
+pub const _NTO_PF_APP_STOPPED: u32 = 67108864;
+pub const _NTO_PF_64BIT: u32 = 134217728;
+pub const _NTO_PF_NET: u32 = 268435456;
+pub const _NTO_PF_NOLAZYSTACK: u32 = 536870912;
+pub const _NTO_PF_NOEXEC_STACK: u32 = 1073741824;
+pub const _NTO_PF_LOADER_PERMS: u32 = 2147483648;
+
+pub const _NTO_TF_INTR_PENDING: u32 = 65536;
+pub const _NTO_TF_DETACHED: u32 = 131072;
+pub const _NTO_TF_SHR_MUTEX: u32 = 262144;
+pub const _NTO_TF_SHR_MUTEX_EUID: u32 = 524288;
+pub const _NTO_TF_THREADS_HOLD: u32 = 1048576;
+pub const _NTO_TF_UNBLOCK_REQ: u32 = 4194304;
+pub const _NTO_TF_ALIGN_FAULT: u32 = 16777216;
+pub const _NTO_TF_SSTEP: u32 = 33554432;
+pub const _NTO_TF_ALLOCED_STACK: u32 = 67108864;
+pub const _NTO_TF_NOMULTISIG: u32 = 134217728;
+pub const _NTO_TF_LOW_LATENCY: u32 = 268435456;
+pub const _NTO_TF_IOPRIV: u32 = 2147483648;
+
+pub const _NTO_TCTL_IO_PRIV: u32 = 1;
+pub const _NTO_TCTL_THREADS_HOLD: u32 = 2;
+pub const _NTO_TCTL_THREADS_CONT: u32 = 3;
+pub const _NTO_TCTL_RUNMASK: u32 = 4;
+pub const _NTO_TCTL_ALIGN_FAULT: u32 = 5;
+pub const _NTO_TCTL_RUNMASK_GET_AND_SET: u32 = 6;
+pub const _NTO_TCTL_PERFCOUNT: u32 = 7;
+pub const _NTO_TCTL_ONE_THREAD_HOLD: u32 = 8;
+pub const _NTO_TCTL_ONE_THREAD_CONT: u32 = 9;
+pub const _NTO_TCTL_RUNMASK_GET_AND_SET_INHERIT: u32 = 10;
+pub const _NTO_TCTL_NAME: u32 = 11;
+pub const _NTO_TCTL_RCM_GET_AND_SET: u32 = 12;
+pub const _NTO_TCTL_SHR_MUTEX: u32 = 13;
+pub const _NTO_TCTL_IO: u32 = 14;
+pub const _NTO_TCTL_NET_KIF_GET_AND_SET: u32 = 15;
+pub const _NTO_TCTL_LOW_LATENCY: u32 = 16;
+pub const _NTO_TCTL_ADD_EXIT_EVENT: u32 = 17;
+pub const _NTO_TCTL_DEL_EXIT_EVENT: u32 = 18;
+pub const _NTO_TCTL_IO_LEVEL: u32 = 19;
+pub const _NTO_TCTL_RESERVED: u32 = 2147483648;
+pub const _NTO_TCTL_IO_LEVEL_INHERIT: u32 = 1073741824;
+pub const _NTO_IO_LEVEL_NONE: u32 = 1;
+pub const _NTO_IO_LEVEL_1: u32 = 2;
+pub const _NTO_IO_LEVEL_2: u32 = 3;
+
+pub const _NTO_THREAD_NAME_MAX: u32 = 100;
+
+pub const _NTO_CHF_FIXED_PRIORITY: u32 = 1;
+pub const _NTO_CHF_UNBLOCK: u32 = 2;
+pub const _NTO_CHF_THREAD_DEATH: u32 = 4;
+pub const _NTO_CHF_DISCONNECT: u32 = 8;
+pub const _NTO_CHF_NET_MSG: u32 = 16;
+pub const _NTO_CHF_SENDER_LEN: u32 = 32;
+pub const _NTO_CHF_COID_DISCONNECT: u32 = 64;
+pub const _NTO_CHF_REPLY_LEN: u32 = 128;
+pub const _NTO_CHF_PULSE_POOL: u32 = 256;
+pub const _NTO_CHF_ASYNC_NONBLOCK: u32 = 512;
+pub const _NTO_CHF_ASYNC: u32 = 1024;
+pub const _NTO_CHF_GLOBAL: u32 = 2048;
+pub const _NTO_CHF_PRIVATE: u32 = 4096;
+pub const _NTO_CHF_MSG_PAUSING: u32 = 8192;
+pub const _NTO_CHF_INHERIT_RUNMASK: u32 = 16384;
+pub const _NTO_CHF_UNBLOCK_TIMER: u32 = 32768;
+
+pub const _NTO_CHO_CUSTOM_EVENT: u32 = 1;
+
+pub const _NTO_COF_CLOEXEC: u32 = 1;
+pub const _NTO_COF_DEAD: u32 = 2;
+pub const _NTO_COF_NOSHARE: u32 = 64;
+pub const _NTO_COF_NETCON: u32 = 128;
+pub const _NTO_COF_NONBLOCK: u32 = 256;
+pub const _NTO_COF_ASYNC: u32 = 512;
+pub const _NTO_COF_GLOBAL: u32 = 1024;
+pub const _NTO_COF_NOEVENT: u32 = 2048;
+pub const _NTO_COF_INSECURE: u32 = 4096;
+pub const _NTO_COF_REG_EVENTS: u32 = 8192;
+pub const _NTO_COF_UNREG_EVENTS: u32 = 16384;
+pub const _NTO_COF_MASK: u32 = 65535;
+
+pub const _NTO_SIDE_CHANNEL: u32 = 1073741824;
+
+pub const _NTO_CONNECTION_SCOID: u32 = 65536;
+pub const _NTO_GLOBAL_CHANNEL: u32 = 1073741824;
+
+pub const _NTO_TIMEOUT_MASK: u32 = (1 << STATE_MAX) - 1;
+pub const _NTO_TIMEOUT_ACTIVE: u32 = 1 << STATE_MAX;
+pub const _NTO_TIMEOUT_IMMEDIATE: u32 = 1 << (STATE_MAX + 1);
+
+pub const _NTO_IC_LATENCY: u32 = 0;
+
+pub const _NTO_INTR_FLAGS_END: u32 = 1;
+pub const _NTO_INTR_FLAGS_NO_UNMASK: u32 = 2;
+pub const _NTO_INTR_FLAGS_PROCESS: u32 = 4;
+pub const _NTO_INTR_FLAGS_TRK_MSK: u32 = 8;
+pub const _NTO_INTR_FLAGS_ARRAY: u32 = 16;
+pub const _NTO_INTR_FLAGS_EXCLUSIVE: u32 = 32;
+pub const _NTO_INTR_FLAGS_FPU: u32 = 64;
+
+pub const _NTO_INTR_CLASS_EXTERNAL: u32 = 0;
+pub const _NTO_INTR_CLASS_SYNTHETIC: u32 = 2147418112;
+
+pub const _NTO_INTR_SPARE: u32 = 2147483647;
+
+pub const _NTO_HOOK_IDLE: u32 = 2147418113;
+pub const _NTO_HOOK_OVERDRIVE: u32 = 2147418114;
+pub const _NTO_HOOK_LAST: u32 = 2147418114;
+pub const _NTO_HOOK_IDLE2_FLAG: u32 = 32768;
+
+pub const _NTO_IH_CMD_SLEEP_SETUP: u32 = 1;
+pub const _NTO_IH_CMD_SLEEP_BLOCK: u32 = 2;
+pub const _NTO_IH_CMD_SLEEP_WAKEUP: u32 = 4;
+pub const _NTO_IH_CMD_SLEEP_ONLINE: u32 = 8;
+pub const _NTO_IH_RESP_NEEDS_BLOCK: u32 = 1;
+pub const _NTO_IH_RESP_NEEDS_WAKEUP: u32 = 2;
+pub const _NTO_IH_RESP_NEEDS_ONLINE: u32 = 4;
+pub const _NTO_IH_RESP_SYNC_TIME: u32 = 16;
+pub const _NTO_IH_RESP_SYNC_TLB: u32 = 32;
+pub const _NTO_IH_RESP_SUGGEST_OFFLINE: u32 = 256;
+pub const _NTO_IH_RESP_SLEEP_MODE_REACHED: u32 = 512;
+pub const _NTO_IH_RESP_DELIVER_INTRS: u32 = 1024;
+
+pub const _NTO_READIOV_SEND: u32 = 0;
+pub const _NTO_READIOV_REPLY: u32 = 1;
+
+pub const _NTO_KEYDATA_VTID: u32 = 2147483648;
+
+pub const _NTO_KEYDATA_PATHSIGN: u32 = 32768;
+pub const _NTO_KEYDATA_OP_MASK: u32 = 255;
+pub const _NTO_KEYDATA_VERIFY: u32 = 0;
+pub const _NTO_KEYDATA_CALCULATE: u32 = 1;
+pub const _NTO_KEYDATA_CALCULATE_REUSE: u32 = 2;
+pub const _NTO_KEYDATA_PATHSIGN_VERIFY: u32 = 32768;
+pub const _NTO_KEYDATA_PATHSIGN_CALCULATE: u32 = 32769;
+pub const _NTO_KEYDATA_PATHSIGN_CALCULATE_REUSE: u32 = 32770;
+
+pub const _NTO_SCTL_SETPRIOCEILING: u32 = 1;
+pub const _NTO_SCTL_GETPRIOCEILING: u32 = 2;
+pub const _NTO_SCTL_SETEVENT: u32 = 3;
+pub const _NTO_SCTL_MUTEX_WAKEUP: u32 = 4;
+pub const _NTO_SCTL_MUTEX_CONSISTENT: u32 = 5;
+pub const _NTO_SCTL_SEM_VALUE: u32 = 6;
+
+pub const _NTO_CLIENTINFO_GETGROUPS: u32 = 1;
+pub const _NTO_CLIENTINFO_GETTYPEID: u32 = 2;
+
+extern "C" {
+    pub fn ChannelCreate(__flags: ::c_uint) -> ::c_int;
+    pub fn ChannelCreate_r(__flags: ::c_uint) -> ::c_int;
+    pub fn ChannelCreatePulsePool(
+        __flags: ::c_uint,
+        __config: *const nto_channel_config,
+    ) -> ::c_int;
+    pub fn ChannelCreateExt(
+        __flags: ::c_uint,
+        __mode: ::mode_t,
+        __bufsize: usize,
+        __maxnumbuf: ::c_uint,
+        __ev: *const ::sigevent,
+        __cred: *mut _cred_info,
+    ) -> ::c_int;
+    pub fn ChannelDestroy(__chid: ::c_int) -> ::c_int;
+    pub fn ChannelDestroy_r(__chid: ::c_int) -> ::c_int;
+    pub fn ConnectAttach(
+        __nd: u32,
+        __pid: ::pid_t,
+        __chid: ::c_int,
+        __index: ::c_uint,
+        __flags: ::c_int,
+    ) -> ::c_int;
+    pub fn ConnectAttach_r(
+        __nd: u32,
+        __pid: ::pid_t,
+        __chid: ::c_int,
+        __index: ::c_uint,
+        __flags: ::c_int,
+    ) -> ::c_int;
+
+    // TODO: The following function uses a structure defined in a header file
+    //       which doesn't appear as part of the default headers found in a
+    //       standard installation of Neutrino 7.1 SDP.  Commented out for now.
+    //pub fn ConnectAttachExt(
+    //    __nd: u32,
+    //    __pid: ::pid_t,
+    //    __chid: ::c_int,
+    //    __index: ::c_uint,
+    //    __flags: ::c_int,
+    //    __cd: *mut _asyncmsg_connection_descriptor,
+    //) -> ::c_int;
+    pub fn ConnectDetach(__coid: ::c_int) -> ::c_int;
+    pub fn ConnectDetach_r(__coid: ::c_int) -> ::c_int;
+    pub fn ConnectServerInfo(__pid: ::pid_t, __coid: ::c_int, __info: *mut _msg_info64) -> ::c_int;
+    pub fn ConnectServerInfo_r(
+        __pid: ::pid_t,
+        __coid: ::c_int,
+        __info: *mut _msg_info64,
+    ) -> ::c_int;
+    pub fn ConnectClientInfoExtraArgs(
+        __scoid: ::c_int,
+        __info_pp: *mut _client_info,
+        __ngroups: ::c_int,
+        __abilities: *mut _client_able,
+        __nable: ::c_int,
+        __type_id: *mut ::c_uint,
+    ) -> ::c_int;
+    pub fn ConnectClientInfoExtraArgs_r(
+        __scoid: ::c_int,
+        __info_pp: *mut _client_info,
+        __ngroups: ::c_int,
+        __abilities: *mut _client_able,
+        __nable: ::c_int,
+        __type_id: *mut ::c_uint,
+    ) -> ::c_int;
+    pub fn ConnectClientInfo(
+        __scoid: ::c_int,
+        __info: *mut _client_info,
+        __ngroups: ::c_int,
+    ) -> ::c_int;
+    pub fn ConnectClientInfo_r(
+        __scoid: ::c_int,
+        __info: *mut _client_info,
+        __ngroups: ::c_int,
+    ) -> ::c_int;
+    pub fn ConnectClientInfoExt(
+        __scoid: ::c_int,
+        __info_pp: *mut *mut _client_info,
+        flags: ::c_int,
+    ) -> ::c_int;
+    pub fn ClientInfoExtFree(__info_pp: *mut *mut _client_info) -> ::c_int;
+    pub fn ConnectClientInfoAble(
+        __scoid: ::c_int,
+        __info_pp: *mut *mut _client_info,
+        flags: ::c_int,
+        abilities: *mut _client_able,
+        nable: ::c_int,
+    ) -> ::c_int;
+    pub fn ConnectFlags(
+        __pid: ::pid_t,
+        __coid: ::c_int,
+        __mask: ::c_uint,
+        __bits: ::c_uint,
+    ) -> ::c_int;
+    pub fn ConnectFlags_r(
+        __pid: ::pid_t,
+        __coid: ::c_int,
+        __mask: ::c_uint,
+        __bits: ::c_uint,
+    ) -> ::c_int;
+    pub fn ChannelConnectAttr(
+        __id: ::c_uint,
+        __old_attr: *mut _channel_connect_attr,
+        __new_attr: *mut _channel_connect_attr,
+        __flags: ::c_uint,
+    ) -> ::c_int;
+    pub fn MsgSend(
+        __coid: ::c_int,
+        __smsg: *const ::c_void,
+        __sbytes: usize,
+        __rmsg: *mut ::c_void,
+        __rbytes: usize,
+    ) -> ::c_long;
+    pub fn MsgSend_r(
+        __coid: ::c_int,
+        __smsg: *const ::c_void,
+        __sbytes: usize,
+        __rmsg: *mut ::c_void,
+        __rbytes: usize,
+    ) -> ::c_long;
+    pub fn MsgSendnc(
+        __coid: ::c_int,
+        __smsg: *const ::c_void,
+        __sbytes: usize,
+        __rmsg: *mut ::c_void,
+        __rbytes: usize,
+    ) -> ::c_long;
+    pub fn MsgSendnc_r(
+        __coid: ::c_int,
+        __smsg: *const ::c_void,
+        __sbytes: usize,
+        __rmsg: *mut ::c_void,
+        __rbytes: usize,
+    ) -> ::c_long;
+    pub fn MsgSendsv(
+        __coid: ::c_int,
+        __smsg: *const ::c_void,
+        __sbytes: usize,
+        __riov: *const ::iovec,
+        __rparts: usize,
+    ) -> ::c_long;
+    pub fn MsgSendsv_r(
+        __coid: ::c_int,
+        __smsg: *const ::c_void,
+        __sbytes: usize,
+        __riov: *const ::iovec,
+        __rparts: usize,
+    ) -> ::c_long;
+    pub fn MsgSendsvnc(
+        __coid: ::c_int,
+        __smsg: *const ::c_void,
+        __sbytes: usize,
+        __riov: *const ::iovec,
+        __rparts: usize,
+    ) -> ::c_long;
+    pub fn MsgSendsvnc_r(
+        __coid: ::c_int,
+        __smsg: *const ::c_void,
+        __sbytes: usize,
+        __riov: *const ::iovec,
+        __rparts: usize,
+    ) -> ::c_long;
+    pub fn MsgSendvs(
+        __coid: ::c_int,
+        __siov: *const ::iovec,
+        __sparts: usize,
+        __rmsg: *mut ::c_void,
+        __rbytes: usize,
+    ) -> ::c_long;
+    pub fn MsgSendvs_r(
+        __coid: ::c_int,
+        __siov: *const ::iovec,
+        __sparts: usize,
+        __rmsg: *mut ::c_void,
+        __rbytes: usize,
+    ) -> ::c_long;
+    pub fn MsgSendvsnc(
+        __coid: ::c_int,
+        __siov: *const ::iovec,
+        __sparts: usize,
+        __rmsg: *mut ::c_void,
+        __rbytes: usize,
+    ) -> ::c_long;
+    pub fn MsgSendvsnc_r(
+        __coid: ::c_int,
+        __siov: *const ::iovec,
+        __sparts: usize,
+        __rmsg: *mut ::c_void,
+        __rbytes: usize,
+    ) -> ::c_long;
+    pub fn MsgSendv(
+        __coid: ::c_int,
+        __siov: *const ::iovec,
+        __sparts: usize,
+        __riov: *const ::iovec,
+        __rparts: usize,
+    ) -> ::c_long;
+    pub fn MsgSendv_r(
+        __coid: ::c_int,
+        __siov: *const ::iovec,
+        __sparts: usize,
+        __riov: *const ::iovec,
+        __rparts: usize,
+    ) -> ::c_long;
+    pub fn MsgSendvnc(
+        __coid: ::c_int,
+        __siov: *const ::iovec,
+        __sparts: usize,
+        __riov: *const ::iovec,
+        __rparts: usize,
+    ) -> ::c_long;
+    pub fn MsgSendvnc_r(
+        __coid: ::c_int,
+        __siov: *const ::iovec,
+        __sparts: usize,
+        __riov: *const ::iovec,
+        __rparts: usize,
+    ) -> ::c_long;
+    pub fn MsgReceive(
+        __chid: ::c_int,
+        __msg: *mut ::c_void,
+        __bytes: usize,
+        __info: *mut _msg_info64,
+    ) -> ::c_int;
+    pub fn MsgReceive_r(
+        __chid: ::c_int,
+        __msg: *mut ::c_void,
+        __bytes: usize,
+        __info: *mut _msg_info64,
+    ) -> ::c_int;
+    pub fn MsgReceivev(
+        __chid: ::c_int,
+        __iov: *const ::iovec,
+        __parts: usize,
+        __info: *mut _msg_info64,
+    ) -> ::c_int;
+    pub fn MsgReceivev_r(
+        __chid: ::c_int,
+        __iov: *const ::iovec,
+        __parts: usize,
+        __info: *mut _msg_info64,
+    ) -> ::c_int;
+    pub fn MsgReceivePulse(
+        __chid: ::c_int,
+        __pulse: *mut ::c_void,
+        __bytes: usize,
+        __info: *mut _msg_info64,
+    ) -> ::c_int;
+    pub fn MsgReceivePulse_r(
+        __chid: ::c_int,
+        __pulse: *mut ::c_void,
+        __bytes: usize,
+        __info: *mut _msg_info64,
+    ) -> ::c_int;
+    pub fn MsgReceivePulsev(
+        __chid: ::c_int,
+        __iov: *const ::iovec,
+        __parts: usize,
+        __info: *mut _msg_info64,
+    ) -> ::c_int;
+    pub fn MsgReceivePulsev_r(
+        __chid: ::c_int,
+        __iov: *const ::iovec,
+        __parts: usize,
+        __info: *mut _msg_info64,
+    ) -> ::c_int;
+    pub fn MsgReply(
+        __rcvid: ::c_int,
+        __status: ::c_long,
+        __msg: *const ::c_void,
+        __bytes: usize,
+    ) -> ::c_int;
+    pub fn MsgReply_r(
+        __rcvid: ::c_int,
+        __status: ::c_long,
+        __msg: *const ::c_void,
+        __bytes: usize,
+    ) -> ::c_int;
+    pub fn MsgReplyv(
+        __rcvid: ::c_int,
+        __status: ::c_long,
+        __iov: *const ::iovec,
+        __parts: usize,
+    ) -> ::c_int;
+    pub fn MsgReplyv_r(
+        __rcvid: ::c_int,
+        __status: ::c_long,
+        __iov: *const ::iovec,
+        __parts: usize,
+    ) -> ::c_int;
+    pub fn MsgReadiov(
+        __rcvid: ::c_int,
+        __iov: *const ::iovec,
+        __parts: usize,
+        __offset: usize,
+        __flags: ::c_int,
+    ) -> isize;
+    pub fn MsgReadiov_r(
+        __rcvid: ::c_int,
+        __iov: *const ::iovec,
+        __parts: usize,
+        __offset: usize,
+        __flags: ::c_int,
+    ) -> isize;
+    pub fn MsgRead(
+        __rcvid: ::c_int,
+        __msg: *mut ::c_void,
+        __bytes: usize,
+        __offset: usize,
+    ) -> isize;
+    pub fn MsgRead_r(
+        __rcvid: ::c_int,
+        __msg: *mut ::c_void,
+        __bytes: usize,
+        __offset: usize,
+    ) -> isize;
+    pub fn MsgReadv(
+        __rcvid: ::c_int,
+        __iov: *const ::iovec,
+        __parts: usize,
+        __offset: usize,
+    ) -> isize;
+    pub fn MsgReadv_r(
+        __rcvid: ::c_int,
+        __iov: *const ::iovec,
+        __parts: usize,
+        __offset: usize,
+    ) -> isize;
+    pub fn MsgWrite(
+        __rcvid: ::c_int,
+        __msg: *const ::c_void,
+        __bytes: usize,
+        __offset: usize,
+    ) -> isize;
+    pub fn MsgWrite_r(
+        __rcvid: ::c_int,
+        __msg: *const ::c_void,
+        __bytes: usize,
+        __offset: usize,
+    ) -> isize;
+    pub fn MsgWritev(
+        __rcvid: ::c_int,
+        __iov: *const ::iovec,
+        __parts: usize,
+        __offset: usize,
+    ) -> isize;
+    pub fn MsgWritev_r(
+        __rcvid: ::c_int,
+        __iov: *const ::iovec,
+        __parts: usize,
+        __offset: usize,
+    ) -> isize;
+    pub fn MsgSendPulse(
+        __coid: ::c_int,
+        __priority: ::c_int,
+        __code: ::c_int,
+        __value: ::c_int,
+    ) -> ::c_int;
+    pub fn MsgSendPulse_r(
+        __coid: ::c_int,
+        __priority: ::c_int,
+        __code: ::c_int,
+        __value: ::c_int,
+    ) -> ::c_int;
+    pub fn MsgSendPulsePtr(
+        __coid: ::c_int,
+        __priority: ::c_int,
+        __code: ::c_int,
+        __value: *mut ::c_void,
+    ) -> ::c_int;
+    pub fn MsgSendPulsePtr_r(
+        __coid: ::c_int,
+        __priority: ::c_int,
+        __code: ::c_int,
+        __value: *mut ::c_void,
+    ) -> ::c_int;
+    pub fn MsgDeliverEvent(__rcvid: ::c_int, __event: *const ::sigevent) -> ::c_int;
+    pub fn MsgDeliverEvent_r(__rcvid: ::c_int, __event: *const ::sigevent) -> ::c_int;
+    pub fn MsgVerifyEvent(__rcvid: ::c_int, __event: *const ::sigevent) -> ::c_int;
+    pub fn MsgVerifyEvent_r(__rcvid: ::c_int, __event: *const ::sigevent) -> ::c_int;
+    pub fn MsgRegisterEvent(__event: *mut ::sigevent, __coid: ::c_int) -> ::c_int;
+    pub fn MsgRegisterEvent_r(__event: *mut ::sigevent, __coid: ::c_int) -> ::c_int;
+    pub fn MsgUnregisterEvent(__event: *const ::sigevent) -> ::c_int;
+    pub fn MsgUnregisterEvent_r(__event: *const ::sigevent) -> ::c_int;
+    pub fn MsgInfo(__rcvid: ::c_int, __info: *mut _msg_info64) -> ::c_int;
+    pub fn MsgInfo_r(__rcvid: ::c_int, __info: *mut _msg_info64) -> ::c_int;
+    pub fn MsgKeyData(
+        __rcvid: ::c_int,
+        __oper: ::c_int,
+        __key: u32,
+        __newkey: *mut u32,
+        __iov: *const ::iovec,
+        __parts: ::c_int,
+    ) -> ::c_int;
+    pub fn MsgKeyData_r(
+        __rcvid: ::c_int,
+        __oper: ::c_int,
+        __key: u32,
+        __newkey: *mut u32,
+        __iov: *const ::iovec,
+        __parts: ::c_int,
+    ) -> ::c_int;
+    pub fn MsgError(__rcvid: ::c_int, __err: ::c_int) -> ::c_int;
+    pub fn MsgError_r(__rcvid: ::c_int, __err: ::c_int) -> ::c_int;
+    pub fn MsgCurrent(__rcvid: ::c_int) -> ::c_int;
+    pub fn MsgCurrent_r(__rcvid: ::c_int) -> ::c_int;
+    pub fn MsgSendAsyncGbl(
+        __coid: ::c_int,
+        __smsg: *const ::c_void,
+        __sbytes: usize,
+        __msg_prio: ::c_uint,
+    ) -> ::c_int;
+    pub fn MsgSendAsync(__coid: ::c_int) -> ::c_int;
+    pub fn MsgReceiveAsyncGbl(
+        __chid: ::c_int,
+        __rmsg: *mut ::c_void,
+        __rbytes: usize,
+        __info: *mut _msg_info64,
+        __coid: ::c_int,
+    ) -> ::c_int;
+    pub fn MsgReceiveAsync(__chid: ::c_int, __iov: *const ::iovec, __parts: ::c_uint) -> ::c_int;
+    pub fn MsgPause(__rcvid: ::c_int, __cookie: ::c_uint) -> ::c_int;
+    pub fn MsgPause_r(__rcvid: ::c_int, __cookie: ::c_uint) -> ::c_int;
+
+    pub fn SignalKill(
+        __nd: u32,
+        __pid: ::pid_t,
+        __tid: ::c_int,
+        __signo: ::c_int,
+        __code: ::c_int,
+        __value: ::c_int,
+    ) -> ::c_int;
+    pub fn SignalKill_r(
+        __nd: u32,
+        __pid: ::pid_t,
+        __tid: ::c_int,
+        __signo: ::c_int,
+        __code: ::c_int,
+        __value: ::c_int,
+    ) -> ::c_int;
+    pub fn SignalKillSigval(
+        __nd: u32,
+        __pid: ::pid_t,
+        __tid: ::c_int,
+        __signo: ::c_int,
+        __code: ::c_int,
+        __value: *const ::sigval,
+    ) -> ::c_int;
+    pub fn SignalKillSigval_r(
+        __nd: u32,
+        __pid: ::pid_t,
+        __tid: ::c_int,
+        __signo: ::c_int,
+        __code: ::c_int,
+        __value: *const ::sigval,
+    ) -> ::c_int;
+    pub fn SignalReturn(__info: *mut _sighandler_info) -> ::c_int;
+    pub fn SignalFault(__sigcode: ::c_uint, __regs: *mut ::c_void, __refaddr: usize) -> ::c_int;
+    pub fn SignalAction(
+        __pid: ::pid_t,
+        __sigstub: unsafe extern "C" fn(),
+        __signo: ::c_int,
+        __act: *const ::sigaction,
+        __oact: *mut ::sigaction,
+    ) -> ::c_int;
+    pub fn SignalAction_r(
+        __pid: ::pid_t,
+        __sigstub: unsafe extern "C" fn(),
+        __signo: ::c_int,
+        __act: *const ::sigaction,
+        __oact: *mut ::sigaction,
+    ) -> ::c_int;
+    pub fn SignalProcmask(
+        __pid: ::pid_t,
+        __tid: ::c_int,
+        __how: ::c_int,
+        __set: *const ::sigset_t,
+        __oldset: *mut ::sigset_t,
+    ) -> ::c_int;
+    pub fn SignalProcmask_r(
+        __pid: ::pid_t,
+        __tid: ::c_int,
+        __how: ::c_int,
+        __set: *const ::sigset_t,
+        __oldset: *mut ::sigset_t,
+    ) -> ::c_int;
+    pub fn SignalSuspend(__set: *const ::sigset_t) -> ::c_int;
+    pub fn SignalSuspend_r(__set: *const ::sigset_t) -> ::c_int;
+    pub fn SignalWaitinfo(__set: *const ::sigset_t, __info: *mut ::siginfo_t) -> ::c_int;
+    pub fn SignalWaitinfo_r(__set: *const ::sigset_t, __info: *mut ::siginfo_t) -> ::c_int;
+    pub fn SignalWaitinfoMask(
+        __set: *const ::sigset_t,
+        __info: *mut ::siginfo_t,
+        __mask: *const ::sigset_t,
+    ) -> ::c_int;
+    pub fn SignalWaitinfoMask_r(
+        __set: *const ::sigset_t,
+        __info: *mut ::siginfo_t,
+        __mask: *const ::sigset_t,
+    ) -> ::c_int;
+    pub fn ThreadCreate(
+        __pid: ::pid_t,
+        __func: unsafe extern "C" fn(__arg: *mut ::c_void) -> *mut ::c_void,
+        __arg: *mut ::c_void,
+        __attr: *const ::_thread_attr,
+    ) -> ::c_int;
+    pub fn ThreadCreate_r(
+        __pid: ::pid_t,
+        __func: unsafe extern "C" fn(__arg: *mut ::c_void) -> *mut ::c_void,
+        __arg: *mut ::c_void,
+        __attr: *const ::_thread_attr,
+    ) -> ::c_int;
+
+    pub fn ThreadDestroy(__tid: ::c_int, __priority: ::c_int, __status: *mut ::c_void) -> ::c_int;
+    pub fn ThreadDestroy_r(__tid: ::c_int, __priority: ::c_int, __status: *mut ::c_void)
+        -> ::c_int;
+    pub fn ThreadDetach(__tid: ::c_int) -> ::c_int;
+    pub fn ThreadDetach_r(__tid: ::c_int) -> ::c_int;
+    pub fn ThreadJoin(__tid: ::c_int, __status: *mut *mut ::c_void) -> ::c_int;
+    pub fn ThreadJoin_r(__tid: ::c_int, __status: *mut *mut ::c_void) -> ::c_int;
+    pub fn ThreadCancel(__tid: ::c_int, __canstub: unsafe extern "C" fn()) -> ::c_int;
+    pub fn ThreadCancel_r(__tid: ::c_int, __canstub: unsafe extern "C" fn()) -> ::c_int;
+    pub fn ThreadCtl(__cmd: ::c_int, __data: *mut ::c_void) -> ::c_int;
+    pub fn ThreadCtl_r(__cmd: ::c_int, __data: *mut ::c_void) -> ::c_int;
+    pub fn ThreadCtlExt(
+        __pid: ::pid_t,
+        __tid: ::c_int,
+        __cmd: ::c_int,
+        __data: *mut ::c_void,
+    ) -> ::c_int;
+    pub fn ThreadCtlExt_r(
+        __pid: ::pid_t,
+        __tid: ::c_int,
+        __cmd: ::c_int,
+        __data: *mut ::c_void,
+    ) -> ::c_int;
+
+    pub fn InterruptHookTrace(
+        __handler: ::Option<unsafe extern "C" fn(arg1: ::c_int) -> *const ::sigevent>,
+        __flags: ::c_uint,
+    ) -> ::c_int;
+    pub fn InterruptHookIdle(
+        __handler: ::Option<unsafe extern "C" fn(arg1: *mut u64, arg2: *mut qtime_entry)>,
+        __flags: ::c_uint,
+    ) -> ::c_int;
+    pub fn InterruptHookIdle2(
+        __handler: ::Option<
+            unsafe extern "C" fn(arg1: ::c_uint, arg2: *mut syspage_entry, arg3: *mut _idle_hook),
+        >,
+        __flags: ::c_uint,
+    ) -> ::c_int;
+    pub fn InterruptHookOverdriveEvent(__event: *const ::sigevent, __flags: ::c_uint) -> ::c_int;
+    pub fn InterruptAttachEvent(
+        __intr: ::c_int,
+        __event: *const ::sigevent,
+        __flags: ::c_uint,
+    ) -> ::c_int;
+    pub fn InterruptAttachEvent_r(
+        __intr: ::c_int,
+        __event: *const ::sigevent,
+        __flags: ::c_uint,
+    ) -> ::c_int;
+    pub fn InterruptAttach(
+        __intr: ::c_int,
+        __handler: ::Option<
+            unsafe extern "C" fn(__area: *mut ::c_void, __id: ::c_int) -> *const ::sigevent,
+        >,
+        __area: *const ::c_void,
+        __size: ::c_int,
+        __flags: ::c_uint,
+    ) -> ::c_int;
+    pub fn InterruptAttach_r(
+        __intr: ::c_int,
+        __handler: ::Option<
+            unsafe extern "C" fn(__area: *mut ::c_void, __id: ::c_int) -> *const ::sigevent,
+        >,
+        __area: *const ::c_void,
+        __size: ::c_int,
+        __flags: ::c_uint,
+    ) -> ::c_int;
+    pub fn InterruptAttachArray(
+        __intr: ::c_int,
+        __handler: ::Option<
+            unsafe extern "C" fn(__area: *mut ::c_void, __id: ::c_int) -> *const *const ::sigevent,
+        >,
+        __area: *const ::c_void,
+        __size: ::c_int,
+        __flags: ::c_uint,
+    ) -> ::c_int;
+    pub fn InterruptAttachArray_r(
+        __intr: ::c_int,
+        __handler: ::Option<
+            unsafe extern "C" fn(__area: *mut ::c_void, __id: ::c_int) -> *const *const ::sigevent,
+        >,
+        __area: *const ::c_void,
+        __size: ::c_int,
+        __flags: ::c_uint,
+    ) -> ::c_int;
+    pub fn InterruptDetach(__id: ::c_int) -> ::c_int;
+    pub fn InterruptDetach_r(__id: ::c_int) -> ::c_int;
+    pub fn InterruptWait(__flags: ::c_int, __timeout: *const u64) -> ::c_int;
+    pub fn InterruptWait_r(__flags: ::c_int, __timeout: *const u64) -> ::c_int;
+    pub fn InterruptCharacteristic(
+        __type: ::c_int,
+        __id: ::c_int,
+        __new: *mut ::c_uint,
+        __old: *mut ::c_uint,
+    ) -> ::c_int;
+    pub fn InterruptCharacteristic_r(
+        __type: ::c_int,
+        __id: ::c_int,
+        __new: *mut ::c_uint,
+        __old: *mut ::c_uint,
+    ) -> ::c_int;
+
+    pub fn SchedGet(__pid: ::pid_t, __tid: ::c_int, __param: *mut ::sched_param) -> ::c_int;
+    pub fn SchedGet_r(__pid: ::pid_t, __tid: ::c_int, __param: *mut ::sched_param) -> ::c_int;
+    pub fn SchedGetCpuNum() -> ::c_uint;
+    pub fn SchedSet(
+        __pid: ::pid_t,
+        __tid: ::c_int,
+        __algorithm: ::c_int,
+        __param: *const ::sched_param,
+    ) -> ::c_int;
+    pub fn SchedSet_r(
+        __pid: ::pid_t,
+        __tid: ::c_int,
+        __algorithm: ::c_int,
+        __param: *const ::sched_param,
+    ) -> ::c_int;
+    pub fn SchedInfo(__pid: ::pid_t, __algorithm: ::c_int, __info: *mut ::_sched_info) -> ::c_int;
+    pub fn SchedInfo_r(__pid: ::pid_t, __algorithm: ::c_int, __info: *mut ::_sched_info)
+        -> ::c_int;
+    pub fn SchedYield() -> ::c_int;
+    pub fn SchedYield_r() -> ::c_int;
+    pub fn SchedCtl(__cmd: ::c_int, __data: *mut ::c_void, __length: usize) -> ::c_int;
+    pub fn SchedCtl_r(__cmd: ::c_int, __data: *mut ::c_void, __length: usize) -> ::c_int;
+    pub fn SchedJobCreate(__job: *mut nto_job_t) -> ::c_int;
+    pub fn SchedJobCreate_r(__job: *mut nto_job_t) -> ::c_int;
+    pub fn SchedJobDestroy(__job: *mut nto_job_t) -> ::c_int;
+    pub fn SchedJobDestroy_r(__job: *mut nto_job_t) -> ::c_int;
+    pub fn SchedWaypoint(
+        __job: *mut nto_job_t,
+        __new: *const i64,
+        __max: *const i64,
+        __old: *mut i64,
+    ) -> ::c_int;
+    pub fn SchedWaypoint_r(
+        __job: *mut nto_job_t,
+        __new: *const i64,
+        __max: *const i64,
+        __old: *mut i64,
+    ) -> ::c_int;
+
+    pub fn TimerCreate(__id: ::clockid_t, __notify: *const ::sigevent) -> ::c_int;
+    pub fn TimerCreate_r(__id: ::clockid_t, __notify: *const ::sigevent) -> ::c_int;
+    pub fn TimerDestroy(__id: ::timer_t) -> ::c_int;
+    pub fn TimerDestroy_r(__id: ::timer_t) -> ::c_int;
+    pub fn TimerSettime(
+        __id: ::timer_t,
+        __flags: ::c_int,
+        __itime: *const ::_itimer,
+        __oitime: *mut ::_itimer,
+    ) -> ::c_int;
+    pub fn TimerSettime_r(
+        __id: ::timer_t,
+        __flags: ::c_int,
+        __itime: *const ::_itimer,
+        __oitime: *mut ::_itimer,
+    ) -> ::c_int;
+    pub fn TimerInfo(
+        __pid: ::pid_t,
+        __id: ::timer_t,
+        __flags: ::c_int,
+        __info: *mut ::_timer_info,
+    ) -> ::c_int;
+    pub fn TimerInfo_r(
+        __pid: ::pid_t,
+        __id: ::timer_t,
+        __flags: ::c_int,
+        __info: *mut ::_timer_info,
+    ) -> ::c_int;
+    pub fn TimerAlarm(
+        __id: ::clockid_t,
+        __itime: *const ::_itimer,
+        __otime: *mut ::_itimer,
+    ) -> ::c_int;
+    pub fn TimerAlarm_r(
+        __id: ::clockid_t,
+        __itime: *const ::_itimer,
+        __otime: *mut ::_itimer,
+    ) -> ::c_int;
+    pub fn TimerTimeout(
+        __id: ::clockid_t,
+        __flags: ::c_int,
+        __notify: *const ::sigevent,
+        __ntime: *const u64,
+        __otime: *mut u64,
+    ) -> ::c_int;
+    pub fn TimerTimeout_r(
+        __id: ::clockid_t,
+        __flags: ::c_int,
+        __notify: *const ::sigevent,
+        __ntime: *const u64,
+        __otime: *mut u64,
+    ) -> ::c_int;
+
+    pub fn SyncTypeCreate(
+        __type: ::c_uint,
+        __sync: *mut ::sync_t,
+        __attr: *const ::_sync_attr,
+    ) -> ::c_int;
+    pub fn SyncTypeCreate_r(
+        __type: ::c_uint,
+        __sync: *mut ::sync_t,
+        __attr: *const ::_sync_attr,
+    ) -> ::c_int;
+    pub fn SyncDestroy(__sync: *mut ::sync_t) -> ::c_int;
+    pub fn SyncDestroy_r(__sync: *mut ::sync_t) -> ::c_int;
+    pub fn SyncCtl(__cmd: ::c_int, __sync: *mut ::sync_t, __data: *mut ::c_void) -> ::c_int;
+    pub fn SyncCtl_r(__cmd: ::c_int, __sync: *mut ::sync_t, __data: *mut ::c_void) -> ::c_int;
+    pub fn SyncMutexEvent(__sync: *mut ::sync_t, event: *const ::sigevent) -> ::c_int;
+    pub fn SyncMutexEvent_r(__sync: *mut ::sync_t, event: *const ::sigevent) -> ::c_int;
+    pub fn SyncMutexLock(__sync: *mut ::sync_t) -> ::c_int;
+    pub fn SyncMutexLock_r(__sync: *mut ::sync_t) -> ::c_int;
+    pub fn SyncMutexUnlock(__sync: *mut ::sync_t) -> ::c_int;
+    pub fn SyncMutexUnlock_r(__sync: *mut ::sync_t) -> ::c_int;
+    pub fn SyncMutexRevive(__sync: *mut ::sync_t) -> ::c_int;
+    pub fn SyncMutexRevive_r(__sync: *mut ::sync_t) -> ::c_int;
+    pub fn SyncCondvarWait(__sync: *mut ::sync_t, __mutex: *mut ::sync_t) -> ::c_int;
+    pub fn SyncCondvarWait_r(__sync: *mut ::sync_t, __mutex: *mut ::sync_t) -> ::c_int;
+    pub fn SyncCondvarSignal(__sync: *mut ::sync_t, __all: ::c_int) -> ::c_int;
+    pub fn SyncCondvarSignal_r(__sync: *mut ::sync_t, __all: ::c_int) -> ::c_int;
+    pub fn SyncSemPost(__sync: *mut ::sync_t) -> ::c_int;
+    pub fn SyncSemPost_r(__sync: *mut ::sync_t) -> ::c_int;
+    pub fn SyncSemWait(__sync: *mut ::sync_t, __tryto: ::c_int) -> ::c_int;
+    pub fn SyncSemWait_r(__sync: *mut ::sync_t, __tryto: ::c_int) -> ::c_int;
+
+    pub fn ClockTime(__id: ::clockid_t, _new: *const u64, __old: *mut u64) -> ::c_int;
+    pub fn ClockTime_r(__id: ::clockid_t, _new: *const u64, __old: *mut u64) -> ::c_int;
+    pub fn ClockAdjust(
+        __id: ::clockid_t,
+        _new: *const ::_clockadjust,
+        __old: *mut ::_clockadjust,
+    ) -> ::c_int;
+    pub fn ClockAdjust_r(
+        __id: ::clockid_t,
+        _new: *const ::_clockadjust,
+        __old: *mut ::_clockadjust,
+    ) -> ::c_int;
+    pub fn ClockPeriod(
+        __id: ::clockid_t,
+        _new: *const ::_clockperiod,
+        __old: *mut ::_clockperiod,
+        __reserved: ::c_int,
+    ) -> ::c_int;
+    pub fn ClockPeriod_r(
+        __id: ::clockid_t,
+        _new: *const ::_clockperiod,
+        __old: *mut ::_clockperiod,
+        __reserved: ::c_int,
+    ) -> ::c_int;
+    pub fn ClockId(__pid: ::pid_t, __tid: ::c_int) -> ::c_int;
+    pub fn ClockId_r(__pid: ::pid_t, __tid: ::c_int) -> ::c_int;
+
+    //
+    //TODO: The following commented out functions are implemented in assembly.
+    //      We can implmement them either via a C stub or rust's inline assembly.
+    //
+    //pub fn InterruptEnable();
+    //pub fn InterruptDisable();
+    pub fn InterruptMask(__intr: ::c_int, __id: ::c_int) -> ::c_int;
+    pub fn InterruptUnmask(__intr: ::c_int, __id: ::c_int) -> ::c_int;
+    //pub fn InterruptLock(__spin: *mut ::intrspin);
+    //pub fn InterruptUnlock(__spin: *mut ::intrspin);
+    //pub fn InterruptStatus() -> ::c_uint;
+}

--- a/src/unix/nto/x86_64.rs
+++ b/src/unix/nto/x86_64.rs
@@ -1,0 +1,132 @@
+pub type c_char = i8;
+pub type wchar_t = u32;
+pub type c_long = i64;
+pub type c_ulong = u64;
+pub type time_t = i64;
+
+s! {
+    #[repr(align(8))]
+    pub struct x86_64_cpu_registers {
+        pub rdi: u64,
+        pub rsi: u64,
+        pub rdx: u64,
+        pub r10: u64,
+        pub r8: u64,
+        pub r9: u64,
+        pub rax: u64,
+        pub rbx: u64,
+        pub rbp: u64,
+        pub rcx: u64,
+        pub r11: u64,
+        pub r12: u64,
+        pub r13: u64,
+        pub r14: u64,
+        pub r15: u64,
+        pub rip: u64,
+        pub cs: u32,
+        rsvd1: u32,
+        pub rflags: u64,
+        pub rsp: u64,
+        pub ss: u32,
+        rsvd2: u32,
+    }
+
+    #[repr(align(8))]
+    pub struct mcontext_t {
+        pub cpu: x86_64_cpu_registers,
+        #[cfg(libc_union)]
+        pub fpu: x86_64_fpu_registers,
+        #[cfg(not(libc_union))]
+        __reserved: [u8; 1024],
+    }
+
+    pub struct stack_t {
+        pub ss_sp: *mut ::c_void,
+        pub ss_size: ::size_t,
+        pub ss_flags: ::c_int,
+    }
+
+    pub struct fsave_area_64 {
+        pub fpu_control_word: u32,
+        pub fpu_status_word: u32,
+        pub fpu_tag_word: u32,
+        pub fpu_ip: u32,
+        pub fpu_cs: u32,
+        pub fpu_op: u32,
+        pub fpu_ds: u32,
+        pub st_regs: [u8; 80],
+   }
+
+    pub struct fxsave_area_64 {
+        pub fpu_control_word: u16,
+        pub fpu_status_word: u16,
+        pub fpu_tag_word: u16,
+        pub fpu_operand: u16,
+        pub fpu_rip: u64,
+        pub fpu_rdp: u64,
+        pub mxcsr: u32,
+        pub mxcsr_mask: u32,
+        pub st_regs: [u8; 128],
+        pub xmm_regs: [u8; 128],
+        reserved2: [u8; 224],
+    }
+
+    pub struct fpu_extention_savearea_64 {
+        pub other: [u8; 512],
+        pub xstate_bv: u64,
+        pub xstate_undef: [u64; 7],
+        pub xstate_info: [u8; 224],
+    }
+}
+
+s_no_extra_traits! {
+    #[cfg(libc_union)]
+    pub union x86_64_fpu_registers {
+        pub fsave_area: fsave_area_64,
+        pub fxsave_area: fxsave_area_64,
+        pub xsave_area: fpu_extention_savearea_64,
+        pub data: [u8; 1024],
+    }
+}
+
+cfg_if! {
+    if #[cfg(feature = "extra_traits")] {
+        #[cfg(libc_union)]
+        impl Eq for x86_64_fpu_registers {}
+
+        #[cfg(libc_union)]
+        impl PartialEq for x86_64_fpu_registers {
+            fn eq(&self, other: &x86_64_fpu_registers) -> bool {
+                unsafe {
+                    self.fsave_area == other.fsave_area
+                        || self.fxsave_area == other.fxsave_area
+                        || self.xsave_area == other.xsave_area
+                }
+            }
+        }
+
+        #[cfg(libc_union)]
+        impl ::fmt::Debug for x86_64_fpu_registers {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                unsafe {
+                    f.debug_struct("x86_64_fpu_registers")
+                        .field("fsave_area", &self.fsave_area)
+                        .field("fxsave_area", &self.fxsave_area)
+                        .field("xsave_area", &self.xsave_area)
+                        .finish()
+                }
+            }
+        }
+
+        #[cfg(libc_union)]
+        impl ::hash::Hash for x86_64_fpu_registers {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                unsafe {
+                    self.fsave_area.hash(state);
+                    self.fxsave_area.hash(state);
+                    self.xsave_area.hash(state);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Test cases (ctest2, all succeed):
QNX/Neutrino 7.1 x86_64:  9884
QNX/Neutrino 7.1 aarch64: 9766

Co-authored-by: Tristan Roach <troach@qnx.com>
Co-authored-by: Florian Bartels <Florian.Bartels@elektrobit.com>
