### PR TITLE
Add `_msize` for Windows targets

### DIFF
--- a/libc-test/semver/windows.txt
+++ b/libc-test/semver/windows.txt
@@ -247,6 +247,7 @@ localtime_s
 lseek
 lseek64
 malloc
+_msize
 memchr
 memcmp
 memcpy

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -345,6 +345,7 @@ extern "C" {
     pub fn strtoull(s: *const c_char, endp: *mut *mut c_char, base: c_int) -> c_ulonglong;
     pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;
     pub fn malloc(size: size_t) -> *mut c_void;
+    pub fn _msize(p: *mut c_void) -> size_t;
     pub fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
     pub fn free(p: *mut c_void);
     pub fn abort() -> !;


### PR DESCRIPTION
Creates a binding for `_msize` for windows targets