### PR TITLE
android: add new syscall constants

### DIFF
--- a/libc-test/semver/android.txt
+++ b/libc-test/semver/android.txt
@@ -2290,7 +2290,9 @@ SYS_clock_gettime
 SYS_clock_nanosleep
 SYS_clock_settime
 SYS_clone
+SYS_clone3
 SYS_close
+SYS_close_range
 SYS_connect
 SYS_copy_file_range
 SYS_delete_module
@@ -2299,12 +2301,14 @@ SYS_dup3
 SYS_epoll_create1
 SYS_epoll_ctl
 SYS_epoll_pwait
+SYS_epoll_pwait2
 SYS_eventfd2
 SYS_execve
 SYS_execveat
 SYS_exit
 SYS_exit_group
 SYS_faccessat
+SYS_faccessat2
 SYS_fallocate
 SYS_fanotify_init
 SYS_fanotify_mark
@@ -2326,7 +2330,9 @@ SYS_fsopen
 SYS_fspick
 SYS_fsync
 SYS_futex
+SYS_futex_waitv
 SYS_get_mempolicy
+SYS_set_mempolicy_home_node
 SYS_get_robust_list
 SYS_getcpu
 SYS_getcwd
@@ -2371,6 +2377,9 @@ SYS_kcmp
 SYS_kexec_load
 SYS_keyctl
 SYS_kill
+SYS_landlock_add_rule
+SYS_landlock_create_ruleset
+SYS_landlock_restrict_self
 SYS_lgetxattr
 SYS_linkat
 SYS_listen
@@ -2383,6 +2392,7 @@ SYS_madvise
 SYS_mbind
 SYS_membarrier
 SYS_memfd_create
+SYS_memfd_secret
 SYS_mincore
 SYS_mkdirat
 SYS_mknodat
@@ -2390,6 +2400,7 @@ SYS_mlock
 SYS_mlock2
 SYS_mlockall
 SYS_mount
+SYS_mount_setattr
 SYS_move_mount
 SYS_move_pages
 SYS_mprotect
@@ -2410,8 +2421,11 @@ SYS_nfsservctl
 SYS_open_by_handle_at
 SYS_open_tree
 SYS_openat
+SYS_openat2
 SYS_perf_event_open
 SYS_personality
+SYS_pidfd_open
+SYS_pidfd_getfd
 SYS_pidfd_send_signal
 SYS_pipe2
 SYS_pivot_root
@@ -2424,6 +2438,8 @@ SYS_pread64
 SYS_preadv
 SYS_preadv2
 SYS_prlimit64
+SYS_process_madvise
+SYS_process_mrelease
 SYS_process_vm_readv
 SYS_process_vm_writev
 SYS_pselect6
@@ -2432,6 +2448,7 @@ SYS_pwrite64
 SYS_pwritev
 SYS_pwritev2
 SYS_quotactl
+SYS_quotactl_fd
 SYS_read
 SYS_readahead
 SYS_readlinkat

--- a/src/unix/linux_like/android/b32/arm.rs
+++ b/src/unix/linux_like/android/b32/arm.rs
@@ -512,6 +512,23 @@ pub const SYS_fsopen: ::c_long = 430;
 pub const SYS_fsconfig: ::c_long = 431;
 pub const SYS_fsmount: ::c_long = 432;
 pub const SYS_fspick: ::c_long = 433;
+pub const SYS_pidfd_open: ::c_long = 434;
+pub const SYS_clone3: ::c_long = 435;
+pub const SYS_close_range: ::c_long = 436;
+pub const SYS_openat2: ::c_long = 437;
+pub const SYS_pidfd_getfd: ::c_long = 438;
+pub const SYS_faccessat2: ::c_long = 439;
+pub const SYS_process_madvise: ::c_long = 440;
+pub const SYS_epoll_pwait2: ::c_long = 441;
+pub const SYS_mount_setattr: ::c_long = 442;
+pub const SYS_quotactl_fd: ::c_long = 443;
+pub const SYS_landlock_create_ruleset: ::c_long = 444;
+pub const SYS_landlock_add_rule: ::c_long = 445;
+pub const SYS_landlock_restrict_self: ::c_long = 446;
+pub const SYS_memfd_secret: ::c_long = 447;
+pub const SYS_process_mrelease: ::c_long = 448;
+pub const SYS_futex_waitv: ::c_long = 449;
+pub const SYS_set_mempolicy_home_node: ::c_long = 450;
 
 // offsets in mcontext_t.gregs from sys/ucontext.h
 pub const REG_R0: ::c_int = 0;

--- a/src/unix/linux_like/android/b32/x86/mod.rs
+++ b/src/unix/linux_like/android/b32/x86/mod.rs
@@ -544,6 +544,23 @@ pub const SYS_fsopen: ::c_long = 430;
 pub const SYS_fsconfig: ::c_long = 431;
 pub const SYS_fsmount: ::c_long = 432;
 pub const SYS_fspick: ::c_long = 433;
+pub const SYS_pidfd_open: ::c_long = 434;
+pub const SYS_clone3: ::c_long = 435;
+pub const SYS_close_range: ::c_long = 436;
+pub const SYS_openat2: ::c_long = 437;
+pub const SYS_pidfd_getfd: ::c_long = 438;
+pub const SYS_faccessat2: ::c_long = 439;
+pub const SYS_process_madvise: ::c_long = 440;
+pub const SYS_epoll_pwait2: ::c_long = 441;
+pub const SYS_mount_setattr: ::c_long = 442;
+pub const SYS_quotactl_fd: ::c_long = 443;
+pub const SYS_landlock_create_ruleset: ::c_long = 444;
+pub const SYS_landlock_add_rule: ::c_long = 445;
+pub const SYS_landlock_restrict_self: ::c_long = 446;
+pub const SYS_memfd_secret: ::c_long = 447;
+pub const SYS_process_mrelease: ::c_long = 448;
+pub const SYS_futex_waitv: ::c_long = 449;
+pub const SYS_set_mempolicy_home_node: ::c_long = 450;
 
 // offsets in user_regs_structs, from sys/reg.h
 pub const EBX: ::c_int = 0;

