### PR TITLE
Add support for OpenHarmony

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3081,7 +3081,7 @@ fn test_linux(target: &str) {
 
     // target_env
     let gnu = target.contains("gnu");
-    let musl = target.contains("musl");
+    let musl = target.contains("musl") || target.contains("ohos");
     let uclibc = target.contains("uclibc");
 
     match (gnu, musl, uclibc) {
@@ -3946,7 +3946,7 @@ fn test_linux(target: &str) {
 // are included (e.g. because including both sets of headers clashes)
 fn test_linux_like_apis(target: &str) {
     let gnu = target.contains("gnu");
-    let musl = target.contains("musl");
+    let musl = target.contains("musl") || target.contains("ohos");
     let linux = target.contains("linux");
     let emscripten = target.contains("emscripten");
     let android = target.contains("android");

--- a/src/unix/linux_like/linux/align.rs
+++ b/src/unix/linux_like/linux/align.rs
@@ -28,9 +28,10 @@ macro_rules! expand_align {
                 size: [u8; ::__SIZEOF_PTHREAD_MUTEXATTR_T],
             }
 
-            #[cfg_attr(any(target_env = "musl", target_pointer_width = "32"),
+            #[cfg_attr(any(target_env = "musl", target_env = "ohos", target_pointer_width = "32"),
                        repr(align(4)))]
             #[cfg_attr(all(not(target_env = "musl"),
+                           not(target_env = "ohos"),
                            target_pointer_width = "64"),
                        repr(align(8)))]
             pub struct pthread_rwlockattr_t {
@@ -63,16 +64,16 @@ macro_rules! expand_align {
         }
 
         s_no_extra_traits! {
-            #[cfg_attr(all(target_env = "musl",
+            #[cfg_attr(all(any(target_env = "musl", target_env = "ohos"),
                            target_pointer_width = "32"),
                        repr(align(4)))]
-            #[cfg_attr(all(target_env = "musl",
+            #[cfg_attr(all(any(target_env = "musl", target_env = "ohos"),
                            target_pointer_width = "64"),
                        repr(align(8)))]
-            #[cfg_attr(all(not(target_env = "musl"),
+            #[cfg_attr(all(not(any(target_env = "musl", target_env = "ohos")),
                            target_arch = "x86"),
                        repr(align(4)))]
