### PR TITLE
s390x-musl: define O_LARGEFILE constant

### DIFF
--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -145,6 +145,7 @@ pub const ETIMEDOUT: ::c_int = 110;
 pub const O_APPEND: ::c_int = 1024;
 pub const O_CREAT: ::c_int = 64;
 pub const O_EXCL: ::c_int = 128;
+pub const O_LARGEFILE: ::c_int = 0x8000;
 pub const O_NONBLOCK: ::c_int = 2048;
 pub const SA_NOCLDWAIT: ::c_int = 2;
 pub const SA_ONSTACK: ::c_int = 0x08000000;


### PR DESCRIPTION
from https://git.musl-libc.org/cgit/musl/tree/arch/s390x/bits/fcntl.h?id=4b125dd408d54487dc8843b9553502aa0c4167f8#n16


it's a nop as noted in https://github.com/rust-lang/libc/commit/75ac488063b968699c48881b59d525cd46ca95eb, but afaik we should still expose the symbol(?)