### PR TITLE
Netlink support for FreeBSD 13.2

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2072,6 +2072,8 @@ fn test_freebsd(target: &str) {
                 "netinet/sctp.h",
                 "netinet/tcp.h",
                 "netinet/udp.h",
+                [freebsd13]:"netlink/netlink.h",
+                [freebsd13]:"netlink/netlink_generic.h",
                 "poll.h",
                 "pthread.h",
                 "pthread_np.h",
@@ -2312,6 +2314,91 @@ fn test_freebsd(target: &str) {
             // Added in FreeBSD 13.0 (r367776 and r367287)
             "SCM_CREDS2" | "LOCAL_CREDS_PERSISTENT" if Some(13) > freebsd_ver => true,
 
+            // Added in FreeBSD 13.2
+            "AF_NETLINK"
+            | "PF_NETLINK"
+            | "SOL_NETLINK"
+            | "NETLINK_ADD_MEMBERSHIP"
+            | "NETLINK_DROP_MEMBERSHIP"
+            | "NETLINK_PKTINFO"
+            | "NETLINK_BROADCAST_ERROR"
+            | "NETLINK_NO_ENOBUFS"
+            | "NETLINK_RX_RING"
+            | "NETLINK_TX_RING"
+            | "NETLINK_LISTEN_ALL_NSID"
+            | "NETLINK_LIST_MEMBERSHIPS"
+            | "NETLINK_CAP_ACK"
+            | "NETLINK_EXT_ACK"
+            | "NETLINK_GET_STRICT_CHK"
+            | "NLM_F_REQUEST"
+            | "NLM_F_MULTI"
+            | "NLM_F_ACK"
+            | "NLM_F_ECHO"
+            | "NLM_F_DUMP_INTR"
+            | "NLM_F_DUMP_FILTERED"
+            | "NLM_F_ROOT"
+            | "NLM_F_MATCH"
+            | "NLM_F_ATOMIC"
+            | "NLM_F_DUMP"
+            | "NLM_F_REPLACE"
+            | "NLM_F_EXCL"
+            | "NLM_F_CREATE"
+            | "NLM_F_APPEND"
+            | "NLM_F_NONREC"
+            | "NLM_F_CAPPED"
+            | "NLM_F_ACK_TLVS"
+            | "NLMSG_NOOP"
+            | "NLMSG_ERROR"
+            | "NLMSG_DONE"
+            | "NLMSG_OVERRUN"
+            | "NETLINK_ROUTE"
+            | "NETLINK_UNUSED"
+            | "NETLINK_USERSOCK"
+            | "NETLINK_FIREWALL"
+            | "NETLINK_SOCK_DIAG"
+            | "NETLINK_NFLOG"
+            | "NETLINK_XFRM"
+            | "NETLINK_SELINUX"
+            | "NETLINK_ISCSI"
+            | "NETLINK_AUDIT"
+            | "NETLINK_FIB_LOOKUP"
+            | "NETLINK_CONNECTOR"
+            | "NETLINK_NETFILTER"
+            | "NETLINK_IP6_FW"
+            | "NETLINK_DNRTMSG"
+            | "NETLINK_KOBJECT_UEVENT"
+            | "NETLINK_GENERIC"
+            | "NLMSG_ALIGNTO"
+            | "CTRL_CMD_UNSPEC"
+            | "CTRL_CMD_NEWFAMILY"
+            | "CTRL_CMD_DELFAMILY"
+            | "CTRL_CMD_GETFAMILY"
+            | "CTRL_CMD_NEWOPS"
+            | "CTRL_CMD_DELOPS"
+            | "CTRL_CMD_GETOPS"
+            | "CTRL_CMD_NEWMCAST_GRP"
+            | "CTRL_CMD_DELMCAST_GRP"
+            | "CTRL_CMD_GETMCAST_GRP"
+            | "CTRL_CMD_GETPOLICY"
+            | "CTRL_ATTR_UNSPEC"
+            | "CTRL_ATTR_FAMILY_ID"
+            | "CTRL_ATTR_FAMILY_NAME"
+            | "CTRL_ATTR_VERSION"
+            | "CTRL_ATTR_HDRSIZE"
+            | "CTRL_ATTR_MAXATTR"
+            | "CTRL_ATTR_OPS"
+            | "CTRL_ATTR_MCAST_GROUPS"
+            | "CTRL_ATTR_POLICY"
+            | "CTRL_ATTR_OP_POLICY"
+            | "CTRL_ATTR_OP"
+            | "CTRL_ATTR_MCAST_GRP_UNSPEC"
+            | "CTRL_ATTR_MCAST_GRP_NAME"
+            | "CTRL_ATTR_MCAST_GRP_ID"
+                if Some(13) > freebsd_ver =>
+            {
+                true
+            }
+
             // Added in FreeBSD 14
             "SPACECTL_DEALLOC" if Some(14) > freebsd_ver => true,
 
@@ -2516,6 +2603,9 @@ fn test_freebsd(target: &str) {
             "sockcred2" if Some(13) > freebsd_ver => true,
             // `shm_largepage_conf` was introduced in FreeBSD 13.
             "shm_largepage_conf" if Some(13) > freebsd_ver => true,
+
+            // `sockaddr_nl` introduced in FreeBSD 13.2
+            "sockaddr_nl" if Some(13) > freebsd_ver => true,
 
             // Those are private types
             "memory_type" => true,

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2453,6 +2453,33 @@ fn test_freebsd(target: &str) {
             // FIXME: The values has been changed in FreeBSD 15:
             "CLOCK_BOOTTIME" if Some(15) <= freebsd_ver => true,
 
+            // submodule ifmib, cannot be checked today
+            "DOT3COMPLIANCE_STATS"
+            | "DOT3COMPLIANCE_COLLS"
+            | "IFDATA_GENERAL"
+            | "IFDATA_LINKSPECIFIC"
+            | "IFDATA_DRIVERNAME"
+            | "IFMIB_IFCOUNT"
+            | "IFMIB_IFDATA"
+            | "IFMIB_SYSTEM"
+            | "NETLINK_GENERIC"
+            | "dot3ChipSetAMD7990"
+            | "dot3ChipSetAMD79900"
+            | "dot3ChipSetAMD79C940"
+            | "dot3ChipSetIntel82586"
+            | "dot3ChipSetIntel82596"
+            | "dot3ChipSetIntel82557"
+            | "dot3ChipSetNational8390"
+            | "dot3ChipSetNationalSonic"
+            | "dot3ChipSetFujitsu86950"
+            | "dot3ChipSetDigitalDC21040"
+            | "dot3ChipSetDigitalDC21140"
+            | "dot3ChipSetDigitalDC21041"
+            | "dot3ChipSetDigitalDC21140A"
+            | "dot3ChipSetDigitalDC21142"
+            | "dot3ChipSetWesternDigital83C690"
+            | "dot3ChipSetWesternDigital83C790" => true,
+
             _ => false,
         }
     });

--- a/src/unix/bsd/freebsdlike/freebsd/ifmib.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/ifmib.rs
@@ -1,0 +1,44 @@
+// sys/net/if_mib.h
+
+/// non-interface-specific
+pub const IFMIB_SYSTEM: ::c_int = 1;
+/// per-interface data table
+pub const IFMIB_IFDATA: ::c_int = 2;
+
+/// generic stats for all kinds of ifaces
+pub const IFDATA_GENERAL: ::c_int = 1;
+/// specific to the type of interface
+pub const IFDATA_LINKSPECIFIC: ::c_int = 2;
+/// driver name and unit
+pub const IFDATA_DRIVERNAME: ::c_int = 3;
+
+/// number of interfaces configured
+pub const IFMIB_IFCOUNT: ::c_int = 1;
+
+/// functions not specific to a type of iface
+pub const NETLINK_GENERIC: ::c_int = 0;
+
+pub const DOT3COMPLIANCE_STATS: ::c_int = 1;
+pub const DOT3COMPLIANCE_COLLS: ::c_int = 2;
+
+pub const dot3ChipSetAMD7990: ::c_int = 1;
+pub const dot3ChipSetAMD79900: ::c_int = 2;
+pub const dot3ChipSetAMD79C940: ::c_int = 3;
+
+pub const dot3ChipSetIntel82586: ::c_int = 1;
+pub const dot3ChipSetIntel82596: ::c_int = 2;
+pub const dot3ChipSetIntel82557: ::c_int = 3;
+
+pub const dot3ChipSetNational8390: ::c_int = 1;
+pub const dot3ChipSetNationalSonic: ::c_int = 2;
+
+pub const dot3ChipSetFujitsu86950: ::c_int = 1;
+
+pub const dot3ChipSetDigitalDC21040: ::c_int = 1;
+pub const dot3ChipSetDigitalDC21140: ::c_int = 2;
+pub const dot3ChipSetDigitalDC21041: ::c_int = 3;
+pub const dot3ChipSetDigitalDC21140A: ::c_int = 4;
+pub const dot3ChipSetDigitalDC21142: ::c_int = 5;
+
+pub const dot3ChipSetWesternDigital83C690: ::c_int = 1;
+pub const dot3ChipSetWesternDigital83C790: ::c_int = 2;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1388,6 +1388,14 @@ s_no_extra_traits! {
         pub sdl_data: [::c_char; 46],
     }
 
+    pub struct sockaddr_nl {
+        pub nl_len: ::c_uchar,
+        pub nl_family: ::sa_family_t,
+        nl_pad: ::c_ushort,
+        pub nl_pid: u32,
+        pub nl_groups: u32
+    }
+
     pub struct mq_attr {
         pub mq_flags: ::c_long,
         pub mq_maxmsg: ::c_long,
@@ -1785,6 +1793,34 @@ cfg_if! {
                 self.sdl_alen.hash(state);
                 self.sdl_slen.hash(state);
                 self.sdl_data.hash(state);
+            }
+        }
+
+        impl PartialEq for sockaddr_nl {
+            fn eq(&self, other: &sockaddr_nl) -> bool {
+                self.nl_len == other.nl_len &&
+                    self.nl_family == other.nl_family &&
+                    self.nl_pid == other.nl_pid &&
+                    self.nl_groups == other.nl_groups
+            }
+        }
+        impl Eq for sockaddr_nl {}
+        impl ::fmt::Debug for sockaddr_nl {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("sockaddr_nl")
+                    .field("nl_len", &self.nl_len)
+                    .field("nl_family", &self.nl_family)
+                    .field("nl_pid", &self.nl_pid)
+                    .field("nl_groups", &self.nl_groups)
+                    .finish()
+            }
+        }
+        impl ::hash::Hash for sockaddr_nl {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                self.nl_len.hash(state);
+                self.nl_family.hash(state);
+                self.nl_pid.hash(state);
+                self.nl_groups.hash(state);
             }
         }
 
