### PR TITLE
Added socketpair and pipe2 for Vita target

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -678,6 +678,17 @@ extern "C" {
         value: *const ::c_void,
         option_len: socklen_t,
     ) -> ::c_int;
+    #[cfg_attr(
+        all(target_os = "macos", target_arch = "x86"),
+        link_name = "socketpair$UNIX2003"
+    )]
+    #[cfg_attr(target_os = "illumos", link_name = "__xnet_socketpair")]
+    pub fn socketpair(
+        domain: ::c_int,
+        type_: ::c_int,
+        protocol: ::c_int,
+        socket_vector: *mut ::c_int,
+    ) -> ::c_int;
     #[cfg(not(all(
         libc_cfg_target_vendor,
         target_arch = "powerpc",
@@ -1400,24 +1411,6 @@ extern "C" {
 
     pub fn lockf(fd: ::c_int, cmd: ::c_int, len: ::off_t) -> ::c_int;
 
-}
-
-cfg_if! {
-    if #[cfg(not(target_os = "vita"))] {
-        extern "C" {
-            #[cfg_attr(
-                all(target_os = "macos", target_arch = "x86"),
-                link_name = "socketpair$UNIX2003"
-            )]
-            #[cfg_attr(target_os = "illumos", link_name = "__xnet_socketpair")]
-            pub fn socketpair(
-                domain: ::c_int,
-                type_: ::c_int,
-                protocol: ::c_int,
-                socket_vector: *mut ::c_int,
-            ) -> ::c_int;
-        }
-    }
 }
 
 cfg_if! {

--- a/src/unix/newlib/vita/mod.rs
+++ b/src/unix/newlib/vita/mod.rs
@@ -229,4 +229,6 @@ extern "C" {
     pub fn pthread_getprocessorid_np() -> ::c_int;
 
     pub fn getentropy(buf: *mut ::c_void, buflen: ::size_t) -> ::c_int;
+
+    pub fn pipe2(fds: *mut ::c_int, flags: ::c_int) -> ::c_int;
 }


### PR DESCRIPTION
As an effort to port `tokio` to Vita, `socketpair` and `pipe2` calls were implemented in Vita newlib.

A PR to newlib with these methods while limitations/implementation details are discussed (vitasdk/newlib/pull/101), but until it is merged there is [vita-newlib-shims](https://crates.io/crates/vita-newlib-shims) crate with these methods implemented.

The implementation may change but methods will certainly remain, and the interface will remain POSIX.

`socketpair` will be needed for `rust-lang/rust` std, `rust-lang/socket2`, `rust-lang/mio`.
`pipe2` will be required for `mio` pipe-based Waker.