### PR TITLE
xous: add initial C definitions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,12 @@ cfg_if! {
 
         mod wasi;
         pub use wasi::*;
+    } else if #[cfg(target_os = "xous")] {
+        mod fixed_width_ints;
+        pub use fixed_width_ints::*;
+
+        mod xous;
+        pub use xous::*;
     } else {
         // non-supported targets: empty...
     }

--- a/src/xous.rs
+++ b/src/xous.rs
@@ -1,0 +1,49 @@
+//! Xous C type definitions
+
+pub type c_schar = i8;
+pub type c_uchar = u8;
+pub type c_short = i16;
+pub type c_ushort = u16;
+pub type c_int = i32;
+pub type c_uint = u32;
+pub type c_float = f32;
+pub type c_double = f64;
+pub type c_longlong = i64;
+pub type c_ulonglong = u64;
+pub type intmax_t = i64;
+pub type uintmax_t = u64;
+
+pub type size_t = usize;
+pub type ptrdiff_t = isize;
+pub type intptr_t = isize;
+pub type uintptr_t = usize;
+pub type ssize_t = isize;
+
+pub type off_t = i64;
+pub type c_char = u8;
+pub type c_long = i64;
+pub type c_ulong = u64;
+pub type wchar_t = u32;
+
+pub const INT_MIN: c_int = -2147483648;
+pub const INT_MAX: c_int = 2147483647;
+
+cfg_if! {
+    if #[cfg(libc_core_cvoid)] {
+        pub use ::ffi::c_void;
+    } else {
+        // Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help
+        // enable more optimization opportunities around it recognizing things
+        // like malloc/free.
+        #[repr(u8)]
+        #[allow(missing_copy_implementations)]
+        #[allow(missing_debug_implementations)]
+        pub enum c_void {
+            // Two dummy variants so the #[repr] attribute can be used.
+            #[doc(hidden)]
+            __variant1,
+            #[doc(hidden)]
+            __variant2,
+        }
+    }
+}


### PR DESCRIPTION
This adds initial C definitions to Xous. There is no C library, so this mostly serves to add C-compatible exports to the `libc` crate.