### PR TITLE
Add group calls to android

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2015,6 +2015,15 @@ fn test_android(target: &str) {
             // Added in API level 28, but some tests use level 24.
             "aligned_alloc" => true,
 
+            // Added in API level 26, but some tests use level 24.
+            "getgrent" => true,
+
+            // Added in API level 26, but some tests use level 24.
+            "setgrent" => true,
+
+            // Added in API level 26, but some tests use level 24.
+            "endgrent" => true,
+
             // FIXME: bad function pointers:
             "isalnum" | "isalpha" | "iscntrl" | "isdigit" | "isgraph" | "islower" | "isprint"
             | "ispunct" | "isspace" | "isupper" | "isxdigit" | "isblank" | "tolower"

--- a/libc-test/semver/android.txt
+++ b/libc-test/semver/android.txt
@@ -3223,6 +3223,7 @@ dlsym
 dup
 dup2
 duplocale
+endgrent
 endservent
 epoll_create
 epoll_create1
@@ -3327,6 +3328,7 @@ getegid
 getenv
 geteuid
 getgid
+getgrent
 getgrgid
 getgrgid_r
 getgrnam
@@ -3724,6 +3726,7 @@ seteuid
 setfsgid
 setfsuid
 setgid
+setgrent
 setgroups
 sethostname
 setlocale

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -3679,6 +3679,9 @@ safe_f! {
 }
 
 extern "C" {
+    pub fn setgrent();
+    pub fn endgrent();
+    pub fn getgrent() -> *mut ::group;
     pub fn getrlimit64(resource: ::c_int, rlim: *mut rlimit64) -> ::c_int;
     pub fn setrlimit64(resource: ::c_int, rlim: *const rlimit64) -> ::c_int;
     pub fn getrlimit(resource: ::c_int, rlim: *mut ::rlimit) -> ::c_int;


### PR DESCRIPTION
Following https://github.com/rust-lang/libc/issues/3014, this PR just implements the group side of the calls, since that doesn't require CI to be updated.