### PR TITLE
uclibc/mips: add missing O_LARGEFILE constant

### DIFF
--- a/src/unix/linux_like/linux/uclibc/mips/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mod.rs
@@ -51,6 +51,7 @@ pub const O_RSYNC: ::c_int = 0x10;
 pub const O_DSYNC: ::c_int = 0x10;
 pub const O_FSYNC: ::c_int = 0x10;
 pub const O_ASYNC: ::c_int = 0x1000;
+pub const O_LARGEFILE: ::c_int = 0x2000;
 pub const O_NDELAY: ::c_int = 0x80;
 
 pub const SOCK_NONBLOCK: ::c_int = 128;


### PR DESCRIPTION
Signed-off-by: Xiaobo Liu <cppcoffee@gmail.com>

This add the O_LARGEFILE constant on Linux and uclibc.
It is defined as part of the uclibc in fcntl.h:

https://cgit.uclibc-ng.org/cgi/cgit/uclibc-ng.git/tree/libc/sysdeps/linux/mips/bits/fcntl.h#n73