### PR TITLE
add `user_regs` for linux on arm

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3811,7 +3811,9 @@ fn test_linux(target: &str) {
         // https://github.com/torvalds/linux/commit/dc8eeef73b63ed8988224ba6b5ed19a615163a7f
         (struct_ == "sockaddr_vm" && field == "svm_zero") ||
         // the `ifr_ifru` field is an anonymous union
-        (struct_ == "ifreq" && field == "ifr_ifru")
+        (struct_ == "ifreq" && field == "ifr_ifru") ||
+        // glibc uses a single array `uregs` instead of individual fields.
+        (struct_ == "user_regs" && arm)
     });
 
     cfg.skip_roundtrip(move |s| match s {

--- a/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
@@ -191,6 +191,27 @@ s! {
         pub arm_cpsr: ::c_ulong,
         pub fault_address: ::c_ulong,
     }
+
+    pub struct user_regs {
+        pub arm_r0: ::c_ulong,
+        pub arm_r1: ::c_ulong,
+        pub arm_r2: ::c_ulong,
+        pub arm_r3: ::c_ulong,
+        pub arm_r4: ::c_ulong,
+        pub arm_r5: ::c_ulong,
+        pub arm_r6: ::c_ulong,
+        pub arm_r7: ::c_ulong,
+        pub arm_r8: ::c_ulong,
+        pub arm_r9: ::c_ulong,
+        pub arm_r10: ::c_ulong,
+        pub arm_fp: ::c_ulong,
+        pub arm_ip: ::c_ulong,
+        pub arm_sp: ::c_ulong,
+        pub arm_lr: ::c_ulong,
+        pub arm_pc: ::c_ulong,
+        pub arm_cpsr: ::c_ulong,
+        pub arm_orig_r0: ::c_ulong,
+    }
 }
 
 pub const VEOF: usize = 4;


### PR DESCRIPTION
This struct is used for `PTRACE_GETREGS` & `PTRACE_SETREGS`. We mirror the name used in `glibc`. This struct is called `pt_regs` in the kernel. Instead of a `uregs` array, we use separate named fields.

> - \[ ] Edit corresponding file(s) under `libc-test/semver` when you add/remove item(s)

AFAICT there's no file for linux on arm (not aarch64). Am I missing something here?