### PR TITLE
Support CRT Static for FreeBSD

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -524,7 +524,9 @@ extern "C" {
     pub fn basename(path: *mut ::c_char) -> *mut ::c_char;
 }
 
-#[link(name = "kvm")]
+#[link(name = "kvm", kind = "static", modifiers = "-bundle",
+    cfg(target_feature = "crt-static"))]
+#[link(name = "kvm", cfg(not(target_feature = "crt-static")))]
 extern "C" {
     pub fn kvm_kerndisp(kd: *mut ::kvm_t) -> ::kssize_t;
 }

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -524,7 +524,9 @@ extern "C" {
     pub fn basename(path: *mut ::c_char) -> *mut ::c_char;
 }
 
-#[link(name = "kvm")]
+#[link(name = "kvm", kind = "static", modifiers = "-bundle",
+    cfg(target_feature = "crt-static"))]
+#[link(name = "kvm", cfg(not(target_feature = "crt-static")))]
 extern "C" {
     pub fn kvm_kerndisp(kd: *mut ::kvm_t) -> ::kssize_t;
 }

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -5391,7 +5391,9 @@ extern "C" {
     pub fn close_range(lowfd: ::c_uint, highfd: ::c_uint, flags: ::c_int) -> ::c_int;
 }
 
-#[link(name = "memstat")]
+#[link(name = "memstat", kind = "static", modifiers = "-bundle",
+    cfg(target_feature = "crt-static"))]
+#[link(name = "memstat", cfg(not(target_feature = "crt-static")))]
 extern "C" {
     pub fn memstat_strerror(error: ::c_int) -> *const ::c_char;
     pub fn memstat_mtl_alloc() -> *mut memory_type_list;
@@ -5407,7 +5409,9 @@ extern "C" {
     pub fn memstat_get_name(mtp: *const memory_type) -> *const ::c_char;
 }
 
-#[link(name = "kvm")]
+#[link(name = "kvm", kind = "static", modifiers = "-bundle",
+    cfg(target_feature = "crt-static"))]
+#[link(name = "kvm", cfg(not(target_feature = "crt-static")))]
 extern "C" {
     pub fn kvm_dpcpu_setcpu(kd: *mut ::kvm_t, cpu: ::c_uint) -> ::c_int;
     pub fn kvm_getargv(kd: *mut ::kvm_t, p: *const kinfo_proc, nchr: ::c_int)
@@ -5444,7 +5448,9 @@ extern "C" {
     ) -> ::ssize_t;
 }
 
-#[link(name = "util")]
+#[link(name = "util", kind = "static", modifiers = "-bundle",
+    cfg(target_feature = "crt-static"))]
+#[link(name = "util", cfg(not(target_feature = "crt-static")))]
 extern "C" {
     pub fn extattr_namespace_to_string(
         attrnamespace: ::c_int,
@@ -5494,7 +5500,9 @@ extern "C" {
     // FIXME: pidfile_signal in due time (both manpage present and updated image snapshot)
 }
 
-#[link(name = "procstat")]
+#[link(name = "procstat", kind = "static", modifiers = "-bundle",
+    cfg(target_feature = "crt-static"))]
+#[link(name = "procstat", cfg(not(target_feature = "crt-static")))]
 extern "C" {
     pub fn procstat_open_sysctl() -> *mut procstat;
     pub fn procstat_getfiles(
@@ -5586,7 +5594,9 @@ extern "C" {
     ) -> ::c_int;
 }
 
-#[link(name = "rt")]
+#[link(name = "rt", kind = "static", modifiers = "-bundle",
+    cfg(target_feature = "crt-static"))]
+#[link(name = "rt", cfg(not(target_feature = "crt-static")))]
 extern "C" {
     pub fn timer_create(clock_id: clockid_t, evp: *mut sigevent, timerid: *mut timer_t) -> ::c_int;
     pub fn timer_delete(timerid: timer_t) -> ::c_int;
@@ -5600,7 +5610,9 @@ extern "C" {
     ) -> ::c_int;
 }
 
