### PR TITLE
Add backtrace definitions and support for statvfs

### DIFF
--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -671,6 +671,9 @@ MNT_RELATIME
 MNT_SOFTDEP
 MNT_SYMPERM
 MNT_UNION
+MNT_WAIT
+MNT_NOWAIT
+MNT_LAZY
 MOD_CLKA
 MOD_CLKB
 MOD_ESTERROR
@@ -1188,6 +1191,11 @@ arc4random
 arc4random_buf
 arc4random_uniform
 arphdr
+backtrace
+backtrace_symbols
+backtrace_symbols_fd
+backtrace_symbols_fmt
+backtrace_symbols_fd_fmt
 bsearch
 chflags
 chroot
@@ -1275,6 +1283,7 @@ getitimer
 getlastlogx
 getline
 getloadavg
+getmntinfo
 getnameinfo
 getopt_long
 getpeereid
@@ -1295,6 +1304,7 @@ getutmpx
 getutxent
 getutxid
 getutxline
+getvfsstat
 getxattr
 glob
 glob_t

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1853,6 +1853,11 @@ pub const MNT_SOFTDEP: ::c_int = 0x80000000;
 pub const MNT_POSIX1EACLS: ::c_int = 0x00000800;
 pub const MNT_ACLS: ::c_int = MNT_POSIX1EACLS;
 
+// For use with vfs_sync and getvfsstat
+pub const MNT_WAIT: ::c_int = 1;
+pub const MNT_NOWAIT: ::c_int = 2;
+pub const MNT_LAZY: ::c_int = 3;
+
 //<sys/timex.h>
 pub const NTP_API: ::c_int = 4;
 pub const MAXPHASE: ::c_long = 500000000;
@@ -3152,6 +3157,38 @@ extern "C" {
     pub fn flags_to_string(flags: ::c_ulong, def: *const ::c_char) -> ::c_int;
 
     pub fn kinfo_getvmmap(pid: ::pid_t, cntp: *mut ::size_t) -> *mut kinfo_vmentry;
+}
+
+#[link(name = "execinfo")]
+extern "C" {
+    pub fn backtrace(addrlist: *mut *mut ::c_void, len: ::size_t) -> ::size_t;
+    pub fn backtrace_symbols(addrlist: *const *mut ::c_void, len: ::size_t) -> *mut *mut ::c_char;
+    pub fn backtrace_symbols_fd(
+        addrlist: *const *mut ::c_void,
+        len: ::size_t,
+        fd: ::c_int,
+    ) -> ::c_int;
+    pub fn backtrace_symbols_fmt(
+        addrlist: *const *mut ::c_void,
+        len: ::size_t,
+        fmt: *const ::c_char,
+    ) -> *mut *mut ::c_char;
+    pub fn backtrace_symbols_fd_fmt(
+        addrlist: *const *mut ::c_void,
+        len: ::size_t,
+        fd: ::c_int,
+        fmt: *const ::c_char,
+    ) -> ::c_int;
+}
+
+cfg_if! {
+    if #[cfg(libc_union)] {
+        extern {
+            // these functions use statvfs:
+            pub fn getmntinfo(mntbufp: *mut *mut ::statvfs, flags: ::c_int) -> ::c_int;
+            pub fn getvfsstat(buf: *mut statvfs, bufsize: ::size_t, flags: ::c_int) -> ::c_int;
+        }
+    }
 }
 
 cfg_if! {


### PR DESCRIPTION
Replaces https://github.com/rust-lang/libc/pull/3359

This allows successful build and use of file deletion, a.k.a. _move to trash_ 

Tested with a source build of `simp` with the **trash** feature enabled.
Without this commit, `simp` fails to build on NetBSD when the **trash** feature is enabled.

Also, I've added the new symbols to semver and made sure these functions are available on a minimal NetBSD environment.
