### PR TITLE
Use a unique name for the Docker image used by CI.

### DIFF
--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -28,7 +28,7 @@ run() {
     echo "Building docker container for target ${1}"
 
     # use -f so we can use ci/ as build context
-    docker build -t libc -f "ci/docker/${1}/Dockerfile" ci/
+    docker build -t "libc-${1}" -f "ci/docker/${1}/Dockerfile" ci/
     mkdir -p target
     if [ -w /dev/kvm ]; then
         kvm="--volume /dev/kvm:/dev/kvm"
@@ -50,7 +50,7 @@ run() {
       $kvm \
       --init \
       --workdir /checkout \
-      libc \
+      "libc-${1}" \
       sh -c "HOME=/tmp PATH=\$PATH:/rust/bin exec ci/run.sh ${1}"
 }
 
@@ -58,7 +58,7 @@ build_switch() {
     echo "Building docker container for target switch"
 
     # use -f so we can use ci/ as build context
-    docker build -t libc -f "ci/docker/switch/Dockerfile" ci/
+    docker build -t libc-switch -f "ci/docker/switch/Dockerfile" ci/
     mkdir -p target
     if [ -w /dev/kvm ]; then
         kvm="--volume /dev/kvm:/dev/kvm"
@@ -82,7 +82,7 @@ build_switch() {
       $kvm \
       --init \
       --workdir /checkout \
-      libc \
+      libc-switch \
       sh -c "HOME=/tmp RUSTUP_HOME=/tmp PATH=\$PATH:/rust/bin rustup default nightly \
         && rustup component add rust-src --target ci/switch.json \
         && cargo build -Z build-std=core,alloc --target ci/switch.json"


### PR DESCRIPTION
This allows testing multiple targets in parallel on the same host machine.