### PR TITLE
Do not dereference uninhabited types refs in Clone implementations

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -120,6 +120,12 @@ macro_rules! s_no_extra_traits {
     );
 }
 
+macro_rules! missing {
+    ($($(#[$attr:meta])* pub enum $i:ident {})*) => ($(
+        $(#[$attr])* #[allow(missing_copy_implementations)] pub enum $i { }
+    )*);
+}
+
 macro_rules! e {
     ($($(#[$attr:meta])* pub enum $i:ident { $($field:tt)* })*) => ($(
         __item! {

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -53,13 +53,9 @@ pub type iconv_t = *mut ::c_void;
 pub type sctp_assoc_t = ::__s32;
 
 pub type eventfd_t = u64;
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
-pub enum fpos64_t {} // FIXME: fill this out with a struct
-impl ::Copy for fpos64_t {}
-impl ::Clone for fpos64_t {
-    fn clone(&self) -> fpos64_t {
-        *self
-    }
+missing! {
+    #[cfg_attr(feature = "extra_traits", derive(Debug))]
+    pub enum fpos64_t {} // FIXME: fill this out with a struct
 }
 
 s! {

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -6,13 +6,9 @@ pub type timer_t = *mut ::c_void;
 pub type key_t = ::c_int;
 pub type id_t = ::c_uint;
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
-pub enum timezone {}
-impl ::Copy for timezone {}
-impl ::Clone for timezone {
-    fn clone(&self) -> timezone {
-        *self
-    }
+missing! {
+    #[cfg_attr(feature = "extra_traits", derive(Debug))]
+    pub enum timezone {}
 }
 
 s! {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -41,13 +41,9 @@ cfg_if! {
     }
 }
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
-pub enum DIR {}
-impl ::Copy for DIR {}
-impl ::Clone for DIR {
-    fn clone(&self) -> DIR {
-        *self
-    }
+missing! {
+    #[cfg_attr(feature = "extra_traits", derive(Debug))]
+    pub enum DIR {}
 }
 pub type locale_t = *mut ::c_void;
 
@@ -414,21 +410,11 @@ cfg_if! {
     }
 }
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
-pub enum FILE {}
-impl ::Copy for FILE {}
-impl ::Clone for FILE {
-    fn clone(&self) -> FILE {
-        *self
-    }
-}
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
-pub enum fpos_t {} // FIXME: fill this out with a struct
-impl ::Copy for fpos_t {}
-impl ::Clone for fpos_t {
-    fn clone(&self) -> fpos_t {
-        *self
-    }
+missing! {
+    #[cfg_attr(feature = "extra_traits", derive(Debug))]
+    pub enum FILE {}
+    #[cfg_attr(feature = "extra_traits", derive(Debug))]
+    pub enum fpos_t {} // FIXME: fill this out with a struct
 }
 
 extern "C" {


### PR DESCRIPTION
A reference to an uninhabited type should never be dereferenced: this is UB. `Copy` should not be implemented on such a type, and an upcoming Clippy lint (`uninhabited_reference`) may flag such
dereferences as suspicious.

Since those types are not structs, they do not need to get `Copy` and `Clone` implementations. A `missing!` macro limits code duplication.
