### PR TITLE
add vm_allocate for apple

### DIFF
--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -2265,6 +2265,8 @@ uselocale
 utimensat
 utmpx
 utmpxname
+vm_allocate
+vm_deallocate
 vm_inherit_t
 vm_map_t
 vm_prot_t

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -6279,6 +6279,13 @@ extern "C" {
         inheritance: ::vm_inherit_t,
     ) -> ::kern_return_t;
 
+    pub fn vm_allocate(
+        target_task: vm_map_t,
+        address: *mut vm_address_t,
+        size: vm_size_t,
+        flags: ::c_int,
+    ) -> ::kern_return_t;
+
     pub fn vm_deallocate(
         target_task: vm_map_t,
         address: vm_address_t,


### PR DESCRIPTION
We have vm_deallocate, why not vm_allocate too?

I am not totally sure whether these should live here or in mach2?