### PR TITLE
fix the size of `posix_spawn_file_actions_t` and `posix_spawnattr_t` on Linux

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3299,6 +3299,7 @@ fn test_vxworks(target: &str) {
 
 fn test_linux(target: &str) {
     assert!(target.contains("linux"));
+    assert!(!target.contains("android"));
 
     // target_env
     let gnu = target.contains("gnu");

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -48,6 +48,10 @@ pub type Elf64_Xword = u64;
 
 pub type eventfd_t = u64;
 
+// these structs sit behind a heap allocation on Android
+pub type posix_spawn_file_actions_t = *mut ::c_void;
+pub type posix_spawnattr_t = *mut ::c_void;
+
 s! {
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -742,6 +742,26 @@ s! {
         pub salt: [::c_uchar; TLS_CIPHER_CHACHA20_POLY1305_SALT_SIZE],
         pub rec_seq: [::c_uchar; TLS_CIPHER_CHACHA20_POLY1305_REC_SEQ_SIZE],
     }
+
+    pub struct posix_spawn_file_actions_t {
+        __allocated: ::c_int,
+        __used: ::c_int,
+        __actions: *mut ::c_int,
+        __pad: [::c_int; 16],
+    }
+
+    pub struct posix_spawnattr_t {
+        __flags: ::c_short,
+        __pgrp: ::pid_t,
+        __sd: ::sigset_t,
+        __ss: ::sigset_t,
+        #[cfg(any(target_env = "musl", target_env = "ohos"))]
+        __prio: ::c_int,
+        #[cfg(not(any(target_env = "musl", target_env = "ohos")))]
+        __sp: ::sched_param,
+        __policy: ::c_int,
+        __pad: [::c_int; 16],
+    }
 }
 
 s_no_extra_traits! {


### PR DESCRIPTION
fixes #3608 