### PR TITLE
Add missing PS Vita definitions, fix some unused ones

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -678,17 +678,6 @@ extern "C" {
         value: *const ::c_void,
         option_len: socklen_t,
     ) -> ::c_int;
-    #[cfg_attr(
-        all(target_os = "macos", target_arch = "x86"),
-        link_name = "socketpair$UNIX2003"
-    )]
-    #[cfg_attr(target_os = "illumos", link_name = "__xnet_socketpair")]
-    pub fn socketpair(
-        domain: ::c_int,
-        type_: ::c_int,
-        protocol: ::c_int,
-        socket_vector: *mut ::c_int,
-    ) -> ::c_int;
     #[cfg(not(all(
         libc_cfg_target_vendor,
         target_arch = "powerpc",
@@ -1412,6 +1401,25 @@ extern "C" {
     pub fn lockf(fd: ::c_int, cmd: ::c_int, len: ::off_t) -> ::c_int;
 
 }
+
+cfg_if! {
+    if #[cfg(not(target_os = "vita"))] {
+        extern "C" {
+            #[cfg_attr(
+                all(target_os = "macos", target_arch = "x86"),
+                link_name = "socketpair$UNIX2003"
+            )]
+            #[cfg_attr(target_os = "illumos", link_name = "__xnet_socketpair")]
+            pub fn socketpair(
+                domain: ::c_int,
+                type_: ::c_int,
+                protocol: ::c_int,
+                socket_vector: *mut ::c_int,
+            ) -> ::c_int;
+        }
+    }
+}
+
 cfg_if! {
     if #[cfg(not(any(target_os = "emscripten",
                      target_os = "android",

--- a/src/unix/newlib/aarch64/mod.rs
+++ b/src/unix/newlib/aarch64/mod.rs
@@ -51,4 +51,4 @@ pub const MSG_WAITALL: ::c_int = 0;
 pub const MSG_MORE: ::c_int = 0;
 pub const MSG_NOSIGNAL: ::c_int = 0;
 
-pub use crate::unix::newlib::generic::{sigset_t, stat};
+pub use crate::unix::newlib::generic::{dirent, sigset_t, stat};

--- a/src/unix/newlib/arm/mod.rs
+++ b/src/unix/newlib/arm/mod.rs
@@ -53,4 +53,4 @@ pub const MSG_WAITALL: ::c_int = 0;
 pub const MSG_MORE: ::c_int = 0;
 pub const MSG_NOSIGNAL: ::c_int = 0;
 
-pub use crate::unix::newlib::generic::{sigset_t, stat};
+pub use crate::unix::newlib::generic::{dirent, sigset_t, stat};

--- a/src/unix/newlib/dirent.rs
+++ b/src/unix/newlib/dirent.rs
@@ -1,0 +1,7 @@
+s! {
+    pub struct dirent {
+        pub d_ino: ::ino_t,
+        pub d_type: ::c_uchar,
+        pub d_name: [::c_char; 256usize],
+    }
+}

--- a/src/unix/newlib/dirent.rs
+++ b/src/unix/newlib/dirent.rs
@@ -1,7 +1,0 @@
-s! {
-    pub struct dirent {
-        pub d_ino: ::ino_t,
-        pub d_type: ::c_uchar,
-        pub d_name: [::c_char; 256usize],
-    }
-}

--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -107,4 +107,4 @@ extern "C" {
     pub fn eventfd(initval: ::c_uint, flags: ::c_int) -> ::c_int;
 }
 
-pub use crate::unix::newlib::generic::{sigset_t, stat};
+pub use crate::unix::newlib::generic::{dirent, sigset_t, stat};

--- a/src/unix/newlib/generic.rs
+++ b/src/unix/newlib/generic.rs
@@ -24,4 +24,10 @@ s! {
         pub st_blocks: ::blkcnt_t,
         pub st_spare4: [::c_long; 2usize],
     }
+
+    pub struct dirent {
+        pub d_ino: ::ino_t,
+        pub d_type: ::c_uchar,
+        pub d_name: [::c_char; 256usize],
+    }
 }

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -266,3 +266,5 @@ extern "C" {
 
     pub fn gethostid() -> ::c_long;
 }
