### PR TITLE
Fix apple tvos support

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -6131,7 +6131,7 @@ cfg_if! {
     }
 }
 cfg_if! {
-    if #[cfg(any(target_os = "macos", target_os = "ios"))] {
+    if #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))] {
         extern "C" {
             pub fn memmem(
                 haystack: *const ::c_void,


### PR DESCRIPTION
This PR adds one missed conditional to support apple tvOS target, it complements https://github.com/rust-lang/libc/pull/2958.
