### PR TITLE
feat: closefrom() and close_range() for FreeBSD

### DIFF
--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -2237,3 +2237,5 @@ xucred
 eaccess
 dirname
 basename
+closefrom
+close_range

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -5422,6 +5422,8 @@ extern "C" {
         new_value: *const itimerspec,
         old_value: *mut itimerspec,
     ) -> ::c_int;
+    pub fn closefrom(lowfd: ::c_int);
+    pub fn close_range(lowfd: ::c_uint, highfd: ::c_uint, flags: ::c_int) -> ::c_int;
 }
 
 #[link(name = "memstat")]


### PR DESCRIPTION
This PR

1. add `closefrom()` for all the FreeBSD versions since this is available since FreeBSD 8.0
2. add `close_range()` for FreeBSD 13/14
    
    `close_range()` seems to be available since FreeBSD 12.2, so I am not sure what we should do about FreeBSD 12 here :<

Ref:

* [Man page for `closefrom()` on FreeBSD 11](https://man.freebsd.org/cgi/man.cgi?query=closefrom&apropos=0&sektion=2&manpath=FreeBSD+11.4-RELEASE+and+Ports&arch=default&format=html)
* [Man page for `close_range()` on FreeBSD 12.2 RELEASE](https://man.freebsd.org/cgi/man.cgi?query=close_range&apropos=0&sektion=2&manpath=FreeBSD+12.2-RELEASE&arch=default&format=html)