### PR TITLE
Add stat64at function declaration to AIX

### DIFF
--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -1,7 +1,6 @@
 pub type c_char = i8;
 pub type caddr_t = *mut ::c_char;
-// FIXME: clockid_t must be c_long, but time.rs accepts only i32
-pub type clockid_t = ::c_int;
+pub type clockid_t = ::c_longlong;
 pub type blkcnt_t = ::c_long;
 pub type clock_t = ::c_int;
 pub type daddr_t = ::c_long;
@@ -3273,7 +3272,13 @@ extern "C" {
     pub fn splice(socket1: ::c_int, socket2: ::c_int, flags: ::c_int) -> ::c_int;
     pub fn srand(seed: ::c_uint);
     pub fn srand48(seed: ::c_long);
-    pub fn stat64(path: *const c_char, buf: *mut stat64) -> ::c_int;
+    pub fn stat64(path: *const ::c_char, buf: *mut stat64) -> ::c_int;
+    pub fn stat64at(
+        dirfd: ::c_int,
+        path: *const ::c_char,
+        buf: *mut stat64,
+        flags: ::c_int,
+    ) -> ::c_int;
     pub fn statfs(path: *const ::c_char, buf: *mut statfs) -> ::c_int;
     pub fn statfs64(path: *const ::c_char, buf: *mut statfs64) -> ::c_int;
     pub fn statvfs64(path: *const ::c_char, buf: *mut statvfs64) -> ::c_int;


### PR DESCRIPTION
In AIX, when large file API enabled, fstatat will be redirected to stat64at.

Also, fix clockid_t to correct definition, as time-rs builds well with this change.