### PR TITLE
Set CLONE_CLEAR_SIGHAND and CLONE_INTO_CGROUP to a large enough type

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1065,8 +1065,8 @@ pub const ELFOSABI_ARM_AEABI: u8 = 64;
 
 // linux/sched.h
 pub const CLONE_NEWTIME: ::c_int = 0x80;
-pub const CLONE_CLEAR_SIGHAND: ::c_int = 0x100000000;
-pub const CLONE_INTO_CGROUP: ::c_int = 0x200000000;
+pub const CLONE_CLEAR_SIGHAND: ::c_ulonglong = 0x100000000;
+pub const CLONE_INTO_CGROUP: ::c_ulonglong = 0x200000000;
 
 // linux/keyctl.h
 pub const KEYCTL_DH_COMPUTE: u32 = 23;


### PR DESCRIPTION
This PR prevents the flags `CLONE_CLEAR_SIGHAND` and `CLONE_INTO_CGROUP` from quietly being set to 0 by assigning them to a variable of a too-small type.

This should fix #3584. Sadly this is a breaking change (well the only thing that might break was buggy before, but I assume that still counts as breaking).

P.S.:

`ci/style.sh` did not pass on my machine, but I'm chalking this up to a shellcheck version difference or something, as I did not touch any shell scripts at all.