### PR TITLE
Update crate version to 0.2.149

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.148"
+version = "0.2.149"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-test"
-version = "0.2.148"
+version = "0.2.149"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.148"
+version = "0.2.149"
 default-features = false
 
 [build-dependencies]


### PR DESCRIPTION
Contains fixes for net structs/calls for Vita target - #3284 and #3366. Required for rust-lang/socket2/pull/465