### PR TITLE
haiku: fix incorrect linked library.

### DIFF
--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -2055,7 +2055,7 @@ extern "C" {
     ) -> ::c_int;
 }
 
-#[link(name = "unix")]
+#[link(name = "gnu")]
 extern "C" {
     pub fn memmem(
         source: *const ::c_void,


### PR DESCRIPTION
Introduced in fb2a763; using a non-existent "libunix". This is in libgnu.