+
+pub use crate::unix::newlib::generic::dirent;

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -787,13 +787,6 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(not(target_os = "vita"))] {
-        mod dirent;
-        pub use self::dirent::*;
-    }
-}
-
-cfg_if! {
     if #[cfg(libc_align)] {
         #[macro_use]
         mod align;

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -1,13 +1,7 @@
 pub type blkcnt_t = i32;
 pub type blksize_t = i32;
 
-cfg_if! {
-    if #[cfg(target_os = "vita")] {
-        pub type clockid_t = ::c_uint;
-    } else {
-        pub type clockid_t = ::c_ulong;
-    }
-}
+pub type clockid_t = ::c_ulong;
 
 cfg_if! {
     if #[cfg(any(target_os = "espidf"))] {
@@ -168,16 +162,6 @@ s! {
         pub sa_handler: extern fn(arg1: ::c_int),
         pub sa_mask: sigset_t,
         pub sa_flags: ::c_int,
-    }
-
-    pub struct dirent {
-        #[cfg(not(target_os = "vita"))]
-        pub d_ino: ino_t,
-        #[cfg(not(target_os = "vita"))]
-        pub d_type: ::c_uchar,
-        #[cfg(target_os = "vita")]
-        __offset: [u8; 88],
-        pub d_name: [::c_char; 256usize],
     }
 
     pub struct stack_t {
@@ -546,8 +530,16 @@ pub const IFF_LINK2: ::c_int = 0x4000; // per link layer defined bit
 pub const IFF_ALTPHYS: ::c_int = IFF_LINK2; // use alternate physical connection
 pub const IFF_MULTICAST: ::c_int = 0x8000; // supports multicast
 
-pub const TCP_NODELAY: ::c_int = 8193;
-pub const TCP_MAXSEG: ::c_int = 8194;
+cfg_if! {
+    if #[cfg(target_os = "vita")] {
+        pub const TCP_NODELAY: ::c_int = 1;
+        pub const TCP_MAXSEG: ::c_int = 2;
+    } else {
+        pub const TCP_NODELAY: ::c_int = 8193;
+        pub const TCP_MAXSEG: ::c_int = 8194;
+    }
+}
+
 pub const TCP_NOPUSH: ::c_int = 4;
 pub const TCP_NOOPT: ::c_int = 8;
 pub const TCP_KEEPIDLE: ::c_int = 256;
@@ -561,13 +553,25 @@ cfg_if! {
         pub const IP_TOS: ::c_int = 3;
     }
 }
-pub const IP_TTL: ::c_int = 8;
+cfg_if! {
+    if #[cfg(target_os = "vita")] {
+        pub const IP_TTL: ::c_int = 4;
+    } else {
+        pub const IP_TTL: ::c_int = 8;
+    }
+}
 pub const IP_MULTICAST_IF: ::c_int = 9;
 pub const IP_MULTICAST_TTL: ::c_int = 10;
 pub const IP_MULTICAST_LOOP: ::c_int = 11;
-pub const IP_ADD_MEMBERSHIP: ::c_int = 11;
-pub const IP_DROP_MEMBERSHIP: ::c_int = 12;
-
+cfg_if! {
+    if #[cfg(target_os = "vita")] {
+        pub const IP_ADD_MEMBERSHIP: ::c_int = 12;
+        pub const IP_DROP_MEMBERSHIP: ::c_int = 13;
+    } else {
+        pub const IP_ADD_MEMBERSHIP: ::c_int = 11;
+        pub const IP_DROP_MEMBERSHIP: ::c_int = 12;
+    }
+}
 pub const IPV6_UNICAST_HOPS: ::c_int = 4;
 pub const IPV6_MULTICAST_IF: ::c_int = 9;
 pub const IPV6_MULTICAST_HOPS: ::c_int = 10;
@@ -598,10 +602,15 @@ pub const NI_NAMEREQD: ::c_int = 4;
 pub const NI_NUMERICSERV: ::c_int = 0;
 pub const NI_DGRAM: ::c_int = 0;
 
-pub const EAI_FAMILY: ::c_int = -303;
-pub const EAI_MEMORY: ::c_int = -304;
-pub const EAI_NONAME: ::c_int = -305;
-pub const EAI_SOCKTYPE: ::c_int = -307;
+cfg_if! {
+    // Defined in vita/mod.rs for "vita"
+    if #[cfg(not(target_os = "vita"))] {
+        pub const EAI_FAMILY: ::c_int = -303;
+        pub const EAI_MEMORY: ::c_int = -304;
+        pub const EAI_NONAME: ::c_int = -305;
+        pub const EAI_SOCKTYPE: ::c_int = -307;
+    }
+}
 
 pub const EXIT_SUCCESS: ::c_int = 0;
 pub const EXIT_FAILURE: ::c_int = 1;
