### PR TITLE
Don't include flock support on Solaris

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1067,7 +1067,11 @@ extern "C" {
     )]
     pub fn realpath(pathname: *const ::c_char, resolved: *mut ::c_char) -> *mut ::c_char;
 
-    pub fn flock(fd: ::c_int, operation: ::c_int) -> ::c_int;
+    cfg_if! {
+        if #[cfg(not(target_os = "solaris"))] {
+            pub fn flock(fd: ::c_int, operation: ::c_int) -> ::c_int;
+        }
+    }
 
     #[cfg_attr(target_os = "netbsd", link_name = "__times13")]
     pub fn times(buf: *mut ::tms) -> ::clock_t;

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -33,6 +33,11 @@ pub const TCP_KEEPCNT: ::c_int = 35;
 pub const TCP_KEEPINTVL: ::c_int = 36;
 pub const TCP_CONGESTION: ::c_int = 37;
 
+pub const LOCK_SH: ::c_int = 1;
+pub const LOCK_EX: ::c_int = 2;
+pub const LOCK_NB: ::c_int = 4;
+pub const LOCK_UN: ::c_int = 8;
+
 // These constants are correct for 64-bit programs or 32-bit programs that are
 // not using large-file mode.  If Rust ever supports anything other than 64-bit
 // compilation on illumos, this may require adjustment:

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1915,10 +1915,16 @@ pub const SHUT_RD: ::c_int = 0;
 pub const SHUT_WR: ::c_int = 1;
 pub const SHUT_RDWR: ::c_int = 2;
 
-pub const LOCK_SH: ::c_int = 1;
-pub const LOCK_EX: ::c_int = 2;
-pub const LOCK_NB: ::c_int = 4;
-pub const LOCK_UN: ::c_int = 8;
+// These don't exist on Solaris, but do on OpenSolaris derivatives
+// e.g. https://illumos.org/man/3C/flock
+cfg_if! {
+    if #[cfg(not(target_os = "solaris"))] {
+        pub const LOCK_SH: ::c_int = 1;
+        pub const LOCK_EX: ::c_int = 2;
+        pub const LOCK_NB: ::c_int = 4;
+        pub const LOCK_UN: ::c_int = 8;
+    }
+}
 
 pub const F_RDLCK: ::c_short = 1;
 pub const F_WRLCK: ::c_short = 2;

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1915,17 +1915,6 @@ pub const SHUT_RD: ::c_int = 0;
 pub const SHUT_WR: ::c_int = 1;
 pub const SHUT_RDWR: ::c_int = 2;
 
-// These don't exist on Solaris, but do on OpenSolaris derivatives
-// e.g. https://illumos.org/man/3C/flock
-cfg_if! {
-    if #[cfg(not(target_os = "solaris"))] {
-        pub const LOCK_SH: ::c_int = 1;
-        pub const LOCK_EX: ::c_int = 2;
-        pub const LOCK_NB: ::c_int = 4;
-        pub const LOCK_UN: ::c_int = 8;
-    }
-}
-
 pub const F_RDLCK: ::c_short = 1;
 pub const F_WRLCK: ::c_short = 2;
 pub const F_UNLCK: ::c_short = 3;


### PR DESCRIPTION
This should disable the flock wrapper and related consts on Solaris, but leave them in place for OpenSolaris derivatives like Illumos which do have a BSD-esque flock.