### PR TITLE
CI: Update Node.js version to v16.20.0

### DIFF
--- a/ci/emscripten-entry.sh
+++ b/ci/emscripten-entry.sh
@@ -5,8 +5,4 @@ set -ex
 # shellcheck disable=SC1091
 source /emsdk-portable/emsdk_env.sh &> /dev/null
 
-# emsdk-portable provides a node binary, but we need version 8 to run wasm
-# NOTE: Do not forget to sync Node.js version with `emscripten.sh`!
-export PATH="/node-v14.17.0-linux-x64/bin:$PATH"
-
 exec "$@"

--- a/ci/emscripten.sh
+++ b/ci/emscripten.sh
@@ -20,9 +20,3 @@ rm -f a.*
 
 # Make emsdk usable by any user
 chmod a+rxw -R /emsdk-portable
-
-# node 8 is required to run wasm
-# NOTE: Do not forget to sync Node.js version with `emscripten-entry.sh`!
-cd /
-curl --retry 5 -L https://nodejs.org/dist/v14.17.0/node-v14.17.0-linux-x64.tar.xz | \
-    tar -xJ


### PR DESCRIPTION
By using the bundled Node from emsdk, which is no longer outdated.

See: emscripten-core/emsdk@d7327b4