### PR TITLE
feat: add close_range for glibc

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3378,6 +3378,7 @@ fn test_linux(target: &str) {
         "sys/fanotify.h",
         // <sys/auxv.h> is not present on uclibc
         [!uclibc]: "sys/auxv.h",
+        [gnu]: "linux/close_range.h",
     }
 
     // note: aio.h must be included before sys/mount.h

--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -665,3 +665,4 @@ getmntent_r
 putpwent
 putgrent
 execveat
+close_range

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1401,11 +1401,7 @@ extern "C" {
     ) -> ::c_int;
 
     // Added in `glibc` 2.34
-    pub fn close_range(
-        first: ::c_uint,
-        last: ::c_uint,
-        flags: ::c_int,
-    ) -> ::c_int;
+    pub fn close_range(first: ::c_uint, last: ::c_uint, flags: ::c_int) -> ::c_int;
 }
 
 cfg_if! {

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1399,6 +1399,13 @@ extern "C" {
         envp: *const *mut c_char,
         flags: ::c_int,
     ) -> ::c_int;
+
+    // Added in `glibc` 2.34
+    pub fn close_range(
+        first: ::c_uint,
+        last: ::c_uint,
+        flags: ::c_int,
+    ) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
This PR adds [`close_range(2)`](https://man7.org/linux/man-pages/man2/close_range.2.html) for Linux/glibc:

```c
#include <linux/close_range.h>

       int close_range(unsigned int first, unsigned int last,
                       unsigned int flags);
```

musl and uClibc don't have wrappers for this syscall