-#[link(name = "devstat")]
+#[link(name = "devstat", kind = "static", modifiers = "-bundle",
+    cfg(target_feature = "crt-static"))]
+#[link(name = "devstat", cfg(not(target_feature = "crt-static")))]
 extern "C" {
     pub fn devstat_getnumdevs(kd: *mut ::kvm_t) -> ::c_int;
     pub fn devstat_getgeneration(kd: *mut ::kvm_t) -> ::c_long;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1787,7 +1787,9 @@ extern "C" {
     ) -> ::c_int;
 }
 
-#[link(name = "rt")]
+#[link(name = "rt", kind = "static", modifiers = "-bundle",
+    cfg(target_feature = "crt-static"))]
+#[link(name = "rt", cfg(not(target_feature = "crt-static")))]
 extern "C" {
     pub fn mq_close(mqd: ::mqd_t) -> ::c_int;
     pub fn mq_getattr(mqd: ::mqd_t, attr: *mut ::mq_attr) -> ::c_int;
@@ -1823,7 +1825,9 @@ extern "C" {
     pub fn mq_unlink(name: *const ::c_char) -> ::c_int;
 }
 
-#[link(name = "util")]
+#[link(name = "util", kind = "static", modifiers = "-bundle",
+    cfg(target_feature = "crt-static"))]
+#[link(name = "util", cfg(not(target_feature = "crt-static")))]
 extern "C" {
     pub fn openpty(
         amaster: *mut ::c_int,
@@ -1848,7 +1852,9 @@ extern "C" {
     ) -> *mut ::c_char;
 }
 
-#[link(name = "execinfo")]
+#[link(name = "execinfo", kind = "static", modifiers = "-bundle",
+    cfg(target_feature = "crt-static"))]
+#[link(name = "execinfo", cfg(not(target_feature = "crt-static")))]
 extern "C" {
     pub fn backtrace(addrlist: *mut *mut ::c_void, len: ::size_t) -> ::size_t;
     pub fn backtrace_symbols(addrlist: *const *mut ::c_void, len: ::size_t) -> *mut *mut ::c_char;
@@ -1859,7 +1865,9 @@ extern "C" {
     ) -> ::c_int;
 }
 
-#[link(name = "kvm")]
+#[link(name = "kvm", kind = "static", modifiers = "-bundle",
+    cfg(target_feature = "crt-static"))]
+#[link(name = "kvm", cfg(not(target_feature = "crt-static")))]
 extern "C" {
     pub fn kvm_open(
         execfile: *const ::c_char,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -401,6 +401,20 @@ cfg_if! {
         #[link(name = "bsd")]
         #[link(name = "pthread")]
         extern {}
+    } else if #[cfg(target_os = "freebsd")] {
+        #[link(name = "c", kind = "static", modifiers = "-bundle",
+            cfg(target_feature = "crt-static"))]
+        #[link(name = "m", kind = "static", modifiers = "-bundle",
+            cfg(target_feature = "crt-static"))]
+        #[link(name = "rt", kind = "static", modifiers = "-bundle",
+            cfg(target_feature = "crt-static"))]
+        #[link(name = "pthread", kind = "static", modifiers = "-bundle",
+            cfg(target_feature = "crt-static"))]
+        #[link(name = "c", cfg(not(target_feature = "crt-static")))]
+        #[link(name = "m", cfg(not(target_feature = "crt-static")))]
+        #[link(name = "rt", cfg(not(target_feature = "crt-static")))]
+        #[link(name = "pthread", cfg(not(target_feature = "crt-static")))]
+        extern {}
     } else {
         #[link(name = "c")]
         #[link(name = "m")]


### PR DESCRIPTION
Modify the dependency links for FreeBSD to support statically linking Rust binaries on FreeBSD.
