### PR TITLE
Add aligned_realloc

### DIFF
--- a/libc-test/semver/windows.txt
+++ b/libc-test/semver/windows.txt
@@ -149,6 +149,7 @@ accept
 access
 aligned_malloc
 aligned_free
+aligned_realloc
 atexit
 atof
 atoi

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -518,6 +518,9 @@ extern "C" {
     pub fn aligned_malloc(size: size_t, alignment: size_t) -> *mut c_void;
     #[link_name = "_aligned_free"]
     pub fn aligned_free(ptr: *mut ::c_void);
+    #[link_name = "_aligned_realloc"]
+    pub fn aligned_realloc(memblock: *mut ::c_void, size: size_t, alignment: size_t)
+        -> *mut c_void;
     #[link_name = "_putenv"]
     pub fn putenv(envstring: *const ::c_char) -> ::c_int;
     #[link_name = "_wputenv"]


### PR DESCRIPTION
Similar to _aligned_malloc and _aligned_free, to realloc aligned allocations we also need _aligned_realloc exposed.

https://github.com/rust-lang/libc/pull/2352
https://github.com/rust-lang/libc/pull/1839
