### PR TITLE
Musl sysemu

### DIFF
--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -257,6 +257,9 @@ pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_SYNC: ::c_int = 0x080000;
 
+pub const PTRACE_SYSEMU: ::c_int = 0x1d;
+pub const PTRACE_SYSEMU_SINGLESTEP: ::c_int = 0x1e;
+
 pub const SOCK_STREAM: ::c_int = 1;
 pub const SOCK_DGRAM: ::c_int = 2;
 pub const SOCK_SEQPACKET: ::c_int = 5;

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -456,6 +456,9 @@ pub const FLUSHO: ::tcflag_t = 0x00001000;
 pub const POLLWRNORM: ::c_short = 0x100;
 pub const POLLWRBAND: ::c_short = 0x200;
 
+pub const PTRACE_SYSEMU: ::c_int = 31;
+pub const PTRACE_SYSEMU_SINGLESTEP: ::c_int = 32;
+
 // Syscall table
 pub const SYS_restart_syscall: ::c_long = 0;
 pub const SYS_exit: ::c_long = 1;

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -173,6 +173,9 @@ pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_SYNC: ::c_int = 0x080000;
 
+pub const PTRACE_SYSEMU: ::c_int = 0x1d;
+pub const PTRACE_SYSEMU_SINGLESTEP: ::c_int = 0x1e;
+
 pub const SOCK_STREAM: ::c_int = 1;
 pub const SOCK_DGRAM: ::c_int = 2;
 

--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -179,6 +179,9 @@ pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_SYNC: ::c_int = 0x080000;
 
+pub const PTRACE_SYSEMU: ::c_int = 31;
+pub const PTRACE_SYSEMU_SINGLESTEP: ::c_int = 32;
+
 pub const EDEADLOCK: ::c_int = 35;
 pub const ENAMETOOLONG: ::c_int = 36;
 pub const ENOLCK: ::c_int = 37;

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -682,6 +682,9 @@ pub const O_RSYNC: ::c_int = 1052672;
 pub const O_DSYNC: ::c_int = 4096;
 pub const O_ASYNC: ::c_int = 0x2000;
 
+pub const PTRACE_SYSEMU: ::c_int = 31;
+pub const PTRACE_SYSEMU_SINGLESTEP: ::c_int = 32;
+
 pub const SIGSTKSZ: ::size_t = 8192;
 pub const MINSIGSTKSZ: ::size_t = 2048;
 


### PR DESCRIPTION
This adds support for the `PTRACE_SYSEMU` and `PTRACE_SYSEMU_SINGLESTEP` on certain musl architectures. I grabbed these constants by doing a `git grep -rnI PTRACE_SYSEMU` in the musl repository and got a list of certain architecture directories.

See #1774

By the way: I am not sure if I should have added support for that many architectures, just because musl supports them. After all, the corresponding glibc only supports `x86(_64)` anyway.