### PR TITLE
feat: IPV6_RECVHOPLIMIT & IP_RECVTTL for FreeBSD

### DIFF
--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -2251,3 +2251,5 @@ closefrom
 close_range
 eventfd_read
 eventfd_write
+IP_RECVTTL
+IPV6_RECVHOPLIMIT

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -3609,6 +3609,8 @@ pub const IP_RSS_LISTEN_BUCKET: ::c_int = 26;
 pub const IP_ORIGDSTADDR: ::c_int = 27;
 pub const IP_RECVORIGDSTADDR: ::c_int = IP_ORIGDSTADDR;
 
+pub const IP_RECVTTL: ::c_int = 65;
+pub const IPV6_RECVHOPLIMIT: ::c_int = 37;
 pub const IP_DONTFRAG: ::c_int = 67;
 pub const IP_RECVTOS: ::c_int = 68;
 


### PR DESCRIPTION
Add 2 constants for FreeBSD:

1. [`IP_RECVTTL`](https://github.com/search?q=repo%3Afreebsd%2Ffreebsd-src%20IP_RECVTTL&type=code)
2. [`IPV6_RECVHOPLIMIT`](https://github.com/search?q=repo%3Afreebsd%2Ffreebsd-src+IPV6_RECVHOPLIMIT&type=code)