### PR TITLE
Fix compatibility with Emscripten >= 3.1.44

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2625,12 +2625,18 @@ fn test_emscripten(target: &str) {
 
             "os_unfair_lock" => "struct os_unfair_lock_s".to_string(),
 
-            t if is_union => format!("union {}", t),
+            // LFS64 types have been removed in Emscripten 3.1.44+
+            // https://github.com/emscripten-core/emscripten/pull/19812
+            "off64_t" => "off_t".to_string(),
 
+            // typedefs don't need any keywords
             t if t.ends_with("_t") => t.to_string(),
 
             // put `struct` in front of all structs:.
             t if is_struct => format!("struct {}", t),
+
+            // put `union` in front of all unions:
+            t if is_union => format!("union {}", t),
 
             t => t.to_string(),
         }
@@ -2658,7 +2664,9 @@ fn test_emscripten(target: &str) {
             // FIXME: The size has been changed due to musl's time64
             "time_t" => true,
 
-            _ => false,
+            // LFS64 types have been removed in Emscripten 3.1.44+
+            // https://github.com/emscripten-core/emscripten/pull/19812
+            t => t.ends_with("64") || t.ends_with("64_t"),
         }
     });
 
@@ -2687,7 +2695,9 @@ fn test_emscripten(target: &str) {
             "utimbuf" | "timeval" | "timespec" | "rusage" | "itimerval" | "sched_param"
             | "stat" | "stat64" | "shmid_ds" | "msqid_ds" => true,
 
-            _ => false,
+            // LFS64 types have been removed in Emscripten 3.1.44+
+            // https://github.com/emscripten-core/emscripten/pull/19812
+            ty => ty.ends_with("64") || ty.ends_with("64_t"),
         }
     });
 
@@ -2728,6 +2738,10 @@ fn test_emscripten(target: &str) {
             | "O_TMPFILE" // to 65
             | "SIG_IGN" // -1
                 => true,
+
+            // LFS64 types have been removed in Emscripten 3.1.44+
+            // https://github.com/emscripten-core/emscripten/pull/19812
+            n if n.starts_with("RLIM64") => true,
 
             _ => false,
         }

--- a/libc-test/semver/emscripten.txt
+++ b/libc-test/semver/emscripten.txt
@@ -1,1 +1,2 @@
 getentropy
+posix_fallocate64

