### PR TITLE
Add the NI_IDN getnameinfo() extension

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3671,6 +3671,10 @@ fn test_linux(target: &str) {
             if name.starts_with("RLIM64") {
                 return true;
             }
+            // CI fails because musl targets use Linux v4 kernel
+            if name.starts_with("NI_IDN") {
+                return true;
+            }
         }
         match name {
             // These constants are not available if gnu headers have been included

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -2103,6 +2103,7 @@ pub const NI_NUMERICSERV: ::c_int = 2;
 pub const NI_NOFQDN: ::c_int = 4;
 pub const NI_NAMEREQD: ::c_int = 8;
 pub const NI_DGRAM: ::c_int = 16;
+pub const NI_IDN: ::c_int = 32;
 
 pub const SYNC_FILE_RANGE_WAIT_BEFORE: ::c_uint = 1;
 pub const SYNC_FILE_RANGE_WRITE: ::c_uint = 2;


### PR DESCRIPTION
This PR adds the `NI_IDN` getnameinfo extension.

I've also tried to add the other two extensions (see: https://man7.org/linux/man-pages/man3/getnameinfo.3.html), but the tests would fail (`-Werror`) because those two are deprecated.
