### PR TITLE
android: add missing syscall constants

### DIFF
--- a/libc-test/semver/android.txt
+++ b/libc-test/semver/android.txt
@@ -2303,7 +2303,11 @@ SYS_finit_module
 SYS_flistxattr
 SYS_flock
 SYS_fremovexattr
+SYS_fsconfig
 SYS_fsetxattr
+SYS_fsmount
+SYS_fsopen
+SYS_fspick
 SYS_fsync
 SYS_futex
 SYS_get_mempolicy
@@ -2341,6 +2345,9 @@ SYS_io_destroy
 SYS_io_getevents
 SYS_io_setup
 SYS_io_submit
+SYS_io_uring_enter
+SYS_io_uring_register
+SYS_io_uring_setup
 SYS_ioctl
 SYS_ioprio_get
 SYS_ioprio_set
@@ -2367,6 +2374,7 @@ SYS_mlock
 SYS_mlock2
 SYS_mlockall
 SYS_mount
+SYS_move_mount
 SYS_move_pages
 SYS_mprotect
 SYS_mq_getsetattr
@@ -2384,9 +2392,11 @@ SYS_name_to_handle_at
 SYS_nanosleep
 SYS_nfsservctl
 SYS_open_by_handle_at
+SYS_open_tree
 SYS_openat
 SYS_perf_event_open
 SYS_personality
+SYS_pidfd_send_signal
 SYS_pipe2
 SYS_pivot_root
 SYS_pkey_alloc
@@ -2473,6 +2483,7 @@ SYS_signalfd4
 SYS_socket
 SYS_socketpair
 SYS_splice
+SYS_statx
 SYS_swapoff
 SYS_swapon
 SYS_symlinkat

--- a/src/unix/linux_like/android/b32/arm.rs
+++ b/src/unix/linux_like/android/b32/arm.rs
@@ -501,9 +501,17 @@ pub const SYS_pwritev2: ::c_long = 393;
 pub const SYS_pkey_mprotect: ::c_long = 394;
 pub const SYS_pkey_alloc: ::c_long = 395;
 pub const SYS_pkey_free: ::c_long = 396;
+pub const SYS_statx: ::c_long = 397;
+pub const SYS_pidfd_send_signal: ::c_long = 424;
 pub const SYS_io_uring_setup: ::c_long = 425;
 pub const SYS_io_uring_enter: ::c_long = 426;
 pub const SYS_io_uring_register: ::c_long = 427;
+pub const SYS_open_tree: ::c_long = 428;
+pub const SYS_move_mount: ::c_long = 429;
+pub const SYS_fsopen: ::c_long = 430;
+pub const SYS_fsconfig: ::c_long = 431;
+pub const SYS_fsmount: ::c_long = 432;
+pub const SYS_fspick: ::c_long = 433;
 
 // offsets in mcontext_t.gregs from sys/ucontext.h
 pub const REG_R0: ::c_int = 0;

--- a/src/unix/linux_like/android/b32/x86/mod.rs
+++ b/src/unix/linux_like/android/b32/x86/mod.rs
@@ -533,9 +533,17 @@ pub const SYS_pwritev2: ::c_long = 379;
 pub const SYS_pkey_mprotect: ::c_long = 380;
 pub const SYS_pkey_alloc: ::c_long = 381;
 pub const SYS_pkey_free: ::c_long = 382;
+pub const SYS_statx: ::c_long = 383;
+pub const SYS_pidfd_send_signal: ::c_long = 424;
 pub const SYS_io_uring_setup: ::c_long = 425;
 pub const SYS_io_uring_enter: ::c_long = 426;
 pub const SYS_io_uring_register: ::c_long = 427;
+pub const SYS_open_tree: ::c_long = 428;
+pub const SYS_move_mount: ::c_long = 429;
+pub const SYS_fsopen: ::c_long = 430;
+pub const SYS_fsconfig: ::c_long = 431;
+pub const SYS_fsmount: ::c_long = 432;
+pub const SYS_fspick: ::c_long = 433;
 
 // offsets in user_regs_structs, from sys/reg.h
 pub const EBX: ::c_int = 0;

