### PR TITLE
Add linux support for `sched_attr` and related syscalls

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3448,6 +3448,7 @@ fn test_linux(target: &str) {
         "linux/reboot.h",
         "linux/rtnetlink.h",
         "linux/sched.h",
+        "linux/sched/types.h",
         "linux/sctp.h",
         "linux/seccomp.h",
         "linux/sock_diag.h",

--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -3741,6 +3741,11 @@ sched_getcpu
 sched_getparam
 sched_getscheduler
 sched_param
+sched_attr
+sched_getattr
+sched_setattr
+SCHED_ATTR_SIZE_VER0
+SCHED_ATTR_SIZE_VER1
 sched_rr_get_interval
 sched_setaffinity
 sched_setparam

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -850,6 +850,19 @@ s_no_extra_traits! {
         pub d_type: ::c_uchar,
         pub d_name: [::c_char; 256],
     }
+
+    pub struct sched_attr {
+        pub size: ::c_uint,
+        pub sched_policy: ::c_uint,
+        pub sched_flags: ::c_ulonglong,
+        pub sched_nice: ::c_int,
+        pub sched_priority: ::c_uint,
+        pub sched_runtime: ::c_ulonglong,
+        pub sched_deadline: ::c_ulonglong,
+        pub sched_period: ::c_ulonglong,
+        pub sched_util_min: ::c_uint,
+        pub sched_util_max: ::c_uint,
+    }
 }
 
 s_no_extra_traits! {
@@ -2011,6 +2024,9 @@ pub const SCHED_BATCH: ::c_int = 3;
 pub const SCHED_IDLE: ::c_int = 5;
 
 pub const SCHED_RESET_ON_FORK: ::c_int = 0x40000000;
+
+pub const SCHED_ATTR_SIZE_VER0: ::c_uint = 48;
+pub const SCHED_ATTR_SIZE_VER1: ::c_uint = 56;
 
 pub const CLONE_PIDFD: ::c_int = 0x1000;
 
@@ -4520,6 +4536,20 @@ pub const NET_DCCP: ::c_int = 20;
 pub const NET_IRDA: ::c_int = 412;
 
 f! {
+    // This is a workaround since glibc provides no wrappers for these syscalls.
+    // Therefore we implement them directly through `syscall`
+    pub fn sched_getattr(
+        pid: ::pid_t,
+        attr: *mut ::sched_attr,
+        size: ::c_uint,
+        flags: ::c_uint
+    ) -> ::c_int {
+        ::syscall(::SYS_sched_getattr, pid, attr, size, flags) as ::c_int
+    }
+    pub fn sched_setattr(pid: ::pid_t, attr: *mut ::sched_attr, flags: ::c_uint) -> ::c_int {
+        ::syscall(::SYS_sched_setattr, pid, attr, flags) as ::c_int
+    }
+
     pub fn NLA_ALIGN(len: ::c_int) -> ::c_int {
         return ((len) + NLA_ALIGNTO - 1) & !(NLA_ALIGNTO - 1)
     }


### PR DESCRIPTION
Hi, 
I this PR should add support for the `sched_attr` config struct and the related `sched_getattr` and `sched_setattr` syscalls.
Since this is my first PR to this repo and I'm not that experienced  with the different standard libraries I encountered some problems and wanted to ask for some assistance/ hints on how this  best implemented in the interests of this project. 

1. **Header file conflict**: The `sched_attr` struct is defined in `linux/sched/types.h` but when I add this file to the includes in the `build.rs` file I get some build errors since the file additionally defines the `sched_param` struct which is also defined by the `bits/types/struct_sched_param.h` header which is included by `pthread.h`.
Can you point me in the right direction how this is best resolved?
2. **Multiple struct versions**: There exist multiple versions of the `sched_attr` struct which are distinguished by the `size` field of the struct. 
Whats in your opinion the best way to represent this in this crate?

Many thanks in advance and sorry for the wall of text above :D
