### PR TITLE
Change branch references to HEAD where possible or main otherwise

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -23,7 +23,7 @@ jobs:
           x86_64-unknown-linux-gnu,
         ]
     steps:
-      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@HEAD
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
           x86_64-apple-darwin,
         ]
     steps:
-      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@HEAD
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v3
@@ -81,7 +81,7 @@ jobs:
           #    ARCH: i686
           - target: i686-pc-windows-msvc
     steps:
-      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@HEAD
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v3
@@ -103,7 +103,7 @@ jobs:
     name: Style check
     runs-on: ubuntu-22.04
     steps:
-      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@HEAD
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v3
@@ -163,7 +163,7 @@ jobs:
           # x86_64-unknown-redox,
         ]
     steps:
-      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@HEAD
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v3
@@ -191,7 +191,7 @@ jobs:
           armv7-unknown-linux-uclibceabihf
         ]
     steps:
-      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@HEAD
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v3
@@ -210,7 +210,7 @@ jobs:
     needs: [docker_linux_tier1, style_check]
     runs-on: ubuntu-22.04
     steps:
-      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@HEAD
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v3
@@ -244,7 +244,7 @@ jobs:
           1.30.0,
         ]
     steps:
-      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@HEAD
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v3
@@ -277,7 +277,7 @@ jobs:
           - { toolchain: 1.30.0, os: macos-11 }
     runs-on: ${{ matrix.target.os }}
     steps:
-      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@HEAD
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v3
@@ -321,7 +321,7 @@ jobs:
     name: "Check #[cfg]s"
     runs-on: ubuntu-22.04
     steps:
-      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@HEAD
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v3
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: docker_linux_tier2
     steps:
-      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@HEAD
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Upload documentation to GitHub Pages
 on:
   push:
     branches:
-      - master
+      - main
 
 # Sets permissions of `GITHUB_TOKEN` to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ of all the exported APIs match the platform that libc is compiled for.
 More detailed information about the design of this library can be found in its
 [associated RFC][rfc].
 
-[rfc]: https://github.com/rust-lang/rfcs/blob/master/text/1291-promote-libc.md
+[rfc]: https://github.com/rust-lang/rfcs/blob/HEAD/text/1291-promote-libc.md
 
 ## Usage
 
@@ -60,10 +60,10 @@ newer Rust features are only available on newer Rust toolchains:
 
 ## Platform support
 
-[Platform-specific documentation (master branch)][docs.master].
+[Platform-specific documentation (HEAD)][docs.head].
 
 See
