### PR TITLE
openbsd: syscall() has been removed in upcoming OpenBSD 7.5

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -565,6 +565,10 @@ fn test_openbsd(target: &str) {
             // Available for openBSD 7.3
             "mimmutable" => true,
 
+            // Removed in OpenBSD 7.5
+            // https://marc.info/?l=openbsd-cvs&m=170239504300386
+            "syscall" => true,
+
             _ => false,
         }
     });


### PR DESCRIPTION
The `syscall` syscall has been removed in upcoming OpenBSD 7.5.
For now, just remove the check from CI to calm down it while running on -current.