### PR TITLE
add MAP_UNINITIALIZED flag (Linux-only) for mmap

### DIFF
--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -1290,6 +1290,7 @@ pub const MAP_NORESERVE: ::c_int = 0x04000;
 pub const MAP_POPULATE: ::c_int = 0x08000;
 pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const EDEADLK: ::c_int = 35;
 pub const ENAMETOOLONG: ::c_int = 36;

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1332,6 +1332,7 @@ pub const RLIMIT_NLIMITS: ::c_int = 15;
 pub const RLIM_NLIMITS: ::c_int = RLIMIT_NLIMITS;
 
 pub const MAP_ANONYMOUS: ::c_int = MAP_ANON;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 #[doc(hidden)]
 #[deprecated(since = "0.2.55", note = "Use SIGSYS instead")]
@@ -1533,6 +1534,7 @@ pub const MAP_NORESERVE: ::c_int = 0x04000;
 pub const MAP_POPULATE: ::c_int = 0x08000;
 pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const SOCK_STREAM: ::c_int = 1;
 pub const SOCK_DGRAM: ::c_int = 2;

--- a/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
@@ -247,6 +247,7 @@ pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_GROWSDOWN: ::c_int = 0x0100;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const EDEADLOCK: ::c_int = 35;
 pub const EUCLEAN: ::c_int = 117;

--- a/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
@@ -190,6 +190,7 @@ pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_GROWSDOWN: ::c_int = 0x0100;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const EDEADLOCK: ::c_int = 35;
 pub const EUCLEAN: ::c_int = 117;

--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -655,6 +655,7 @@ pub const MAP_LOCKED: ::c_int = 0x8000;
 pub const MAP_POPULATE: ::c_int = 0x10000;
 pub const MAP_NONBLOCK: ::c_int = 0x20000;
 pub const MAP_STACK: ::c_int = 0x40000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const SOCK_STREAM: ::c_int = 2;
 pub const SOCK_DGRAM: ::c_int = 1;

--- a/src/unix/linux_like/linux/gnu/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/gnu/b32/powerpc.rs
@@ -199,6 +199,7 @@ pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_GROWSDOWN: ::c_int = 0x0100;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const EDEADLOCK: ::c_int = 58;
 pub const EUCLEAN: ::c_int = 117;

--- a/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
@@ -385,6 +385,7 @@ pub const MAP_POPULATE: ::c_int = 32768;
 pub const MAP_NONBLOCK: ::c_int = 65536;
 pub const MAP_STACK: ::c_int = 131072;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 pub const EDEADLOCK: ::c_int = 35;
 pub const EUCLEAN: ::c_int = 117;
 pub const ENOTNAM: ::c_int = 118;

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -219,6 +219,7 @@ pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const EDEADLK: ::c_int = 78;
 pub const ENAMETOOLONG: ::c_int = 63;

--- a/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
@@ -404,6 +404,7 @@ pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_GROWSDOWN: ::c_int = 0x0100;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const EDEADLOCK: ::c_int = 35;
 pub const EUCLEAN: ::c_int = 117;

--- a/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
@@ -418,6 +418,7 @@ pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const EDEADLOCK: ::c_int = 35;
 

--- a/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
@@ -712,6 +712,7 @@ pub const MAP_POPULATE: ::c_int = 0x8000;
 pub const MAP_NONBLOCK: ::c_int = 0x10000;
 pub const MAP_STACK: ::c_int = 0x20000;
 pub const MAP_HUGETLB: ::c_int = 0x40000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 pub const MAP_SYNC: ::c_int = 0x080000;
 pub const MCL_CURRENT: ::c_int = 0x0001;
 pub const MCL_FUTURE: ::c_int = 0x0002;

--- a/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
@@ -747,6 +747,7 @@ pub const MAP_POPULATE: ::c_int = 0x10000;
 pub const MAP_NONBLOCK: ::c_int = 0x20000;
 pub const MAP_STACK: ::c_int = 0x40000;
 pub const MAP_HUGETLB: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const SOCK_STREAM: ::c_int = 2;
 pub const SOCK_DGRAM: ::c_int = 1;

--- a/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
@@ -226,6 +226,7 @@ pub const MAP_POPULATE: ::c_int = 0x08000;
 pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const EDEADLK: ::c_int = 35;
 pub const ENAMETOOLONG: ::c_int = 36;

--- a/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
@@ -418,6 +418,7 @@ pub const MAP_POPULATE: ::c_int = 32768;
 pub const MAP_NONBLOCK: ::c_int = 65536;
 pub const MAP_STACK: ::c_int = 131072;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 pub const EDEADLOCK: ::c_int = 35;
 pub const EUCLEAN: ::c_int = 117;
 pub const ENOTNAM: ::c_int = 118;

--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -369,6 +369,7 @@ pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const EDEADLOCK: ::c_int = 35;
 pub const ENAMETOOLONG: ::c_int = 36;

