### PR TITLE
uclibc/mips: fixed SA_* mismatched types

### DIFF
--- a/src/unix/linux_like/linux/uclibc/mips/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mod.rs
@@ -23,10 +23,10 @@ pub const ECOMM: ::c_int = 70;
 pub const EPROTO: ::c_int = 71;
 pub const EDOTDOT: ::c_int = 73;
 
-pub const SA_NODEFER: ::c_int = 0x40000000;
-pub const SA_RESETHAND: ::c_int = 0x80000000;
-pub const SA_RESTART: ::c_int = 0x10000000;
-pub const SA_NOCLDSTOP: ::c_int = 0x00000001;
+pub const SA_NODEFER: ::c_ulong = 0x40000000;
+pub const SA_RESETHAND: ::c_ulong = 0x80000000;
+pub const SA_RESTART: ::c_ulong = 0x10000000;
+pub const SA_NOCLDSTOP: ::c_ulong = 0x00000001;
 
 pub const EPOLL_CLOEXEC: ::c_int = 0x80000;
 
@@ -158,9 +158,9 @@ pub const SOCK_STREAM: ::c_int = 2;
 pub const SOCK_DGRAM: ::c_int = 1;
 pub const SOCK_SEQPACKET: ::c_int = 5;
 
-pub const SA_ONSTACK: ::c_uint = 0x08000000;
-pub const SA_SIGINFO: ::c_uint = 0x00000008;
-pub const SA_NOCLDWAIT: ::c_int = 0x00010000;
+pub const SA_ONSTACK: ::c_ulong = 0x08000000;
+pub const SA_SIGINFO: ::c_ulong = 0x00000008;
+pub const SA_NOCLDWAIT: ::c_ulong = 0x00010000;
 
 pub const SIGCHLD: ::c_int = 18;
 pub const SIGBUS: ::c_int = 10;


### PR DESCRIPTION
```
error[E0308]: mismatched types
   --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/nix-0.24.3/src/macros.rs:70:35
    |
70  |                       const $Flag = libc::$Flag $(as $cast)*;
    |                                     ^^^^^^^^^^^ expected `u32`, found `i32`
    |
   ::: /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/nix-0.24.3/src/sys/signal.rs:436:1
    |
436 | / libc_bitflags!{
437 | |     /// Controls the behavior of a [`SigAction`]
438 | |     #[cfg_attr(docsrs, doc(cfg(feature = "signal")))]
439 | |     pub struct SaFlags: SaFlags_t {
...   |
461 | |     }
462 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `libc_bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)

```