### PR TITLE
freebsdlike: Unify getrandom/getentropy declarations

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -3805,11 +3805,6 @@ pub const F_SEAL_WRITE: ::c_int = 8;
 // for use with fspacectl
 pub const SPACECTL_DEALLOC: ::c_int = 1;
 
-// For getrandom()
-pub const GRND_NONBLOCK: ::c_uint = 0x1;
-pub const GRND_RANDOM: ::c_uint = 0x2;
-pub const GRND_INSECURE: ::c_uint = 0x4;
-
 // For realhostname* api
 pub const HOSTNAME_FOUND: ::c_int = 0;
 pub const HOSTNAME_INCORRECTNAME: ::c_int = 1;
@@ -5315,8 +5310,6 @@ extern "C" {
 
     pub fn fdatasync(fd: ::c_int) -> ::c_int;
 
-    pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
-    pub fn getentropy(buf: *mut ::c_void, buflen: ::size_t) -> ::c_int;
     pub fn elf_aux_info(aux: ::c_int, buf: *mut ::c_void, buflen: ::c_int) -> ::c_int;
     pub fn setproctitle_fast(fmt: *const ::c_char, ...);
     pub fn timingsafe_bcmp(a: *const ::c_void, b: *const ::c_void, len: ::size_t) -> ::c_int;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1331,6 +1331,11 @@ pub const EUI64_LEN: usize = 8;
 // https://github.com/freebsd/freebsd/blob/HEAD/sys/net/bpf.h
 pub const BPF_ALIGNMENT: usize = SIZEOF_LONG;
 
+// For getrandom()
+pub const GRND_NONBLOCK: ::c_uint = 0x1;
+pub const GRND_RANDOM: ::c_uint = 0x2;
+pub const GRND_INSECURE: ::c_uint = 0x4;
+
 // Values for rtprio struct (prio field) and syscall (function argument)
 pub const RTP_PRIO_MIN: ::c_ushort = 0;
 pub const RTP_PRIO_MAX: ::c_ushort = 31;
@@ -1781,6 +1786,11 @@ extern "C" {
         search_path: *const ::c_char,
         argv: *const *mut ::c_char,
     ) -> ::c_int;
+
+    // Added in FreeBSD 12.0 and DragonFly BSD 5.7
+    pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
+    // Added in FreeBSD 12.0 and DragonFly BSD 5.6
+    pub fn getentropy(buf: *mut ::c_void, buflen: ::size_t) -> ::c_int;
 }
 
 #[link(name = "rt")]


### PR DESCRIPTION
Dragonfly BSD also supports getrandom/getentropy

FreeBSD bindings were added in #1982

See: https://github.com/rust-lang/rust/pull/122356 and https://github.com/rust-lang/rust/pull/121942
