### PR TITLE
Fix `SOCK_SEQPACKET` and `MAP_SYNC` on musl powerpc and s390.

### DIFF
--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -261,6 +261,7 @@ pub const MAP_NORESERVE: ::c_int = 0x0400;
 pub const MAP_POPULATE: ::c_int = 0x10000;
 pub const MAP_NONBLOCK: ::c_int = 0x20000;
 pub const MAP_STACK: ::c_int = 0x40000;
+pub const MAP_HUGETLB: ::c_int = 0x80000;
 
 pub const EDEADLK: ::c_int = 45;
 pub const ENAMETOOLONG: ::c_int = 78;
@@ -381,8 +382,6 @@ pub const SIG_BLOCK: ::c_int = 1;
 pub const SIG_UNBLOCK: ::c_int = 2;
 
 pub const EXTPROC: ::tcflag_t = 0o200000;
-
-pub const MAP_HUGETLB: ::c_int = 0x80000;
 
 pub const F_GETLK: ::c_int = 33;
 pub const F_GETOWN: ::c_int = 23;

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -254,6 +254,8 @@ pub const MAP_NORESERVE: ::c_int = 0x00040;
 pub const MAP_POPULATE: ::c_int = 0x08000;
 pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
+pub const MAP_HUGETLB: ::c_int = 0x040000;
+pub const MAP_SYNC: ::c_int = 0x080000;
 
 pub const SOCK_STREAM: ::c_int = 1;
 pub const SOCK_DGRAM: ::c_int = 2;

--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -177,6 +177,7 @@ pub const MAP_POPULATE: ::c_int = 0x08000;
 pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
+pub const MAP_SYNC: ::c_int = 0x080000;
 
 pub const EDEADLOCK: ::c_int = 35;
 pub const ENAMETOOLONG: ::c_int = 36;


### PR DESCRIPTION
 - On powerpc musl, add definitions for `MAP_HUGETLB` and `MAP_SYNC`.
 - On powerpc64 musl, add a definition for `SOCK_SEQPACKET`.
 - On s390x musl, add definitions for `SOCK_SEQPACKET` and `MAP_SYNC`.
 - On mips, just move the existing `MAP_HUGETLB` definition to be near the other `MAP_*` constants.
