### PR TITLE
Add reentrant glibc getmntent_r

### DIFF
--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -670,3 +670,4 @@ strptime
 dirname
 posix_basename
 gnu_basename
+getmntent_r

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1395,6 +1395,16 @@ extern "C" {
     ) -> ::c_int;
 }
 
+// mntent.h
+extern "C" {
+    pub fn getmntent_r(
+        stream: *mut ::FILE,
+        mntbuf: *mut ::mntent,
+        buf: *mut ::c_char,
+        buflen: ::c_int,
+    ) -> *mut ::mntent;
+}
+
 cfg_if! {
     if #[cfg(any(target_arch = "x86",
                  target_arch = "arm",


### PR DESCRIPTION
- \[x] Edit corresponding file(s) under `libc-test/semver` when you add/remove item(s)
- \[x] `rustc ci/style.rs && ./style src`
- \[ ] `cd libc-test && cargo test` (This might fail on your env due to environment difference between your env and CI. Ignore failures if you are not sure.)
  <details>
    <summary>**Maybe**, see the cargo test output -- I am unsure about the failures</summary>

  ```
  …/libc-rust/libc-test on  add-reentrant-getmntent_r [⇕] is 📦 v0.2.140 via 🦀 v1.67.0 via   (nix-shell-env) at 23:04:37 nu
  ❯ cargo test
     Compiling libc v0.2.140 (/home/rmk35/programming/rust/libc-rust)
     Compiling libc-test v0.2.140 (/home/rmk35/programming/rust/libc-rust/libc-test)
  The following warnings were emitted during compilation:
  
  warning: In file included from /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/sys/types.h:25,
  warning:                  from /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/sys/param.h:25,
  warning:                  from src/cmsg.c:1:
  warning: /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/features.h:412:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
  warning:   412 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
  warning:       |    ^~~~~~~
  warning: In file included from /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/sys/types.h:25,
  warning:                  from src/makedev.c:1:
  warning: /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/features.h:412:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
  warning:   412 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
  warning:       |    ^~~~~~~
  warning: In file included from /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/time.h:25,
  warning:                  from src/errqueue.c:1:
  warning: /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/features.h:412:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
  warning:   412 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
  warning:       |    ^~~~~~~
  warning: In file included from /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/signal.h:25,
  warning:                  from src/sigrt.c:1:
  warning: /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/features.h:412:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
  warning:   412 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
  warning:       |    ^~~~~~~
  warning: In file included from /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/bits/libc-header-start.h:33,
  warning:                  from /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/stdio.h:27,
  warning:                  from /home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/main.c:1:
  warning: /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/features.h:412:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]
  warning:   412 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
  warning:       |    ^~~~~~~
  warning: /home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/main.c: In function ‘__test_roundtrip_inotify_event’:
  warning: /home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/main.c:23145:13: note: the ABI of passing struct with a flexible array member has changed in GCC 4.4
  warning: 23145 |             ) {
  warning:       |             ^
  warning: /home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/main.c: In function ‘__test_fsize_af_alg_iv_iv’:
  warning: /home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/main.c:25567:34: error: invalid application of ‘sizeof’ to incomplete type ‘__u8[]’ {aka ‘unsigned char[]’}
  warning: 25567 |                     return sizeof(foo->iv);
  warning:       |                                  ^
  warning: /home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/main.c:25568:17: error: control reaches end of non-void function [-Werror=return-type]
  warning: 25568 |                 }
  warning:       |                 ^
  warning: At top level:
  warning: cc1: note: unrecognized command-line option ‘-Wno-unknown-warning-option’ may have been intended to silence earlier diagnostics
  warning: cc1: all warnings being treated as errors
  
  error: failed to run custom build command for `libc-test v0.2.140 (/home/rmk35/programming/rust/libc-rust/libc-test)`
  
  Caused by:
    process didn't exit successfully: `/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-e11b1093bd48972c/build-script-build` (exit status: 1)
    --- stdout
    TARGET = Some("x86_64-unknown-linux-gnu")
    OPT_LEVEL = Some("0")
    HOST = Some("x86_64-unknown-linux-gnu")
    cargo:rerun-if-env-changed=CC_x86_64-unknown-linux-gnu
    CC_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=CC_x86_64_unknown_linux_gnu
    CC_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_CC
    HOST_CC = None
    cargo:rerun-if-env-changed=CC
    CC = Some("gcc")
    cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
    CFLAGS_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
    CFLAGS_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_CFLAGS
    HOST_CFLAGS = None
    cargo:rerun-if-env-changed=CFLAGS
    CFLAGS = None
    cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
    CRATE_CC_NO_DEFAULTS = None
    DEBUG = Some("true")
    CARGO_CFG_TARGET_FEATURE = Some("fxsr,sse,sse2")
    running: "gcc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64" "-Wall" "-Wextra" "-o" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/src/cmsg.o" "-c" "src/cmsg.c"
    cargo:warning=In file included from /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/sys/types.h:25,
    cargo:warning=                 from /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/sys/param.h:25,
    cargo:warning=                 from src/cmsg.c:1:
    cargo:warning=/nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/features.h:412:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
    cargo:warning=  412 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    cargo:warning=      |    ^~~~~~~
    exit status: 0
    cargo:rerun-if-env-changed=AR_x86_64-unknown-linux-gnu
    AR_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=AR_x86_64_unknown_linux_gnu
    AR_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_AR
    HOST_AR = None
    cargo:rerun-if-env-changed=AR
    AR = Some("ar")
    cargo:rerun-if-env-changed=ARFLAGS_x86_64-unknown-linux-gnu
    ARFLAGS_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=ARFLAGS_x86_64_unknown_linux_gnu
    ARFLAGS_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_ARFLAGS
    HOST_ARFLAGS = None
    cargo:rerun-if-env-changed=ARFLAGS
    ARFLAGS = None
    running: "ar" "cq" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/libcmsg.a" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/src/cmsg.o"
    exit status: 0
    running: "ar" "s" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/libcmsg.a"
    exit status: 0
    cargo:rustc-link-lib=static=cmsg
    cargo:rustc-link-search=native=/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out
    TARGET = Some("x86_64-unknown-linux-gnu")
    OPT_LEVEL = Some("0")
    HOST = Some("x86_64-unknown-linux-gnu")
    cargo:rerun-if-env-changed=CC_x86_64-unknown-linux-gnu
    CC_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=CC_x86_64_unknown_linux_gnu
    CC_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_CC
    HOST_CC = None
    cargo:rerun-if-env-changed=CC
    CC = Some("gcc")
    cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
    CFLAGS_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
    CFLAGS_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_CFLAGS
    HOST_CFLAGS = None
    cargo:rerun-if-env-changed=CFLAGS
    CFLAGS = None
    cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
    CRATE_CC_NO_DEFAULTS = None
    DEBUG = Some("true")
    CARGO_CFG_TARGET_FEATURE = Some("fxsr,sse,sse2")
    running: "gcc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64" "-Wall" "-Wextra" "-o" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/src/makedev.o" "-c" "src/makedev.c"
    cargo:warning=In file included from /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/sys/types.h:25,
    cargo:warning=                 from src/makedev.c:1:
    cargo:warning=/nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/features.h:412:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
    cargo:warning=  412 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    cargo:warning=      |    ^~~~~~~
    exit status: 0
    cargo:rerun-if-env-changed=AR_x86_64-unknown-linux-gnu
    AR_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=AR_x86_64_unknown_linux_gnu
    AR_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_AR
    HOST_AR = None
    cargo:rerun-if-env-changed=AR
    AR = Some("ar")
    cargo:rerun-if-env-changed=ARFLAGS_x86_64-unknown-linux-gnu
    ARFLAGS_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=ARFLAGS_x86_64_unknown_linux_gnu
    ARFLAGS_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_ARFLAGS
    HOST_ARFLAGS = None
    cargo:rerun-if-env-changed=ARFLAGS
    ARFLAGS = None
    running: "ar" "cq" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/libmakedev.a" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/src/makedev.o"
    exit status: 0
    running: "ar" "s" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/libmakedev.a"
    exit status: 0
    cargo:rustc-link-lib=static=makedev
    cargo:rustc-link-search=native=/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out
    TARGET = Some("x86_64-unknown-linux-gnu")
    OPT_LEVEL = Some("0")
    HOST = Some("x86_64-unknown-linux-gnu")
    cargo:rerun-if-env-changed=CC_x86_64-unknown-linux-gnu
    CC_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=CC_x86_64_unknown_linux_gnu
    CC_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_CC
    HOST_CC = None
    cargo:rerun-if-env-changed=CC
    CC = Some("gcc")
    cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
    CFLAGS_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
    CFLAGS_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_CFLAGS
    HOST_CFLAGS = None
    cargo:rerun-if-env-changed=CFLAGS
    CFLAGS = None
    cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
    CRATE_CC_NO_DEFAULTS = None
    DEBUG = Some("true")
    CARGO_CFG_TARGET_FEATURE = Some("fxsr,sse,sse2")
    running: "gcc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64" "-Wall" "-Wextra" "-o" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/src/errqueue.o" "-c" "src/errqueue.c"
    cargo:warning=In file included from /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/time.h:25,
    cargo:warning=                 from src/errqueue.c:1:
    cargo:warning=/nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/features.h:412:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
    cargo:warning=  412 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    cargo:warning=      |    ^~~~~~~
    exit status: 0
    cargo:rerun-if-env-changed=AR_x86_64-unknown-linux-gnu
    AR_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=AR_x86_64_unknown_linux_gnu
    AR_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_AR
    HOST_AR = None
    cargo:rerun-if-env-changed=AR
    AR = Some("ar")
    cargo:rerun-if-env-changed=ARFLAGS_x86_64-unknown-linux-gnu
    ARFLAGS_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=ARFLAGS_x86_64_unknown_linux_gnu
    ARFLAGS_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_ARFLAGS
    HOST_ARFLAGS = None
    cargo:rerun-if-env-changed=ARFLAGS
    ARFLAGS = None
    running: "ar" "cq" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/liberrqueue.a" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/src/errqueue.o"
    exit status: 0
    running: "ar" "s" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/liberrqueue.a"
    exit status: 0
    cargo:rustc-link-lib=static=errqueue
    cargo:rustc-link-search=native=/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out
    TARGET = Some("x86_64-unknown-linux-gnu")
    OPT_LEVEL = Some("0")
    HOST = Some("x86_64-unknown-linux-gnu")
    cargo:rerun-if-env-changed=CC_x86_64-unknown-linux-gnu
    CC_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=CC_x86_64_unknown_linux_gnu
    CC_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_CC
    HOST_CC = None
    cargo:rerun-if-env-changed=CC
    CC = Some("gcc")
    cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
    CFLAGS_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
    CFLAGS_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_CFLAGS
    HOST_CFLAGS = None
    cargo:rerun-if-env-changed=CFLAGS
    CFLAGS = None
    cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
    CRATE_CC_NO_DEFAULTS = None
    DEBUG = Some("true")
    CARGO_CFG_TARGET_FEATURE = Some("fxsr,sse,sse2")
    running: "gcc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64" "-Wall" "-Wextra" "-o" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/src/sigrt.o" "-c" "src/sigrt.c"
    cargo:warning=In file included from /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/signal.h:25,
    cargo:warning=                 from src/sigrt.c:1:
    cargo:warning=/nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/features.h:412:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
    cargo:warning=  412 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    cargo:warning=      |    ^~~~~~~
    exit status: 0
    cargo:rerun-if-env-changed=AR_x86_64-unknown-linux-gnu
    AR_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=AR_x86_64_unknown_linux_gnu
    AR_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_AR
    HOST_AR = None
    cargo:rerun-if-env-changed=AR
    AR = Some("ar")
    cargo:rerun-if-env-changed=ARFLAGS_x86_64-unknown-linux-gnu
    ARFLAGS_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=ARFLAGS_x86_64_unknown_linux_gnu
    ARFLAGS_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_ARFLAGS
    HOST_ARFLAGS = None
    cargo:rerun-if-env-changed=ARFLAGS
    ARFLAGS = None
    running: "ar" "cq" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/libsigrt.a" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/src/sigrt.o"
    exit status: 0
    running: "ar" "s" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/libsigrt.a"
    exit status: 0
    cargo:rustc-link-lib=static=sigrt
    cargo:rustc-link-search=native=/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out
    -----------------------------------------
    cargo:rerun-if-changed=../src/lib.rs
    cargo:rerun-if-changed=../src/macros.rs
    cargo:rerun-if-changed=../src/fixed_width_ints.rs
    cargo:rerun-if-changed=../src/unix/mod.rs
    cargo:rerun-if-changed=../src/unix/linux_like/mod.rs
    cargo:rerun-if-changed=../src/unix/linux_like/linux/mod.rs
    cargo:rerun-if-changed=../src/unix/linux_like/linux/gnu/mod.rs
    cargo:rerun-if-changed=../src/unix/linux_like/linux/gnu/b64/mod.rs
    cargo:rerun-if-changed=../src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
    cargo:rerun-if-changed=../src/unix/linux_like/linux/gnu/b64/x86_64/not_x32.rs
    cargo:rerun-if-changed=../src/unix/linux_like/linux/arch/mod.rs
    cargo:rerun-if-changed=../src/unix/linux_like/linux/arch/generic/mod.rs
    cargo:rerun-if-changed=../src/unix/linux_like/linux/align.rs
    OPT_LEVEL = Some("0")
    HOST = Some("x86_64-unknown-linux-gnu")
    cargo:rerun-if-env-changed=CC_x86_64-unknown-linux-gnu
    CC_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=CC_x86_64_unknown_linux_gnu
    CC_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_CC
    HOST_CC = None
    cargo:rerun-if-env-changed=CC
    CC = Some("gcc")
    cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
    CFLAGS_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
    CFLAGS_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_CFLAGS
    HOST_CFLAGS = None
    cargo:rerun-if-env-changed=CFLAGS
    CFLAGS = None
    cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
    CRATE_CC_NO_DEFAULTS = None
    DEBUG = Some("true")
    CARGO_CFG_TARGET_FEATURE = Some("fxsr,sse,sse2")
    running: "gcc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64" "-Wall" "-Wextra" "-Wall" "-Wextra" "-Werror" "-Wno-unused-parameter" "-Wno-type-limits" "-Wno-address-of-packed-member" "-Wno-unknown-warning-option" "-Wno-deprecated-declarations" "-D_GNU_SOURCE" "-D__GLIBC_USE_DEPRECATED_SCANF" "-o" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/02794b85cf18899c-main.o" "-c" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/main.c"
    cargo:warning=In file included from /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/bits/libc-header-start.h:33,
    cargo:warning=                 from /nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/stdio.h:27,
    cargo:warning=                 from /home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/main.c:1:
    cargo:warning=/nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev/include/features.h:412:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]
    cargo:warning=  412 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    cargo:warning=      |    ^~~~~~~
    cargo:warning=/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/main.c: In function ‘__test_roundtrip_inotify_event’:
    cargo:warning=/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/main.c:23145:13: note: the ABI of passing struct with a flexible array member has changed in GCC 4.4
    cargo:warning=23145 |             ) {
    cargo:warning=      |             ^
    cargo:warning=/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/main.c: In function ‘__test_fsize_af_alg_iv_iv’:
    cargo:warning=/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/main.c:25567:34: error: invalid application of ‘sizeof’ to incomplete type ‘__u8[]’ {aka ‘unsigned char[]’}
    cargo:warning=25567 |                     return sizeof(foo->iv);
    cargo:warning=      |                                  ^
    cargo:warning=/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/main.c:25568:17: error: control reaches end of non-void function [-Werror=return-type]
    cargo:warning=25568 |                 }
    cargo:warning=      |                 ^
    cargo:warning=At top level:
    cargo:warning=cc1: note: unrecognized command-line option ‘-Wno-unknown-warning-option’ may have been intended to silence earlier diagnostics
    cargo:warning=cc1: all warnings being treated as errors
    exit status: 1
  
    --- stderr
    rust version: 1.67.0
  
  
    error occurred: Command "gcc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64" "-Wall" "-Wextra" "-Wall" "-Wextra" "-Werror" "-Wno-unused-parameter" "-Wno-type-limits" "-Wno-address-of-packed-member" "-Wno-unknown-warning-option" "-Wno-deprecated-declarations" "-D_GNU_SOURCE" "-D__GLIBC_USE_DEPRECATED_SCANF" "-o" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/02794b85cf18899c-main.o" "-c" "/home/rmk35/programming/rust/libc-rust/target/debug/build/libc-test-3af459ed2042c40f/out/main.c" with args "gcc" did not execute successfully (status code exit status: 1).
  
  
  
  …/libc-rust/libc-test on  add-reentrant-getmntent_r [⇕] is 📦 v0.2.140 via 🦀 v1.67.0 via   (nix-shell-env) took 4s at 23:04:44 ✖ 101 nu
  ❯
  ```
  </details>