### PR TITLE
Fix libc-tests for illumos/solaris target

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1008,6 +1008,10 @@ fn test_solarish(target: &str) {
             "madvise" | "mprotect" if is_illumos => true,
             "door_call" | "door_return" | "door_create" if is_illumos => true,
 
+            // The compat functions use these "native" functions linked to their
+            // non-prefixed implementations in libc.
+            "native_getpwent_r" | "native_getgrent_r" => true,
+
             // Not visible when build with _XOPEN_SOURCE=700
             "mmapobj" | "mmap64" | "meminfo" | "getpagesizes" | "getpagesizes2" => true,
 
@@ -1015,6 +1019,12 @@ fn test_solarish(target: &str) {
             // configuration of the compilation environment, but the return
             // value is not useful (always 0) so we can ignore it:
             "setservent" | "endservent" if is_illumos => true,
+
+            // Following illumos#3729, getifaddrs was changed to a
+            // redefine_extname symbol in order to preserve compatibility.
+            // Until better symbol binding story is figured out, it must be
+            // excluded from the tests.
+            "getifaddrs" if is_illumos => true,
 
             _ => false,
         }

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -3203,9 +3203,9 @@ extern "C" {
 
     pub fn sync();
 
-    fn __major(version: ::c_int, devnum: ::dev_t) -> ::major_t;
-    fn __minor(version: ::c_int, devnum: ::dev_t) -> ::minor_t;
-    fn __makedev(version: ::c_int, majdev: ::major_t, mindev: ::minor_t) -> ::dev_t;
+    pub fn __major(version: ::c_int, devnum: ::dev_t) -> ::major_t;
+    pub fn __minor(version: ::c_int, devnum: ::dev_t) -> ::minor_t;
+    pub fn __makedev(version: ::c_int, majdev: ::major_t, mindev: ::minor_t) -> ::dev_t;
 }
 
 #[link(name = "sendfile")]


### PR DESCRIPTION
This brings the tests back to passing on modern illumos machines.