### PR TITLE
Simplify build.rs by using the question mark operator

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -231,20 +231,14 @@ fn rustc_minor_nightly() -> (u32, bool) {
 }
 
 fn which_freebsd() -> Option<i32> {
-    let output = std::process::Command::new("freebsd-version").output().ok();
-    if output.is_none() {
-        return None;
-    }
-    let output = output.unwrap();
+    let output = std::process::Command::new("freebsd-version")
+        .output()
+        .ok()?;
     if !output.status.success() {
         return None;
     }
 
-    let stdout = String::from_utf8(output.stdout).ok();
-    if stdout.is_none() {
-        return None;
-    }
-    let stdout = stdout.unwrap();
+    let stdout = String::from_utf8(output.stdout).ok()?;
 
     match &stdout {
         s if s.starts_with("10") => Some(10),
@@ -260,20 +254,12 @@ fn emcc_version_code() -> Option<u64> {
     let output = std::process::Command::new("emcc")
         .arg("-dumpversion")
         .output()
-        .ok();
-    if output.is_none() {
-        return None;
-    }
-    let output = output.unwrap();
+        .ok()?;
     if !output.status.success() {
         return None;
     }
 
-    let stdout = String::from_utf8(output.stdout).ok();
-    if stdout.is_none() {
-        return None;
-    }
-    let version = stdout.unwrap();
+    let version = String::from_utf8(output.stdout).ok()?;
 
     // Some Emscripten versions come with `-git` attached, so split the
     // version string also on the `-` char.


### PR DESCRIPTION
The `question_mark` clippy lint currently overlooks some patterns that could be replaced by the question mark operator. This will be fixed shortly by https://github.com/rust-lang/rust-clippy/pull/11994.
