### PR TITLE
add execveat for glibc

### DIFF
--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -664,3 +664,4 @@ gnu_basename
 getmntent_r
 putpwent
 putgrent
+execveat

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1391,6 +1391,14 @@ extern "C" {
         buf: *mut ::c_char,
         buflen: ::c_int,
     ) -> *mut ::mntent;
+
+    pub fn execveat(
+        dirfd: ::c_int,
+        pathname: *const ::c_char,
+        argv: *const *mut c_char,
+        envp: *const *mut c_char,
+        flags: ::c_int,
+    ) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
Addd [`execveat(2)`](https://man7.org/linux/man-pages/man2/execveat.2.html) for glibc

```
       #include <linux/fcntl.h>      /* Definition of AT_* constants */
       #include <unistd.h>

       int execveat(int dirfd, const char *pathname,
                    char *const _Nullable argv[],
                    char *const _Nullable envp[],
                    int flags);
```


This wrapper is not available on:
1. musl
2. uClibc
3. bionic (Android)