### PR TITLE
Declare SYS_pidfd_open and SYS_pidfd_getfd for android

### DIFF
--- a/libc-test/semver/android-aarch64.txt
+++ b/libc-test/semver/android-aarch64.txt
@@ -10,6 +10,8 @@ HWCAP2_SVESM4
 PROT_BTI
 PROT_MTE
 SYS_arch_specific_syscall
+SYS_pidfd_getfd
+SYS_pidfd_open
 SYS_syscalls
 SYS_fcntl
 __system_property_wait

--- a/libc-test/semver/android-arm.txt
+++ b/libc-test/semver/android-arm.txt
@@ -68,6 +68,8 @@ SYS_pause
 SYS_pciconfig_iobase
 SYS_pciconfig_read
 SYS_pciconfig_write
+SYS_pidfd_getfd
+SYS_pidfd_open
 SYS_pipe
 SYS_poll
 SYS_readlink

--- a/libc-test/semver/android-x86_64.txt
+++ b/libc-test/semver/android-x86_64.txt
@@ -49,6 +49,8 @@ SYS_msgget
 SYS_msgrcv
 SYS_msgsnd
 SYS_newfstatat
+SYS_pidfd_getfd
+SYS_pidfd_open
 SYS_security
 SYS_semctl
 SYS_semget

--- a/src/unix/linux_like/android/b32/arm.rs
+++ b/src/unix/linux_like/android/b32/arm.rs
@@ -512,6 +512,8 @@ pub const SYS_fsopen: ::c_long = 430;
 pub const SYS_fsconfig: ::c_long = 431;
 pub const SYS_fsmount: ::c_long = 432;
 pub const SYS_fspick: ::c_long = 433;
+pub const SYS_pidfd_open: ::c_long = 434;
+pub const SYS_pidfd_getfd: ::c_long = 438;
 
 // offsets in mcontext_t.gregs from sys/ucontext.h
 pub const REG_R0: ::c_int = 0;

--- a/src/unix/linux_like/android/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/android/b64/aarch64/mod.rs
@@ -410,7 +410,9 @@ pub const SYS_fsopen: ::c_long = 430;
 pub const SYS_fsconfig: ::c_long = 431;
 pub const SYS_fsmount: ::c_long = 432;
 pub const SYS_fspick: ::c_long = 433;
+pub const SYS_pidfd_open: ::c_long = 434;
 pub const SYS_syscalls: ::c_long = 436;
+pub const SYS_pidfd_getfd: ::c_long = 438;
 
 pub const PROT_BTI: ::c_int = 0x10;
 pub const PROT_MTE: ::c_int = 0x20;

--- a/src/unix/linux_like/android/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/android/b64/riscv64/mod.rs
@@ -343,7 +343,9 @@ pub const SYS_fsopen: ::c_long = 430;
 pub const SYS_fsconfig: ::c_long = 431;
 pub const SYS_fsmount: ::c_long = 432;
 pub const SYS_fspick: ::c_long = 433;
+pub const SYS_pidfd_open: ::c_long = 434;
 pub const SYS_syscalls: ::c_long = 436;
+pub const SYS_pidfd_getfd: ::c_long = 438;
 
 cfg_if! {
     if #[cfg(libc_align)] {

--- a/src/unix/linux_like/android/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/android/b64/x86_64/mod.rs
@@ -739,6 +739,8 @@ pub const SYS_fsopen: ::c_long = 430;
 pub const SYS_fsconfig: ::c_long = 431;
 pub const SYS_fsmount: ::c_long = 432;
 pub const SYS_fspick: ::c_long = 433;
+pub const SYS_pidfd_open: ::c_long = 434;
+pub const SYS_pidfd_getfd: ::c_long = 438;
 
 // offsets in user_regs_structs, from sys/reg.h
 pub const R15: ::c_int = 0;


### PR DESCRIPTION
Add pidfd_open, pidfd_getfd and pidfd_send_signal
    
Add pidfd_open, pidfd_getfd and pidfd_send_signal for android.  Add
missing systemcall constants SYS_pidfd_open and SYS_pidfd_getfd. Android
supports pidfd call since API level 31 [1].
    
[1] https://cs.android.com/android/platform/superproject/+/main:bionic/libc/include/sys/pidfd.h