### PR TITLE
Don't import std::string::String

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::process::Command;
 use std::str;
-use std::string::String;
 
 // List of cfgs this build script is allowed to set. The list is needed to support check-cfg, as we
 // need to know all the possible cfgs that this script will set. If you need to set another cfg


### PR DESCRIPTION
.../std/src/prelude/mod.rs:105:13
  |
  = note: the item `String` is already defined here
  |
  = note: `#[warn(unused_imports)]` on by default



