### PR TITLE
aix: add siginfo_t accessors for symmetry with other platforms

### DIFF
--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -192,6 +192,29 @@ s_no_extra_traits! {
     }
 }
 
+impl siginfo_t {
+    pub unsafe fn si_addr(&self) -> *mut ::c_void {
+        self.si_addr
+    }
+
+    #[cfg(libc_union)]
+    pub unsafe fn si_value(&self) -> ::sigval {
+        self.si_value
+    }
+
+    pub unsafe fn si_pid(&self) -> ::pid_t {
+        self.si_pid
+    }
+
+    pub unsafe fn si_uid(&self) -> ::uid_t {
+        self.si_uid
+    }
+
+    pub unsafe fn si_status(&self) -> ::c_int {
+        self.si_status
+    }
+}
+
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         #[cfg(libc_union)]


### PR DESCRIPTION
On other platforms it's possible to call e.g. `si_status()`, it was missing on AIX.

btw, the `#[cfg(libc_union)]` usage in the `siginfo_t` itself looks quite wrong…