### PR TITLE
Correct the value of FAN_MARK_IGNORE

### DIFF
--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -4074,7 +4074,7 @@ pub const FAN_MARK_IGNORED_MASK: ::c_uint = 0x0000_0020;
 pub const FAN_MARK_IGNORED_SURV_MODIFY: ::c_uint = 0x0000_0040;
 pub const FAN_MARK_FLUSH: ::c_uint = 0x0000_0080;
 pub const FAN_MARK_EVICTABLE: ::c_uint = 0x0000_0200;
-pub const FAN_MARK_IGNORE: ::c_uint = 0x0000_0100;
+pub const FAN_MARK_IGNORE: ::c_uint = 0x0000_0400;
 
 pub const FAN_MARK_INODE: ::c_uint = 0x0000_0000;
 pub const FAN_MARK_MOUNT: ::c_uint = 0x0000_0010;


### PR DESCRIPTION
This PR aligns the value of `FAN_MARK_IGNORE` in libc with that in [`uapi/linux/fanotify.h`](https://github.com/torvalds/linux/blob/741e9d66/include/uapi/linux/fanotify.h#L87).

Previously, it was incorrectly set to the value of `FAN_MARK_MOUNT`, which can cause subtle but catastrophic bugs when one tries to mark a file as ignored.