-            #[cfg_attr(all(not(target_env = "musl"),
+            #[cfg_attr(all(not(any(target_env = "musl", target_env = "ohos")),
                            not(target_arch = "x86")),
                        repr(align(8)))]
             pub struct pthread_cond_t {

--- a/src/unix/linux_like/linux/arch/generic/mod.rs
+++ b/src/unix/linux_like/linux/arch/generic/mod.rs
@@ -95,7 +95,7 @@ cfg_if! {
     if #[cfg(all(any(target_arch = "x86",
                      target_arch = "x86_64",
                      target_arch = "aarch64"),
-                 not(target_env = "musl")))] {
+                 not(any(target_env = "musl", target_env = "ohos"))))] {
         pub const SO_TIMESTAMP_NEW: ::c_int = 63;
         pub const SO_TIMESTAMPNS_NEW: ::c_int = 64;
         pub const SO_TIMESTAMPING_NEW: ::c_int = 65;
@@ -252,7 +252,7 @@ cfg_if! {
         pub const RLIMIT_RTTIME: ::__rlimit_resource_t = 15;
         pub const RLIMIT_NLIMITS: ::__rlimit_resource_t = RLIM_NLIMITS;
 
-    } else if #[cfg(target_env = "musl")] {
+    } else if #[cfg(any(target_env = "musl", target_env = "ohos"))] {
 
         pub const RLIMIT_CPU: ::c_int = 0;
         pub const RLIMIT_FSIZE: ::c_int = 1;

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -287,12 +287,14 @@ s_no_extra_traits! {
 
     // FIXME: musl added paddings and adjusted
     // layout in 1.2.0 but our CI is still 1.1.24.
-    // So, I'm leaving some fields as comments for now.
+    // So, I'm leaving some fields as cfg for now.
     // ref. https://github.com/bminor/musl/commit/
     // 1e7f0fcd7ff2096904fd93a2ee6d12a2392be392
+    //
+    // OpenHarmony uses the musl 1.2 layout.
     pub struct utmpx {
         pub ut_type: ::c_short,
-        //__ut_pad1: ::c_short,
+        __ut_pad1: ::c_short,
         pub ut_pid: ::pid_t,
         pub ut_line: [::c_char; 32],
         pub ut_id: [::c_char; 4],
@@ -300,15 +302,22 @@ s_no_extra_traits! {
         pub ut_host: [::c_char; 256],
         pub ut_exit: __exit_status,
 
-        //#[cfg(target_endian = "little")]
+        #[cfg(target_env = "musl")]
         pub ut_session: ::c_long,
-        //#[cfg(target_endian = "little")]
-        //__ut_pad2: ::c_long,
 
-        //#[cfg(not(target_endian = "little"))]
-        //__ut_pad2: ::c_int,
-        //#[cfg(not(target_endian = "little"))]
-        //pub ut_session: ::c_int,
+        #[cfg(target_env = "ohos")]
+        #[cfg(target_endian = "little")]
+        pub ut_session: ::c_int,
+        #[cfg(target_env = "ohos")]
+        #[cfg(target_endian = "little")]
+        __ut_pad2: ::c_int,
+
+        #[cfg(target_env = "ohos")]
+        #[cfg(not(target_endian = "little"))]
+        __ut_pad2: ::c_int,
+        #[cfg(target_env = "ohos")]
+        #[cfg(not(target_endian = "little"))]
+        pub ut_session: ::c_int,
 
         pub ut_tv: ::timeval,
         pub ut_addr_v6: [::c_uint; 4],

--- a/src/unix/linux_like/linux/no_align.rs
+++ b/src/unix/linux_like/linux/no_align.rs
@@ -11,7 +11,7 @@ macro_rules! expand_align {
                           target_arch = "riscv32",
                           target_arch = "loongarch64",
                           all(target_arch = "aarch64",
-                              target_env = "musl")))]
+                              any(target_env = "musl", target_env = "ohos"))))]
                 __align: [::c_int; 0],
                 #[cfg(not(any(target_arch = "x86_64",
                               target_arch = "powerpc64",
@@ -22,15 +22,15 @@ macro_rules! expand_align {
                               target_arch = "riscv32",
                               target_arch = "loongarch64",
                               all(target_arch = "aarch64",
-                                  target_env = "musl"))))]
+                                  any(target_env = "musl", target_env = "ohos")))))]
                 __align: [::c_long; 0],
                 size: [u8; ::__SIZEOF_PTHREAD_MUTEXATTR_T],
             }
 
             pub struct pthread_rwlockattr_t {
-                #[cfg(target_env = "musl")]
+                #[cfg(any(target_env = "musl", target_env = "ohos"))]
                 __align: [::c_int; 0],
-                #[cfg(not(target_env = "musl"))]
+                #[cfg(not(any(target_env = "musl", target_env = "ohos")))]
                 __align: [::c_long; 0],
                 size: [u8; ::__SIZEOF_PTHREAD_RWLOCKATTR_T],
             }
