### PR TITLE
Fix "Bump to 0.2.142" libc dependency version

### DIFF
--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.122"
+version = "0.2.142"
 default-features = false
 
 [build-dependencies]


### PR DESCRIPTION
Typo during the previous upgrade in

    commit 38702b2623a2acfbf1957263f0c84950ef071aa4
    Author: Dan Johnson <computerdruid@google.com>
    Date:   Wed Apr 19 14:17:19 2023 -0700

        Bump to 0.2.142