### PR TITLE
Fix libc-tests for loongarch64

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3316,6 +3316,7 @@ fn test_linux(target: &str) {
     let gnueabihf = target.contains("gnueabihf");
     let x86_64_gnux32 = target.contains("gnux32") && x86_64;
     let riscv64 = target.contains("riscv64");
+    let loongarch64 = target.contains("loongarch64");
     let uclibc = target.contains("uclibc");
 
     let mut cfg = ctest_cfg();
@@ -3437,6 +3438,7 @@ fn test_linux(target: &str) {
     // Include linux headers at the end:
     headers! {
         cfg:
+        [loongarch64]: "asm/hwcap.h",
         "asm/mman.h",
         [gnu]: "linux/aio_abi.h",
         "linux/can.h",

--- a/libc-test/semver/linux-aarch64.txt
+++ b/libc-test/semver/linux-aarch64.txt
@@ -66,6 +66,7 @@ SKF_NET_OFF
 SO_PRIORITY
 SO_PROTOCOL
 SYS_accept
+SYS_fstat
 SYS_msgctl
 SYS_msgget
 SYS_msgrcv
@@ -79,6 +80,7 @@ SYS_semctl
 SYS_semget
 SYS_semop
 SYS_semtimedop
+SYS_setrlimit
 SYS_shmat
 SYS_shmctl
 SYS_shmdt

--- a/libc-test/semver/linux-i686.txt
+++ b/libc-test/semver/linux-i686.txt
@@ -96,6 +96,7 @@ SYS_fadvise64_64
 SYS_fchown32
 SYS_fcntl64
 SYS_fork
+SYS_fstat
 SYS_fstat64
 SYS_fstatat64
 SYS_fstatfs64
@@ -165,6 +166,7 @@ SYS_setregid32
 SYS_setresgid32
 SYS_setresuid32
 SYS_setreuid32
+SYS_setrlimit
 SYS_setuid32
 SYS_sgetmask
 SYS_sigaction

--- a/libc-test/semver/linux-mips.txt
+++ b/libc-test/semver/linux-mips.txt
@@ -30,6 +30,7 @@ SYS_epoll_wait
 SYS_eventfd
 SYS_fcntl64
 SYS_fork
+SYS_fstat
 SYS_fstat64
 SYS_fstatfs64
 SYS_ftime
@@ -77,6 +78,7 @@ SYS_send
 SYS_sendfile
 SYS_sendfile64
 SYS_set_thread_area
+SYS_setrlimit
 SYS_sgetmask
 SYS_sigaction
 SYS_signal

--- a/libc-test/semver/linux-powerpc.txt
+++ b/libc-test/semver/linux-powerpc.txt
@@ -54,6 +54,7 @@ SYS_fadvise64
 SYS_fadvise64_64
 SYS_fcntl64
 SYS_fork
+SYS_fstat
 SYS_fstat64
 SYS_fstatat64
 SYS_fstatfs64
@@ -110,6 +111,7 @@ SYS_select
 SYS_send
 SYS_sendfile
 SYS_sendfile64
+SYS_setrlimit
 SYS_sgetmask
 SYS_sigaction
 SYS_signal

--- a/libc-test/semver/linux-powerpc64.txt
+++ b/libc-test/semver/linux-powerpc64.txt
@@ -66,6 +66,7 @@ SYS_epoll_create
 SYS_epoll_wait
 SYS_eventfd
 SYS_fork
+SYS_fstat
 SYS_fstatfs64
 SYS_ftime
 SYS_futimesat
@@ -117,6 +118,7 @@ SYS_rtas
 SYS_select
 SYS_send
 SYS_sendfile
+SYS_setrlimit
 SYS_sgetmask
 SYS_sigaction
 SYS_signal

--- a/libc-test/semver/linux-powerpc64le.txt
+++ b/libc-test/semver/linux-powerpc64le.txt
@@ -66,6 +66,7 @@ SYS_epoll_create
 SYS_epoll_wait
 SYS_eventfd
 SYS_fork
+SYS_fstat
 SYS_fstatfs64
 SYS_ftime
 SYS_futimesat
@@ -117,6 +118,7 @@ SYS_rtas
 SYS_select
 SYS_send
 SYS_sendfile
+SYS_setrlimit
 SYS_sgetmask
 SYS_sigaction
 SYS_signal

--- a/libc-test/semver/linux-riscv64gc.txt
+++ b/libc-test/semver/linux-riscv64gc.txt
@@ -46,6 +46,7 @@ SO_TIMESTAMPNS
 SO_WIFI_STATUS
 SYS_accept
 SYS_fadvise64
+SYS_fstat
 SYS_msgctl
 SYS_msgget
 SYS_msgrcv
@@ -59,6 +60,7 @@ SYS_semget
 SYS_semop
 SYS_semtimedop
 SYS_sendfile
+SYS_setrlimit
 SYS_shmat
 SYS_shmctl
 SYS_shmdt

--- a/libc-test/semver/linux-s390x.txt
+++ b/libc-test/semver/linux-s390x.txt
@@ -44,6 +44,7 @@ SYS_epoll_wait
 SYS_eventfd
 SYS_fadvise64
 SYS_fork
+SYS_fstat
 SYS_fstatfs64
 SYS_futimesat
 SYS_get_kernel_syms
@@ -76,6 +77,7 @@ SYS_s390_pci_mmio_write
 SYS_s390_runtime_instr
 SYS_select
 SYS_sendfile
+SYS_setrlimit
 SYS_sigaction
 SYS_signal
 SYS_signalfd

--- a/libc-test/semver/linux-sparc64.txt
+++ b/libc-test/semver/linux-sparc64.txt
@@ -40,6 +40,7 @@ SYS_execv
 SYS_fadvise64
 SYS_fadvise64_64
 SYS_fork
+SYS_fstat
 SYS_fstat64
 SYS_fstatat64
 SYS_fstatfs64
@@ -79,6 +80,7 @@ SYS_sched_set_affinity
 SYS_select
 SYS_sendfile
 SYS_sendfile64
+SYS_setrlimit
 SYS_sgetmask
 SYS_sigaction
 SYS_signal

--- a/libc-test/semver/linux-x86_64.txt
+++ b/libc-test/semver/linux-x86_64.txt
@@ -93,6 +93,7 @@ SYS_epoll_wait
 SYS_eventfd
 SYS_fadvise64
 SYS_fork
+SYS_fstat
 SYS_futimesat
 SYS_getdents
 SYS_getpgrp
@@ -120,6 +121,7 @@ SYS_renameat
 SYS_rmdir
 SYS_select
 SYS_sendfile
+SYS_setrlimit
 SYS_signalfd
 SYS_stat
 SYS_symlink

--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -2901,7 +2901,6 @@ SYS_flistxattr
 SYS_flock
 SYS_fremovexattr
 SYS_fsetxattr
-SYS_fstat
 SYS_fstatfs
 SYS_fsync
 SYS_ftruncate
@@ -3056,7 +3055,6 @@ SYS_setregid
 SYS_setresgid
 SYS_setresuid
 SYS_setreuid
-SYS_setrlimit
 SYS_setsid
 SYS_setsockopt
 SYS_settimeofday

--- a/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
@@ -256,20 +256,20 @@ pub const PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t = pthread_mut
     ],
 };
 
-pub const HWCAP_CPUCFG: ::c_ulong = 1 << 0;
-pub const HWCAP_LAM: ::c_ulong = 1 << 1;
-pub const HWCAP_UAL: ::c_ulong = 1 << 2;
-pub const HWCAP_FPU: ::c_ulong = 1 << 3;
-pub const HWCAP_LSX: ::c_ulong = 1 << 4;
-pub const HWCAP_LASX: ::c_ulong = 1 << 5;
-pub const HWCAP_CRC32: ::c_ulong = 1 << 6;
-pub const HWCAP_COMPLEX: ::c_ulong = 1 << 7;
-pub const HWCAP_CRYPTO: ::c_ulong = 1 << 8;
-pub const HWCAP_LVZ: ::c_ulong = 1 << 9;
-pub const HWCAP_LBT_X86: ::c_ulong = 1 << 10;
-pub const HWCAP_LBT_ARM: ::c_ulong = 1 << 11;
-pub const HWCAP_LBT_MIPS: ::c_ulong = 1 << 12;
-pub const HWCAP_PTW: ::c_ulong = 1 << 13;
+pub const HWCAP_LOONGARCH_CPUCFG: ::c_ulong = 1 << 0;
+pub const HWCAP_LOONGARCH_LAM: ::c_ulong = 1 << 1;
+pub const HWCAP_LOONGARCH_UAL: ::c_ulong = 1 << 2;
+pub const HWCAP_LOONGARCH_FPU: ::c_ulong = 1 << 3;
+pub const HWCAP_LOONGARCH_LSX: ::c_ulong = 1 << 4;
+pub const HWCAP_LOONGARCH_LASX: ::c_ulong = 1 << 5;
+pub const HWCAP_LOONGARCH_CRC32: ::c_ulong = 1 << 6;
+pub const HWCAP_LOONGARCH_COMPLEX: ::c_ulong = 1 << 7;
+pub const HWCAP_LOONGARCH_CRYPTO: ::c_ulong = 1 << 8;
+pub const HWCAP_LOONGARCH_LVZ: ::c_ulong = 1 << 9;
+pub const HWCAP_LOONGARCH_LBT_X86: ::c_ulong = 1 << 10;
+pub const HWCAP_LOONGARCH_LBT_ARM: ::c_ulong = 1 << 11;
+pub const HWCAP_LOONGARCH_LBT_MIPS: ::c_ulong = 1 << 12;
+pub const HWCAP_LOONGARCH_PTW: ::c_ulong = 1 << 13;
 
 pub const SYS_io_setup: ::c_long = 0;
 pub const SYS_io_destroy: ::c_long = 1;


### PR DESCRIPTION
Fix hwcaps and syscalls tests for LoongArch64.

### hwcaps

Move hwcaps to keep naming same as in c header files.

### syscalls

This PR moves `SYS_fstat` and `SYS_setrlimit` from `linux.txt` to `linux-$arch.txt`. The rationale behind this change is the absence of these two system call numbers for certain architectures, such as LoongArch, which employ generic Linux syscall numbers. In these cases, [__ARCH_WANT_NEW_STAT](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/include/uapi/asm-generic/unistd.h?h=v6.6.12#n209) and [__ARCH_WANT_SET_GET_RLIMIT](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/include/uapi/asm-generic/unistd.h?h=v6.6.12#n435) are not defined.