### PR TITLE
linux/musl: Fix multiple definitions of MAP_HUGETLB

### DIFF
--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -380,8 +380,6 @@ pub const SIG_UNBLOCK: ::c_int = 0x01;
 
 pub const EXTPROC: ::tcflag_t = 0x10000000;
 
-pub const MAP_HUGETLB: ::c_int = 0x040000;
-
 pub const F_GETLK: ::c_int = 12;
 pub const F_GETOWN: ::c_int = 9;
 pub const F_SETLK: ::c_int = 13;


### PR DESCRIPTION
Currently, the build for powerpc-unknown-linux-musl is failing due to multiple definitions of MAP_HUGETLB.

```console
$ cargo build -Zbuild-std=core --target powerpc-unknown-linux-musl
   Compiling libc v0.2.147 (...)
error[E0428]: the name `MAP_HUGETLB` is defined multiple times
   --> src/unix/linux_like/linux/musl/b32/powerpc.rs:383:1
    |
257 | pub const MAP_HUGETLB: ::c_int = 0x040000;
    | ------------------------------------------ previous definition of the value `MAP_HUGETLB` here
...
383 | pub const MAP_HUGETLB: ::c_int = 0x040000;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MAP_HUGETLB` redefined here
    |
    = note: `MAP_HUGETLB` must be defined only once in the value namespace of this module

For more information about this error, try `rustc --explain E0428`.
```