### PR TITLE
Remove the `use_std` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,8 +139,6 @@ align = []
 rustc-dep-of-std = ['align', 'rustc-std-workspace-core']
 extra_traits = []
 const-extern-fn = []
-# use_std is deprecated, use `std` instead
-use_std = ['std']
 
 [workspace]
 members = ["libc-test"]

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ libc = "0.2"
   If you use Rust >= 1.62, this feature is implicitly enabled.
   Otherwise it requires a nightly rustc.
 
-* **deprecated**: `use_std` is deprecated, and is equivalent to `std`.
-
 ## Rust version support
 
 The minimum supported Rust toolchain version is currently **Rust 1.71.0**

--- a/build.rs
+++ b/build.rs
@@ -40,13 +40,6 @@ fn main() {
     let libc_check_cfg = env::var("LIBC_CHECK_CFG").is_ok();
     let const_extern_fn_cargo_feature = env::var("CARGO_FEATURE_CONST_EXTERN_FN").is_ok();
 
-    if env::var("CARGO_FEATURE_USE_STD").is_ok() {
-        println!(
-            "cargo:warning=\"libc's use_std cargo feature is deprecated since libc 0.2.55; \
-             please consider using the `std` cargo feature instead\""
-        );
-    }
-
     // The ABI of libc used by std is backward compatible with FreeBSD 12.
     // The ABI of libc from crates.io is backward compatible with FreeBSD 11.
     //


### PR DESCRIPTION
It has been deprecated for a while and it's good time to remove.