### PR TITLE
Add SOMAXCONN to vita on 0.2 (to fix std)

### DIFF
--- a/src/unix/newlib/vita/mod.rs
+++ b/src/unix/newlib/vita/mod.rs
@@ -94,6 +94,8 @@ pub const SOCK_RAW: ::c_int = 3;
 pub const SOCK_RDM: ::c_int = 4;
 pub const SOCK_SEQPACKET: ::c_int = 5;
 
+pub const SOMAXCONN: ::c_int = 128;
+
 pub const FIONBIO: ::c_ulong = 1;
 
 pub const POLLIN: ::c_short = 0x0001;


### PR DESCRIPTION
Hey, I realized we actually need it on `libc-0.2` as it needs to be released and used by `std`, so I cherry-picked the commit from `main`

Thanks a lot!

Original PR: https://github.com/rust-lang/libc/pull/3538