### PR TITLE
Drop `armv7-apple-ios` target support

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -285,7 +285,6 @@ if [ "${RUST}" = "nightly" ] && [ "${OS}" = "linux" ]; then
 fi
 
 RUST_APPLE_NO_CORE_TARGETS="\
-armv7-apple-ios \
 armv7s-apple-ios \
 i686-apple-darwin \
 i386-apple-ios \


### PR DESCRIPTION
... as https://github.com/rust-lang/rust/pull/104385 removed the target.