### PR TITLE
Define `TFD_TIMER_*` constants on FreeBSD.

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2425,7 +2425,11 @@ fn test_freebsd(target: &str) {
             "AT_USRSTACKBASE" | "AT_USRSTACKLIM" if Some(13) > freebsd_ver => true,
 
             // Added in FreeBSD 14
-            "TFD_CLOEXEC" | "TFD_NONBLOCK" if Some(14) > freebsd_ver => true,
+            "TFD_CLOEXEC" | "TFD_NONBLOCK" | "TFD_TIMER_ABSTIME" | "TFD_TIMER_CANCEL_ON_SET"
+                if Some(14) > freebsd_ver =>
+            {
+                true
+            }
 
             _ => false,
         }

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -4732,6 +4732,8 @@ pub const RB_MULTIPLE: ::c_int = 0x20000000;
 
 pub const TFD_NONBLOCK: ::c_int = ::O_NONBLOCK;
 pub const TFD_CLOEXEC: ::c_int = O_CLOEXEC;
+pub const TFD_TIMER_ABSTIME: ::c_int = 0x01;
+pub const TFD_TIMER_CANCEL_ON_SET: ::c_int = 0x02;
 
 cfg_if! {
     if #[cfg(libc_const_extern_fn)] {


### PR DESCRIPTION
Following up on #3341, add `TFD_TIMER_*` constants for use with the timerfd API on FreeBSD.
