### PR TITLE
Add `newer-api` Cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ align = []
 rustc-dep-of-std = ['align', 'rustc-std-workspace-core']
 extra_traits = []
 const-extern-fn = []
+newer-api = []
 # use_std is deprecated, use `std` instead
 use_std = ['std']
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ libc = "0.2"
   If you use Rust >= 1.62, this feature is implicitly enabled.
   Otherwise it requires a nightly rustc.
 
+* `newer-api`: Opt-in the items from newer APIs.
+  This feature may introduce breaking changes on any releases.
+
 * **deprecated**: `use_std` is deprecated, and is equivalent to `std`.
 
 ## Rust version support


### PR DESCRIPTION
This is an attempt to accept the `breakage-candidate`s without a major release.