### PR TITLE
android: add memmem

### DIFF
--- a/libc-test/semver/android.txt
+++ b/libc-test/semver/android.txt
@@ -3186,6 +3186,7 @@ memalign
 memchr
 memcmp
 memcpy
+memmem
 memmove
 memrchr
 memset

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -3549,6 +3549,13 @@ extern "C" {
 
     pub fn sync();
     pub fn syncfs(fd: ::c_int) -> ::c_int;
+
+    pub fn memmem(
+        haystack: *const ::c_void,
+        haystacklen: ::size_t,
+        needle: *const ::c_void,
+        needlelen: ::size_t,
+    ) -> *mut ::c_void;
 }
 
 cfg_if! {


### PR DESCRIPTION
Adding `memmem` to Android bindings.

Android NDK has had `memmem` probably since the beginning but definitely as early as Android 2.2.

https://android.googlesource.com/platform/ndk.git/+/refs/tags/android-2.2_r1/build/platforms/android-3/arch-arm/usr/include/string.h#44