### PR TITLE
Support posix_spawn on Android

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1613,6 +1613,7 @@ fn test_android(target: &str) {
                "sched.h",
                "semaphore.h",
                "signal.h",
+               "spawn.h",
                "stddef.h",
                "stdint.h",
                "stdio.h",
@@ -1979,14 +1980,30 @@ fn test_android(target: &str) {
 
             // Added in API level 28, but some tests use level 24.
             "getrandom" => true,
-
-            // Added in API level 28, but some tests use level 24.
             "syncfs" => true,
-
-            // Added in API level 28, but some tests use level 24.
             "pthread_attr_getinheritsched" | "pthread_attr_setinheritsched" => true,
-            // Added in API level 28, but some tests use level 24.
             "fread_unlocked" | "fwrite_unlocked" | "fgets_unlocked" | "fflush_unlocked" => true,
+            "posix_spawn"
+            | "posix_spawnp"
+            | "posix_spawnattr_init"
+            | "posix_spawnattr_destroy"
+            | "posix_spawnattr_getsigdefault"
+            | "posix_spawnattr_setsigdefault"
+            | "posix_spawnattr_getsigmask"
+            | "posix_spawnattr_setsigmask"
+            | "posix_spawnattr_getflags"
+            | "posix_spawnattr_setflags"
+            | "posix_spawnattr_getpgroup"
+            | "posix_spawnattr_setpgroup"
+            | "posix_spawnattr_getschedpolicy"
+            | "posix_spawnattr_setschedpolicy"
+            | "posix_spawnattr_getschedparam"
+            | "posix_spawnattr_setschedparam"
+            | "posix_spawn_file_actions_init"
+            | "posix_spawn_file_actions_destroy"
+            | "posix_spawn_file_actions_addopen"
+            | "posix_spawn_file_actions_addclose"
+            | "posix_spawn_file_actions_adddup2" => true,
 
             // FIXME: bad function pointers:
             "isalnum" | "isalpha" | "iscntrl" | "isdigit" | "isgraph" | "islower" | "isprint"
@@ -2706,6 +2723,7 @@ fn test_emscripten(target: &str) {
                "semaphore.h",
                "shadow.h",
                "signal.h",
+               "spawn.h",
                "stddef.h",
                "stdint.h",
                "stdio.h",
@@ -3597,6 +3615,10 @@ fn test_linux(target: &str) {
             "priority_t" if musl => true,
             "name_t" if musl => true,
 
+            // These are intended to be opaque, but glibc and musl define them.
+            "posix_spawn_file_actions_t" => true,
+            "posix_spawnattr_t" => true,
+
             t => {
                 if musl {
                     // LFS64 types have been removed in musl 1.2.4+
@@ -3744,6 +3766,10 @@ fn test_linux(target: &str) {
             // fail. The problem doesn't seem to be present in more recent versions of the linux
             // kernel so we can drop this and test the type once this new version is used in CI.
             "sched_attr" => true,
+
+            // These are intended to be opaque, but glibc and musl define them.
+            "posix_spawn_file_actions_t" => true,
+            "posix_spawnattr_t" => true,
 
             _ => false,
         }

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -452,26 +452,6 @@ s! {
         pub mnt_passno: ::c_int,
     }
 
-    pub struct posix_spawn_file_actions_t {
-        __allocated: ::c_int,
-        __used: ::c_int,
-        __actions: *mut ::c_int,
-        __pad: [::c_int; 16],
-    }
-
-    pub struct posix_spawnattr_t {
-        __flags: ::c_short,
-        __pgrp: ::pid_t,
-        __sd: ::sigset_t,
-        __ss: ::sigset_t,
-        #[cfg(any(target_env = "musl", target_env = "ohos"))]
-        __prio: ::c_int,
-        #[cfg(not(any(target_env = "musl", target_env = "ohos")))]
-        __sp: ::sched_param,
-        __policy: ::c_int,
-        __pad: [::c_int; 16],
-    }
-
     pub struct genlmsghdr {
         pub cmd: u8,
         pub version: u8,
@@ -1858,8 +1838,6 @@ pub const POSIX_MADV_NORMAL: ::c_int = 0;
 pub const POSIX_MADV_RANDOM: ::c_int = 1;
 pub const POSIX_MADV_SEQUENTIAL: ::c_int = 2;
 pub const POSIX_MADV_WILLNEED: ::c_int = 3;
-pub const POSIX_SPAWN_USEVFORK: ::c_int = 64;
-pub const POSIX_SPAWN_SETSID: ::c_int = 128;
 
 pub const S_IEXEC: mode_t = 64;
 pub const S_IWRITE: mode_t = 128;
@@ -2616,13 +2594,6 @@ pub const ETH_P_TRAILER: ::c_int = 0x001C;
 pub const ETH_P_PHONET: ::c_int = 0x00F5;
 pub const ETH_P_IEEE802154: ::c_int = 0x00F6;
 pub const ETH_P_CAIF: ::c_int = 0x00F7;
-
-pub const POSIX_SPAWN_RESETIDS: ::c_int = 0x01;
-pub const POSIX_SPAWN_SETPGROUP: ::c_int = 0x02;
-pub const POSIX_SPAWN_SETSIGDEF: ::c_int = 0x04;
-pub const POSIX_SPAWN_SETSIGMASK: ::c_int = 0x08;
-pub const POSIX_SPAWN_SETSCHEDPARAM: ::c_int = 0x10;
-pub const POSIX_SPAWN_SETSCHEDULER: ::c_int = 0x20;
 
 pub const NLMSG_NOOP: ::c_int = 0x1;
 pub const NLMSG_ERROR: ::c_int = 0x2;
@@ -5453,82 +5424,6 @@ extern "C" {
     pub fn endmntent(streamp: *mut ::FILE) -> ::c_int;
     pub fn hasmntopt(mnt: *const ::mntent, opt: *const ::c_char) -> *mut ::c_char;
 
-    pub fn posix_spawn(
-        pid: *mut ::pid_t,
-        path: *const ::c_char,
-        file_actions: *const ::posix_spawn_file_actions_t,
-        attrp: *const ::posix_spawnattr_t,
-        argv: *const *mut ::c_char,
-        envp: *const *mut ::c_char,
-    ) -> ::c_int;
-    pub fn posix_spawnp(
-        pid: *mut ::pid_t,
-        file: *const ::c_char,
-        file_actions: *const ::posix_spawn_file_actions_t,
-        attrp: *const ::posix_spawnattr_t,
-        argv: *const *mut ::c_char,
-        envp: *const *mut ::c_char,
-    ) -> ::c_int;
-    pub fn posix_spawnattr_init(attr: *mut posix_spawnattr_t) -> ::c_int;
-    pub fn posix_spawnattr_destroy(attr: *mut posix_spawnattr_t) -> ::c_int;
-    pub fn posix_spawnattr_getsigdefault(
-        attr: *const posix_spawnattr_t,
-        default: *mut ::sigset_t,
-    ) -> ::c_int;
-    pub fn posix_spawnattr_setsigdefault(
-        attr: *mut posix_spawnattr_t,
-        default: *const ::sigset_t,
-    ) -> ::c_int;
-    pub fn posix_spawnattr_getsigmask(
-        attr: *const posix_spawnattr_t,
-        default: *mut ::sigset_t,
-    ) -> ::c_int;
-    pub fn posix_spawnattr_setsigmask(
-        attr: *mut posix_spawnattr_t,
-        default: *const ::sigset_t,
-    ) -> ::c_int;
-    pub fn posix_spawnattr_getflags(
-        attr: *const posix_spawnattr_t,
-        flags: *mut ::c_short,
-    ) -> ::c_int;
-    pub fn posix_spawnattr_setflags(attr: *mut posix_spawnattr_t, flags: ::c_short) -> ::c_int;
-    pub fn posix_spawnattr_getpgroup(
-        attr: *const posix_spawnattr_t,
-        flags: *mut ::pid_t,
-    ) -> ::c_int;
-    pub fn posix_spawnattr_setpgroup(attr: *mut posix_spawnattr_t, flags: ::pid_t) -> ::c_int;
-    pub fn posix_spawnattr_getschedpolicy(
-        attr: *const posix_spawnattr_t,
-        flags: *mut ::c_int,
-    ) -> ::c_int;
-    pub fn posix_spawnattr_setschedpolicy(attr: *mut posix_spawnattr_t, flags: ::c_int) -> ::c_int;
-    pub fn posix_spawnattr_getschedparam(
-        attr: *const posix_spawnattr_t,
-        param: *mut ::sched_param,
-    ) -> ::c_int;
-    pub fn posix_spawnattr_setschedparam(
-        attr: *mut posix_spawnattr_t,
-        param: *const ::sched_param,
-    ) -> ::c_int;
-
-    pub fn posix_spawn_file_actions_init(actions: *mut posix_spawn_file_actions_t) -> ::c_int;
-    pub fn posix_spawn_file_actions_destroy(actions: *mut posix_spawn_file_actions_t) -> ::c_int;
-    pub fn posix_spawn_file_actions_addopen(
-        actions: *mut posix_spawn_file_actions_t,
-        fd: ::c_int,
-        path: *const ::c_char,
-        oflag: ::c_int,
-        mode: ::mode_t,
-    ) -> ::c_int;
-    pub fn posix_spawn_file_actions_addclose(
-        actions: *mut posix_spawn_file_actions_t,
-        fd: ::c_int,
-    ) -> ::c_int;
-    pub fn posix_spawn_file_actions_adddup2(
-        actions: *mut posix_spawn_file_actions_t,
-        fd: ::c_int,
-        newfd: ::c_int,
-    ) -> ::c_int;
     pub fn fread_unlocked(
         buf: *mut ::c_void,
         size: ::size_t,

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -6,6 +6,13 @@ pub type timer_t = *mut ::c_void;
 pub type key_t = ::c_int;
 pub type id_t = ::c_uint;
 
+cfg_if! {
+    if #[cfg(not(target_os = "emscripten"))] {
+        pub type posix_spawn_file_actions_t = *mut ::c_void;
+        pub type posix_spawnattr_t = *mut ::c_void;
+    }
+}
+
 missing! {
     #[cfg_attr(feature = "extra_traits", derive(Debug))]
     pub enum timezone {}
@@ -1531,6 +1538,19 @@ cfg_if! {
     }
 }
 
+cfg_if! {
+    if #[cfg(not(target_os = "emscripten"))] {
+        pub const POSIX_SPAWN_RESETIDS: ::c_int = 0x01;
+        pub const POSIX_SPAWN_SETPGROUP: ::c_int = 0x02;
+        pub const POSIX_SPAWN_SETSIGDEF: ::c_int = 0x04;
+        pub const POSIX_SPAWN_SETSIGMASK: ::c_int = 0x08;
+        pub const POSIX_SPAWN_SETSCHEDPARAM: ::c_int = 0x10;
+        pub const POSIX_SPAWN_SETSCHEDULER: ::c_int = 0x20;
+        pub const POSIX_SPAWN_USEVFORK: ::c_int = 0x40;
+        pub const POSIX_SPAWN_SETSID: ::c_int = 0x80;
+    }
+}
+
 const_fn! {
     {const} fn CMSG_ALIGN(len: usize) -> usize {
         len + ::mem::size_of::<usize>() - 1 & !(::mem::size_of::<usize>() - 1)
@@ -1875,6 +1895,102 @@ cfg_if! {
                 name: *mut ::c_char,
                 termp: *const termios,
                 winp: *const ::winsize,
+            ) -> ::c_int;
+        }
+    }
+}
+
+cfg_if! {
+    if #[cfg(not(target_os = "emscripten"))] {
+        extern "C" {
+            pub fn posix_spawn(
+                pid: *mut ::pid_t,
+                path: *const ::c_char,
+                file_actions: *const ::posix_spawn_file_actions_t,
+                attrp: *const ::posix_spawnattr_t,
+                argv: *const *mut ::c_char,
+                envp: *const *mut ::c_char,
+            ) -> ::c_int;
+            pub fn posix_spawnp(
+                pid: *mut ::pid_t,
+                file: *const ::c_char,
+                file_actions: *const ::posix_spawn_file_actions_t,
+                attrp: *const ::posix_spawnattr_t,
+                argv: *const *mut ::c_char,
+                envp: *const *mut ::c_char,
+            ) -> ::c_int;
+            pub fn posix_spawnattr_init(attr: *mut posix_spawnattr_t) -> ::c_int;
+            pub fn posix_spawnattr_destroy(attr: *mut posix_spawnattr_t) -> ::c_int;
+            pub fn posix_spawnattr_getsigdefault(
+                attr: *const posix_spawnattr_t,
+                default: *mut ::sigset_t,
+            ) -> ::c_int;
+            pub fn posix_spawnattr_setsigdefault(
+                attr: *mut posix_spawnattr_t,
+                default: *const ::sigset_t,
+            ) -> ::c_int;
+            pub fn posix_spawnattr_getsigmask(
+                attr: *const posix_spawnattr_t,
+                default: *mut ::sigset_t,
+            ) -> ::c_int;
+            pub fn posix_spawnattr_setsigmask(
+                attr: *mut posix_spawnattr_t,
+                default: *const ::sigset_t,
+            ) -> ::c_int;
+            pub fn posix_spawnattr_getflags(
+                attr: *const posix_spawnattr_t,
+                flags: *mut ::c_short,
+            ) -> ::c_int;
+            pub fn posix_spawnattr_setflags(
+              attr: *mut posix_spawnattr_t,
+                flags: ::c_short,
+            ) -> ::c_int;
+            pub fn posix_spawnattr_getpgroup(
+                attr: *const posix_spawnattr_t,
+                flags: *mut ::pid_t,
+            ) -> ::c_int;
+            pub fn posix_spawnattr_setpgroup(
+              attr: *mut posix_spawnattr_t,
+                flags: ::pid_t,
+            ) -> ::c_int;
+            pub fn posix_spawnattr_getschedpolicy(
+                attr: *const posix_spawnattr_t,
+                flags: *mut ::c_int,
+            ) -> ::c_int;
+            pub fn posix_spawnattr_setschedpolicy(
+              attr: *mut posix_spawnattr_t,
+                flags: ::c_int,
+            ) -> ::c_int;
+            pub fn posix_spawnattr_getschedparam(
+                attr: *const posix_spawnattr_t,
+                param: *mut ::sched_param,
+            ) -> ::c_int;
+            pub fn posix_spawnattr_setschedparam(
+                attr: *mut posix_spawnattr_t,
+                param: *const ::sched_param,
+            ) -> ::c_int;
+
+            pub fn posix_spawn_file_actions_init(
+              actions: *mut posix_spawn_file_actions_t,
+            ) -> ::c_int;
+            pub fn posix_spawn_file_actions_destroy(
+              actions: *mut posix_spawn_file_actions_t,
+            ) -> ::c_int;
+            pub fn posix_spawn_file_actions_addopen(
+                actions: *mut posix_spawn_file_actions_t,
+                fd: ::c_int,
+                path: *const ::c_char,
+                oflag: ::c_int,
+                mode: ::mode_t,
+            ) -> ::c_int;
+            pub fn posix_spawn_file_actions_addclose(
+                actions: *mut posix_spawn_file_actions_t,
+                fd: ::c_int,
+            ) -> ::c_int;
+            pub fn posix_spawn_file_actions_adddup2(
+                actions: *mut posix_spawn_file_actions_t,
+                fd: ::c_int,
+                newfd: ::c_int,
             ) -> ::c_int;
         }
     }


### PR DESCRIPTION
Android exposes the same functions and constants as the other linux_like platforms, but its posix_spawnattr_t and posix_spawn_file_actions_t are opaque. See:

https://github.com/aosp-mirror/platform_bionic/blob/2215ad406b253f12e270cdd0876e19e9df2aa6d4/libc/include/spawn.h

Since the fields in the linux implementation are private, let's make it opaque on all linux_like platforms.