### PR TITLE
Fix: time_t is 64 bits on Emscripten

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,7 @@ use std::string::String;
 // make sure to add it to this list as well.
 const ALLOWED_CFGS: &'static [&'static str] = &[
     "emscripten_new_stat_abi",
+    "emscripten_64_bit_time_t",
     "freebsd10",
     "freebsd11",
     "freebsd12",
@@ -56,7 +57,13 @@ fn main() {
     }
 
     match emcc_version_code() {
-        Some(v) if (v >= 30142) => set_cfg("emscripten_new_stat_abi"),
+        Some(v) if (v >= 30142) => {
+            set_cfg("emscripten_new_stat_abi");
+            set_cfg("emscripten_64_bit_time_t");
+        }
+        Some(v) if (v >= 30116) => {
+            set_cfg("emscripten_64_bit_time_t");
+        }
         // Non-Emscripten or version < 3.1.42.
         Some(_) | None => (),
     }

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -16,7 +16,24 @@ pub type loff_t = i64;
 pub type pthread_key_t = ::c_uint;
 
 pub type clock_t = c_long;
-pub type time_t = c_long;
+
+// time_t was type:
+//
+//   - long   from v1.5.4  (2013/08/08)  until v3.1.11
+//   - int    from v3.1.11 (2022/05/20)  until v3.1.16
+//   - _Int64 from v3.1.16  (2022/07/14)
+//
+//  And it's still int64 today. The change from long to int was marked as a
+//  nonfunctional change since wasm64 was considered to be not working yet in
+//  v3.1.11. So it suffices to say it's 32 bit until v3.1.16 and 64 bit after.
+cfg_if! {
+    if #[cfg(emscripten_64_bit_time_t)] {
+        pub type time_t = i64;
+    } else {
+        pub type time_t = i32;
+    }
+}
+
 pub type suseconds_t = c_long;
 pub type ino_t = u64;
 pub type off_t = i64;


### PR DESCRIPTION
Since July 8, 2022:
https://github.com/emscripten-core/emscripten/pull/17401 https://github.com/emscripten-core/emscripten/blob/main/system/lib/libc/musl/arch/emscripten/bits/alltypes.h?plain=1#L83

Fixes https://github.com/rust-lang/libc/issues/3306
