### PR TITLE
Add glibc extensions for posix_spawn*.

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3693,6 +3693,10 @@ fn test_linux(target: &str) {
             // FIXME: the glibc version used by the Sparc64 build jobs
             // which use Debian 10.0 is too old.
             "statx" if sparc64 => true,
+            // Needs glibc 2.34 or later.
+            "posix_spawn_file_actions_addclosefrom_np" if gnu && sparc64 => true,
+            // Needs glibc 2.35 or later.
+            "posix_spawn_file_actions_addtcsetpgrp_np" if gnu && sparc64 => true,
 
             // FIXME: Deprecated since glibc 2.30. Remove fn once upstream does.
             "sysctl" if gnu => true,

--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -626,6 +626,10 @@ ntp_adjtime
 ntp_gettime
 ntptimeval
 open_wmemstream
+posix_spawn_file_actions_addchdir_np
+posix_spawn_file_actions_addfchdir_np
+posix_spawn_file_actions_addclosefrom_np
+posix_spawn_file_actions_addtcsetpgrp_np
 preadv2
 preadv64
 prlimit

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1377,6 +1377,30 @@ extern "C" {
     pub fn gnu_get_libc_version() -> *const ::c_char;
 }
 
+// posix/spawn.h
+extern "C" {
+    // Added in `glibc` 2.29
+    pub fn posix_spawn_file_actions_addchdir_np(
+        actions: *mut ::posix_spawn_file_actions_t,
+        path: *const ::c_char,
+    ) -> ::c_int;
+    // Added in `glibc` 2.29
+    pub fn posix_spawn_file_actions_addfchdir_np(
+        actions: *mut ::posix_spawn_file_actions_t,
+        fd: ::c_int,
+    ) -> ::c_int;
+    // Added in `glibc` 2.34
+    pub fn posix_spawn_file_actions_addclosefrom_np(
+        actions: *mut ::posix_spawn_file_actions_t,
+        from: ::c_int,
+    ) -> ::c_int;
+    // Added in `glibc` 2.35
+    pub fn posix_spawn_file_actions_addtcsetpgrp_np(
+        actions: *mut ::posix_spawn_file_actions_t,
+        tcfd: ::c_int,
+    ) -> ::c_int;
+}
+
 cfg_if! {
     if #[cfg(any(target_arch = "x86",
                  target_arch = "arm",


### PR DESCRIPTION
This PR adds support for posix spawn extensions implemented by glibc: https://elixir.bootlin.com/glibc/glibc-2.37.9000/source/posix/spawn.h#L201.