### PR TITLE
Deprecate FreeBSD 11 module

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -5713,7 +5713,9 @@ cfg_if! {
         mod freebsd12;
         pub use self::freebsd12::*;
     } else if #[cfg(any(freebsd10, freebsd11))] {
+        #[deprecated(note = "Use freebsd12 or newer instead", since = "0.2.151")]
         mod freebsd11;
+        #[allow(deprecated)]
         pub use self::freebsd11::*;
     } else {
         // Unknown freebsd version


### PR DESCRIPTION
It reached EoL about 2 years ago and std removed the support, it's time to deprecate and remove it in the future.