### PR TITLE
Use `build-std=core` instead of `build-std` alone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ targets = [
     "x86_64-unknown-redox",
     "x86_64-wrs-vxworks"
 ]
-cargo-args = ["-Zbuild-std"]
+cargo-args = ["-Zbuild-std=core"]
 
 [dependencies]
 rustc-std-workspace-core = { version = "1.0.0", optional = true }


### PR DESCRIPTION
Should help with https://github.com/rust-lang/libc/issues/3289.