### PR TITLE
Added getentropy to vita target

### DIFF
--- a/src/unix/newlib/vita/mod.rs
+++ b/src/unix/newlib/vita/mod.rs
@@ -168,6 +168,8 @@ extern "C" {
     ) -> ::c_int;
 
     pub fn pthread_getprocessorid_np() -> ::c_int;
+
+    pub fn getentropy(buf: *mut ::c_void, buflen: ::size_t) -> ::c_int;
 }
 
 pub use crate::unix::newlib::generic::{sigset_t, stat};


### PR DESCRIPTION
This is a late addition to https://github.com/rust-lang/libc/pull/3209. This definition is required in order to implement random in std correctly.

As the previous PR, getentropy is a standard C function, should be implemented by newlib provider, and is not Sony's intellectual property.