### PR TITLE
feat: getrandom() for DragonFlyBSD

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1268,6 +1268,7 @@ fn test_dragonflybsd(target: &str) {
         "sys/mount.h",
         "sys/procctl.h",
         "sys/ptrace.h",
+        "sys/random.h",
         "sys/reboot.h",
         "sys/resource.h",
         "sys/rtprio.h",

--- a/libc-test/semver/dragonfly.txt
+++ b/libc-test/semver/dragonfly.txt
@@ -1587,3 +1587,7 @@ xucred
 eaccess
 dirname
 basename
+GRND_RANDOM
+GRND_NONBLOCK
+GRND_INSECURE
+getrandom

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1522,6 +1522,11 @@ pub const NGROUPS: usize = 16;
 pub const RB_PAUSE: ::c_int = 0x40000;
 pub const RB_VIDEO: ::c_int = 0x20000000;
 
+// For getrandom()
+pub const GRND_RANDOM: ::c_uint = 0x1;
+pub const GRND_NONBLOCK: ::c_uint = 0x2;
+pub const GRND_INSECURE: ::c_uint = 0x4;
+
 const_fn! {
     {const} fn _CMSG_ALIGN(n: usize) -> usize {
         (n + (::mem::size_of::<::c_long>() - 1)) & !(::mem::size_of::<::c_long>() - 1)
@@ -1684,6 +1689,7 @@ extern "C" {
         mntvbufp: *mut *mut ::statvfs,
         flags: ::c_int,
     ) -> ::c_int;
+    pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
 }
 
 #[link(name = "rt")]


### PR DESCRIPTION
Add `getrandom()` for DragonFlyBSD:


1. man page: https://leaf.dragonflybsd.org/cgi/web-man?command=getrandom
2. defs for those 3 constants: https://github.com/search?q=repo%3ADragonFlyBSD%2FDragonFlyBSD%20GRND_NONBLOCK&type=code



-----


ref upstream Rust issue: [Latest nightly `1.78.0-nightly (7065f0ef4 2024-03-12)` is broken in DragonFlyBSD ](https://github.com/rust-lang/rust/issues/122585)
