### PR TITLE
Move testing of primitive types from std

### DIFF
--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -85,3 +85,8 @@ harness = true
 name = "semver"
 path = "test/semver.rs"
 harness = false
+
+[[test]]
+name = "primitive_types"
+path = "test/primitive_types.rs"
+harness = true

--- a/libc-test/test/primitive_types.rs
+++ b/libc-test/test/primitive_types.rs
@@ -1,0 +1,15 @@
+use std::any::TypeId;
+
+macro_rules! ok {
+    ($($t:ident)*) => {$(
+        assert!(TypeId::of::<libc::$t>() == TypeId::of::<ffi::$t>(),
+                "{} is wrong", stringify!($t));
+    )*}
+}
+
+#[test]
+fn same() {
+    use std::ffi;
+    ok!(c_char c_schar c_uchar c_short c_ushort c_int c_uint c_long c_ulong
+        c_longlong c_ulonglong c_float c_double);
+}


### PR DESCRIPTION
std shouldn't need to depend on libc for platforms that don't require it, but currently [one test](https://github.com/rust-lang/rust/blob/01d73d4041969cde4a79bf9793521ef323248a24/library/std/src/os/raw/tests.rs) means it is required.

It was suggested that this test more properly belongs in the libc crate itself, so I've made this PR for your consideration.