### PR TITLE
m68k: Fix incorrect type for sigaction::sa_flags

### DIFF
--- a/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
@@ -5,7 +5,7 @@ s! {
     pub struct sigaction {
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: ::sigset_t,
-        pub sa_flags: ::c_ulong,
+        pub sa_flags: ::c_int,
         pub sa_restorer: ::Option<extern fn()>,
     }
 


### PR DESCRIPTION
This fixes a trivial bug where the wrong type was assumed for sigaction::sa_flags.