### PR TITLE
Add wasi-emulated-mman cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ extra_traits = []
 const-extern-fn = []
 # use_std is deprecated, use `std` instead
 use_std = [ 'std' ]
+wasi-emulated-mman = []
 
 [workspace]
 members = ["libc-test"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ extra_traits = []
 const-extern-fn = []
 # use_std is deprecated, use `std` instead
 use_std = [ 'std' ]
-wasi-emulated-mman = []
 
 [workspace]
 members = ["libc-test"]

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -434,174 +434,106 @@ pub const NOEXPR: ::nl_item = 0x50001;
 pub const YESSTR: ::nl_item = 0x50002;
 pub const NOSTR: ::nl_item = 0x50003;
 
-cfg_if! {
-    if #[cfg(feature = "wasi-emulated-mman")] {
-        // wasi-libc @ 5d8a140, musl 1.2.3: libc-top-half/musl/include/sys/mman.h
+pub const MAP_FAILED: *mut ::c_void = !0 as *mut ::c_void;
 
-        pub const MAP_FAILED: *mut ::c_void = !0 as *mut ::c_void;
+pub const MAP_SHARED: ::c_int = 0x01;
+pub const MAP_PRIVATE: ::c_int = 0x02;
+pub const MAP_SHARED_VALIDATE: ::c_int = 0x03;
+pub const MAP_TYPE: ::c_int = 0x0f;
+pub const MAP_FIXED: ::c_int = 0x10;
+pub const MAP_ANON: ::c_int = 0x20;
+pub const MAP_ANONYMOUS: ::c_int = MAP_ANON;
+pub const MAP_NORESERVE: ::c_int = 0x4000;
+pub const MAP_GROWSDOWN: ::c_int = 0x0100;
+pub const MAP_DENYWRITE: ::c_int = 0x0800;
+pub const MAP_EXECUTABLE: ::c_int = 0x1000;
+pub const MAP_LOCKED: ::c_int = 0x2000;
+pub const MAP_POPULATE: ::c_int = 0x8000;
+pub const MAP_NONBLOCK: ::c_int = 0x10000;
+pub const MAP_STACK: ::c_int = 0x20000;
+pub const MAP_HUGETLB: ::c_int = 0x40000;
+pub const MAP_SYNC: ::c_int = 0x80000;
+pub const MAP_FIXED_NOREPLACE: ::c_int = 0x100000;
+pub const MAP_FILE: ::c_int = 0;
 
-        pub const MAP_SHARED: ::c_int = 0x01;
-        pub const MAP_PRIVATE: ::c_int = 0x02;
-        pub const MAP_SHARED_VALIDATE: ::c_int = 0x03;
-        pub const MAP_TYPE: ::c_int = 0x0f;
-        pub const MAP_FIXED: ::c_int = 0x10;
-        pub const MAP_ANON: ::c_int = 0x20;
-        pub const MAP_ANONYMOUS: ::c_int = MAP_ANON;
-        pub const MAP_NORESERVE: ::c_int = 0x4000;
-        pub const MAP_GROWSDOWN: ::c_int = 0x0100;
-        pub const MAP_DENYWRITE: ::c_int = 0x0800;
-        pub const MAP_EXECUTABLE: ::c_int = 0x1000;
-        pub const MAP_LOCKED: ::c_int = 0x2000;
-        pub const MAP_POPULATE: ::c_int = 0x8000;
-        pub const MAP_NONBLOCK: ::c_int = 0x10000;
-        pub const MAP_STACK: ::c_int = 0x20000;
-        pub const MAP_HUGETLB: ::c_int = 0x40000;
-        pub const MAP_SYNC: ::c_int = 0x80000;
-        pub const MAP_FIXED_NOREPLACE: ::c_int = 0x100000;
-        pub const MAP_FILE: ::c_int = 0;
+pub const MAP_HUGE_SHIFT: ::c_int = 26;
+pub const MAP_HUGE_MASK: ::c_int = 0x3f;
+pub const MAP_HUGE_16KB: ::c_int = 14 << MAP_HUGE_SHIFT;
+pub const MAP_HUGE_64KB: ::c_int = 16 << MAP_HUGE_SHIFT;
+pub const MAP_HUGE_512KB: ::c_int = 19 << MAP_HUGE_SHIFT;
+pub const MAP_HUGE_1MB: ::c_int = 20 << MAP_HUGE_SHIFT;
+pub const MAP_HUGE_2MB: ::c_int = 21 << MAP_HUGE_SHIFT;
+pub const MAP_HUGE_8MB: ::c_int = 23 << MAP_HUGE_SHIFT;
+pub const MAP_HUGE_16MB: ::c_int = 24 << MAP_HUGE_SHIFT;
+pub const MAP_HUGE_32MB: ::c_int = 25 << MAP_HUGE_SHIFT;
+pub const MAP_HUGE_256MB: ::c_int = 28 << MAP_HUGE_SHIFT;
+pub const MAP_HUGE_512MB: ::c_int = 29 << MAP_HUGE_SHIFT;
+pub const MAP_HUGE_1GB: ::c_int = 30 << MAP_HUGE_SHIFT;
+pub const MAP_HUGE_2GB: ::c_int = 31 << MAP_HUGE_SHIFT;
+pub const MAP_HUGE_16GB: ::c_int = 34 << MAP_HUGE_SHIFT;
 
-        pub const MAP_HUGE_SHIFT: ::c_int = 26;
-        pub const MAP_HUGE_MASK: ::c_int = 0x3f;
-        pub const MAP_HUGE_16KB: ::c_int = 14 << MAP_HUGE_SHIFT;
-        pub const MAP_HUGE_64KB: ::c_int = 16 << MAP_HUGE_SHIFT;
-        pub const MAP_HUGE_512KB: ::c_int = 19 << MAP_HUGE_SHIFT;
-        pub const MAP_HUGE_1MB: ::c_int = 20 << MAP_HUGE_SHIFT;
-        pub const MAP_HUGE_2MB: ::c_int = 21 << MAP_HUGE_SHIFT;
-        pub const MAP_HUGE_8MB: ::c_int = 23 << MAP_HUGE_SHIFT;
-        pub const MAP_HUGE_16MB: ::c_int = 24 << MAP_HUGE_SHIFT;
-        pub const MAP_HUGE_32MB: ::c_int = 25 << MAP_HUGE_SHIFT;
-        pub const MAP_HUGE_256MB: ::c_int = 28 << MAP_HUGE_SHIFT;
-        pub const MAP_HUGE_512MB: ::c_int = 29 << MAP_HUGE_SHIFT;
-        pub const MAP_HUGE_1GB: ::c_int = 30 << MAP_HUGE_SHIFT;
-        pub const MAP_HUGE_2GB: ::c_int = 31 << MAP_HUGE_SHIFT;
-        pub const MAP_HUGE_16GB: ::c_int = 34 << MAP_HUGE_SHIFT;
+pub const PROT_NONE: ::c_int = 0;
+pub const PROT_READ: ::c_int = 1;
+pub const PROT_WRITE: ::c_int = 2;
+pub const PROT_EXEC: ::c_int = 4;
+pub const PROT_GROWSDOWN: ::c_int = 0x01000000;
+pub const PROT_GROWSUP: ::c_int = 0x02000000;
 
-        pub const PROT_NONE: ::c_int = 0;
-        pub const PROT_READ: ::c_int = 1;
-        pub const PROT_WRITE: ::c_int = 2;
-        pub const PROT_EXEC: ::c_int = 4;
-        pub const PROT_GROWSDOWN: ::c_int = 0x01000000;
-        pub const PROT_GROWSUP: ::c_int = 0x02000000;
+pub const MS_ASYNC: ::c_int = 1;
+pub const MS_INVALIDATE: ::c_int = 2;
+pub const MS_SYNC: ::c_int = 4;
 
-        pub const MS_ASYNC: ::c_int = 1;
-        pub const MS_INVALIDATE: ::c_int = 2;
-        pub const MS_SYNC: ::c_int = 4;
+pub const MCL_CURRENT: ::c_int = 1;
+pub const MCL_FUTURE: ::c_int = 2;
+pub const MCL_ONFAULT: ::c_int = 4;
 
-        pub const MCL_CURRENT: ::c_int = 1;
-        pub const MCL_FUTURE: ::c_int = 2;
-        pub const MCL_ONFAULT: ::c_int = 4;
+pub const POSIX_MADV_NORMAL: ::c_int = 0;
+pub const POSIX_MADV_RANDOM: ::c_int = 1;
+pub const POSIX_MADV_SEQUENTIAL: ::c_int = 2;
+pub const POSIX_MADV_WILLNEED: ::c_int = 3;
+pub const POSIX_MADV_DONTNEED: ::c_int = 4;
 
-        pub const POSIX_MADV_NORMAL: ::c_int = 0;
-        pub const POSIX_MADV_RANDOM: ::c_int = 1;
-        pub const POSIX_MADV_SEQUENTIAL: ::c_int = 2;
-        pub const POSIX_MADV_WILLNEED: ::c_int = 3;
-        pub const POSIX_MADV_DONTNEED: ::c_int = 4;
+// #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+pub const MADV_NORMAL: ::c_int = 0;
+pub const MADV_RANDOM: ::c_int = 1;
+pub const MADV_SEQUENTIAL: ::c_int = 2;
+pub const MADV_WILLNEED: ::c_int = 3;
+pub const MADV_DONTNEED: ::c_int = 4;
+pub const MADV_FREE: ::c_int = 8;
+pub const MADV_REMOVE: ::c_int = 9;
+pub const MADV_DONTFORK: ::c_int = 10;
+pub const MADV_DOFORK: ::c_int = 11;
+pub const MADV_MERGEABLE: ::c_int = 12;
+pub const MADV_UNMERGEABLE: ::c_int = 13;
+pub const MADV_HUGEPAGE: ::c_int = 14;
+pub const MADV_NOHUGEPAGE: ::c_int = 15;
+pub const MADV_DONTDUMP: ::c_int = 16;
+pub const MADV_DODUMP: ::c_int = 17;
+pub const MADV_WIPEONFORK: ::c_int = 18;
+pub const MADV_KEEPONFORK: ::c_int = 19;
+pub const MADV_COLD: ::c_int = 20;
+pub const MADV_PAGEOUT: ::c_int = 21;
+pub const MADV_HWPOISON: ::c_int = 100;
+pub const MADV_SOFT_OFFLINE: ::c_int = 101;
+// #endif
 
-        // #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
-        pub const MADV_NORMAL: ::c_int = 0;
-        pub const MADV_RANDOM: ::c_int = 1;
-        pub const MADV_SEQUENTIAL: ::c_int = 2;
-        pub const MADV_WILLNEED: ::c_int = 3;
-        pub const MADV_DONTNEED: ::c_int = 4;
-        pub const MADV_FREE: ::c_int = 8;
-        pub const MADV_REMOVE: ::c_int = 9;
-        pub const MADV_DONTFORK: ::c_int = 10;
-        pub const MADV_DOFORK: ::c_int = 11;
-        pub const MADV_MERGEABLE: ::c_int = 12;
-        pub const MADV_UNMERGEABLE: ::c_int = 13;
-        pub const MADV_HUGEPAGE: ::c_int = 14;
-        pub const MADV_NOHUGEPAGE: ::c_int = 15;
-        pub const MADV_DONTDUMP: ::c_int = 16;
-        pub const MADV_DODUMP: ::c_int = 17;
-        pub const MADV_WIPEONFORK: ::c_int = 18;
-        pub const MADV_KEEPONFORK: ::c_int = 19;
-        pub const MADV_COLD: ::c_int = 20;
-        pub const MADV_PAGEOUT: ::c_int = 21;
-        pub const MADV_HWPOISON: ::c_int = 100;
-        pub const MADV_SOFT_OFFLINE: ::c_int = 101;
-        // #endif
+// #ifdef _GNU_SOURCE
+pub const MREMAP_MAYMOVE: ::c_int = 1;
+pub const MREMAP_FIXED: ::c_int = 2;
+pub const MREMAP_DONTUNMAP: ::c_int = 4;
 
-        // #ifdef _GNU_SOURCE
-        pub const MREMAP_MAYMOVE: ::c_int = 1;
-        pub const MREMAP_FIXED: ::c_int = 2;
-        pub const MREMAP_DONTUNMAP: ::c_int = 4;
+pub const MLOCK_ONFAULT: ::c_uint = 0x01;
 
-        pub const MLOCK_ONFAULT: ::c_uint = 0x01;
+pub const MFD_CLOEXEC: ::c_uint = 0x0001;
+pub const MFD_ALLOW_SEALING: ::c_uint = 0x0002;
+pub const MFD_HUGETLB: ::c_uint = 0x0004;
+// #endif
 
-        pub const MFD_CLOEXEC: ::c_uint = 0x0001;
-        pub const MFD_ALLOW_SEALING: ::c_uint = 0x0002;
-        pub const MFD_HUGETLB: ::c_uint = 0x0004;
-        // #endif
-
-        // Included for future reference (for mmap64):
-        // #if defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)
-        // #define off64_t off_t
-        // #define mmap64 mmap
-        // #endif
-
-        #[cfg_attr(
-            feature = "rustc-dep-of-std",
-            link(
-                name = "c",
-                kind = "static",
-                modifiers = "-bundle",
-                cfg(target_feature = "crt-static")
-            )
-        )]
-        #[cfg_attr(
-            feature = "rustc-dep-of-std",
-            link(name = "c", cfg(not(target_feature = "crt-static")))
-        )]
-        extern "C" {
-            pub fn mmap(
-                addr: *mut ::c_void,
-                len: ::size_t,
-                prot: ::c_int,
-                flags: ::c_int,
-                fd: ::c_int,
-                offset: off_t,
-            ) -> *mut ::c_void;
-            pub fn munmap(addr: *mut ::c_void, len: ::size_t) -> ::c_int;
-
-            pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
-            pub fn msync(addr: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::c_int;
-
-            pub fn posix_madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
-
-            pub fn mlock(addr: *const ::c_void, len: ::size_t) -> ::c_int;
-            pub fn munlock(addr: *const ::c_void, len: ::size_t) -> ::c_int;
-            pub fn mlockall(flags: ::c_int) -> ::c_int;
-            pub fn munlockall() -> ::c_int;
-
-            // #ifdef _GNU_SOURCE
-            pub fn mremap(
-                addr: *mut ::c_void,
-                len: ::size_t,
-                new_len: ::size_t,
-                flags: ::c_int,
-                ...
-            ) -> *mut ::c_void;
-            pub fn remap_file_pages(
-                addr: *mut ::c_void,
-                size: ::size_t,
-                prot: ::c_int,
-                pgoff: ::size_t,
-                flags: ::c_int,
-            ) -> ::c_int;
-            pub fn memfd_create(name: *const ::c_char, flags: ::c_uint) -> ::c_int;
-            pub fn mlock2(addr: *const ::c_void, len: ::size_t, flags: ::c_uint) -> ::c_int;
-            // #endif
-
-            // #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
-            pub fn madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
-            pub fn mincore(addr: *mut ::c_void, len: ::size_t, vec: *mut ::c_uchar) -> ::c_int;
-            // #endif
-
-            pub fn shm_open(name: *const c_char, oflag: ::c_int, mode: mode_t) -> ::c_int;
-            pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
-        }
-    }
-}
+// Included for future reference (for mmap64):
+// #if defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)
+// #define off64_t off_t
+// #define mmap64 mmap
+// #endif
 
 #[cfg_attr(
     feature = "rustc-dep-of-std",
