### PR TITLE
riscv64/musl: Add landlock syscalls

### DIFF
--- a/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
@@ -469,6 +469,9 @@ pub const SYS_faccessat2: ::c_long = 439;
 pub const SYS_process_madvise: ::c_long = 440;
 pub const SYS_epoll_pwait2: ::c_long = 441;
 pub const SYS_mount_setattr: ::c_long = 442;
+pub const SYS_landlock_create_ruleset: ::c_long = 444;
+pub const SYS_landlock_add_rule: ::c_long = 445;
+pub const SYS_landlock_restrict_self: ::c_long = 446;
 
 pub const O_APPEND: ::c_int = 1024;
 pub const O_DIRECT: ::c_int = 0x4000;


### PR DESCRIPTION
The landlock syscalls were added to the musl libc in upstream commit ee05b11b67d5[1]:
```
bits/syscall.h: add landlock syscalls from linux v5.13
see

  linux commit a49f4f81cb48925e8d7cbd9e59068f516e984144
  arch: Wire up Landlock syscalls

  linuxcommit 17ae69aba89dbfa2139b7f8024b757ab3cc42f59
  Merge tag 'landlock_v34' of ... jmorris/linux-security

Landlock provides for unprivileged application sandboxing. The goal of
Landlock is to enable to restrict ambient rights (e.g. global filesystem
access) for a set of processes. Landlock is inspired by seccomp-bpf but
instead of filtering syscalls and their raw arguments, a Landlock rule
can restrict the use of kernel objects like file hierarchies, according
to the kernel semantic.
```

Add them to our definitions accordingly

[1] https://git.musl-libc.org/cgit/musl/commit/arch/riscv64/bits?id=ee05b11b67d59a6c5bb4b9d661bcc20bbd0bbe7a