### PR TITLE
Use aligned `cmsghdr` structs `test_cmsg_nxthdr`

### DIFF
--- a/libc-test/test/cmsg.rs
+++ b/libc-test/test/cmsg.rs
@@ -55,34 +55,32 @@ mod t {
     // https://github.com/rust-lang/libc/issues/1239
     #[cfg(not(target_arch = "sparc64"))]
     #[test]
-    // FIXME: This triggers alignment checks for pointer dereferences:
-    // https://github.com/rust-lang/libc/issues/3181
-    #[ignore]
     fn test_cmsg_nxthdr() {
         use std::ptr;
+        // Helps to align the buffer on the stack.
+        #[repr(align(8))]
+        struct Align8<T>(T);
 
-        let mut buffer = [0u8; 256];
+        const CAPACITY: usize = 512;
+        let mut buffer = Align8([0_u8; CAPACITY]);
         let mut mhdr: msghdr = unsafe { mem::zeroed() };
-        let pmhdr = &mhdr as *const msghdr;
         for start_ofs in 0..64 {
-            let pcmsghdr = &mut buffer[start_ofs] as *mut u8 as *mut cmsghdr;
+            let pcmsghdr = buffer.0.as_mut_ptr().cast::<cmsghdr>();
             mhdr.msg_control = pcmsghdr as *mut c_void;
             mhdr.msg_controllen = (160 - start_ofs) as _;
             for cmsg_len in 0..64 {
                 for next_cmsg_len in 0..32 {
-                    for i in buffer[start_ofs..].iter_mut() {
-                        *i = 0;
-                    }
                     unsafe {
+                        pcmsghdr.cast::<u8>().write_bytes(0, CAPACITY);
                         (*pcmsghdr).cmsg_len = cmsg_len;
-                        let libc_next = libc::CMSG_NXTHDR(pmhdr, pcmsghdr);
-                        let next = cmsg_nxthdr(pmhdr, pcmsghdr);
+                        let libc_next = libc::CMSG_NXTHDR(&mhdr, pcmsghdr);
+                        let next = cmsg_nxthdr(&mhdr, pcmsghdr);
                         assert_eq!(libc_next, next);
 
                         if libc_next != ptr::null_mut() {
                             (*libc_next).cmsg_len = next_cmsg_len;
-                            let libc_next = libc::CMSG_NXTHDR(pmhdr, pcmsghdr);
-                            let next = cmsg_nxthdr(pmhdr, pcmsghdr);
+                            let libc_next = libc::CMSG_NXTHDR(&mhdr, pcmsghdr);
+                            let next = cmsg_nxthdr(&mhdr, pcmsghdr);
                             assert_eq!(libc_next, next);
                         }
                     }


### PR DESCRIPTION
Fixes #3181.

I could find no reason for using unaligned structs in this test.