### PR TITLE
add p_name field in kinfo_proc struct on OpenBSD

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -498,6 +498,7 @@ s! {
         pub p_tid: i32,
         pub p_rtableid: u32,
         pub p_pledge: u64,
+        pub p_name: [::c_char; KI_MAXCOMLEN as usize],
     }
 
     pub struct kinfo_vmentry {


### PR DESCRIPTION
pthread_get_name_np() and pthread_set_name_np() are now using a kernel storage  and could be viewed from outside the process.

Reference: https://github.com/openbsd/src/commit/cef5a146e600a27064f0ea2aa25fc5f8663cb9b7