### PR TITLE
Add struct ctl_info

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -83,6 +83,11 @@ fn main() {
         println!("cargo:rustc-cfg=libc_non_exhaustive");
     }
 
+    // Rust >= 1.47 supports long array:
+    if rustc_minor_ver >= 47 || rustc_dep_of_std {
+        println!("cargo:rustc-cfg=libc_long_array");
+    }
+
     if rustc_minor_ver >= 51 || rustc_dep_of_std {
         println!("cargo:rustc-cfg=libc_ptr_addr_of");
     }

--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -266,6 +266,7 @@ CTLFLAG_RD
 CTLFLAG_RW
 CTLFLAG_SECURE
 CTLFLAG_WR
+CTLIOCGINFO
 CTLTYPE
 CTLTYPE_INT
 CTLTYPE_NODE
@@ -1844,6 +1845,7 @@ copyfile
 copyfile_flags_t
 cpu_subtype_t
 cpu_type_t
+ctl_info
 difftime
 dirfd
 disconnectx

--- a/src/unix/bsd/apple/long_array.rs
+++ b/src/unix/bsd/apple/long_array.rs
@@ -1,0 +1,8 @@
+s! {
+    pub struct ctl_info {
+        pub ctl_id: u32,
+        pub ctl_name: [::c_char; MAX_KCTL_NAME],
+    }
+}
+
+pub const MAX_KCTL_NAME: usize = 96;

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -3313,6 +3313,8 @@ pub const MINCORE_MODIFIED: ::c_int = 0x4;
 pub const MINCORE_REFERENCED_OTHER: ::c_int = 0x8;
 pub const MINCORE_MODIFIED_OTHER: ::c_int = 0x10;
 
+pub const CTLIOCGINFO: c_ulong = 0xc0644e03;
+
 //
 // sys/netinet/in.h
 // Protocols (RFC 1700)
@@ -5929,5 +5931,12 @@ cfg_if! {
         pub use self::b64::*;
     } else {
         // Unknown target_arch
+    }
+}
+
+cfg_if! {
+    if #[cfg(libc_long_array)] {
+        mod long_array;
+        pub use self::long_array::*;
     }
 }


### PR DESCRIPTION
Add the struct mentioned in #3045 

Not sure if I should add `CTLIOCGINFO ` because it is wrapped in a macro:

```c
#define CTLIOCGINFO     _IOWR('N', 3, struct ctl_info)  /* get id from name */
```

The C definition of `ctl_info` is:
```c
/*!
 *       @defined MAX_KCTL_NAME
 *   @discussion Kernel control names must be no longer than
 *       MAX_KCTL_NAME.
 */
#define MAX_KCTL_NAME   96

/*
 * Controls destined to the Controller Manager.
 */

/*!
 *       @struct ctl_info
 *       @discussion This structure is used with the CTLIOCGINFO ioctl to
 *               translate from a kernel control name to a control id.
 *       @field ctl_id The kernel control id, filled out upon return.
 *       @field ctl_name The kernel control name to find.
 */
struct ctl_info {
	u_int32_t   ctl_id;                             /* Kernel Controller ID  */
	char        ctl_name[MAX_KCTL_NAME];            /* Kernel Controller Name (a C string) */
};
```