### PR TITLE
feat: add new struct definitions from fanotify linux api

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3495,7 +3495,8 @@ fn test_linux(target: &str) {
             "type_"
                 if struct_ == "input_event"
                     || struct_ == "input_mask"
-                    || struct_ == "ff_effect" =>
+                    || struct_ == "ff_effect"
+                    || struct_ == "fanotify_response_info_header" =>
             {
                 "type".to_string()
             }

--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -1423,6 +1423,7 @@ MAP_STACK
 MAP_TYPE
 MAXTTL
 MAX_ADDR_LEN
+MAX_HANDLE_SZ
 MAX_IPOPTLEN
 MCAST_BLOCK_SOURCE
 MCAST_EXCLUDE
@@ -3435,10 +3436,16 @@ execvpe
 faccessat
 fallocate
 fallocate64
+fanotify_event_info_error
+fanotify_event_info_fid
+fanotify_event_info_header
+fanotify_event_info_pidfd
 fanotify_event_metadata
 fanotify_init
 fanotify_mark
 fanotify_response
+fanotify_response_info_header
+fanotify_response_info_audit_rule
 fchdir
 fdatasync
 fdopendir

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -503,9 +503,45 @@ s! {
         pub len: u32
     }
 
+    pub struct fanotify_event_info_header {
+        pub info_type: ::__u8,
+        _pad: ::__u8,
+        pub len: ::__u16,
+    }
+
+    pub struct fanotify_event_info_fid {
+        pub hdr: fanotify_event_info_header,
+        pub fsid: ::fsid_t,
+        pub handle: [::c_uchar; 0],
+    }
+
+    pub struct fanotify_event_info_pidfd {
+        pub hdr: fanotify_event_info_header,
+        pub pidfd: ::__s32,
+    }
+
+    pub struct fanotify_event_info_error {
+        pub hdr: fanotify_event_info_header,
+        pub error: ::__s32,
+        pub error_count: ::__u32,
+    }
+
     pub struct fanotify_response {
         pub fd: ::c_int,
-        pub response: __u32,
+        pub response: ::__u32,
+    }
+
+    pub struct fanotify_response_info_header {
+        pub type_: ::__u8,
+        pub pad: ::__u8,
+        pub len: ::__u16,
+    }
+
+    pub struct fanotify_response_info_audit_rule {
+        pub hdr: fanotify_response_info_header,
+        pub rule_number: ::__u32,
+        pub subj_trust: ::__u32,
+        pub obj_trust: ::__u32,
     }
 
     pub struct sockaddr_vm {


### PR DESCRIPTION
#3408 introduced new constants for the fanotify linux API. Among those constants, some are used to request additional data, which are formatted according to several C structs that are defined in `fanotify.h` but missing from this crate.

As continuation of the first PR, this PR adds missing structures from `fanotify.h` to fully support the newest features.