--- a/src/unix/linux_like/android/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/android/b64/aarch64/mod.rs
@@ -374,9 +374,17 @@ pub const SYS_pwritev2: ::c_long = 287;
 pub const SYS_pkey_mprotect: ::c_long = 288;
 pub const SYS_pkey_alloc: ::c_long = 289;
 pub const SYS_pkey_free: ::c_long = 290;
+pub const SYS_statx: ::c_long = 291;
+pub const SYS_pidfd_send_signal: ::c_long = 424;
 pub const SYS_io_uring_setup: ::c_long = 425;
 pub const SYS_io_uring_enter: ::c_long = 426;
 pub const SYS_io_uring_register: ::c_long = 427;
+pub const SYS_open_tree: ::c_long = 428;
+pub const SYS_move_mount: ::c_long = 429;
+pub const SYS_fsopen: ::c_long = 430;
+pub const SYS_fsconfig: ::c_long = 431;
+pub const SYS_fsmount: ::c_long = 432;
+pub const SYS_fspick: ::c_long = 433;
 pub const SYS_syscalls: ::c_long = 436;
 
 cfg_if! {

--- a/src/unix/linux_like/android/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/android/b64/riscv64/mod.rs
@@ -332,6 +332,17 @@ pub const SYS_pwritev2: ::c_long = 287;
 pub const SYS_pkey_mprotect: ::c_long = 288;
 pub const SYS_pkey_alloc: ::c_long = 289;
 pub const SYS_pkey_free: ::c_long = 290;
+pub const SYS_statx: ::c_long = 291;
+pub const SYS_pidfd_send_signal: ::c_long = 424;
+pub const SYS_io_uring_setup: ::c_long = 425;
+pub const SYS_io_uring_enter: ::c_long = 426;
+pub const SYS_io_uring_register: ::c_long = 427;
+pub const SYS_open_tree: ::c_long = 428;
+pub const SYS_move_mount: ::c_long = 429;
+pub const SYS_fsopen: ::c_long = 430;
+pub const SYS_fsconfig: ::c_long = 431;
+pub const SYS_fsmount: ::c_long = 432;
+pub const SYS_fspick: ::c_long = 433;
 pub const SYS_syscalls: ::c_long = 436;
 
 cfg_if! {

--- a/src/unix/linux_like/android/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/android/b64/x86_64/mod.rs
@@ -728,9 +728,17 @@ pub const SYS_pwritev2: ::c_long = 328;
 pub const SYS_pkey_mprotect: ::c_long = 329;
 pub const SYS_pkey_alloc: ::c_long = 330;
 pub const SYS_pkey_free: ::c_long = 331;
+pub const SYS_statx: ::c_long = 332;
+pub const SYS_pidfd_send_signal: ::c_long = 424;
 pub const SYS_io_uring_setup: ::c_long = 425;
 pub const SYS_io_uring_enter: ::c_long = 426;
 pub const SYS_io_uring_register: ::c_long = 427;
+pub const SYS_open_tree: ::c_long = 428;
+pub const SYS_move_mount: ::c_long = 429;
+pub const SYS_fsopen: ::c_long = 430;
+pub const SYS_fsconfig: ::c_long = 431;
+pub const SYS_fsmount: ::c_long = 432;
+pub const SYS_fspick: ::c_long = 433;
 
 // offsets in user_regs_structs, from sys/reg.h
 pub const R15: ::c_int = 0;


### PR DESCRIPTION
This adds all syscall constants that are available in NDK `r21d` but were so far missing in this library.
See `semver/android.txt` changes for the complete list.

Refs:
 * https://android.googlesource.com/platform/bionic/+/refs/tags/ndk-r21d/libc/kernel/uapi/asm-generic/unistd.h
 * https://android.googlesource.com/platform/bionic/+/refs/tags/ndk-r21d/libc/include/bits/glibc-syscalls.h