### PR TITLE
backtrace definitions and support for getmntinfo and getvfsstat

### DIFF
--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -671,6 +671,9 @@ MNT_RELATIME
 MNT_SOFTDEP
 MNT_SYMPERM
 MNT_UNION
+MNT_WAIT
+MNT_NOWAIT
+MNT_LAZY
 MOD_CLKA
 MOD_CLKB
 MOD_ESTERROR
@@ -1188,6 +1191,11 @@ arc4random
 arc4random_buf
 arc4random_uniform
 arphdr
+backtrace
+backtrace_symbols
+backtrace_symbols_fd
+backtrace_symbols_fmt
+backtrace_symbols_fd_fmt
 bsearch
 chflags
 chroot
@@ -1275,6 +1283,7 @@ getitimer
 getlastlogx
 getline
 getloadavg
+getmntinfo
 getnameinfo
 getopt_long
 getpeereid
@@ -1295,6 +1304,7 @@ getutmpx
 getutxent
 getutxid
 getutxline
+getvfsstat
 getxattr
 glob
 glob_t

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1852,6 +1852,9 @@ pub const MNT_NODEVMTIME: ::c_int = 0x40000000;
 pub const MNT_SOFTDEP: ::c_int = 0x80000000;
 pub const MNT_POSIX1EACLS: ::c_int = 0x00000800;
 pub const MNT_ACLS: ::c_int = MNT_POSIX1EACLS;
+pub const MNT_WAIT: ::c_int = 1;
+pub const MNT_NOWAIT: ::c_int = 2;
+pub const MNT_LAZY: ::c_int = 3;
 
 //<sys/timex.h>
 pub const NTP_API: ::c_int = 4;
@@ -3152,6 +3155,38 @@ extern "C" {
     pub fn flags_to_string(flags: ::c_ulong, def: *const ::c_char) -> ::c_int;
 
     pub fn kinfo_getvmmap(pid: ::pid_t, cntp: *mut ::size_t) -> *mut kinfo_vmentry;
+}
+
+#[link(name = "execinfo")]
+extern "C" {
+    pub fn backtrace(addrlist: *mut *mut ::c_void, len: ::size_t) -> ::size_t;
+    pub fn backtrace_symbols(addrlist: *const *mut ::c_void, len: ::size_t) -> *mut *mut ::c_char;
+    pub fn backtrace_symbols_fd(
+        addrlist: *const *mut ::c_void,
+        len: ::size_t,
+        fd: ::c_int,
+    ) -> ::c_int;
+    pub fn backtrace_symbols_fmt(
+        addrlist: *const *mut ::c_void,
+        len: ::size_t,
+        fmt: *const ::c_char,
+    ) -> *mut *mut ::c_char;
+    pub fn backtrace_symbols_fd_fmt(
+        addrlist: *const *mut ::c_void,
+        len: ::size_t,
+        fd: ::c_int,
+        fmt: *const ::c_char,
+    ) -> ::c_int;
+}
+
+cfg_if! {
+    if #[cfg(libc_union)] {
+        extern {
+            // these functions use statvfs:
+            pub fn getmntinfo(mntbufp: *mut *mut ::statvfs, flags: ::c_int) -> ::c_int;
+            pub fn getvfsstat(buf: *mut statvfs, bufsize: ::size_t, flags: ::c_int) -> ::c_int;
+        }
+    }
 }
 
 cfg_if! {


### PR DESCRIPTION
After the failures of merging https://github.com/rust-lang/libc/pull/3361 as a follow-up to https://github.com/rust-lang/libc/pull/3359 I've spent sometime making sure everything is indeed supported and defined.

```
~> grep -r "MNT_WAIT" /usr/include/sys/fstypes.h; grep -r "MNT_NOWAIT" /usr/include/sys/fstypes.h; grep -r "MNT_LAZY" /usr/include/sys/fstypes.h
#define	MNT_WAIT	1	/* synchronously wait for I/O to complete */
#define	MNT_NOWAIT	2	/* start all I/O, but do not wait for it */
#define	MNT_LAZY 	3	/* push data not written by filesystem syncer */
```

```
~> grep -r "getmntinfo" /usr/include/sys/; grep -r "getvfsstat" /usr/include/sys/
/usr/include/sys/statvfs.h:int	getmntinfo(struct statvfs **, int)
/usr/include/sys/statvfs.h:    __RENAME(__getmntinfo90);
/usr/include/sys/fstypes.h: * waitfor flags to vfs_sync() and getvfsstat()
/usr/include/sys/statvfs.h:int	getvfsstat(struct statvfs *, size_t, int)
/usr/include/sys/statvfs.h:    __RENAME(__getvfsstat90);
/usr/include/sys/syscall.h:/* syscall: "compat_90_getvfsstat" ret: "int" args: "struct statvfs90 *" "size_t" "int" */
/usr/include/sys/syscall.h:#define	SYS_compat_90_getvfsstat	356
/usr/include/sys/syscall.h:/* syscall: "__getvfsstat90" ret: "int" args: "struct statvfs *" "size_t" "int" */
/usr/include/sys/syscall.h:#define	SYS___getvfsstat90	483
/usr/include/sys/syscallargs.h:struct compat_90_sys_getvfsstat_args {
/usr/include/sys/syscallargs.h:check_syscall_args(compat_90_sys_getvfsstat)
/usr/include/sys/syscallargs.h:struct sys___getvfsstat90_args {
/usr/include/sys/syscallargs.h:check_syscall_args(sys___getvfsstat90)
/usr/include/sys/syscallargs.h:int	compat_90_sys_getvfsstat(struct lwp *, const struct compat_90_sys_getvfsstat_args *, register_t *);
/usr/include/sys/syscallargs.h:int	sys___getvfsstat90(struct lwp *, const struct sys___getvfsstat90_args *, register_t *);
```

Also, I've made sure the code compiles with rustc 1.72.0 without warning or errors.

```
~> cargo build --release
    Updating crates.io index
   Compiling libc v0.2.148 (/home/pin/Git/libc)
    Finished release [optimized] target(s) in 8.87s
```

Moreover, the _move to trash_ functionality has again been verified using [simp](https://github.com/Kl4rry/simp) compiled with this commit as patch, in combination with the patch submited to [trash-rs](https://github.com/Byron/trash-rs/pull/84).

@JohnTitor Please give bors another try
