### PR TITLE
Add waitid function for OpenBSD

### DIFF
--- a/libc-test/semver/openbsd.txt
+++ b/libc-test/semver/openbsd.txt
@@ -1274,4 +1274,5 @@ utimensat
 utmp
 utrace
 wait4
+waitid
 xucred

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -747,6 +747,12 @@ extern "C" {
         argv: *const *const ::c_char,
         envp: *const *const ::c_char,
     ) -> ::c_int;
+    pub fn waitid(
+        idtype: idtype_t,
+        id: ::id_t,
+        infop: *mut ::siginfo_t,
+        options: ::c_int,
+    ) -> ::c_int;
 }
 
 extern "C" {

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2776,12 +2776,6 @@ extern "C" {
         timeout: *const ::timespec,
     ) -> ::c_int;
     pub fn sigwaitinfo(set: *const sigset_t, info: *mut siginfo_t) -> ::c_int;
-    pub fn waitid(
-        idtype: idtype_t,
-        id: ::id_t,
-        infop: *mut ::siginfo_t,
-        options: ::c_int,
-    ) -> ::c_int;
 
     pub fn duplocale(base: ::locale_t) -> ::locale_t;
     pub fn freelocale(loc: ::locale_t);


### PR DESCRIPTION
To compile on OpenBSD a Rust project using [shared_child](https://docs.rs/shared_child/) crate, I need `waitid` libc function.

- Same prototype for `waitid` function on NetBSD and OpenBSD.
- To support it on OpenBSD, move definition from `src/unix/bsd/netbsdlike/netbsd/mod.rs` to `src/unix/bsd/netbsdlike/mod.rs` => available on both BSD OS

