### PR TITLE
linux_like: IPPROTO_MPTCP are supported in all linux_like platforms

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1795,6 +1795,8 @@ fn test_android(target: &str) {
             | "MADV_POPULATE_READ"
             | "MADV_POPULATE_WRITE" => true,
 
+            // kernel 5.6 minimum required
+            "IPPROTO_MPTCP" => true,
 
             _ => false,
         }

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1933,8 +1933,6 @@ pub const CLONE_PIDFD: ::c_int = 0x1000;
 // netinet/in.h
 // NOTE: These are in addition to the constants defined in src/unix/mod.rs
 
-/// Multipath TCP
-pub const IPPROTO_MPTCP: ::c_int = 262;
 #[deprecated(
     since = "0.2.80",
     note = "This value was increased in the newer kernel \

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -916,6 +916,8 @@ pub const IPPROTO_UDPLITE: ::c_int = 136;
 pub const IPPROTO_RAW: ::c_int = 255;
 pub const IPPROTO_BEETPH: ::c_int = 94;
 pub const IPPROTO_MPLS: ::c_int = 137;
+/// Multipath TCP
+pub const IPPROTO_MPTCP: ::c_int = 262;
 
 pub const MCAST_EXCLUDE: ::c_int = 0;
 pub const MCAST_INCLUDE: ::c_int = 1;


### PR DESCRIPTION
`IPPROTO_MPTCP` is supported on Android.

Android: https://android.googlesource.com/platform/external/kernel-headers/+/refs/heads/master/original/uapi/linux/in.h#85