### PR TITLE
Add PF_ROUTE-related structures on Apple systems

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -435,6 +435,80 @@ s! {
         pub ifm_data: if_data,
     }
 
+    pub struct ifa_msghdr {
+        pub ifam_msglen: ::c_ushort,
+        pub ifam_version: ::c_uchar,
+        pub ifam_type: ::c_uchar,
+        pub ifam_addrs: ::c_int,
+        pub ifam_flags: ::c_int,
+        pub ifam_index: ::c_ushort,
+        pub ifam_metric: ::c_int,
+    }
+
+    pub struct ifma_msghdr {
+        pub ifmam_msglen: ::c_ushort,
+        pub ifmam_version: ::c_uchar,
+        pub ifmam_type: ::c_uchar,
+        pub ifmam_addrs: ::c_int,
+        pub ifmam_flags: ::c_int,
+        pub ifmam_index: ::c_ushort,
+    }
+
+    pub struct ifma_msghdr2 {
+        pub ifmam_msglen: ::c_ushort,
+        pub ifmam_version: ::c_uchar,
+        pub ifmam_type: ::c_uchar,
+        pub ifmam_addrs: ::c_int,
+        pub ifmam_flags: ::c_int,
+        pub ifmam_index: ::c_ushort,
+        pub ifmam_refcount: i32,
+    }
+
+    pub struct rt_metrics {
+        pub rmx_locks: u32,
+        pub rmx_mtu: u32,
+        pub rmx_hopcount: u32,
+        pub rmx_expire: i32,
+        pub rmx_recvpipe: u32,
+        pub rmx_sendpipe: u32,
+        pub rmx_ssthresh: u32,
+        pub rmx_rtt: u32,
+        pub rmx_rttvar: u32,
+        pub rmx_pksent: u32,
+        pub rmx_state: u32,
+        pub rmx_filler: [u32; 3],
+    }
+
+    pub struct rt_msghdr {
+        pub rtm_msglen: ::c_ushort,
+        pub rtm_version: ::c_uchar,
+        pub rtm_type: ::c_uchar,
+        pub rtm_index: ::c_ushort,
+        pub rtm_flags: ::c_int,
+        pub rtm_addrs: ::c_int,
+        pub rtm_pid: ::pid_t,
+        pub rtm_seq: ::c_int,
+        pub rtm_errno: ::c_int,
+        pub rtm_use: ::c_int,
+        pub rtm_inits: u32,
+        pub rtm_rmx: rt_metrics,
+    }
+
+    pub struct rt_msghdr2 {
+        pub rtm_msglen: ::c_ushort,
+        pub rtm_version: ::c_uchar,
+        pub rtm_type: ::c_uchar,
+        pub rtm_index: ::c_ushort,
+        pub rtm_flags: ::c_int,
+        pub rtm_addrs: ::c_int,
+        pub rtm_refcnt: i32,
+        pub rtm_parentflags: ::c_int,
+        pub rtm_reserved: ::c_int,
+        pub rtm_use: ::c_int,
+        pub rtm_inits: u32,
+        pub rtm_rmx: rt_metrics,
+    }
+
     pub struct termios {
         pub c_iflag: ::tcflag_t,
         pub c_oflag: ::tcflag_t,


### PR DESCRIPTION
This commit adds the following structures from [net/route.h](https://github.com/roblabla/MacOSX-SDKs/blob/master/MacOSX13.3.sdk/usr/include/net/route.h):

- rt_msghdr
- rt_msghdr2
- rt_metrics

and the following structures from [net/if.h](https://github.com/roblabla/MacOSX-SDKs/blob/master/MacOSX13.3.sdk/usr/include/net/if.h):

- ifa_msghdr
- ifma_msghdr
- ifma_msghdr2