### PR TITLE
freebsd: move net/if_mib.h contents to submodule

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2453,6 +2453,33 @@ fn test_freebsd(target: &str) {
             // FIXME: The values has been changed in FreeBSD 15:
             "CLOCK_BOOTTIME" if Some(15) <= freebsd_ver => true,
 
+            // submodule ifmib, cannot be checked today
+            "DOT3COMPLIANCE_STATS"
+            | "DOT3COMPLIANCE_COLLS"
+            | "IFDATA_GENERAL"
+            | "IFDATA_LINKSPECIFIC"
+            | "IFDATA_DRIVERNAME"
+            | "IFMIB_IFCOUNT"
+            | "IFMIB_IFDATA"
+            | "IFMIB_SYSTEM"
+            | "NETLINK_GENERIC"
+            | "dot3ChipSetAMD7990"
+            | "dot3ChipSetAMD79900"
+            | "dot3ChipSetAMD79C940"
+            | "dot3ChipSetIntel82586"
+            | "dot3ChipSetIntel82596"
+            | "dot3ChipSetIntel82557"
+            | "dot3ChipSetNational8390"
+            | "dot3ChipSetNationalSonic"
+            | "dot3ChipSetFujitsu86950"
+            | "dot3ChipSetDigitalDC21040"
+            | "dot3ChipSetDigitalDC21140"
+            | "dot3ChipSetDigitalDC21041"
+            | "dot3ChipSetDigitalDC21140A"
+            | "dot3ChipSetDigitalDC21142"
+            | "dot3ChipSetWesternDigital83C690"
+            | "dot3ChipSetWesternDigital83C790" => true,
+
             _ => false,
         }
     });

--- a/src/unix/bsd/freebsdlike/freebsd/ifmib.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/ifmib.rs
@@ -1,0 +1,44 @@
+// sys/net/if_mib.h
+
+/// non-interface-specific
+pub const IFMIB_SYSTEM: ::c_int = 1;
+/// per-interface data table
+pub const IFMIB_IFDATA: ::c_int = 2;
+
+/// generic stats for all kinds of ifaces
+pub const IFDATA_GENERAL: ::c_int = 1;
+/// specific to the type of interface
+pub const IFDATA_LINKSPECIFIC: ::c_int = 2;
+/// driver name and unit
+pub const IFDATA_DRIVERNAME: ::c_int = 3;
+
+/// number of interfaces configured
+pub const IFMIB_IFCOUNT: ::c_int = 1;
+
+/// functions not specific to a type of iface
+pub const NETLINK_GENERIC: ::c_int = 0;
+
+pub const DOT3COMPLIANCE_STATS: ::c_int = 1;
+pub const DOT3COMPLIANCE_COLLS: ::c_int = 2;
+
+pub const dot3ChipSetAMD7990: ::c_int = 1;
+pub const dot3ChipSetAMD79900: ::c_int = 2;
+pub const dot3ChipSetAMD79C940: ::c_int = 3;
+
+pub const dot3ChipSetIntel82586: ::c_int = 1;
+pub const dot3ChipSetIntel82596: ::c_int = 2;
+pub const dot3ChipSetIntel82557: ::c_int = 3;
+
+pub const dot3ChipSetNational8390: ::c_int = 1;
+pub const dot3ChipSetNationalSonic: ::c_int = 2;
+
+pub const dot3ChipSetFujitsu86950: ::c_int = 1;
+
+pub const dot3ChipSetDigitalDC21040: ::c_int = 1;
+pub const dot3ChipSetDigitalDC21140: ::c_int = 2;
+pub const dot3ChipSetDigitalDC21041: ::c_int = 3;
+pub const dot3ChipSetDigitalDC21140A: ::c_int = 4;
+pub const dot3ChipSetDigitalDC21142: ::c_int = 5;
+
+pub const dot3ChipSetWesternDigital83C690: ::c_int = 1;
+pub const dot3ChipSetWesternDigital83C790: ::c_int = 2;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -3483,51 +3483,6 @@ pub const IFDR_MSG_SIZE: ::c_int = 64;
 pub const IFDR_REASON_MSG: ::c_int = 1;
 pub const IFDR_REASON_VENDOR: ::c_int = 2;
 
-// sys/net/if_mib.h
-
-/// non-interface-specific
-pub const IFMIB_SYSTEM: ::c_int = 1;
-/// per-interface data table
-pub const IFMIB_IFDATA: ::c_int = 2;
-
-/// generic stats for all kinds of ifaces
-pub const IFDATA_GENERAL: ::c_int = 1;
-/// specific to the type of interface
-pub const IFDATA_LINKSPECIFIC: ::c_int = 2;
-/// driver name and unit
-pub const IFDATA_DRIVERNAME: ::c_int = 3;
-
-/// number of interfaces configured
-pub const IFMIB_IFCOUNT: ::c_int = 1;
-
-/// functions not specific to a type of iface
-pub const NETLINK_GENERIC: ::c_int = 0;
-
-pub const DOT3COMPLIANCE_STATS: ::c_int = 1;
-pub const DOT3COMPLIANCE_COLLS: ::c_int = 2;
-
-pub const dot3ChipSetAMD7990: ::c_int = 1;
-pub const dot3ChipSetAMD79900: ::c_int = 2;
-pub const dot3ChipSetAMD79C940: ::c_int = 3;
-
-pub const dot3ChipSetIntel82586: ::c_int = 1;
-pub const dot3ChipSetIntel82596: ::c_int = 2;
-pub const dot3ChipSetIntel82557: ::c_int = 3;
-
-pub const dot3ChipSetNational8390: ::c_int = 1;
-pub const dot3ChipSetNationalSonic: ::c_int = 2;
-
-pub const dot3ChipSetFujitsu86950: ::c_int = 1;
-
-pub const dot3ChipSetDigitalDC21040: ::c_int = 1;
-pub const dot3ChipSetDigitalDC21140: ::c_int = 2;
-pub const dot3ChipSetDigitalDC21041: ::c_int = 3;
-pub const dot3ChipSetDigitalDC21140A: ::c_int = 4;
-pub const dot3ChipSetDigitalDC21142: ::c_int = 5;
-
-pub const dot3ChipSetWesternDigital83C690: ::c_int = 1;
-pub const dot3ChipSetWesternDigital83C790: ::c_int = 2;
-
 // sys/netinet/in.h
 // Protocols (RFC 1700)
 // NOTE: These are in addition to the constants defined in src/unix/mod.rs
@@ -5883,3 +5838,6 @@ cfg_if! {
         // Unknown target_arch
     }
 }
+
+// sys/net/if_mib.h
+pub mod ifmib;


### PR DESCRIPTION
There is a conflict of NETLINK_GENERIC definitions between net/if_mib.h and netlink/netlink.h.  netlink.h is already exported in the crate root for Linux (and those definitions are already used by at least crates neli and netlink-packet-route), and if_mib is not much used yet, so this moves if_mib contents into its own namespace to leave place for netlink support on FreeBSD (rust-lang/libc#3201).

Looks like it is the first time namespacing is used in the libc crate, so I had to guess a few things, being quite new to this project.

The moved symbols did not appear in semver, so I just added the new ones.  `sysinfo` from @GuillaumeGomez seems to be the only impacted public crate.