### PR TITLE
linux's sockaddr_vm update for kernel >= 5.11.

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4237,6 +4237,8 @@ fn test_linux(target: &str) {
         // Linux >= 5.11 tweaked the `svm_zero` field of the `sockaddr_vm` struct.
         // https://github.com/torvalds/linux/commit/dc8eeef73b63ed8988224ba6b5ed19a615163a7f
         (struct_ == "sockaddr_vm" && field == "svm_zero") ||
+        // Linux >= 5.11 had added the svm_flags field to the `sockaddr_vm` struct.
+        (struct_ == "sockaddr_vm" && field == "svm_flags") ||
         // the `ifr_ifru` field is an anonymous union
         (struct_ == "ifreq" && field == "ifr_ifru") ||
         // the `ifc_ifcu` field is an anonymous union

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -509,7 +509,8 @@ s! {
         pub svm_reserved1: ::c_ushort,
         pub svm_port: ::c_uint,
         pub svm_cid: ::c_uint,
-        pub svm_zero: [u8; 4]
+        pub svm_flags: u8,
+        pub svm_zero: [u8; 3]
     }
 
     pub struct regmatch_t {


### PR DESCRIPTION
close #3460