@@ -3182,6 +3218,104 @@ pub const SO_TS_REALTIME: ::c_int = 2;
 pub const SO_TS_MONOTONIC: ::c_int = 3;
 pub const SO_TS_DEFAULT: ::c_int = SO_TS_REALTIME_MICRO;
 pub const SO_TS_CLOCK_MAX: ::c_int = SO_TS_MONOTONIC;
+
+/// netlink constants
+
+// sys/socket.h
+pub const AF_NETLINK: ::c_int = 38;
+pub const PF_NETLINK: ::c_int = AF_NETLINK;
+
+// netlink/netlink.h
+pub const SOL_NETLINK: ::c_int = 270;
+pub const NETLINK_ADD_MEMBERSHIP: ::c_int = 1;
+pub const NETLINK_DROP_MEMBERSHIP: ::c_int = 2;
+pub const NETLINK_PKTINFO: ::c_int = 3;
+pub const NETLINK_BROADCAST_ERROR: ::c_int = 4;
+pub const NETLINK_NO_ENOBUFS: ::c_int = 5;
+pub const NETLINK_RX_RING: ::c_int = 6;
+pub const NETLINK_TX_RING: ::c_int = 7;
+pub const NETLINK_LISTEN_ALL_NSID: ::c_int = 8;
+pub const NETLINK_LIST_MEMBERSHIPS: ::c_int = 9;
+pub const NETLINK_CAP_ACK: ::c_int = 10;
+pub const NETLINK_EXT_ACK: ::c_int = 11;
+pub const NETLINK_GET_STRICT_CHK: ::c_int = 12;
+//
+pub const NLM_F_REQUEST: ::c_int = 0x01;
+pub const NLM_F_MULTI: ::c_int = 0x02;
+pub const NLM_F_ACK: ::c_int = 0x04;
+pub const NLM_F_ECHO: ::c_int = 0x08;
+pub const NLM_F_DUMP_INTR: ::c_int = 0x10;
+pub const NLM_F_DUMP_FILTERED: ::c_int = 0x20;
+//
+pub const NLM_F_ROOT: ::c_int = 0x100;
+pub const NLM_F_MATCH: ::c_int = 0x200;
+pub const NLM_F_ATOMIC: ::c_int = 0x400;
+pub const NLM_F_DUMP: ::c_int = NLM_F_ROOT | NLM_F_MATCH;
+//
+pub const NLM_F_REPLACE: ::c_int = 0x100;
+pub const NLM_F_EXCL: ::c_int = 0x200;
+pub const NLM_F_CREATE: ::c_int = 0x400;
+pub const NLM_F_APPEND: ::c_int = 0x800;
+//
+pub const NLM_F_NONREC: ::c_int = 0x100;
+//
+pub const NLM_F_CAPPED: ::c_int = 0x100;
+pub const NLM_F_ACK_TLVS: ::c_int = 0x200;
+//
+pub const NLMSG_NOOP: ::c_int = 0x1;
+pub const NLMSG_ERROR: ::c_int = 0x2;
+pub const NLMSG_DONE: ::c_int = 0x3;
+pub const NLMSG_OVERRUN: ::c_int = 0x4;
+//
+pub const NETLINK_ROUTE: ::c_int = 0;
+pub const NETLINK_UNUSED: ::c_int = 1;
+pub const NETLINK_USERSOCK: ::c_int = 2;
+pub const NETLINK_FIREWALL: ::c_int = 3;
+pub const NETLINK_SOCK_DIAG: ::c_int = 4;
+pub const NETLINK_NFLOG: ::c_int = 5;
+pub const NETLINK_XFRM: ::c_int = 6;
+pub const NETLINK_SELINUX: ::c_int = 7;
+pub const NETLINK_ISCSI: ::c_int = 8;
+pub const NETLINK_AUDIT: ::c_int = 9;
+pub const NETLINK_FIB_LOOKUP: ::c_int = 10;
+pub const NETLINK_CONNECTOR: ::c_int = 11;
+pub const NETLINK_NETFILTER: ::c_int = 12;
+pub const NETLINK_IP6_FW: ::c_int = 13;
+pub const NETLINK_DNRTMSG: ::c_int = 14;
+pub const NETLINK_KOBJECT_UEVENT: ::c_int = 15;
+pub const NETLINK_GENERIC: ::c_int = 16;
+//
+const NL_ITEM_ALIGN_SIZE: ::c_int = 4; // mem::size_of::<u32>(); FIXME accept new dep?
+pub const NLMSG_ALIGNTO: ::c_int = NL_ITEM_ALIGN_SIZE;
+
+// netlink/netlink_generic.h
+pub const CTRL_CMD_UNSPEC: ::c_int = 0;
+pub const CTRL_CMD_NEWFAMILY: ::c_int = 1;
+pub const CTRL_CMD_DELFAMILY: ::c_int = 2;
+pub const CTRL_CMD_GETFAMILY: ::c_int = 3;
+pub const CTRL_CMD_NEWOPS: ::c_int = 4;
+pub const CTRL_CMD_DELOPS: ::c_int = 5;
+pub const CTRL_CMD_GETOPS: ::c_int = 6;
+pub const CTRL_CMD_NEWMCAST_GRP: ::c_int = 7;
+pub const CTRL_CMD_DELMCAST_GRP: ::c_int = 8;
+pub const CTRL_CMD_GETMCAST_GRP: ::c_int = 9;
+pub const CTRL_CMD_GETPOLICY: ::c_int = 10;
+//
+pub const CTRL_ATTR_UNSPEC: ::c_int = 0;
+pub const CTRL_ATTR_FAMILY_ID: ::c_int = 1;
+pub const CTRL_ATTR_FAMILY_NAME: ::c_int = 2;
+pub const CTRL_ATTR_VERSION: ::c_int = 3;
+pub const CTRL_ATTR_HDRSIZE: ::c_int = 4;
+pub const CTRL_ATTR_MAXATTR: ::c_int = 5;
+pub const CTRL_ATTR_OPS: ::c_int = 6;
+pub const CTRL_ATTR_MCAST_GROUPS: ::c_int = 7;
+pub const CTRL_ATTR_POLICY: ::c_int = 8;
+pub const CTRL_ATTR_OP_POLICY: ::c_int = 9;
+pub const CTRL_ATTR_OP: ::c_int = 10;
+//
+pub const CTRL_ATTR_MCAST_GRP_UNSPEC: ::c_int = 0;
+pub const CTRL_ATTR_MCAST_GRP_NAME: ::c_int = 1;
+pub const CTRL_ATTR_MCAST_GRP_ID: ::c_int = 2;
 
 pub const LOCAL_CREDS: ::c_int = 2;
 pub const LOCAL_CREDS_PERSISTENT: ::c_int = 3;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -3483,51 +3483,6 @@ pub const IFDR_MSG_SIZE: ::c_int = 64;
 pub const IFDR_REASON_MSG: ::c_int = 1;
 pub const IFDR_REASON_VENDOR: ::c_int = 2;
 
