### PR TITLE
Add glibc's function: malloc_stats

### DIFF
--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -643,6 +643,7 @@ lio_listio
 mallinfo
 mallinfo2
 malloc_info
+malloc_stats
 malloc_trim
 malloc_usable_size
 mallopt

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1426,6 +1426,7 @@ extern "C" {
     pub fn pthread_sigqueue(thread: ::pthread_t, sig: ::c_int, value: ::sigval) -> ::c_int;
     pub fn mallinfo() -> ::mallinfo;
     pub fn mallinfo2() -> ::mallinfo2;
+    pub fn malloc_stats();
     pub fn malloc_info(options: ::c_int, stream: *mut ::FILE) -> ::c_int;
     pub fn malloc_usable_size(ptr: *mut ::c_void) -> ::size_t;
     pub fn getpwent_r(


### PR DESCRIPTION
The function is used to report stats about glibc's memory allocator to stderr:

```
Arena 0:
system bytes     = 1350406144
in use bytes     = 3725633952
Arena 1:
system bytes     = 1895907328
in use bytes     = 1653748608
Total (incl. mmap):
system bytes     =  277286912
in use bytes     = 2410356000
max mmap regions =         56
max mmap bytes   = 2876198912
```