### PR TITLE
macOS AF_MULTIPATH for Multipath-TCP

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -3571,6 +3571,10 @@ pub const AF_NETBIOS: ::c_int = 33;
 pub const AF_PPP: ::c_int = 34;
 pub const pseudo_AF_HDRCMPLT: ::c_int = 35;
 pub const AF_SYS_CONTROL: ::c_int = 2;
+pub const AF_AFP: ::c_int = 36;
+pub const AF_IEEE80211: ::c_int = 37;
+pub const AF_UTUN: ::c_int = 38;
+pub const AF_MULTIPATH: ::c_int = 39;
 
 pub const SYSPROTO_EVENT: ::c_int = 1;
 pub const SYSPROTO_CONTROL: ::c_int = 2;


### PR DESCRIPTION
This commit also adds AF_* from 36 ~ 39 defined in bsd/sys/socket.h

References:

- http://blog.multipath-tcp.org/blog/html/2018/12/17/multipath_tcp_apis.html
- https://opensource.apple.com/source/xnu/xnu-3789.70.16/bsd/sys/socket.h

Thanks for considering submitting a PR!

Here's a checklist for things that will be checked during review or continuous integration.

- \[x] Edit corresponding file(s) under `libc-test/semver` when you add/remove item(s)
- \[x] `rustc ci/style.rs && ./style src`
- \[x] `cd libc-test && cargo test` (This might fail on your env due to environment difference between your env and CI. Ignore failures if you are not sure.)
- \[x] Your PR that bumps up the crate version doesn't contain any other changes

Delete this line and everything above before opening your PR.
