### PR TITLE
Add ucred struct and field type aliases for redox

### DIFF
--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -48,6 +48,9 @@ pub type suseconds_t = ::c_int;
 pub type tcflag_t = u32;
 pub type time_t = ::c_longlong;
 pub type id_t = ::c_uint;
+pub type pid_t = usize;
+pub type uid_t = u32;
+pub type gid_t = u32;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum timezone {}
@@ -258,9 +261,9 @@ s! {
     }
 
     pub struct ucred {
-        pub pid: i32,
-        pub uid: i32,
-        pub gid: i32,
+        pub pid: pid_t,
+        pub uid: uid_t,
+        pub gid: gid_t,
     }
 }
 

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -256,6 +256,12 @@ s! {
         pub tm_gmtoff: ::c_long,
         pub tm_zone: *const ::c_char,
     }
+
+    pub struct ucred {
+        pub pid: i32,
+        pub uid: i32,
+        pub gid: i32,
+    }
 }
 
 pub const UTSLENGTH: usize = 65;


### PR DESCRIPTION
This PR is redox-os specific and adds the ucred struct and type aliases for its fields into the unix/redox/mod.rs file.

This will enable a number of packages (e.g. Tokio) to compile for redox-os using the existing code for linux and other unix-lioke target_os. If this is merged, then follow-up PRs will be made to Tokio and other crates to add "redox" to the list of target_os that said code is enabled for, without adding code to Tokio. 

Then tokio as-is will build on redox, and no fork or patch will need to be maintained by the redox team.

- \[X] `cd libc-test && cargo test` --> Tests pass
