### PR TITLE
Fix broken vita std compilation by adding SOMAXCONN

### DIFF
--- a/src/unix/newlib/vita/mod.rs
+++ b/src/unix/newlib/vita/mod.rs
@@ -94,6 +94,8 @@ pub const SOCK_RAW: ::c_int = 3;
 pub const SOCK_RDM: ::c_int = 4;
 pub const SOCK_SEQPACKET: ::c_int = 5;
 
+pub const SOMAXCONN: ::c_int = 128;
+
 pub const FIONBIO: ::c_ulong = 1;
 
 pub const POLLIN: ::c_short = 0x0001;


### PR DESCRIPTION
std is broken on PS Vita since https://github.com/rust-lang/rust/pull/119026

- vita's SOMAXCONN discovered empirically
- ~~esp-idf's SOMAXCONN from https://github.com/espressif/esp-idf/blob/b3f7e2c8a4d354df8ef8558ea7caddc07283a57b/components/newlib/platform_include/net/if.h#L20~~ (removed as it was probably incorrect, see [comment](https://github.com/rust-lang/libc/pull/3538#issuecomment-1889107265))

~~@ivmarkov can you confirm the esp change?~~