### PR TITLE
mac time.h functions

### DIFF
--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -1819,6 +1819,8 @@ arc4random
 arc4random_buf
 arc4random_uniform
 arphdr
+asctime
+asctime_r
 attrgroup_t
 attribute_set_t
 attrlist
@@ -1845,6 +1847,8 @@ copyfile
 copyfile_flags_t
 cpu_subtype_t
 cpu_type_t
+ctime
+ctime_r
 ctl_info
 difftime
 dirfd
@@ -1880,6 +1884,7 @@ futimes
 getattrlist
 getattrlistat
 getattrlistbulk
+getdate
 getdomainname
 getdtablesize
 getfsstat
@@ -2181,8 +2186,10 @@ stack_t
 statfs
 strcasecmp
 strcasestr
+strftime
 strncasecmp
 strndup
+strptime
 strsignal
 strtonum
 sync

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -5121,6 +5121,23 @@ extern "C" {
     pub fn endutxent();
     pub fn utmpxname(file: *const ::c_char) -> ::c_int;
 
+    pub fn asctime(tm: *const ::tm) -> *mut ::c_char;
+    pub fn ctime(clock: *const time_t) -> *mut ::c_char;
+    pub fn getdate(datestr: *const ::c_char) -> *mut ::tm;
+    pub fn strftime(
+        buf: *mut ::c_char,
+        maxsize: ::size_t,
+        format: *const ::c_char,
+        timeptr: *const ::tm,
+    ) -> ::size_t;
+    pub fn strptime(
+        buf: *const ::c_char,
+        format: *const ::c_char,
+        timeptr: *mut ::tm,
+    ) -> *mut ::c_char;
+    pub fn asctime_r(tm: *const ::tm, result: *mut ::c_char) -> *mut ::c_char;
+    pub fn ctime_r(clock: *const time_t, result: *mut ::c_char) -> *mut ::c_char;
+
     pub fn getnameinfo(
         sa: *const ::sockaddr,
         salen: ::socklen_t,


### PR DESCRIPTION
I used these in https://github.com/shua/graf because I'm used to them, and don't really want to pull in time or chrono just for some stuff already present in libc.h . Compilation worked fine on my linux target, but failed on mac osx because these weren't defined in rust-lang/libc (but these are all present in 13.1 SDK).