### PR TITLE
Add kexec_file_load system call for arm linux

### DIFF
--- a/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
@@ -837,6 +837,7 @@ pub const SYS_pkey_alloc: ::c_long = 395;
 pub const SYS_pkey_free: ::c_long = 396;
 pub const SYS_statx: ::c_long = 397;
 pub const SYS_rseq: ::c_long = 398;
+pub const SYS_kexec_file_load: ::c_long = 401;
 pub const SYS_pidfd_send_signal: ::c_long = 424;
 pub const SYS_io_uring_setup: ::c_long = 425;
 pub const SYS_io_uring_enter: ::c_long = 426;


### PR DESCRIPTION
This syscall was introduced in Linux 5.0. References:

- torvalds/linux@4ab65ba7a5cbad47520274d88d066bf8eb83f161