--- a/src/unix/linux_like/emscripten/lfs64.rs
+++ b/src/unix/linux_like/emscripten/lfs64.rs
@@ -1,0 +1,213 @@
+// In-sync with ../linux/musl/lfs64.rs except for fallocate64, prlimit64 and sendfile64
+
+#[inline]
+pub unsafe extern "C" fn creat64(path: *const ::c_char, mode: ::mode_t) -> ::c_int {
+    ::creat(path, mode)
+}
+
+#[inline]
+pub unsafe extern "C" fn fgetpos64(stream: *mut ::FILE, pos: *mut ::fpos64_t) -> ::c_int {
+    ::fgetpos(stream, pos as *mut _)
+}
+
+#[inline]
+pub unsafe extern "C" fn fopen64(pathname: *const ::c_char, mode: *const ::c_char) -> *mut ::FILE {
+    ::fopen(pathname, mode)
+}
+
+#[inline]
+pub unsafe extern "C" fn freopen64(
+    pathname: *const ::c_char,
+    mode: *const ::c_char,
+    stream: *mut ::FILE,
+) -> *mut ::FILE {
+    ::freopen(pathname, mode, stream)
+}
+
+#[inline]
+pub unsafe extern "C" fn fseeko64(
+    stream: *mut ::FILE,
+    offset: ::off64_t,
+    whence: ::c_int,
+) -> ::c_int {
+    ::fseeko(stream, offset, whence)
+}
+
+#[inline]
+pub unsafe extern "C" fn fsetpos64(stream: *mut ::FILE, pos: *const ::fpos64_t) -> ::c_int {
+    ::fsetpos(stream, pos as *mut _)
+}
+
+#[inline]
+pub unsafe extern "C" fn fstat64(fildes: ::c_int, buf: *mut ::stat64) -> ::c_int {
+    ::fstat(fildes, buf as *mut _)
+}
+
+#[inline]
+pub unsafe extern "C" fn fstatat64(
+    fd: ::c_int,
+    path: *const ::c_char,
+    buf: *mut ::stat64,
+    flag: ::c_int,
+) -> ::c_int {
+    ::fstatat(fd, path, buf as *mut _, flag)
+}
+
+#[inline]
+pub unsafe extern "C" fn fstatfs64(fd: ::c_int, buf: *mut ::statfs64) -> ::c_int {
+    ::fstatfs(fd, buf as *mut _)
+}
+
+#[inline]
+pub unsafe extern "C" fn fstatvfs64(fd: ::c_int, buf: *mut ::statvfs64) -> ::c_int {
+    ::fstatvfs(fd, buf as *mut _)
+}
+
+#[inline]
+pub unsafe extern "C" fn ftello64(stream: *mut ::FILE) -> ::off64_t {
+    ::ftello(stream)
+}
+
+#[inline]
+pub unsafe extern "C" fn ftruncate64(fd: ::c_int, length: ::off64_t) -> ::c_int {
+    ::ftruncate(fd, length)
+}
+
+#[inline]
+pub unsafe extern "C" fn getrlimit64(resource: ::c_int, rlim: *mut ::rlimit64) -> ::c_int {
+    ::getrlimit(resource, rlim as *mut _)
+}
+
+#[inline]
+pub unsafe extern "C" fn lseek64(fd: ::c_int, offset: ::off64_t, whence: ::c_int) -> ::off64_t {
+    ::lseek(fd, offset, whence)
+}
+
+#[inline]
+pub unsafe extern "C" fn lstat64(path: *const ::c_char, buf: *mut ::stat64) -> ::c_int {
+    ::lstat(path, buf as *mut _)
+}
+
+#[inline]
+pub unsafe extern "C" fn mmap64(
+    addr: *mut ::c_void,
+    length: ::size_t,
+    prot: ::c_int,
+    flags: ::c_int,
+    fd: ::c_int,
+    offset: ::off64_t,
+) -> *mut ::c_void {
+    ::mmap(addr, length, prot, flags, fd, offset)
+}
+
+// These functions are variadic in the C ABI since the `mode` argument is "optional".  Variadic
+// `extern "C"` functions are unstable in Rust so we cannot write a shim function for these
+// entrypoints.  See https://github.com/rust-lang/rust/issues/44930.
+//
+// These aliases are mostly fine though, neither function takes a LFS64-namespaced type as an
+// argument, nor do their names clash with any declared types.
+pub use open as open64;
+pub use openat as openat64;
+
+#[inline]
+pub unsafe extern "C" fn posix_fadvise64(
+    fd: ::c_int,
+    offset: ::off64_t,
+    len: ::off64_t,
+    advice: ::c_int,
+) -> ::c_int {
+    ::posix_fadvise(fd, offset, len, advice)
+}
+
+#[inline]
+pub unsafe extern "C" fn posix_fallocate64(
+    fd: ::c_int,
+    offset: ::off64_t,
+    len: ::off64_t,
+) -> ::c_int {
+    ::posix_fallocate(fd, offset, len)
+}
+
+#[inline]
+pub unsafe extern "C" fn pread64(
+    fd: ::c_int,
+    buf: *mut ::c_void,
+    count: ::size_t,
+    offset: ::off64_t,
+) -> ::ssize_t {
+    ::pread(fd, buf, count, offset)
+}
+
+#[inline]
+pub unsafe extern "C" fn preadv64(
+    fd: ::c_int,
+    iov: *const ::iovec,
+    iovcnt: ::c_int,
+    offset: ::off64_t,
+) -> ::ssize_t {
+    ::preadv(fd, iov, iovcnt, offset)
+}
+
+#[inline]
+pub unsafe extern "C" fn pwrite64(
+    fd: ::c_int,
+    buf: *const ::c_void,
+    count: ::size_t,
+    offset: ::off64_t,
+) -> ::ssize_t {
+    ::pwrite(fd, buf, count, offset)
+}
+
+#[inline]
+pub unsafe extern "C" fn pwritev64(
+    fd: ::c_int,
+    iov: *const ::iovec,
+    iovcnt: ::c_int,
+    offset: ::off64_t,
+) -> ::ssize_t {
+    ::pwritev(fd, iov, iovcnt, offset)
+}
+
+#[inline]
+pub unsafe extern "C" fn readdir64(dirp: *mut ::DIR) -> *mut ::dirent64 {
+    ::readdir(dirp) as *mut _
+}
+
+#[inline]
+pub unsafe extern "C" fn readdir64_r(
+    dirp: *mut ::DIR,
+    entry: *mut ::dirent64,
+    result: *mut *mut ::dirent64,
+) -> ::c_int {
+    ::readdir_r(dirp, entry as *mut _, result as *mut _)
+}
+
+#[inline]
+pub unsafe extern "C" fn setrlimit64(resource: ::c_int, rlim: *const ::rlimit64) -> ::c_int {
+    ::setrlimit(resource, rlim as *mut _)
+}
+
+#[inline]
+pub unsafe extern "C" fn stat64(pathname: *const ::c_char, statbuf: *mut ::stat64) -> ::c_int {
+    ::stat(pathname, statbuf as *mut _)
+}
+
+#[inline]
+pub unsafe extern "C" fn statfs64(pathname: *const ::c_char, buf: *mut ::statfs64) -> ::c_int {
+    ::statfs(pathname, buf as *mut _)
+}
+
+#[inline]
+pub unsafe extern "C" fn statvfs64(path: *const ::c_char, buf: *mut ::statvfs64) -> ::c_int {
+    ::statvfs(path, buf as *mut _)
+}
+
+#[inline]
+pub unsafe extern "C" fn tmpfile64() -> *mut ::FILE {
+    ::tmpfile()
+}
+
+#[inline]
+pub unsafe extern "C" fn truncate64(path: *const ::c_char, length: ::off64_t) -> ::c_int {
+    ::truncate(path, length)
+}

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -5,10 +5,6 @@ pub type dev_t = u32;
 pub type socklen_t = u32;
 pub type pthread_t = c_ulong;
 pub type mode_t = u32;