@@ -991,4 +923,51 @@ extern "C" {
     pub fn arc4random() -> u32;
     pub fn arc4random_buf(a: *mut c_void, b: size_t);
     pub fn arc4random_uniform(a: u32) -> u32;
+
+    pub fn mmap(
+        addr: *mut ::c_void,
+        len: ::size_t,
+        prot: ::c_int,
+        flags: ::c_int,
+        fd: ::c_int,
+        offset: off_t,
+    ) -> *mut ::c_void;
+    pub fn munmap(addr: *mut ::c_void, len: ::size_t) -> ::c_int;
+
+    pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
+    pub fn msync(addr: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::c_int;
+
+    pub fn posix_madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
+
+    pub fn mlock(addr: *const ::c_void, len: ::size_t) -> ::c_int;
+    pub fn munlock(addr: *const ::c_void, len: ::size_t) -> ::c_int;
+    pub fn mlockall(flags: ::c_int) -> ::c_int;
+    pub fn munlockall() -> ::c_int;
+
+    // #ifdef _GNU_SOURCE
+    pub fn mremap(
+        addr: *mut ::c_void,
+        len: ::size_t,
+        new_len: ::size_t,
+        flags: ::c_int,
+        ...
+    ) -> *mut ::c_void;
+    pub fn remap_file_pages(
+        addr: *mut ::c_void,
+        size: ::size_t,
+        prot: ::c_int,
+        pgoff: ::size_t,
+        flags: ::c_int,
+    ) -> ::c_int;
+    pub fn memfd_create(name: *const ::c_char, flags: ::c_uint) -> ::c_int;
+    pub fn mlock2(addr: *const ::c_void, len: ::size_t, flags: ::c_uint) -> ::c_int;
+    // #endif
+
+    // #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+    pub fn madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
+    pub fn mincore(addr: *mut ::c_void, len: ::size_t, vec: *mut ::c_uchar) -> ::c_int;
+    // #endif
+
+    pub fn shm_open(name: *const c_char, oflag: ::c_int, mode: mode_t) -> ::c_int;
+    pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
 }

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -437,7 +437,6 @@ pub const NOSTR: ::nl_item = 0x50003;
 cfg_if! {
     if #[cfg(feature = "wasi-emulated-mman")] {
         // wasi-libc @ 5d8a140, musl 1.2.3: libc-top-half/musl/include/sys/mman.h
-        // TODO we need to check types on everything below
 
         // FIXME MAP_FAILED in C is #define MAP_FAILED ((void *) -1)
         pub const MAP_FAILED: *mut ::c_void = !0 as *mut ::c_void;
@@ -476,7 +475,7 @@ cfg_if! {
         pub const MAP_HUGE_512MB: ::c_int = 29 << MAP_HUGE_SHIFT;
         pub const MAP_HUGE_1GB: ::c_int = 30 << MAP_HUGE_SHIFT;
         pub const MAP_HUGE_2GB: ::c_int = 31 << MAP_HUGE_SHIFT;
-        pub const MAP_HUGE_16GB: ::c_int = 34 << MAP_HUGE_SHIFT; // FIXME type? this was 34U in C
+        pub const MAP_HUGE_16GB: ::c_int = 34 << MAP_HUGE_SHIFT;
 
         pub const PROT_NONE: ::c_int = 0;
         pub const PROT_READ: ::c_int = 1;
@@ -528,7 +527,7 @@ cfg_if! {
         pub const MREMAP_FIXED: ::c_int = 2;
         pub const MREMAP_DONTUNMAP: ::c_int = 4;
 
-        pub const MLOCK_ONFAULT: ::c_uint = 0x01; // FIXME type? shouldn't this be c_int
+        pub const MLOCK_ONFAULT: ::c_uint = 0x01;
 
         pub const MFD_CLOEXEC: ::c_uint = 0x0001;
         pub const MFD_ALLOW_SEALING: ::c_uint = 0x0002;

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -434,6 +434,114 @@ pub const NOEXPR: ::nl_item = 0x50001;
 pub const YESSTR: ::nl_item = 0x50002;
 pub const NOSTR: ::nl_item = 0x50003;
 
+cfg_if! {
+    if #[cfg(feature = "wasi-emulated-mman")] {
+        // wasi-libc @ 5d8a140, musl 1.2.3: libc-top-half/musl/include/sys/mman.h
+        // TODO we need to check types on everything below
+
+        // FIXME MAP_FAILED in C is #define MAP_FAILED ((void *) -1)
+        pub const MAP_FAILED: *mut ::c_void = !0 as *mut ::c_void;
+
+        pub const MAP_SHARED: ::c_int = 0x01;
+        pub const MAP_PRIVATE: ::c_int = 0x02;
+        pub const MAP_SHARED_VALIDATE: ::c_int = 0x03;
+        pub const MAP_TYPE: ::c_int = 0x0f;
+        pub const MAP_FIXED: ::c_int = 0x10;
+        pub const MAP_ANON: ::c_int = 0x20;
+        pub const MAP_ANONYMOUS: ::c_int = MAP_ANON;
+        pub const MAP_NORESERVE: ::c_int = 0x4000;
+        pub const MAP_GROWSDOWN: ::c_int = 0x0100;
+        pub const MAP_DENYWRITE: ::c_int = 0x0800;
+        pub const MAP_EXECUTABLE: ::c_int = 0x1000;
+        pub const MAP_LOCKED: ::c_int = 0x2000;
+        pub const MAP_POPULATE: ::c_int = 0x8000;
+        pub const MAP_NONBLOCK: ::c_int = 0x10000;
+        pub const MAP_STACK: ::c_int = 0x20000;
+        pub const MAP_HUGETLB: ::c_int = 0x40000;
+        pub const MAP_SYNC: ::c_int = 0x80000;
+        pub const MAP_FIXED_NOREPLACE: ::c_int = 0x100000;
+        pub const MAP_FILE: ::c_int = 0;
+
+        pub const MAP_HUGE_SHIFT: ::c_int = 26;
+        pub const MAP_HUGE_MASK: ::c_int = 0x3f;
+        pub const MAP_HUGE_16KB: ::c_int = 14 << MAP_HUGE_SHIFT;
+        pub const MAP_HUGE_64KB: ::c_int = 16 << MAP_HUGE_SHIFT;
+        pub const MAP_HUGE_512KB: ::c_int = 19 << MAP_HUGE_SHIFT;
+        pub const MAP_HUGE_1MB: ::c_int = 20 << MAP_HUGE_SHIFT;
+        pub const MAP_HUGE_2MB: ::c_int = 21 << MAP_HUGE_SHIFT;
+        pub const MAP_HUGE_8MB: ::c_int = 23 << MAP_HUGE_SHIFT;
+        pub const MAP_HUGE_16MB: ::c_int = 24 << MAP_HUGE_SHIFT;
+        pub const MAP_HUGE_32MB: ::c_int = 25 << MAP_HUGE_SHIFT;
+        pub const MAP_HUGE_256MB: ::c_int = 28 << MAP_HUGE_SHIFT;
+        pub const MAP_HUGE_512MB: ::c_int = 29 << MAP_HUGE_SHIFT;
+        pub const MAP_HUGE_1GB: ::c_int = 30 << MAP_HUGE_SHIFT;
+        pub const MAP_HUGE_2GB: ::c_int = 31 << MAP_HUGE_SHIFT;
+        pub const MAP_HUGE_16GB: ::c_int = 34 << MAP_HUGE_SHIFT; // FIXME type? this was 34U in C
+
+        pub const PROT_NONE: ::c_int = 0;
+        pub const PROT_READ: ::c_int = 1;
+        pub const PROT_WRITE: ::c_int = 2;
+        pub const PROT_EXEC: ::c_int = 4;
+        pub const PROT_GROWSDOWN: ::c_int = 0x01000000;
+        pub const PROT_GROWSUP: ::c_int = 0x02000000;
+
+        pub const MS_ASYNC: ::c_int = 1;
+        pub const MS_INVALIDATE: ::c_int = 2;
+        pub const MS_SYNC: ::c_int = 4;
+
+        pub const MCL_CURRENT: ::c_int = 1;
+        pub const MCL_FUTURE: ::c_int = 2;
+        pub const MCL_ONFAULT: ::c_int = 4;
+
+        pub const POSIX_MADV_NORMAL: ::c_int = 0;
+        pub const POSIX_MADV_RANDOM: ::c_int = 1;
+        pub const POSIX_MADV_SEQUENTIAL: ::c_int = 2;
+        pub const POSIX_MADV_WILLNEED: ::c_int = 3;
+        pub const POSIX_MADV_DONTNEED: ::c_int = 4;
+
+        // #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+        pub const MADV_NORMAL: ::c_int = 0;
+        pub const MADV_RANDOM: ::c_int = 1;
+        pub const MADV_SEQUENTIAL: ::c_int = 2;
+        pub const MADV_WILLNEED: ::c_int = 3;
+        pub const MADV_DONTNEED: ::c_int = 4;
+        pub const MADV_FREE: ::c_int = 8;
+        pub const MADV_REMOVE: ::c_int = 9;
+        pub const MADV_DONTFORK: ::c_int = 10;
+        pub const MADV_DOFORK: ::c_int = 11;
+        pub const MADV_MERGEABLE: ::c_int = 12;
+        pub const MADV_UNMERGEABLE: ::c_int = 13;
+        pub const MADV_HUGEPAGE: ::c_int = 14;
+        pub const MADV_NOHUGEPAGE: ::c_int = 15;
+        pub const MADV_DONTDUMP: ::c_int = 16;
+        pub const MADV_DODUMP: ::c_int = 17;
+        pub const MADV_WIPEONFORK: ::c_int = 18;
+        pub const MADV_KEEPONFORK: ::c_int = 19;
+        pub const MADV_COLD: ::c_int = 20;
+        pub const MADV_PAGEOUT: ::c_int = 21;
+        pub const MADV_HWPOISON: ::c_int = 100;
+        pub const MADV_SOFT_OFFLINE: ::c_int = 101;
+        // #endif
+
+        // #ifdef _GNU_SOURCE
+        pub const MREMAP_MAYMOVE: ::c_int = 1;
+        pub const MREMAP_FIXED: ::c_int = 2;
+        pub const MREMAP_DONTUNMAP: ::c_int = 4;
+
+        pub const MLOCK_ONFAULT: ::c_uint = 0x01; // FIXME type? shouldn't this be c_int
+
+        pub const MFD_CLOEXEC: ::c_uint = 0x0001;
+        pub const MFD_ALLOW_SEALING: ::c_uint = 0x0002;
+        pub const MFD_HUGETLB: ::c_uint = 0x0004;
+        // #endif
+
+        // Included for future reference (for mmap64):
+        // #if defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)
+        // #define off64_t off_t
+        // #endif
+    }
+}
+
 #[cfg_attr(
     feature = "rustc-dep-of-std",
     link(
@@ -579,6 +687,64 @@ extern "C" {
     pub fn memcpy(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
     pub fn memmove(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
     pub fn memset(dest: *mut c_void, c: c_int, n: size_t) -> *mut c_void;
+
+    cfg_if! {
+        if #[cfg(feature = "wasi-emulated-mman")] {
+            // wasi-libc @ 5d8a140, musl 1.2.3: libc-top-half/musl/include/sys/mman.h
+
+            pub fn mmap(
+                addr: *mut ::c_void,
+                len: ::size_t,
+                prot: ::c_int,
+                flags: ::c_int,
+                fd: ::c_int,
+                offset: off_t,
+            ) -> *mut ::c_void;
+            pub fn munmap(addr: *mut ::c_void, len: ::size_t) -> ::c_int;
+
+            pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
+            pub fn msync(addr: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::c_int;
+
+            pub fn posix_madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
+
+            pub fn mlock(addr: *const ::c_void, len: ::size_t) -> ::c_int;
+            pub fn munlock(addr: *const ::c_void, len: ::size_t) -> ::c_int;
+            pub fn mlockall(flags: ::c_int) -> ::c_int;
+            pub fn munlockall() -> ::c_int;
+
+            // #ifdef _GNU_SOURCE
+            pub fn mremap(
+                addr: *mut ::c_void,
+                len: ::size_t,
+                new_len: ::size_t,
+                flags: ::c_int,
+                ...
+            ) -> *mut ::c_void;
+            pub fn remap_file_pages(
+                addr: *mut ::c_void,
+                size: ::size_t,
+                prot: ::c_int,
+                pgoff: ::size_t,
+                flags: ::c_int,
+            ) -> ::c_int;
+            pub fn memfd_create(name: *const ::c_char, flags: ::c_uint) -> ::c_int;
+            pub fn mlock2(addr: *const ::c_void, len: ::size_t, flags: ::c_uint) -> ::c_int;
+            // #endif
+
+            // #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+            pub fn madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
+            pub fn mincore(addr: *mut ::c_void, len: ::size_t, vec: *mut ::c_uchar) -> ::c_int;
+            // #endif
+
+            pub fn shm_open(name: *const c_char, oflag: ::c_int, mode: mode_t) -> ::c_int;
+            pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
+
+            // Included for future reference (for mmap64):
+            // #if defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)
+            // #define mmap64 mmap
+            // #endif
+        }
+    }
 
     pub fn fprintf(stream: *mut ::FILE, format: *const ::c_char, ...) -> ::c_int;
     pub fn printf(format: *const ::c_char, ...) -> ::c_int;


### PR DESCRIPTION
Fixes #3091 by adding a `wasi-emulated-mman` cargo feature that adds bindings for `wasi-libc`'s emulated mman.

I am not sure if I implemented this completely correctly; feedback would be highly appreciated!

Some general comments/questions:
1. I did *not* implement `mmap64` here, as I was unsure how to handle C's `#define mmap64 mmap`. I only started learning Rust a couple months ago so I am not sure what would be analogous here.
2. I am not 100% sure what is up with the `_GNU_SOURCE` and `_BSD_SOURCE` conditional includes in the C header, so I included the relevant bindings in the hopes that I could get feedback on that from someone here.
3. ~The unix/linux-like `MAP_FAILED` is implemented as `pub const MAP_FAILED: *mut ::c_void = !0 as *mut ::c_void;`, which confused me. The `mman.h` in `wasi-libc` is `#define MAP_FAILED ((void *) -1)`. What is the correct rust binding for this constant?~ I failed to realize the `!0` is just the bitwise operator; all set here.
4. There is no `libc-test/semver/wasi.txt`?
5. And finally, a big newbie question: originally, I thought this library provided the target's libc (like wasi-libc), but that appears to be wrong as far as I can tell. How exactly does the target's libc get built & linked? Is this overridable using environment variables with cargo at build time (e.g. `CC="clang ... --sysroot=..." cargo build --target="..."`)? Or through some different mechanism?
