### PR TITLE
Fixed pthread_attr_t and pthread_rwlockattr_t for newlib

### DIFF
--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -234,11 +234,11 @@ s! {
     }
 
     pub struct pthread_attr_t { // Unverified
-        __size: [u64; __SIZEOF_PTHREAD_ATTR_T]
+        __size: [u8; __SIZEOF_PTHREAD_ATTR_T]
     }
 
     pub struct pthread_rwlockattr_t { // Unverified
-        __size: [u64; __SIZEOF_PTHREAD_RWLOCKATTR_T]
+        __size: [u8; __SIZEOF_PTHREAD_RWLOCKATTR_T]
     }
 }
 


### PR DESCRIPTION
A follow-up to #3255 (https://github.com/rust-lang/libc/pull/3255/files#diff-11a2a6578a3a63a601856de0cbfaa5c7f41dcecab5532a1c8b9662656894e126L222)

My apologies, these should have been u8 arrays.
