### PR TITLE
Add secure_getenv function for Linux variants

### DIFF
--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -3413,6 +3413,7 @@ sched_setparam
 sched_setscheduler
 sctp_assoc_t
 seccomp_data
+secure_getenv
 seed48
 seekdir
 sem_close

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1736,6 +1736,7 @@ extern "C" {
     pub fn pthread_rwlockattr_setpshared(attr: *mut pthread_rwlockattr_t, val: ::c_int) -> ::c_int;
     pub fn ptsname_r(fd: ::c_int, buf: *mut ::c_char, buflen: ::size_t) -> ::c_int;
     pub fn clearenv() -> ::c_int;
+    pub fn secure_getenv(name: *const ::c_char) -> *mut ::c_char;
     pub fn waitid(idtype: idtype_t, id: id_t, infop: *mut ::siginfo_t, options: ::c_int)
         -> ::c_int;
     pub fn getresuid(ruid: *mut ::uid_t, euid: *mut ::uid_t, suid: *mut ::uid_t) -> ::c_int;


### PR DESCRIPTION
This adds the [`secure_getenv`](https://www.gnu.org/software/libc/manual/html_node/Environment-Access.html#index-secure_005fgetenv) function for Linux variants as it is supported in both GNU libc (2.17+) and musl ([1.1.24+](https://git.musl-libc.org/cgit/musl/commit/?h=v1.1.24&id=ea9525c8bcf6170df59364c4bcd616de1acf8703)).

It is recommended to be used over the regular `getenv`, and there is a [standing issue](https://github.com/rust-lang/rust/issues/92558) for the Rust library to use it instead.

I can't properly test it on my machine as there is some funky stuff going on with musl. I'll open up a [separate issue](https://github.com/rust-lang/libc/issues/3305) with the output as it doesn't concern this fairly simple change.