### PR TITLE
fix: CMSG_HEADER_ALIGNMENT was not properly equal to the C Header file in illumos

### DIFF
--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2579,7 +2579,7 @@ pub const AT_SUN_FPTYPE: ::c_uint = 2027;
 // and 4 bytes everywhere else:
 #[cfg(target_arch = "sparc64")]
 const _CMSG_HDR_ALIGNMENT: usize = 8;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(not(target_arch = "sparc64"))]
 const _CMSG_HDR_ALIGNMENT: usize = 4;
 
 const _CMSG_DATA_ALIGNMENT: usize = ::mem::size_of::<::c_int>();


### PR DESCRIPTION
A small fix for illumos so we can add more archs to the definition. This aligns the defintions in libc with the corresponding C Headers.


I ran all the steps it asked me and only got an issue with `cc1: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics` although that seems to me like I am using a different gcc that CI. 

This is part of the ARM work goin on at the moment. 
CC: @richlowe and @jclulow for coordination.
