### PR TITLE
Unpin cc dependency version

### DIFF
--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -16,8 +16,7 @@ version = "0.2.151"
 default-features = false
 
 [build-dependencies]
-# FIXME: 1.0.84 has a bug about macOS version detection.
-cc = "=1.0.83"
+cc = "1.0.83"
 # FIXME: Use fork ctest until the maintainer gets back.
 ctest2 = "0.4.3"
 


### PR DESCRIPTION
1.0.84 has been yanked and we no longer need to pin the version.