--- a/src/unix/linux_like/android/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/android/b64/aarch64/mod.rs
@@ -410,7 +410,24 @@ pub const SYS_fsopen: ::c_long = 430;
 pub const SYS_fsconfig: ::c_long = 431;
 pub const SYS_fsmount: ::c_long = 432;
 pub const SYS_fspick: ::c_long = 433;
-pub const SYS_syscalls: ::c_long = 436;
+pub const SYS_pidfd_open: ::c_long = 434;
+pub const SYS_clone3: ::c_long = 435;
+pub const SYS_close_range: ::c_long = 436;
+pub const SYS_openat2: ::c_long = 437;
+pub const SYS_pidfd_getfd: ::c_long = 438;
+pub const SYS_faccessat2: ::c_long = 439;
+pub const SYS_process_madvise: ::c_long = 440;
+pub const SYS_epoll_pwait2: ::c_long = 441;
+pub const SYS_mount_setattr: ::c_long = 442;
+pub const SYS_quotactl_fd: ::c_long = 443;
+pub const SYS_landlock_create_ruleset: ::c_long = 444;
+pub const SYS_landlock_add_rule: ::c_long = 445;
+pub const SYS_landlock_restrict_self: ::c_long = 446;
+pub const SYS_memfd_secret: ::c_long = 447;
+pub const SYS_process_mrelease: ::c_long = 448;
+pub const SYS_futex_waitv: ::c_long = 449;
+pub const SYS_set_mempolicy_home_node: ::c_long = 450;
+pub const SYS_syscalls: ::c_long = 451;
 
 cfg_if! {
     if #[cfg(libc_align)] {

--- a/src/unix/linux_like/android/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/android/b64/riscv64/mod.rs
@@ -343,7 +343,24 @@ pub const SYS_fsopen: ::c_long = 430;
 pub const SYS_fsconfig: ::c_long = 431;
 pub const SYS_fsmount: ::c_long = 432;
 pub const SYS_fspick: ::c_long = 433;
-pub const SYS_syscalls: ::c_long = 436;
+pub const SYS_pidfd_open: ::c_long = 434;
+pub const SYS_clone3: ::c_long = 435;
+pub const SYS_close_range: ::c_long = 436;
+pub const SYS_openat2: ::c_long = 437;
+pub const SYS_pidfd_getfd: ::c_long = 438;
+pub const SYS_faccessat2: ::c_long = 439;
+pub const SYS_process_madvise: ::c_long = 440;
+pub const SYS_epoll_pwait2: ::c_long = 441;
+pub const SYS_mount_setattr: ::c_long = 442;
+pub const SYS_quotactl_fd: ::c_long = 443;
+pub const SYS_landlock_create_ruleset: ::c_long = 444;
+pub const SYS_landlock_add_rule: ::c_long = 445;
+pub const SYS_landlock_restrict_self: ::c_long = 446;
+pub const SYS_memfd_secret: ::c_long = 447;
+pub const SYS_process_mrelease: ::c_long = 448;
+pub const SYS_futex_waitv: ::c_long = 449;
+pub const SYS_set_mempolicy_home_node: ::c_long = 450;
+pub const SYS_syscalls: ::c_long = 451;
 
 cfg_if! {
     if #[cfg(libc_align)] {

--- a/src/unix/linux_like/android/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/android/b64/x86_64/mod.rs
@@ -739,6 +739,23 @@ pub const SYS_fsopen: ::c_long = 430;
 pub const SYS_fsconfig: ::c_long = 431;
 pub const SYS_fsmount: ::c_long = 432;
 pub const SYS_fspick: ::c_long = 433;
+pub const SYS_pidfd_open: ::c_long = 434;
+pub const SYS_clone3: ::c_long = 435;
+pub const SYS_close_range: ::c_long = 436;
+pub const SYS_openat2: ::c_long = 437;
+pub const SYS_pidfd_getfd: ::c_long = 438;
+pub const SYS_faccessat2: ::c_long = 439;
+pub const SYS_process_madvise: ::c_long = 440;
+pub const SYS_epoll_pwait2: ::c_long = 441;
+pub const SYS_mount_setattr: ::c_long = 442;
+pub const SYS_quotactl_fd: ::c_long = 443;
+pub const SYS_landlock_create_ruleset: ::c_long = 444;
+pub const SYS_landlock_add_rule: ::c_long = 445;
+pub const SYS_landlock_restrict_self: ::c_long = 446;
+pub const SYS_memfd_secret: ::c_long = 447;
+pub const SYS_process_mrelease: ::c_long = 448;
+pub const SYS_futex_waitv: ::c_long = 449;
+pub const SYS_set_mempolicy_home_node: ::c_long = 450;
 
 // offsets in user_regs_structs, from sys/reg.h
 pub const R15: ::c_int = 0;


### PR DESCRIPTION
Similar to #3062, this adds all syscall constants that are available in NDK `r25c` but were so far missing in this library. See `semver/android.txt` changes for the complete list.

Refs:
 * https://android.googlesource.com/platform/bionic/+/refs/tags/ndk-r25c/libc/kernel/uapi/asm-generic/unistd.h
 * https://android.googlesource.com/platform/bionic/+/refs/tags/ndk-r25c/libc/include/bits/glibc-syscalls.h