-pub type ino64_t = u64;
-pub type off64_t = i64;
-pub type blkcnt64_t = i32;
-pub type rlim64_t = u64;
 pub type shmatt_t = ::c_ulong;
 pub type mqd_t = ::c_int;
 pub type msgqnum_t = ::c_ulong;
@@ -29,10 +25,22 @@ pub type blkcnt_t = i32;
 pub type blksize_t = c_long;
 pub type fsblkcnt_t = u32;
 pub type fsfilcnt_t = u32;
-pub type rlim_t = ::c_ulonglong;
+pub type rlim_t = u64;
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type nlink_t = u32;
+
+pub type ino64_t = ::ino_t;
+pub type off64_t = ::off_t;
+pub type blkcnt64_t = ::blkcnt_t;
+pub type rlim64_t = ::rlim_t;
+
+pub type rlimit64 = ::rlimit;
+pub type flock64 = ::flock;
+pub type stat64 = ::stat;
+pub type statfs64 = ::statfs;
+pub type statvfs64 = ::statvfs;
+pub type dirent64 = ::dirent;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum fpos64_t {} // FIXME: fill this out with a struct
@@ -44,11 +52,6 @@ impl ::Clone for fpos64_t {
 }
 
 s! {
-    pub struct rlimit64 {
-        pub rlim_cur: rlim64_t,
-        pub rlim_max: rlim64_t,
-    }
-
     pub struct glob_t {
         pub gl_pathc: ::size_t,
         pub gl_pathv: *mut *mut c_char,
@@ -223,14 +226,6 @@ s! {
         pub l_pid: ::pid_t,
     }
 
-    pub struct flock64 {
-        pub l_type: ::c_short,
-        pub l_whence: ::c_short,
-        pub l_start: ::off64_t,
-        pub l_len: ::off64_t,
-        pub l_pid: ::pid_t,
-    }
-
     pub struct pthread_attr_t {
         __size: [u32; 11]
     }
@@ -259,31 +254,6 @@ s! {
         __val: [::c_int; 4],
     }
     pub struct stat {
-        pub st_dev: ::dev_t,
-        #[cfg(not(emscripten_new_stat_abi))]
-        __st_dev_padding: ::c_int,
-        #[cfg(not(emscripten_new_stat_abi))]
-        __st_ino_truncated: ::c_long,
-        pub st_mode: ::mode_t,
-        pub st_nlink: ::nlink_t,
-        pub st_uid: ::uid_t,
-        pub st_gid: ::gid_t,
-        pub st_rdev: ::dev_t,
-        #[cfg(not(emscripten_new_stat_abi))]
-        __st_rdev_padding: ::c_int,
-        pub st_size: ::off_t,
-        pub st_blksize: ::blksize_t,
-        pub st_blocks: ::blkcnt_t,
-        pub st_atime: ::time_t,
-        pub st_atime_nsec: ::c_long,
-        pub st_mtime: ::time_t,
-        pub st_mtime_nsec: ::c_long,
-        pub st_ctime: ::time_t,
-        pub st_ctime_nsec: ::c_long,
-        pub st_ino: ::ino_t,
-    }
-
-    pub struct stat64 {
         pub st_dev: ::dev_t,
         #[cfg(not(emscripten_new_stat_abi))]
         __st_dev_padding: ::c_int,
@@ -370,37 +340,6 @@ s! {
         _align: [usize; 0],
     }
 
-    pub struct statfs64 {
-        pub f_type: ::c_ulong,
-        pub f_bsize: ::c_ulong,
-        pub f_blocks: ::fsblkcnt_t,
-        pub f_bfree: ::fsblkcnt_t,
-        pub f_bavail: ::fsblkcnt_t,
-        pub f_files: ::fsfilcnt_t,
-        pub f_ffree: ::fsfilcnt_t,
-        pub f_fsid: ::fsid_t,
-        pub f_namelen: ::c_ulong,
-        pub f_frsize: ::c_ulong,
-        pub f_flags: ::c_ulong,
-        pub f_spare: [::c_ulong; 4],
-    }
-
-    pub struct statvfs64 {
-        pub f_bsize: ::c_ulong,
-        pub f_frsize: ::c_ulong,
-        pub f_blocks: u32,
-        pub f_bfree: u32,
-        pub f_bavail: u32,
-        pub f_files: u32,
-        pub f_ffree: u32,
-        pub f_favail: u32,
-        pub f_fsid: ::c_ulong,
-        __f_unused: ::c_int,
-        pub f_flag: ::c_ulong,
-        pub f_namemax: ::c_ulong,
-        __f_spare: [::c_int; 6],
-    }
-
     pub struct arpd_request {
         pub req: ::c_ushort,
         pub ip: u32,
@@ -415,14 +354,6 @@ s_no_extra_traits! {
     pub struct dirent {
         pub d_ino: ::ino_t,
         pub d_off: ::off_t,
-        pub d_reclen: ::c_ushort,
-        pub d_type: ::c_uchar,
-        pub d_name: [::c_char; 256],
-    }
-
-    pub struct dirent64 {
-        pub d_ino: ::ino64_t,
-        pub d_off: ::off64_t,
         pub d_reclen: ::c_ushort,
         pub d_type: ::c_uchar,
         pub d_name: [::c_char; 256],
@@ -482,41 +413,6 @@ cfg_if! {
             }
         }
         impl ::hash::Hash for dirent {
-            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                self.d_ino.hash(state);
-                self.d_off.hash(state);
-                self.d_reclen.hash(state);
-                self.d_type.hash(state);
-                self.d_name.hash(state);
-            }
-        }
-
-        impl PartialEq for dirent64 {
-            fn eq(&self, other: &dirent64) -> bool {
-                self.d_ino == other.d_ino
-                    && self.d_off == other.d_off
-                    && self.d_reclen == other.d_reclen
-                    && self.d_type == other.d_type
-                    && self
-                    .d_name
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
-            }
-        }
-        impl Eq for dirent64 {}
-        impl ::fmt::Debug for dirent64 {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                f.debug_struct("dirent64")
-                    .field("d_ino", &self.d_ino)
-                    .field("d_off", &self.d_off)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_type", &self.d_type)
-                    // FIXME: .field("d_name", &self.d_name)
-                    .finish()
-            }
-        }
-        impl ::hash::Hash for dirent64 {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
                 self.d_off.hash(state);
@@ -1763,8 +1659,6 @@ safe_f! {
 }
 
 extern "C" {
-    pub fn getrlimit64(resource: ::c_int, rlim: *mut rlimit64) -> ::c_int;
-    pub fn setrlimit64(resource: ::c_int, rlim: *const rlimit64) -> ::c_int;
     pub fn getrlimit(resource: ::c_int, rlim: *mut ::rlimit) -> ::c_int;
     pub fn setrlimit(resource: ::c_int, rlim: *const ::rlimit) -> ::c_int;
     pub fn strerror_r(errnum: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
@@ -1785,17 +1679,6 @@ extern "C" {
     pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
     pub fn __errno_location() -> *mut ::c_int;
 
-    pub fn fopen64(filename: *const c_char, mode: *const c_char) -> *mut ::FILE;
-    pub fn freopen64(
-        filename: *const c_char,
-        mode: *const c_char,
-        file: *mut ::FILE,
-    ) -> *mut ::FILE;
-    pub fn tmpfile64() -> *mut ::FILE;
-    pub fn fgetpos64(stream: *mut ::FILE, ptr: *mut fpos64_t) -> ::c_int;
-    pub fn fsetpos64(stream: *mut ::FILE, ptr: *const fpos64_t) -> ::c_int;
-    pub fn fseeko64(stream: *mut ::FILE, offset: ::off64_t, whence: ::c_int) -> ::c_int;
-    pub fn ftello64(stream: *mut ::FILE) -> ::off64_t;
     pub fn posix_fallocate(fd: ::c_int, offset: ::off_t, len: ::off_t) -> ::c_int;
     pub fn pwritev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t)
         -> ::ssize_t;
@@ -1891,6 +1774,10 @@ extern "C" {
 
     pub fn getentropy(buf: *mut ::c_void, buflen: ::size_t) -> ::c_int;
 }
+
+// Alias <foo> to <foo>64 to mimic glibc's LFS64 support
+mod lfs64;
+pub use self::lfs64::*;
 
 cfg_if! {
     if #[cfg(libc_align)] {

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1783,10 +1783,10 @@ extern "C" {
 
 // LFS64 extensions
 //
-// * musl has 64-bit versions only so aliases the LFS64 symbols to the standard ones
+// * musl and Emscripten has 64-bit versions only so aliases the LFS64 symbols to the standard ones
 // * ulibc doesn't have preadv64/pwritev64
 cfg_if! {
-    if #[cfg(not(target_env = "musl"))] {
+    if #[cfg(not(any(target_env = "musl", target_os = "emscripten")))] {
         extern "C" {
             pub fn fstatfs64(fd: ::c_int, buf: *mut statfs64) -> ::c_int;
             pub fn statvfs64(path: *const ::c_char, buf: *mut statvfs64) -> ::c_int;
@@ -1844,7 +1844,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(not(any(target_env = "uclibc", target_env = "musl")))] {
+    if #[cfg(not(any(target_env = "uclibc", target_env = "musl", target_os = "emscripten")))] {
         extern "C" {
             pub fn preadv64(
                 fd: ::c_int,


### PR DESCRIPTION
By aliasing all LFS64 symbols to their non-LFS64 counterparts.

Context:
https://github.com/rust-lang/libc/pull/2935
https://github.com/emscripten-core/emscripten/pull/19812