### PR TITLE
Fix size/align of `ucontext_t` on aarch64-apple-darwin

### DIFF
--- a/src/unix/bsd/apple/b64/aarch64/align.rs
+++ b/src/unix/bsd/apple/b64/aarch64/align.rs
@@ -15,7 +15,6 @@ s! {
         pub uc_link: *mut ::ucontext_t,
         pub uc_mcsize: usize,
         pub uc_mcontext: mcontext_t,
-        __mcontext_data: __darwin_mcontext64,
     }
 
     pub struct __darwin_mcontext64 {


### PR DESCRIPTION
This commit effectively reverts #2817. Currently `ucontext_t` has both the wrong size and the wrong alignment for aarch64-apple-darwin which causes problems for users referencing the structure [1]. The issue linked from #2817 claimed that it fixed #2812 but that's still an issue where FFI warnings are still emitted for usage of `ucontext_t` due to its transitive usage of `u128`. I'm not sure how to fix #2812 myself, but given that #2817 doesn't appear to solve its original intent and additionally the size/align are currently wrong this commit reverts in the meantime.

[1]: https://github.com/bytecodealliance/wasmtime/issues/6785#issuecomment-1661292561


