### PR TITLE
Fix libc-tests for loongarch64 hwcaps

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3261,6 +3261,7 @@ fn test_linux(target: &str) {
     let gnueabihf = target.contains("gnueabihf");
     let x86_64_gnux32 = target.contains("gnux32") && x86_64;
     let riscv64 = target.contains("riscv64");
+    let loongarch64 = target.contains("loongarch64");
     let uclibc = target.contains("uclibc");
 
     let mut cfg = ctest_cfg();
@@ -3383,6 +3384,7 @@ fn test_linux(target: &str) {
     // Include linux headers at the end:
     headers! {
         cfg:
+        [loongarch64]: "asm/hwcap.h",
         "asm/mman.h",
         "linux/can.h",
         "linux/can/raw.h",

--- a/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
@@ -264,20 +264,20 @@ align_const! {
         };
 }
 
-pub const HWCAP_CPUCFG: ::c_ulong = 1 << 0;
-pub const HWCAP_LAM: ::c_ulong = 1 << 1;
-pub const HWCAP_UAL: ::c_ulong = 1 << 2;
-pub const HWCAP_FPU: ::c_ulong = 1 << 3;
-pub const HWCAP_LSX: ::c_ulong = 1 << 4;
-pub const HWCAP_LASX: ::c_ulong = 1 << 5;
-pub const HWCAP_CRC32: ::c_ulong = 1 << 6;
-pub const HWCAP_COMPLEX: ::c_ulong = 1 << 7;
-pub const HWCAP_CRYPTO: ::c_ulong = 1 << 8;
-pub const HWCAP_LVZ: ::c_ulong = 1 << 9;
-pub const HWCAP_LBT_X86: ::c_ulong = 1 << 10;
-pub const HWCAP_LBT_ARM: ::c_ulong = 1 << 11;
-pub const HWCAP_LBT_MIPS: ::c_ulong = 1 << 12;
-pub const HWCAP_PTW: ::c_ulong = 1 << 13;
+pub const HWCAP_LOONGARCH_CPUCFG: ::c_ulong = 1 << 0;
+pub const HWCAP_LOONGARCH_LAM: ::c_ulong = 1 << 1;
+pub const HWCAP_LOONGARCH_UAL: ::c_ulong = 1 << 2;
+pub const HWCAP_LOONGARCH_FPU: ::c_ulong = 1 << 3;
+pub const HWCAP_LOONGARCH_LSX: ::c_ulong = 1 << 4;
+pub const HWCAP_LOONGARCH_LASX: ::c_ulong = 1 << 5;
+pub const HWCAP_LOONGARCH_CRC32: ::c_ulong = 1 << 6;
+pub const HWCAP_LOONGARCH_COMPLEX: ::c_ulong = 1 << 7;
+pub const HWCAP_LOONGARCH_CRYPTO: ::c_ulong = 1 << 8;
+pub const HWCAP_LOONGARCH_LVZ: ::c_ulong = 1 << 9;
+pub const HWCAP_LOONGARCH_LBT_X86: ::c_ulong = 1 << 10;
+pub const HWCAP_LOONGARCH_LBT_ARM: ::c_ulong = 1 << 11;
+pub const HWCAP_LOONGARCH_LBT_MIPS: ::c_ulong = 1 << 12;
+pub const HWCAP_LOONGARCH_PTW: ::c_ulong = 1 << 13;
 
 pub const SYS_io_setup: ::c_long = 0;
 pub const SYS_io_destroy: ::c_long = 1;


### PR DESCRIPTION
I overlooked the crucial aspect of maintaining consistency between the names in hwcaps and the C header files for libc-test. As far as I'm aware, it has not been utilized yet, and it is high time to address this issue promptly.
