### PR TITLE
fix typos in libc

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3281,7 +3281,7 @@ fn test_linux(target: &str) {
 
     let mut cfg = ctest_cfg();
     cfg.define("_GNU_SOURCE", None);
-    // This macro re-deifnes fscanf,scanf,sscanf to link to the symbols that are
+    // This macro re-defines fscanf,scanf,sscanf to link to the symbols that are
     // deprecated since glibc >= 2.29. This allows Rust binaries to link against
     // glibc versions older than 2.29.
     cfg.define("__GLIBC_USE_DEPRECATED_SCANF", None);
@@ -3849,7 +3849,7 @@ fn test_linux(target: &str) {
             "PR_SET_VMA" | "PR_SET_VMA_ANON_NAME" => true,
 
             // present in recent kernels only
-            "PR_SCHED_CORE" | "PR_SCHED_CORE_CREATE" | "PR_SCHED_CORE_GET" | "PR_SCHED_CORE_MAX" | "PR_SCHED_CORE_SCOPE_PROCESS_GROUP" | "PR_SCHED_CORE_SCOPE_THREAD" | "PR_SCHED_CORE_SCOPE_THREAD_GROUP" | "PR_SCHED_CORE_SHARE_FROM" | "PR_SCHED_CORE_SHARE_TO" => true, 
+            "PR_SCHED_CORE" | "PR_SCHED_CORE_CREATE" | "PR_SCHED_CORE_GET" | "PR_SCHED_CORE_MAX" | "PR_SCHED_CORE_SCOPE_PROCESS_GROUP" | "PR_SCHED_CORE_SCOPE_THREAD" | "PR_SCHED_CORE_SCOPE_THREAD_GROUP" | "PR_SCHED_CORE_SHARE_FROM" | "PR_SCHED_CORE_SHARE_TO" => true,
 
             // present in recent kernels only >= 5.13
             "PR_PAC_SET_ENABLED_KEYS" | "PR_PAC_GET_ENABLED_KEYS" => true,

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -6239,7 +6239,7 @@ extern "C" {
         buffersize: u32,
     ) -> ::c_int;
     pub fn proc_kmsgbuf(buffer: *mut ::c_void, buffersize: u32) -> ::c_int;
-    pub fn proc_libversion(major: *mut ::c_int, mintor: *mut ::c_int) -> ::c_int;
+    pub fn proc_libversion(major: *mut ::c_int, minor: *mut ::c_int) -> ::c_int;
     pub fn proc_pid_rusage(pid: ::c_int, flavor: ::c_int, buffer: *mut rusage_info_t) -> ::c_int;
 
     // Available from Big Sur

--- a/src/unix/linux_like/linux/uclibc/x86_64/l4re.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/l4re.rs
@@ -13,7 +13,7 @@ s! {
         /// Combination of granularity and offset.
         ///
         /// The granularity defines how many CPUs each bit in map describes.
-        /// The offset is the numer of the first CPU described by the first
+        /// The offset is the number of the first CPU described by the first
         /// bit in the bitmap.
         /// offset must be a multiple of 2^graularity.
         ///


### PR DESCRIPTION
Fixing some typos:

For the change in `src/unix/bsd/apple/mod.rs`, I don't think changing the name of a param changes ABI so I think it's safe to change, but could be wrong. I believe the correct spelling is here: https://opensource.apple.com/source/Libc/Libc-498/darwin/libproc.c.auto.html which indicates it should be `minor`.