### PR TITLE
Removed `vfork`

### DIFF
--- a/libc-test/semver/android.txt
+++ b/libc-test/semver/android.txt
@@ -3814,7 +3814,6 @@ utimes
 utmp
 utmpname
 utsname
-vfork
 vmsplice
 wait
 wait4

--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -3963,7 +3963,6 @@ unshare
 useconds_t
 uselocale
 utimensat
-vfork
 vhangup
 vmsplice
 wait4

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1739,11 +1739,6 @@ extern "C" {
     pub fn acct(filename: *const ::c_char) -> ::c_int;
     pub fn brk(addr: *mut ::c_void) -> ::c_int;
     pub fn sbrk(increment: ::intptr_t) -> *mut ::c_void;
-    #[deprecated(
-        since = "0.2.66",
-        note = "causes memory corruption, see rust-lang/libc#1596"
-    )]
-    pub fn vfork() -> ::pid_t;
     pub fn setresgid(rgid: ::gid_t, egid: ::gid_t, sgid: ::gid_t) -> ::c_int;
     pub fn setresuid(ruid: ::uid_t, euid: ::uid_t, suid: ::uid_t) -> ::c_int;
     pub fn wait4(


### PR DESCRIPTION
Removed `vfork` as described in the tracking issues for libc #3248 after it was deprecated [here](https://github.com/rust-lang/libc/pull/1574).