### PR TITLE
[DRAFT] MSVC: Add `msvc_crt_link` options

### DIFF
--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -254,10 +254,97 @@ pub const SIG_GET: ::sighandler_t = 2;
 pub const SIG_SGE: ::sighandler_t = 3;
 pub const SIG_ACK: ::sighandler_t = 4;
 
-// inline comment below appeases style checker
-#[cfg(all(target_env = "msvc", feature = "rustc-dep-of-std"))] // " if "
-#[link(name = "msvcrt", cfg(not(target_feature = "crt-static")))]
-#[link(name = "libcmt", cfg(target_feature = "crt-static"))]
+// MSVC C RunTime (CRT) link options.
+//
+// If `target_feature = "crt-static" then use the static CRT. Otherwise use the
+// dll.
+//
+// Linking the CRT can be further configured using the `msvc_crt_link` cfg.
+// It can be set in rustflags with `--cfg msvc_crt_link=option` where "option"
+// can be:
+//
+// * `nocrt`: do not link the crt. This makes other options be no-ops.
+// * `debug`: use the debug crt libraries
+// * `dynamic-ucrt`: link the ucrt dynamically even if using the static C runtime
+#[cfg(all(target_env = "msvc", feature = "rustc-dep-of-std"))]
+#[link(
+    // MSVC dynamic crt (release)
+    name = "msvcrt",
+    cfg(all(
+        not(target_feature = "crt-static"),
+        not(msvc_crt_link = "debug"),
+        not(msvc_crt_link = "nocrt")
+    ))
+)]
+#[link(
+    // MSVC dynamic crt (debug)
+    name = "msvcrtd",
+    cfg(all(
+        not(target_feature = "crt-static"),
+        msvc_crt_link = "debug",
+        not(msvc_crt_link = "nocrt")
+    ))
+)]
+#[link(
+    // MSVC static crt (release)
+    name = "libcmt",
+    cfg(all(
+        target_feature = "crt-static",
+        not(msvc_crt_link = "debug"),
+        not(msvc_crt_link = "nocrt")
+    ))
+)]
+#[link(
+    // MSVC static crt (debug)
+    name = "libcmtd",
+    cfg(all(
+        target_feature = "crt-static",
+        msvc_crt_link = "debug",
+        not(msvc_crt_link = "nocrt")
+    ))
+)]
+#[link(
+    // Link the ucrt dynamically (release)
+    name = "ucrt",
+    cfg(all(
+        target_feature = "crt-static",
+        msvc_crt_link = "dynamic-ucrt",
+        not(msvc_crt_link = "debug"),
+        not(msvc_crt_link = "nocrt")
+    ))
+)]
+#[link(
+    // Disable the static ucrt (release)
+    name = "/nodefaultlib:libucrt",
+    cfg(all(
+        target_feature = "crt-static",
+        msvc_crt_link = "dynamic-ucrt",
+        not(msvc_crt_link = "debug"),
+        not(msvc_crt_link = "nocrt")
+    )),
+    modifiers = "+verbatim"
+)]
+#[link(
+    // Link the ucrt dynamically (debug)
+    name = "ucrtd",
+    cfg(all(
+        target_feature = "crt-static",
+        msvc_crt_link = "dynamic-ucrt",
+        msvc_crt_link = "debug",
+        not(msvc_crt_link = "nocrt")
+    ))
+)]
+#[link(
+    // Disable the static ucrt (debug)
+    name = "/nodefaultlib:libucrtd",
+    cfg(all(
+        target_feature = "crt-static",
+        msvc_crt_link = "dynamic-ucrt",
+        msvc_crt_link = "debug",
+        not(msvc_crt_link = "nocrt")
+    )),
+    modifiers = "+verbatim"
+)]
 extern "C" {}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -266,7 +266,9 @@ pub const SIG_ACK: ::sighandler_t = 4;
 // * `nocrt`: do not link the crt. This makes other options be no-ops.
 // * `debug`: use the debug crt libraries
 // * `dynamic-ucrt`: link the ucrt dynamically even if using the static C runtime
-#[cfg(all(target_env = "msvc", feature = "rustc-dep-of-std"))]
+//
+// note: inline comment below appeases style checker
+#[cfg(all(target_env = "msvc", feature = "rustc-dep-of-std"))] // " if "
 #[link(
     // MSVC dynamic crt (release)
     name = "msvcrt",


### PR DESCRIPTION
> **Note**
> This only applies when libc is used as a dependency of std.
>
> PR is for testing/discussion purposes only. It should not be merged yet.
>
> See https://github.com/rust-lang/rust/issues/39016 for more background

Currently libc hard codes the MSVC CRT that's used by the compiler. Users can select between two CRTs (dynamic and static) by toggling the `target-feature=crt-static` option. However, this is far from ideal given the number of possible configurations, especially when attempting to co-exist with existing C/C++ builds.

At a minimum, it's also useful to be able to use the debug or release versions of these libraries. The following table shows these possible combinations:

||Release|Debug|
|--|--|--|
|**Dynamic**|`msvcrt`|`msvcrtd`|
|**Static**|`libcmt`|`libcmtd`|

Furthermore, users may want to disable linking the crt entirely so that they can fully control what is linked and how.

To support these different configurations, this PR adds a new cfg, `msvc_crt_link=option`, where `option` is the link configuration option. This can be set in global rustflags (using `--cfg`) so that it's applied consistently. The two possible options are:

* `debug`: Use the debug versions of the CRT libraries
* `nocrt`: disable all CRT linking. This obviously overrides all other options because nothing is linked
