### PR TITLE
Solaris/Illumos: use correct types for getrandom(2) flags

### DIFF
--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1280,8 +1280,8 @@ pub const FILENAME_MAX: ::c_uint = 1024;
 pub const L_tmpnam: ::c_uint = 25;
 pub const TMP_MAX: ::c_uint = 17576;
 
-pub const GRND_NONBLOCK: ::c_int = 0x0001;
-pub const GRND_RANDOM: ::c_int = 0x0002;
+pub const GRND_NONBLOCK: ::c_uint = 0x0001;
+pub const GRND_RANDOM: ::c_uint = 0x0002;
 
 pub const O_RDONLY: ::c_int = 0;
 pub const O_WRONLY: ::c_int = 1;


### PR DESCRIPTION
On Solaris (and any other platform that supports it), the `getrandom(2)` syscall has signature:

```rust
fn getrandom(buf: *mut c_void, buflen: size_t, flags: c_uint) -> ssize_t;
```
so the flag constants (`GRND_NONBLOCK`, `GRND_RANDOM`, etc...) should be of type `c_uint`.

I'm not sure if this sort of "bug fix" counts as a breaking change, there weren't any Solaris/Illumos files under `libc-test/semver`.

Signed-off-by: Joe Richey <joerichey@google.com>
