### PR TITLE
Generate `aarch64-apple-darwin` docs on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ Raw FFI bindings to platform libraries like libc.
 features = ["const-extern-fn", "extra_traits"]
 default-target = "x86_64-unknown-linux-gnu"
 targets = [
+    "aarch64-apple-darwin",
     "aarch64-apple-ios",
     "aarch64-linux-android",
     "aarch64-pc-windows-msvc",


### PR DESCRIPTION
Fixes #3289 (I think we've now added most targets on Apple devices)