@@ -59,9 +59,9 @@ macro_rules! expand_align {
 
         s_no_extra_traits! {
             pub struct pthread_cond_t {
-                #[cfg(target_env = "musl")]
+                #[cfg(any(target_env = "musl", target_env = "ohos"))]
                 __align: [*const ::c_void; 0],
-                #[cfg(not(target_env = "musl"))]
+                #[cfg(not(any(target_env = "musl", target_env = "ohos")))]
                 __align: [::c_longlong; 0],
                 size: [u8; ::__SIZEOF_PTHREAD_COND_T],
             }

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -108,13 +108,13 @@ s! {
 
     pub struct sched_param {
         pub sched_priority: ::c_int,
-        #[cfg(any(target_env = "musl", target_os = "emscripten"))]
+        #[cfg(any(target_env = "musl", target_os = "emscripten", target_env = "ohos"))]
         pub sched_ss_low_priority: ::c_int,
-        #[cfg(any(target_env = "musl", target_os = "emscripten"))]
+        #[cfg(any(target_env = "musl", target_os = "emscripten", target_env = "ohos"))]
         pub sched_ss_repl_period: ::timespec,
-        #[cfg(any(target_env = "musl", target_os = "emscripten"))]
+        #[cfg(any(target_env = "musl", target_os = "emscripten", target_env = "ohos"))]
         pub sched_ss_init_budget: ::timespec,
-        #[cfg(any(target_env = "musl", target_os = "emscripten"))]
+        #[cfg(any(target_env = "musl", target_os = "emscripten", target_env = "ohos"))]
         pub sched_ss_max_repl: ::c_int,
     }
 
@@ -557,7 +557,21 @@ pub const XATTR_CREATE: ::c_int = 0x1;
 pub const XATTR_REPLACE: ::c_int = 0x2;
 
 cfg_if! {
-    if #[cfg(not(target_env = "uclibc"))] {
+    if #[cfg(target_env = "ohos")] {
+        pub const LC_CTYPE: ::c_int = 0;
+        pub const LC_NUMERIC: ::c_int = 1;
+        pub const LC_TIME: ::c_int = 2;
+        pub const LC_COLLATE: ::c_int = 3;
+        pub const LC_MONETARY: ::c_int = 4;
+        pub const LC_MESSAGES: ::c_int = 5;
+        pub const LC_PAPER: ::c_int = 6;
+        pub const LC_NAME: ::c_int = 7;
+        pub const LC_ADDRESS: ::c_int = 8;
+        pub const LC_TELEPHONE: ::c_int = 9;
+        pub const LC_MEASUREMENT: ::c_int = 10;
+        pub const LC_IDENTIFICATION: ::c_int = 11;
+        pub const LC_ALL: ::c_int = 12;
+    } else if #[cfg(not(target_env = "uclibc"))] {
         pub const LC_CTYPE: ::c_int = 0;
         pub const LC_NUMERIC: ::c_int = 1;
         pub const LC_TIME: ::c_int = 2;
@@ -973,7 +987,11 @@ pub const TCP_QUICKACK: ::c_int = 12;
 pub const TCP_CONGESTION: ::c_int = 13;
 pub const TCP_MD5SIG: ::c_int = 14;
 cfg_if! {
-    if #[cfg(all(target_os = "linux", any(target_env = "gnu", target_env = "musl")))] {
+    if #[cfg(all(target_os = "linux", any(
+            target_env = "gnu",
+            target_env = "musl",
+            target_env = "ohos"
+        )))] {
         // WARN: deprecated
         pub const TCP_COOKIE_TRANSACTIONS: ::c_int = 15;
     }

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -130,7 +130,7 @@ s! {
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         __pad14: u32,
 
-        #[cfg(any(target_env = "musl", target_os = "emscripten"))]
+        #[cfg(any(target_env = "musl", target_env = "ohos", target_os = "emscripten"))]
         __reserved: [c_long; 16],
     }
 
@@ -351,7 +351,7 @@ cfg_if! {
         #[link(name = "dl", cfg(not(target_feature = "crt-static")))]
         #[link(name = "c", cfg(not(target_feature = "crt-static")))]
         extern {}
-    } else if #[cfg(target_env = "musl")] {
+    } else if #[cfg(any(target_env = "musl", target_env = "ohos"))] {
         #[cfg_attr(feature = "rustc-dep-of-std",
                    link(name = "c", kind = "static", modifiers = "-bundle",
                         cfg(target_feature = "crt-static")))]