--- a/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
@@ -230,6 +230,7 @@ pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const EDEADLK: ::c_int = 78;
 pub const ENAMETOOLONG: ::c_int = 63;

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -618,6 +618,7 @@ pub const MAP_POPULATE: ::c_int = 0x08000;
 pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const EDEADLOCK: ::c_int = 35;
 pub const EUCLEAN: ::c_int = 117;

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -323,6 +323,7 @@ pub const MAP_POPULATE: ::c_int = 0x08000;
 pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const SOCK_STREAM: ::c_int = 1;
 pub const SOCK_DGRAM: ::c_int = 2;

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -262,6 +262,7 @@ pub const MAP_POPULATE: ::c_int = 0x10000;
 pub const MAP_NONBLOCK: ::c_int = 0x20000;
 pub const MAP_STACK: ::c_int = 0x40000;
 pub const MAP_HUGETLB: ::c_int = 0x80000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const EDEADLK: ::c_int = 45;
 pub const ENAMETOOLONG: ::c_int = 78;

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -256,6 +256,7 @@ pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const PTRACE_SYSEMU: ::c_int = 0x1d;
 pub const PTRACE_SYSEMU_SINGLESTEP: ::c_int = 0x1e;

--- a/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
@@ -365,6 +365,7 @@ pub const MAP_POPULATE: ::c_int = 32768;
 pub const MAP_NONBLOCK: ::c_int = 65536;
 pub const MAP_STACK: ::c_int = 131072;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 pub const EDEADLOCK: ::c_int = 35;
 pub const EUCLEAN: ::c_int = 117;
 pub const ENOTNAM: ::c_int = 118;

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -312,6 +312,7 @@ pub const MAP_POPULATE: ::c_int = 0x08000;
 pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const SOCK_STREAM: ::c_int = 1;
 pub const SOCK_DGRAM: ::c_int = 2;

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -213,6 +213,7 @@ pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const SOCK_STREAM: ::c_int = 1;
 pub const SOCK_DGRAM: ::c_int = 2;

--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -564,6 +564,7 @@ pub const MAP_POPULATE: ::c_int = 0x10000;
 pub const MAP_NONBLOCK: ::c_int = 0x20000;
 pub const MAP_STACK: ::c_int = 0x40000;
 pub const MAP_HUGETLB: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const SOCK_STREAM: ::c_int = 2;
 pub const SOCK_DGRAM: ::c_int = 1;

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -172,6 +172,7 @@ pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const PTRACE_SYSEMU: ::c_int = 0x1d;
 pub const PTRACE_SYSEMU_SINGLESTEP: ::c_int = 0x1e;

--- a/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
@@ -627,6 +627,7 @@ pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const MCL_CURRENT: ::c_int = 0x0001;
 pub const MCL_FUTURE: ::c_int = 0x0002;

--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -179,6 +179,7 @@ pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const PTRACE_SYSEMU: ::c_int = 31;
 pub const PTRACE_SYSEMU_SINGLESTEP: ::c_int = 32;

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -828,6 +828,7 @@ pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
 pub const MAP_HUGETLB: ::c_int = 0x040000;
 pub const MAP_SYNC: ::c_int = 0x080000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const MCL_CURRENT: ::c_int = 0x0001;
 pub const MCL_FUTURE: ::c_int = 0x0002;

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -486,6 +486,8 @@ pub const MAP_HUGE_1GB: ::c_int = 30 << MAP_HUGE_SHIFT;
 pub const MAP_HUGE_2GB: ::c_int = 31 << MAP_HUGE_SHIFT;
 pub const MAP_HUGE_16GB: ::c_int = 34 << MAP_HUGE_SHIFT;
 
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
+
 pub const MS_RMT_MASK: ::c_ulong = 0x02800051;
 
 pub const SFD_CLOEXEC: ::c_int = 0x080000;

--- a/src/unix/linux_like/linux/uclibc/arm/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/arm/mod.rs
@@ -436,6 +436,7 @@ pub const MAP_NONBLOCK: ::c_int = 0x10000;
 pub const MAP_NORESERVE: ::c_int = 0x4000;
 pub const MAP_POPULATE: ::c_int = 0x8000;
 pub const MAP_STACK: ::c_int = 0x20000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 pub const NLDLY: ::tcflag_t = 0x100;
 pub const NOFLSH: ::tcflag_t = 0x80;
 pub const OLCUC: ::tcflag_t = 0x2;

--- a/src/unix/linux_like/linux/uclibc/mips/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mod.rs
@@ -151,6 +151,7 @@ pub const MAP_LOCKED: ::c_int = 0x8000;
 pub const MAP_POPULATE: ::c_int = 0x10000;
 pub const MAP_NONBLOCK: ::c_int = 0x20000;
 pub const MAP_STACK: ::c_int = 0x40000;
+pub const MAP_UNINITIALIZED: ::c_int = 0x4000000;
 
 pub const NLDLY: ::tcflag_t = 0o0000400;
 


### PR DESCRIPTION
MAP_UNINITIALIZED is a Linux-only flag for mmap that is generically defined in mmap-common.h: https://elixir.bootlin.com/linux/latest/source/include/uapi/asm-generic/mman-common.h#L33
