### PR TITLE
add RTLD_MAIN_ONLY

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -4189,6 +4189,7 @@ pub const RTLD_FIRST: ::c_int = 0x100;
 pub const RTLD_NODELETE: ::c_int = 0x80;
 pub const RTLD_NOLOAD: ::c_int = 0x10;
 pub const RTLD_GLOBAL: ::c_int = 0x8;
+pub const RTLD_MAIN_ONLY: *mut ::c_void = -5isize as *mut c_void;
 
 pub const _WSTOPPED: ::c_int = 0o177;
 

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -4189,7 +4189,7 @@ pub const RTLD_FIRST: ::c_int = 0x100;
 pub const RTLD_NODELETE: ::c_int = 0x80;
 pub const RTLD_NOLOAD: ::c_int = 0x10;
 pub const RTLD_GLOBAL: ::c_int = 0x8;
-pub const RTLD_MAIN_ONLY: *mut ::c_void = -5isize as *mut c_void;
+pub const RTLD_MAIN_ONLY: *mut ::c_void = -5isize as *mut ::c_void;
 
 pub const _WSTOPPED: ::c_int = 0o177;
 


### PR DESCRIPTION
Apple's dynamic linker has this special handle called `RTLD_MAIN_ONLY` which you can feed to `dlsym(3)`.  Their `dlfcn.h` says it has been around since Mac OS X 10.5.