@@ -1217,7 +1217,10 @@ extern "C" {
     pub fn gai_strerror(errcode: ::c_int) -> *const ::c_char;
     #[cfg_attr(
         any(
-            all(target_os = "linux", not(target_env = "musl")),
+            all(
+                target_os = "linux",
+                not(any(target_env = "musl", target_env = "ohos"))
+            ),
             target_os = "freebsd",
             target_os = "dragonfly",
             target_os = "haiku"
@@ -1236,11 +1239,11 @@ extern "C" {
     pub fn res_init() -> ::c_int;
 
     #[cfg_attr(target_os = "netbsd", link_name = "__gmtime_r50")]
-    #[cfg_attr(target_env = "musl", allow(deprecated))]
+    #[cfg_attr(any(target_env = "musl", target_env = "ohos"), allow(deprecated))]
     // FIXME: for `time_t`
     pub fn gmtime_r(time_p: *const time_t, result: *mut tm) -> *mut tm;
     #[cfg_attr(target_os = "netbsd", link_name = "__localtime_r50")]
-    #[cfg_attr(target_env = "musl", allow(deprecated))]
+    #[cfg_attr(any(target_env = "musl", target_env = "ohos"), allow(deprecated))]
     // FIXME: for `time_t`
     pub fn localtime_r(time_p: *const time_t, result: *mut tm) -> *mut tm;
     #[cfg_attr(
@@ -1248,27 +1251,27 @@ extern "C" {
         link_name = "mktime$UNIX2003"
     )]
     #[cfg_attr(target_os = "netbsd", link_name = "__mktime50")]
-    #[cfg_attr(target_env = "musl", allow(deprecated))]
+    #[cfg_attr(any(target_env = "musl", target_env = "ohos"), allow(deprecated))]
     // FIXME: for `time_t`
     pub fn mktime(tm: *mut tm) -> time_t;
     #[cfg_attr(target_os = "netbsd", link_name = "__time50")]
-    #[cfg_attr(target_env = "musl", allow(deprecated))]
+    #[cfg_attr(any(target_env = "musl", target_env = "ohos"), allow(deprecated))]
     // FIXME: for `time_t`
     pub fn time(time: *mut time_t) -> time_t;
     #[cfg_attr(target_os = "netbsd", link_name = "__gmtime50")]
-    #[cfg_attr(target_env = "musl", allow(deprecated))]
+    #[cfg_attr(any(target_env = "musl", target_env = "ohos"), allow(deprecated))]
     // FIXME: for `time_t`
     pub fn gmtime(time_p: *const time_t) -> *mut tm;
     #[cfg_attr(target_os = "netbsd", link_name = "__locatime50")]
-    #[cfg_attr(target_env = "musl", allow(deprecated))]
+    #[cfg_attr(any(target_env = "musl", target_env = "ohos"), allow(deprecated))]
     // FIXME: for `time_t`
     pub fn localtime(time_p: *const time_t) -> *mut tm;
     #[cfg_attr(target_os = "netbsd", link_name = "__difftime50")]
-    #[cfg_attr(target_env = "musl", allow(deprecated))]
+    #[cfg_attr(any(target_env = "musl", target_env = "ohos"), allow(deprecated))]
     // FIXME: for `time_t`
     pub fn difftime(time1: time_t, time0: time_t) -> ::c_double;
     #[cfg_attr(target_os = "netbsd", link_name = "__timegm50")]
-    #[cfg_attr(target_env = "musl", allow(deprecated))]
+    #[cfg_attr(any(target_env = "musl", target_env = "ohos"), allow(deprecated))]
     // FIXME: for `time_t`
     pub fn timegm(tm: *mut ::tm) -> time_t;
 


### PR DESCRIPTION
This PR adds support for [OpenHarmony](https://gitee.com/openharmony/docs/) targets:
- `aarch64-linux-ohos`
- `arm-linux-ohos`

Compiler team MCP: https://github.com/rust-lang/compiler-team/issues/568

OpenHarmony uses a fork of musl with minor modifications, so most of the code is shared with other musl targets. Additionally, although OpenHarmony uses musl 1.2, it is still ABI-compatible with musl 1.1 so the existing bindings should continue to work until https://github.com/rust-lang/libc/pull/3068 is merged.

A PR to add the targets to rustc will follow after this is merged.