### PR TITLE
linux-gnu: add putpwent/putgrent

### DIFF
--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -654,3 +654,5 @@ dirname
 posix_basename
 gnu_basename
 getmntent_r
+putpwent
+putgrent

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1302,6 +1302,9 @@ extern "C" {
         result: *mut *mut ::group,
     ) -> ::c_int;
 
+    pub fn putpwent(p: *const ::passwd, stream: *mut ::FILE) -> ::c_int;
+    pub fn putgrent(grp: *const ::group, stream: *mut ::FILE) -> ::c_int;
+
     pub fn sethostid(hostid: ::c_long) -> ::c_int;
 
     pub fn memfd_create(name: *const ::c_char, flags: ::c_uint) -> ::c_int;


### PR DESCRIPTION
adds the [`putpwent(3)`](https://www.man7.org/linux/man-pages/man3/putpwent.3.html) and [`putgrent(3)`](https://www.man7.org/linux/man-pages/man3/putgrent.3.html) glibc extensions. these don't appear to be present anywhere else from what i could tell, correct me if i'm wrong.
