### PR TITLE
Add missing targets for documentation and remove duplicates for list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ Raw FFI bindings to platform libraries like libc.
 features = ["const-extern-fn", "extra_traits"]
 default-target = "x86_64-unknown-linux-gnu"
 targets = [
+    "aarch64-apple-ios",
     "aarch64-linux-android",
     "aarch64-pc-windows-msvc",
     "aarch64-unknown-freebsd",
@@ -102,12 +103,12 @@ targets = [
     "wasm32-unknown-emscripten",
     "wasm32-unknown-unknown",
     "wasm32-wasi",
+    "x86_64-apple-darwin",
+    "x86_64-apple-ios",
     "x86_64-fortanix-unknown-sgx",
     "x86_64-linux-android",
     "x86_64-pc-solaris",
     "x86_64-pc-windows-gnu",
-    "x86_64-pc-windows-gnu",
-    "x86_64-pc-windows-msvc",
     "x86_64-pc-windows-msvc",
     "x86_64-unknown-dragonfly",
     "x86_64-unknown-freebsd",


### PR DESCRIPTION
I just noticed that the apple targets were not documented on docs.rs so I added them.

I also saw some duplicates in the list. Do you want me to add a check to ensure that there are no duplicates?