-[`ci/build.sh`](https://github.com/rust-lang/libc/blob/master/ci/build.sh)
+[`ci/build.sh`](https://github.com/rust-lang/libc/blob/HEAD/ci/build.sh)
 for the platforms on which `libc` is guaranteed to build for each Rust
 toolchain. The test-matrix at [GitHub Actions] and [Cirrus CI] show the
 platforms in which `libc` tests are run.
@@ -75,10 +75,10 @@ platforms in which `libc` tests are run.
 This project is licensed under either of
 
 * [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-  ([LICENSE-APACHE](https://github.com/rust-lang/libc/blob/master/LICENSE-APACHE))
+  ([LICENSE-APACHE](https://github.com/rust-lang/libc/blob/HEAD/LICENSE-APACHE))
 
 * [MIT License](https://opensource.org/licenses/MIT)
-  ([LICENSE-MIT](https://github.com/rust-lang/libc/blob/master/LICENSE-MIT))
+  ([LICENSE-MIT](https://github.com/rust-lang/libc/blob/HEAD/LICENSE-MIT))
 
 at your option.
 
@@ -87,7 +87,7 @@ at your option.
 We welcome all people who want to contribute. Please see the [contributing
 instructions] for more information.
 
-[contributing instructions]: https://github.com/rust-lang/libc/blob/master/CONTRIBUTING.md
+[contributing instructions]: https://github.com/rust-lang/libc/blob/HEAD/CONTRIBUTING.md
 
 Contributions in any form (issues, pull requests, etc.) to this project
 must adhere to Rust's [Code of Conduct].
@@ -107,4 +107,4 @@ dual licensed as above, without any additional terms or conditions.
 [Documentation]: https://docs.rs/libc/badge.svg
 [docs.rs]: https://docs.rs/libc
 [License]: https://img.shields.io/crates/l/libc.svg
-[docs.master]: https://rust-lang.github.io/libc/#platform-specific-documentation
+[docs.head]: https://rust-lang.github.io/libc/#platform-specific-documentation

--- a/ci/README.md
+++ b/ci/README.md
@@ -42,9 +42,9 @@ The remaining architectures look like:
 * The BSD builds, currently OpenBSD and FreeBSD, use QEMU to boot up a system
   and compile/run tests. More information on that below.
 
-[Actions config]: https://github.com/rust-lang/libc/tree/master/.github/workflows
-[Cirrus config]: https://github.com/rust-lang/libc/blob/master/.cirrus.yml
-[android-docker]: https://github.com/rust-lang/libc/blob/master/ci/docker/x86_64-linux-android/Dockerfile
+[Actions config]: https://github.com/rust-lang/libc/tree/HEAD/.github/workflows
+[Cirrus config]: https://github.com/rust-lang/libc/blob/HEAD/.cirrus.yml
+[android-docker]: https://github.com/rust-lang/libc/blob/HEAD/ci/docker/x86_64-linux-android/Dockerfile
 
 ## QEMU
 

--- a/ci/linux-s390x.sh
+++ b/ci/linux-s390x.sh
@@ -5,7 +5,7 @@ set -ex
 mkdir -m 777 /qemu
 cd /qemu
 
-curl --retry 5 -LO https://github.com/qemu/qemu/raw/master/pc-bios/s390-ccw.img
+curl --retry 5 -LO https://github.com/qemu/qemu/raw/HEAD/pc-bios/s390-ccw.img
 curl --retry 5 -LO http://ftp.debian.org/debian/dists/testing/main/installer-s390x/20220914/images/generic/kernel.debian
 curl --retry 5 -LO http://ftp.debian.org/debian/dists/testing/main/installer-s390x/20220914/images/generic/initrd.debian
 

--- a/ci/rust.css
+++ b/ci/rust.css
@@ -1,4 +1,4 @@
-/* This is taken from https://github.com/rust-lang/rust/blob/master/src/doc/rust.css */
+/* This is taken from https://github.com/rust-lang/rust/blob/HEAD/src/doc/rust.css */
 
 @font-face {
   font-family: 'Fira Sans';

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -3797,7 +3797,7 @@ pub const MSG_RCVMORE: ::c_int = 0x4000;
 pub const SCM_TIMESTAMP: ::c_int = 0x02;
 pub const SCM_CREDS: ::c_int = 0x03;
 
-// https://github.com/aosm/xnu/blob/master/bsd/net/if.h#L140-L156
+// https://github.com/aosm/xnu/blob/HEAD/bsd/net/if.h#L140-L156
 pub const IFF_UP: ::c_int = 0x1; // interface is up
 pub const IFF_BROADCAST: ::c_int = 0x2; // broadcast address valid
 pub const IFF_DEBUG: ::c_int = 0x4; // turn on debugging
@@ -4594,7 +4594,7 @@ pub const DLT_ATM_RFC1483: ::c_uint = 11; // LLC/SNAP encapsulated atm
 pub const DLT_RAW: ::c_uint = 12; // raw IP
 pub const DLT_LOOP: ::c_uint = 108;
 
-// https://github.com/apple/darwin-xnu/blob/master/bsd/net/bpf.h#L100
+// https://github.com/apple/darwin-xnu/blob/HEAD/bsd/net/bpf.h#L100
 // sizeof(i32)
 pub const BPF_ALIGNMENT: ::c_int = 4;
 

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1133,7 +1133,7 @@ pub const PROC_REAP_STATUS: ::c_int = 0x0003;
 pub const PROC_PDEATHSIG_CTL: ::c_int = 0x0004;
 pub const PROC_PDEATHSIG_STATUS: ::c_int = 0x0005;
 
-// https://github.com/DragonFlyBSD/DragonFlyBSD/blob/master/sys/net/if.h#L101
+// https://github.com/DragonFlyBSD/DragonFlyBSD/blob/HEAD/sys/net/if.h#L101
 pub const IFF_UP: ::c_int = 0x1; // interface is up
 pub const IFF_BROADCAST: ::c_int = 0x2; // broadcast address valid
 pub const IFF_DEBUG: ::c_int = 0x4; // turn on debugging

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1339,7 +1339,7 @@ pub const CMGROUP_MAX: usize = 16;
 
 pub const EUI64_LEN: usize = 8;
 
-// https://github.com/freebsd/freebsd/blob/master/sys/net/bpf.h
+// https://github.com/freebsd/freebsd/blob/HEAD/sys/net/bpf.h
 pub const BPF_ALIGNMENT: usize = SIZEOF_LONG;
 
 // Values for rtprio struct (prio field) and syscall (function argument)

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1441,7 +1441,7 @@ pub const MS_SYNC: ::c_int = 0x4;
 pub const MS_INVALIDATE: ::c_int = 0x2;
 
 // Here because they are not present on OpenBSD
-// (https://github.com/openbsd/src/blob/master/sys/sys/resource.h)
+// (https://github.com/openbsd/src/blob/HEAD/sys/sys/resource.h)
 pub const RLIMIT_SBSIZE: ::c_int = 9;
 pub const RLIMIT_AS: ::c_int = 10;
 pub const RLIMIT_NTHR: ::c_int = 11;

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -110,7 +110,7 @@ s! {
     pub struct mfs_args {
         pub fspec: *mut ::c_char,
         pub export_info: export_args,
-        // https://github.com/openbsd/src/blob/master/sys/sys/types.h#L134
+        // https://github.com/openbsd/src/blob/HEAD/sys/sys/types.h#L134
         pub base: *mut ::c_char,
         pub size: ::c_ulong,
     }
@@ -190,7 +190,7 @@ s! {
         pub cr_uid: ::uid_t,
         pub cr_gid: ::gid_t,
         pub cr_ngroups: ::c_short,
-        //https://github.com/openbsd/src/blob/master/sys/sys/syslimits.h#L44
+        //https://github.com/openbsd/src/blob/HEAD/sys/sys/syslimits.h#L44
         pub cr_groups: [::gid_t; 16],
     }
 
@@ -1515,7 +1515,7 @@ pub const OLCUC: ::tcflag_t = 0x20;
 pub const ONOCR: ::tcflag_t = 0x40;
 pub const ONLRET: ::tcflag_t = 0x80;
 
-//https://github.com/openbsd/src/blob/master/sys/sys/mount.h
+//https://github.com/openbsd/src/blob/HEAD/sys/sys/mount.h
 pub const ISOFSMNT_NORRIP: ::c_int = 0x1; // disable Rock Ridge Ext
 pub const ISOFSMNT_GENS: ::c_int = 0x2; // enable generation numbers
 pub const ISOFSMNT_EXTATT: ::c_int = 0x4; // enable extended attr
@@ -1579,7 +1579,7 @@ pub const TMPFS_ARGS_VERSION: ::c_int = 1;
 pub const MAP_STACK: ::c_int = 0x4000;
 pub const MAP_CONCEAL: ::c_int = 0x8000;
 
-// https://github.com/openbsd/src/blob/master/sys/net/if.h#L187
+// https://github.com/openbsd/src/blob/HEAD/sys/net/if.h#L187
 pub const IFF_UP: ::c_int = 0x1; // interface is up
 pub const IFF_BROADCAST: ::c_int = 0x2; // broadcast address valid
 pub const IFF_DEBUG: ::c_int = 0x4; // turn on debugging

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -979,7 +979,7 @@ pub const MADV_WILLNEED: ::c_int = 4;
 pub const MADV_DONTNEED: ::c_int = 5;
 pub const MADV_FREE: ::c_int = 6;
 
-// https://github.com/haiku/haiku/blob/master/headers/posix/net/if.h#L80
+// https://github.com/haiku/haiku/blob/HEAD/headers/posix/net/if.h#L80
 pub const IFF_UP: ::c_int = 0x0001;
 pub const IFF_BROADCAST: ::c_int = 0x0002; // valid broadcast address
 pub const IFF_LOOPBACK: ::c_int = 0x0008;

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -2466,8 +2466,7 @@ pub const IFF_PERSIST: ::c_int = 0x0800;
 pub const IFF_NOFILTER: ::c_int = 0x1000;
 
 // start android/platform/bionic/libc/kernel/uapi/linux/if_ether.h
-// from https://android.googlesource.com/
-// platform/bionic/+/master/libc/kernel/uapi/linux/if_ether.h
+// from https://android.googlesource.com/platform/bionic/+/HEAD/libc/kernel/uapi/linux/if_ether.h
 pub const ETH_ALEN: ::c_int = 6;
 pub const ETH_HLEN: ::c_int = 14;
 pub const ETH_ZLEN: ::c_int = 60;

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -498,8 +498,7 @@ pub const SOCK_CLOEXEC: ::c_int = O_CLOEXEC;
 
 pub const INET_ADDRSTRLEN: ::c_int = 16;
 
-// https://github.
-// com/bminor/newlib/blob/master/newlib/libc/sys/linux/include/net/if.h#L121
+// https://github.com/bminor/newlib/blob/HEAD/newlib/libc/sys/linux/include/net/if.h#L121
 pub const IFF_UP: ::c_int = 0x1; // interface is up
 pub const IFF_BROADCAST: ::c_int = 0x2; // broadcast address valid
 pub const IFF_DEBUG: ::c_int = 0x4; // turn on debugging

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -7,7 +7,7 @@ allow-unauthenticated = [
 new_pr = true
 
 [assign]
-contributing_url = "https://github.com/rust-lang/libc/blob/master/CONTRIBUTING.md"
+contributing_url = "https://github.com/rust-lang/libc/blob/HEAD/CONTRIBUTING.md"
 
 [assign.owners]
 "*" = ["@JohnTitor"]


### PR DESCRIPTION
This updates CI, documentation, and similar to work with a `main`
branch. It also renames references to *other* repositories to work, as
well, which additionally makes it easier to search for remaining
references.

I verified that all modified links still work.