### PR TITLE
Set correct `FD_SETSIZE` for `espidf`

### DIFF
--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -271,7 +271,7 @@ pub const PTHREAD_MUTEX_RECURSIVE: ::c_int = 1;
 pub const PTHREAD_MUTEX_ERRORCHECK: ::c_int = 2;
 
 cfg_if! {
-    if #[cfg(target_os = "horizon")] {
+    if #[cfg(any(target_os = "horizon", target_os = "espidf"))] {
         pub const FD_SETSIZE: usize = 64;
     } else {
         pub const FD_SETSIZE: usize = 1024;


### PR DESCRIPTION
Source: https://github.com/espressif/newlib-esp32/blob/esp_based_on_4_1_0/newlib/libc/include/sys/select.h#L31
@ivmarkov @igrr @MabezDev Please correct me if I'm wrong