### PR TITLE
Define `FICLONE` on mips and power.

### DIFF
--- a/src/unix/linux_like/linux/arch/generic/mod.rs
+++ b/src/unix/linux_like/linux/arch/generic/mod.rs
@@ -104,6 +104,8 @@ cfg_if! {
         pub const SO_DETACH_REUSEPORT_BPF: ::c_int = 68;
     }
 }
+// pub const SO_PREFER_BUSY_POLL: ::c_int = 69;
+// pub const SO_BUSY_POLL_BUDGET: ::c_int = 70;
 
 cfg_if! {
     if #[cfg(any(target_arch = "x86",
@@ -114,16 +116,8 @@ cfg_if! {
                  target_arch = "s390x"))] {
         pub const FICLONE: ::c_ulong = 0x40049409;
         pub const FICLONERANGE: ::c_ulong = 0x4020940D;
-    } else if #[cfg(any(target_arch = "mips",
-                        target_arch = "mips64",
-                        target_arch = "powerpc",
-                        target_arch = "powerpc64"))] {
-        pub const FICLONE: ::c_ulong = 0x80049409;
-        pub const FICLONERANGE: ::c_ulong = 0x8020940D;
     }
 }
-// pub const SO_PREFER_BUSY_POLL: ::c_int = 69;
-// pub const SO_BUSY_POLL_BUDGET: ::c_int = 70;
 
 // Defined in unix/linux_like/mod.rs
 // pub const SCM_TIMESTAMP: ::c_int = SO_TIMESTAMP;

--- a/src/unix/linux_like/linux/arch/mips/mod.rs
+++ b/src/unix/linux_like/linux/arch/mips/mod.rs
@@ -103,6 +103,9 @@ pub const SO_TIMESTAMPING: ::c_int = 37;
 // pub const SO_PREFER_BUSY_POLL: ::c_int = 69;
 // pub const SO_BUSY_POLL_BUDGET: ::c_int = 70;
 
+pub const FICLONE: ::c_ulong = 0x80049409;
+pub const FICLONERANGE: ::c_ulong = 0x8020940D;
+
 // Defined in unix/linux_like/mod.rs
 // pub const SCM_TIMESTAMP: ::c_int = SO_TIMESTAMP;
 pub const SCM_TIMESTAMPNS: ::c_int = SO_TIMESTAMPNS;

--- a/src/unix/linux_like/linux/arch/powerpc/mod.rs
+++ b/src/unix/linux_like/linux/arch/powerpc/mod.rs
@@ -85,6 +85,9 @@ pub const SO_BINDTOIFINDEX: ::c_int = 62;
 // pub const SO_PREFER_BUSY_POLL: ::c_int = 69;
 // pub const SO_BUSY_POLL_BUDGET: ::c_int = 70;
 
+pub const FICLONE: ::c_ulong = 0x80049409;
+pub const FICLONERANGE: ::c_ulong = 0x8020940D;
+
 // Defined in unix/linux_like/mod.rs
 // pub const SCM_TIMESTAMP: ::c_int = SO_TIMESTAMP;
 pub const SCM_TIMESTAMPNS: ::c_int = SO_TIMESTAMPNS;


### PR DESCRIPTION
PR #3173 added definitions of `FICLONE` for mips and power to a generic file, however mips and power have their own versions of this file, so move their `FICLONE` definitions into their own files.
