### PR TITLE
Move strftime, strftime_l, strptime to linux_like

### DIFF
--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -691,9 +691,6 @@ euidaccess
 eaccess
 asctime_r
 ctime_r
-strftime
-strftime_l
-strptime
 dirname
 posix_basename
 gnu_basename

--- a/libc-test/semver/linux-musl.txt
+++ b/libc-test/semver/linux-musl.txt
@@ -77,8 +77,5 @@ timex
 euidaccess
 eaccess
 asctime_r
-strftime
-strftime_l
-strptime
 dirname
 basename

--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -3832,8 +3832,11 @@ statvfs64
 strcasecmp
 strcasestr
 strchrnul
+strftime
+strftime_l
 strncasecmp
 strndup
+strptime
 strsignal
 swapoff
 swapon

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1478,21 +1478,6 @@ extern "C" {
     pub fn asctime_r(tm: *const ::tm, buf: *mut ::c_char) -> *mut ::c_char;
     pub fn ctime_r(timep: *const time_t, buf: *mut ::c_char) -> *mut ::c_char;
 
-    pub fn strftime(
-        s: *mut ::c_char,
-        max: ::size_t,
-        format: *const ::c_char,
-        tm: *const ::tm,
-    ) -> ::size_t;
-    pub fn strftime_l(
-        s: *mut ::c_char,
-        max: ::size_t,
-        format: *const ::c_char,
-        tm: *const ::tm,
-        locale: ::locale_t,
-    ) -> ::size_t;
-    pub fn strptime(s: *const ::c_char, format: *const ::c_char, tm: *mut ::tm) -> *mut ::c_char;
-
     pub fn dirname(path: *mut ::c_char) -> *mut ::c_char;
     /// POSIX version of `basename(3)`, defined in `libgen.h`.
     #[link_name = "__xpg_basename"]

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -883,21 +883,6 @@ extern "C" {
 
     pub fn asctime_r(tm: *const ::tm, buf: *mut ::c_char) -> *mut ::c_char;
 
-    pub fn strftime(
-        s: *mut ::c_char,
-        max: ::size_t,
-        format: *const ::c_char,
-        tm: *const ::tm,
-    ) -> ::size_t;
-    pub fn strftime_l(
-        s: *mut ::c_char,
-        max: ::size_t,
-        format: *const ::c_char,
-        tm: *const ::tm,
-        locale: ::locale_t,
-    ) -> ::size_t;
-    pub fn strptime(s: *const ::c_char, format: *const ::c_char, tm: *mut ::tm) -> *mut ::c_char;
-
     pub fn dirname(path: *mut ::c_char) -> *mut ::c_char;
     pub fn basename(path: *mut ::c_char) -> *mut ::c_char;
 }

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1795,6 +1795,21 @@ extern "C" {
     pub fn uname(buf: *mut ::utsname) -> ::c_int;
 
     pub fn strchrnul(s: *const ::c_char, c: ::c_int) -> *mut ::c_char;
+
+    pub fn strftime(
+        s: *mut ::c_char,
+        max: ::size_t,
+        format: *const ::c_char,
+        tm: *const ::tm,
+    ) -> ::size_t;
+    pub fn strftime_l(
+        s: *mut ::c_char,
+        max: ::size_t,
+        format: *const ::c_char,
+        tm: *const ::tm,
+        locale: ::locale_t,
+    ) -> ::size_t;
+    pub fn strptime(s: *const ::c_char, format: *const ::c_char, tm: *mut ::tm) -> *mut ::c_char;
 }
 
 // LFS64 extensions


### PR DESCRIPTION
Bionic, uclibc and emscripten all support these functions. See:

https://github.com/aosp-mirror/platform_bionic/blob/2215ad406b253f12e270cdd0876e19e9df2aa6d4/libc/include/time.h https://github.com/wbx-github/uclibc-ng/blame/fc3b6dc46a80e1f4aa468472aa6c7083f3bc6581/include/time.h https://github.com/emscripten-core/emscripten/blob/e25fa53069665c1f6c3be4ba5ed1d6ae82339849/system/lib/libc/musl/include/time.h