### PR TITLE
Re-enable `i686-pc-windows-gnu` CI

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -73,12 +73,10 @@ jobs:
               ARCH_BITS: 64
               ARCH: x86_64
           - target: x86_64-pc-windows-msvc
-          # Disabled because broken:
-          #  https://github.com/rust-lang/libc/issues/1592
-          #- target: i686-pc-windows-gnu
-          #  env:
-          #    ARCH_BITS: 32
-          #    ARCH: i686
+          - target: i686-pc-windows-gnu
+            env:
+              ARCH_BITS: 32
+              ARCH: i686
           - target: i686-pc-windows-msvc
     steps:
       - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@HEAD

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,12 +58,10 @@ jobs:
               ARCH_BITS: 64
               ARCH: x86_64
           - target: x86_64-pc-windows-msvc
-          # Disabled because broken:
-          #  https://github.com/rust-lang/libc/issues/1592
-          #- target: i686-pc-windows-gnu
-          #  env:
-          #    ARCH_BITS: 32
-          #    ARCH: i686
+          - target: i686-pc-windows-gnu
+            env:
+              ARCH_BITS: 32
+              ARCH: i686
           - target: i686-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -618,6 +618,7 @@ fn test_openbsd(target: &str) {
 fn test_windows(target: &str) {
     assert!(target.contains("windows"));
     let gnu = target.contains("gnu");
+    let i686 = target.contains("i686");
 
     let mut cfg = ctest_cfg();
     if target.contains("msvc") {
@@ -684,6 +685,8 @@ fn test_windows(target: &str) {
     cfg.skip_type(move |name| match name {
         "SSIZE_T" if !gnu => true,
         "ssize_t" if !gnu => true,
+        // FIXME: The size and alignment of this type are incorrect
+        "time_t" if gnu && i686 => true,
         _ => false,
     });
 
@@ -691,7 +694,11 @@ fn test_windows(target: &str) {
         if ty.starts_with("__c_anonymous_") {
             return true;
         }
-        return false;
+        match ty {
+            // FIXME: The size and alignment of this struct are incorrect
+            "timespec" if gnu && i686 => true,
+            _ => false,
+        }
     });
 
     cfg.skip_const(move |name| {


### PR DESCRIPTION
~~Let's see if GCC doesn't crash anymore.~~ It's now fixed 🎉 
Fixes #1592