@@ -774,6 +783,13 @@ cfg_if! {
         // Only tested on ARM so far. Other platforms might have different
         // definitions for types and constants.
         pub use target_arch_not_implemented;
+    }
+}
+
+cfg_if! {
+    if #[cfg(not(target_os = "vita"))] {
+        mod dirent;
+        pub use self::dirent::*;
     }
 }
 

--- a/src/unix/newlib/powerpc/mod.rs
+++ b/src/unix/newlib/powerpc/mod.rs
@@ -5,7 +5,7 @@ pub type wchar_t = ::c_int;
 pub type c_long = i32;
 pub type c_ulong = u32;
 
-pub use crate::unix::newlib::generic::{sigset_t, stat};
+pub use crate::unix::newlib::generic::{dirent, sigset_t, stat};
 
 // the newlib shipped with devkitPPC does not support the following components:
 // - sockaddr

--- a/src/unix/newlib/vita/mod.rs
+++ b/src/unix/newlib/vita/mod.rs
@@ -9,6 +9,16 @@ pub type c_ulong = u32;
 pub type sigset_t = ::c_ulong;
 
 s! {
+    pub struct msghdr {
+        pub msg_name: *mut ::c_void,
+        pub msg_namelen: ::socklen_t,
+        pub msg_iov: *mut ::iovec,
+        pub msg_iovlen: ::c_int,
+        pub msg_control: *mut ::c_void,
+        pub msg_controllen: ::socklen_t,
+        pub msg_flags: ::c_int,
+    }
+
     pub struct sockaddr {
         pub sa_len: u8,
         pub sa_family: ::sa_family_t,
@@ -35,6 +45,7 @@ s! {
     }
 
     pub struct sockaddr_un {
+        pub ss_len: u8,
         pub sun_family: ::sa_family_t,
         pub sun_path: [::c_char; 108usize],
     }
@@ -42,9 +53,9 @@ s! {
     pub struct sockaddr_storage {
         pub ss_len: u8,
         pub ss_family: ::sa_family_t,
-        pub __ss_pad1: [u8; 4],
+        pub __ss_pad1: [u8; 2],
         pub __ss_align: i64,
-        pub __ss_pad2: [u8; 4],
+        pub __ss_pad2: [u8; 116],
     }
 
     pub struct sched_param {
@@ -67,16 +78,31 @@ s! {
         pub st_blocks: ::blkcnt_t,
         pub st_spare4: [::c_long; 2usize],
     }
+
+    #[repr(align(8))]
+    pub struct dirent {
+        __offset: [u8; 88],
+        pub d_name: [::c_char; 256usize],
+        __pad: [u8; 8],
+    }
 }
 
 pub const AF_UNIX: ::c_int = 1;
 pub const AF_INET6: ::c_int = 24;
+
+pub const SOCK_RAW: ::c_int = 3;
+pub const SOCK_RDM: ::c_int = 4;
+pub const SOCK_SEQPACKET: ::c_int = 5;
 
 pub const FIONBIO: ::c_ulong = 1;
 
 pub const POLLIN: ::c_short = 0x0001;
 pub const POLLPRI: ::c_short = POLLIN;
 pub const POLLOUT: ::c_short = 0x0004;
+pub const POLLRDNORM: ::c_short = POLLIN;
+pub const POLLRDBAND: ::c_short = POLLIN;
+pub const POLLWRNORM: ::c_short = POLLOUT;
+pub const POLLWRBAND: ::c_short = POLLOUT;
 pub const POLLERR: ::c_short = 0x0008;
 pub const POLLHUP: ::c_short = 0x0010;
 pub const POLLNVAL: ::c_short = 0x0020;
@@ -141,10 +167,15 @@ pub const _SC_PAGESIZE: ::c_int = 8;
 pub const _SC_GETPW_R_SIZE_MAX: ::c_int = 51;
 pub const PTHREAD_STACK_MIN: ::size_t = 32 * 1024;
 
+pub const IP_HDRINCL: ::c_int = 2;
+
 extern "C" {
     pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
     pub fn writev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
     pub fn readv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
+
+    pub fn sendmsg(s: ::c_int, msg: *const ::msghdr, flags: ::c_int) -> ::ssize_t;
+    pub fn recvmsg(s: ::c_int, msg: *mut ::msghdr, flags: ::c_int) -> ::ssize_t;
 
     pub fn pthread_create(
         native: *mut ::pthread_t,


### PR DESCRIPTION
This PR improves vita's newlib support for std by adding some missing definitions and fixing some duplicated ones (e.g. `EAI_NONAME` from `src/unix/newlib/vita/mod.rs` was not being used as it was already defined on `src/unix/newlib/mod.rs`)

Previous work: #3209 #3255 

cc @nikarh 