### PR TITLE
redox: add openpty, login_tty, TIOCSCTTY, and organize functions

### DIFF
--- a/libc-test/semver/redox.txt
+++ b/libc-test/semver/redox.txt
@@ -145,6 +145,7 @@ TCGETS
 TCP_KEEPIDLE
 TCSETS
 TIOCGPGRP
+TIOCSCTTY
 TIOCSPGRP
 UTSLENGTH
 VDISCARD
@@ -207,11 +208,13 @@ getservbyport
 getservent
 killpg
 lockf
+login_tty
 madvise
 memalign
 nice
 open_memstream
 open_wmemstream
+openpty
 pipe2
 pthread_condattr_setclock
 qsort

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -729,6 +729,7 @@ pub const FIOCLEX: ::c_ulong = 0x5451;
 pub const TCGETS: ::c_ulong = 0x5401;
 pub const TCSETS: ::c_ulong = 0x5402;
 pub const TCFLSH: ::c_ulong = 0x540B;
+pub const TIOCSCTTY: ::c_ulong = 0x540E;
 pub const TIOCGPGRP: ::c_ulong = 0x540F;
 pub const TIOCSPGRP: ::c_ulong = 0x5410;
 pub const TIOCGWINSZ: ::c_ulong = 0x5413;
@@ -1138,6 +1139,15 @@ extern "C" {
         clock_id: ::clockid_t,
     ) -> ::c_int;
 
+    //pty.h
+    pub fn openpty(
+        amaster: *mut ::c_int,
+        aslave: *mut ::c_int,
+        name: *mut ::c_char,
+        termp: *const termios,
+        winp: *const ::winsize,
+    ) -> ::c_int;
+
     // pwd.h
     pub fn getpwent() -> *mut passwd;
     pub fn setpwent();
@@ -1173,9 +1183,15 @@ extern "C" {
     pub fn sigwait(set: *const sigset_t, sig: *mut ::c_int) -> ::c_int;
 
     // stdlib.h
+    pub fn getsubopt(
+        optionp: *mut *mut c_char,
+        tokens: *const *mut c_char,
+        valuep: *mut *mut c_char,
+    ) -> ::c_int;
     pub fn reallocarray(ptr: *mut ::c_void, nmemb: ::size_t, size: ::size_t) -> *mut ::c_void;
 
     // string.h
+    pub fn explicit_bzero(p: *mut ::c_void, len: ::size_t);
     pub fn strlcat(dst: *mut ::c_char, src: *const ::c_char, siz: ::size_t) -> ::size_t;
     pub fn strlcpy(dst: *mut ::c_char, src: *const ::c_char, siz: ::size_t) -> ::size_t;
 
@@ -1202,6 +1218,8 @@ extern "C" {
     pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
 
     // sys/resource.h
+    pub fn getpriority(which: ::c_int, who: ::id_t) -> ::c_int;
+    pub fn setpriority(which: ::c_int, who: ::id_t, prio: ::c_int) -> ::c_int;
     pub fn getrlimit(resource: ::c_int, rlim: *mut ::rlimit) -> ::c_int;
     pub fn setrlimit(resource: ::c_int, rlim: *const ::rlimit) -> ::c_int;
 
@@ -1230,17 +1248,8 @@ extern "C" {
     pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::timezone) -> ::c_int;
     pub fn clock_gettime(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
 
-    // strings.h
-    pub fn explicit_bzero(p: *mut ::c_void, len: ::size_t);
-
-    pub fn getpriority(which: ::c_int, who: ::id_t) -> ::c_int;
-    pub fn setpriority(which: ::c_int, who: ::id_t, prio: ::c_int) -> ::c_int;
-
-    pub fn getsubopt(
-        optionp: *mut *mut c_char,
-        tokens: *const *mut c_char,
-        valuep: *mut *mut c_char,
-    ) -> ::c_int;
+    // utmp.h
+    pub fn login_tty(fd: ::c_int) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
The added items are used by terminal programs.  I have organized some functions that were not sorted by header name. Sorting by header name makes it easier to keep this in sync with the Redox OS libc, `relibc`.
