### PR TITLE
Fix libc-tests for loongarch64 syscall

### DIFF
--- a/libc-test/semver/linux-aarch64.txt
+++ b/libc-test/semver/linux-aarch64.txt
@@ -66,6 +66,7 @@ SKF_NET_OFF
 SO_PRIORITY
 SO_PROTOCOL
 SYS_accept
+SYS_fstat
 SYS_msgctl
 SYS_msgget
 SYS_msgrcv
@@ -79,6 +80,7 @@ SYS_semctl
 SYS_semget
 SYS_semop
 SYS_semtimedop
+SYS_setrlimit
 SYS_shmat
 SYS_shmctl
 SYS_shmdt

--- a/libc-test/semver/linux-i686.txt
+++ b/libc-test/semver/linux-i686.txt
@@ -96,6 +96,7 @@ SYS_fadvise64_64
 SYS_fchown32
 SYS_fcntl64
 SYS_fork
+SYS_fstat
 SYS_fstat64
 SYS_fstatat64
 SYS_fstatfs64
@@ -165,6 +166,7 @@ SYS_setregid32
 SYS_setresgid32
 SYS_setresuid32
 SYS_setreuid32
+SYS_setrlimit
 SYS_setuid32
 SYS_sgetmask
 SYS_sigaction

--- a/libc-test/semver/linux-mips.txt
+++ b/libc-test/semver/linux-mips.txt
@@ -30,6 +30,7 @@ SYS_epoll_wait
 SYS_eventfd
 SYS_fcntl64
 SYS_fork
+SYS_fstat
 SYS_fstat64
 SYS_fstatfs64
 SYS_ftime
@@ -77,6 +78,7 @@ SYS_send
 SYS_sendfile
 SYS_sendfile64
 SYS_set_thread_area
+SYS_setrlimit
 SYS_sgetmask
 SYS_sigaction
 SYS_signal

--- a/libc-test/semver/linux-powerpc.txt
+++ b/libc-test/semver/linux-powerpc.txt
@@ -54,6 +54,7 @@ SYS_fadvise64
 SYS_fadvise64_64
 SYS_fcntl64
 SYS_fork
+SYS_fstat
 SYS_fstat64
 SYS_fstatat64
 SYS_fstatfs64
@@ -110,6 +111,7 @@ SYS_select
 SYS_send
 SYS_sendfile
 SYS_sendfile64
+SYS_setrlimit
 SYS_sgetmask
 SYS_sigaction
 SYS_signal

--- a/libc-test/semver/linux-powerpc64.txt
+++ b/libc-test/semver/linux-powerpc64.txt
@@ -66,6 +66,7 @@ SYS_epoll_create
 SYS_epoll_wait
 SYS_eventfd
 SYS_fork
+SYS_fstat
 SYS_fstatfs64
 SYS_ftime
 SYS_futimesat
@@ -117,6 +118,7 @@ SYS_rtas
 SYS_select
 SYS_send
 SYS_sendfile
+SYS_setrlimit
 SYS_sgetmask
 SYS_sigaction
 SYS_signal

--- a/libc-test/semver/linux-powerpc64le.txt
+++ b/libc-test/semver/linux-powerpc64le.txt
@@ -66,6 +66,7 @@ SYS_epoll_create
 SYS_epoll_wait
 SYS_eventfd
 SYS_fork
+SYS_fstat
 SYS_fstatfs64
 SYS_ftime
 SYS_futimesat
@@ -117,6 +118,7 @@ SYS_rtas
 SYS_select
 SYS_send
 SYS_sendfile
+SYS_setrlimit
 SYS_sgetmask
 SYS_sigaction
 SYS_signal

--- a/libc-test/semver/linux-riscv64gc.txt
+++ b/libc-test/semver/linux-riscv64gc.txt
@@ -46,6 +46,7 @@ SO_TIMESTAMPNS
 SO_WIFI_STATUS
 SYS_accept
 SYS_fadvise64
+SYS_fstat
 SYS_msgctl
 SYS_msgget
 SYS_msgrcv
@@ -59,6 +60,7 @@ SYS_semget
 SYS_semop
 SYS_semtimedop
 SYS_sendfile
+SYS_setrlimit
 SYS_shmat
 SYS_shmctl
 SYS_shmdt

--- a/libc-test/semver/linux-s390x.txt
+++ b/libc-test/semver/linux-s390x.txt
@@ -44,6 +44,7 @@ SYS_epoll_wait
 SYS_eventfd
 SYS_fadvise64
 SYS_fork
+SYS_fstat
 SYS_fstatfs64
 SYS_futimesat
 SYS_get_kernel_syms
@@ -76,6 +77,7 @@ SYS_s390_pci_mmio_write
 SYS_s390_runtime_instr
 SYS_select
 SYS_sendfile
+SYS_setrlimit
 SYS_sigaction
 SYS_signal
 SYS_signalfd

--- a/libc-test/semver/linux-sparc64.txt
+++ b/libc-test/semver/linux-sparc64.txt
@@ -40,6 +40,7 @@ SYS_execv
 SYS_fadvise64
 SYS_fadvise64_64
 SYS_fork
+SYS_fstat
 SYS_fstat64
 SYS_fstatat64
 SYS_fstatfs64
@@ -79,6 +80,7 @@ SYS_sched_set_affinity
 SYS_select
 SYS_sendfile
 SYS_sendfile64
+SYS_setrlimit
 SYS_sgetmask
 SYS_sigaction
 SYS_signal

--- a/libc-test/semver/linux-x86_64.txt
+++ b/libc-test/semver/linux-x86_64.txt
@@ -93,6 +93,7 @@ SYS_epoll_wait
 SYS_eventfd
 SYS_fadvise64
 SYS_fork
+SYS_fstat
 SYS_futimesat
 SYS_getdents
 SYS_getpgrp
@@ -120,6 +121,7 @@ SYS_renameat
 SYS_rmdir
 SYS_select
 SYS_sendfile
+SYS_setrlimit
 SYS_signalfd
 SYS_stat
 SYS_symlink

--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -2853,7 +2853,6 @@ SYS_flistxattr
 SYS_flock
 SYS_fremovexattr
 SYS_fsetxattr
-SYS_fstat
 SYS_fstatfs
 SYS_fsync
 SYS_ftruncate
@@ -3008,7 +3007,6 @@ SYS_setregid
 SYS_setresgid
 SYS_setresuid
 SYS_setreuid
-SYS_setrlimit
 SYS_setsid
 SYS_setsockopt
 SYS_settimeofday


### PR DESCRIPTION
This PR moves `SYS_fstat` and `SYS_setrlimit` from `linux.txt` to `linux-$arch.txt`. The rationale behind this change is the absence of these two system call numbers for certain architectures, such as LoongArch, which employ generic Linux syscall numbers. In these cases, [__ARCH_WANT_NEW_STAT](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/include/uapi/asm-generic/unistd.h?h=v6.6.12#n209) and [__ARCH_WANT_SET_GET_RLIMIT](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/include/uapi/asm-generic/unistd.h?h=v6.6.12#n435) are not defined.