### PR TITLE
uclibc/mips: add O_NOATIME & O_PATH constant

### DIFF
--- a/src/unix/linux_like/linux/uclibc/mips/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mod.rs
@@ -38,6 +38,8 @@ pub const O_ACCMODE: ::c_int = 3;
 pub const O_DIRECT: ::c_int = 0x8000;
 pub const O_DIRECTORY: ::c_int = 0x10000;
 pub const O_NOFOLLOW: ::c_int = 0x20000;
+pub const O_NOATIME: ::c_int = 0x40000;
+pub const O_PATH: ::c_int = 0o010000000;
 
 pub const O_APPEND: ::c_int = 8;
 pub const O_CREAT: ::c_int = 256;


### PR DESCRIPTION
Signed-off-by: Xiaobo Liu <cppcoffee@gmail.com>

This adds the O_NOATIME & O_PATH constant on Linux and uclibc.
It is defined as part of the uclibc in fcntl.h:

https://cgit.uclibc-ng.org/cgi/cgit/uclibc-ng.git/tree/libc/sysdeps/linux/mips/bits/fcntl.h?id=9efce41dd3bb5d721a5b771931126f32a85e1958#n56

https://cgit.uclibc-ng.org/cgi/cgit/uclibc-ng.git/tree/libc/sysdeps/linux/mips/bits/fcntl.h?id=9efce41dd3bb5d721a5b771931126f32a85e1958#n57