### PR TITLE
ANDROID: Add syncfs API in liblibc

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1806,6 +1806,9 @@ fn test_android(target: &str) {
             // Added in API level 28, but some tests use level 24.
             "getrandom" => true,
 
+            // Added in API level 28, but some tests use level 24.
+            "syncfs" => true,
+
             _ => false,
         }
     });

--- a/libc-test/semver/android.txt
+++ b/libc-test/semver/android.txt
@@ -3517,6 +3517,7 @@ swapoff
 swapon
 symlink
 symlinkat
+syncfs
 syscall
 sysconf
 sysinfo

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -3506,6 +3506,8 @@ extern "C" {
         longopts: *const option,
         longindex: *mut ::c_int,
     ) -> ::c_int;
+
+    pub fn syncfs(fd: ::c_int) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
This is required to sync everything in a single filesystem. Other solutions like sync() flushes all filesystems which is unnecessary, it is also impractical to call fsync on all files of the filesystem.