-// sys/net/if_mib.h
-
-/// non-interface-specific
-pub const IFMIB_SYSTEM: ::c_int = 1;
-/// per-interface data table
-pub const IFMIB_IFDATA: ::c_int = 2;
-
-/// generic stats for all kinds of ifaces
-pub const IFDATA_GENERAL: ::c_int = 1;
-/// specific to the type of interface
-pub const IFDATA_LINKSPECIFIC: ::c_int = 2;
-/// driver name and unit
-pub const IFDATA_DRIVERNAME: ::c_int = 3;
-
-/// number of interfaces configured
-pub const IFMIB_IFCOUNT: ::c_int = 1;
-
-/// functions not specific to a type of iface
-pub const NETLINK_GENERIC: ::c_int = 0;
-
-pub const DOT3COMPLIANCE_STATS: ::c_int = 1;
-pub const DOT3COMPLIANCE_COLLS: ::c_int = 2;
-
-pub const dot3ChipSetAMD7990: ::c_int = 1;
-pub const dot3ChipSetAMD79900: ::c_int = 2;
-pub const dot3ChipSetAMD79C940: ::c_int = 3;
-
-pub const dot3ChipSetIntel82586: ::c_int = 1;
-pub const dot3ChipSetIntel82596: ::c_int = 2;
-pub const dot3ChipSetIntel82557: ::c_int = 3;
-
-pub const dot3ChipSetNational8390: ::c_int = 1;
-pub const dot3ChipSetNationalSonic: ::c_int = 2;
-
-pub const dot3ChipSetFujitsu86950: ::c_int = 1;
-
-pub const dot3ChipSetDigitalDC21040: ::c_int = 1;
-pub const dot3ChipSetDigitalDC21140: ::c_int = 2;
-pub const dot3ChipSetDigitalDC21041: ::c_int = 3;
-pub const dot3ChipSetDigitalDC21140A: ::c_int = 4;
-pub const dot3ChipSetDigitalDC21142: ::c_int = 5;
-
-pub const dot3ChipSetWesternDigital83C690: ::c_int = 1;
-pub const dot3ChipSetWesternDigital83C790: ::c_int = 2;
-
 // sys/netinet/in.h
 // Protocols (RFC 1700)
 // NOTE: These are in addition to the constants defined in src/unix/mod.rs
@@ -5883,3 +5838,6 @@ cfg_if! {
         // Unknown target_arch
     }
 }
+
+// sys/net/if_mib.h
+pub mod ifmib;


### PR DESCRIPTION
Closes #3194, to the point that [Xen Guest Agent](https://gitlab.com/xen-project/xen-guest-agent) can works on FreeBSD.

Requires breaking-change #3367.

Downstream support in `rust-netlink`:
- [x] `netlink-packet-route`: FreeBSD support available since v0.18
- [x] `rtnetlink`: FreeBSD support available since v0.14.1 (from https://github.com/rust-netlink/rtnetlink/pull/49)

Also see https://github.com/rust-lang/libc/pull/3555 for a backport to `libc-0.2` branch using a feature flag to avoid the breaking change by default.