### PR TITLE
Make CMSG_SPACE on aix const

### DIFF
--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -2054,7 +2054,7 @@ f! {
         ::mem::size_of::<::cmsghdr>() as ::c_uint + length
     }
 
-    pub fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
+    pub {const} fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
         ::mem::size_of::<::cmsghdr>() as ::c_uint + length
     }
 


### PR DESCRIPTION
Now `CMSG_SPACE` is const (when `libc_const_extern_fn`) on every platform that has it
