### PR TITLE
wasi: add __errno_location

### DIFF
--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -825,4 +825,6 @@ extern "C" {
     pub fn arc4random() -> u32;
     pub fn arc4random_buf(a: *mut c_void, b: size_t);
     pub fn arc4random_uniform(a: u32) -> u32;
+
+    pub fn __errno_location() -> *mut ::c_int;
 }


### PR DESCRIPTION
This was also missing from wasi's .rs. It seems to work as on other targets with wasm32-wasi on nightly.