### PR TITLE
Set type of POSIX_SPAWN_* flags to c_short

### DIFF
--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -1249,13 +1249,13 @@ pub const ENTER: ::c_int = 1;
 pub const SEM_FAILED: *mut sem_t = -1isize as *mut ::sem_t;
 
 // spawn.h
-pub const POSIX_SPAWN_SETPGROUP: ::c_int = 0x1;
-pub const POSIX_SPAWN_SETSIGMASK: ::c_int = 0x2;
-pub const POSIX_SPAWN_SETSIGDEF: ::c_int = 0x4;
-pub const POSIX_SPAWN_SETSCHEDULER: ::c_int = 0x8;
-pub const POSIX_SPAWN_SETSCHEDPARAM: ::c_int = 0x10;
-pub const POSIX_SPAWN_RESETIDS: ::c_int = 0x20;
-pub const POSIX_SPAWN_FORK_HANDLERS: ::c_int = 0x1000;
+pub const POSIX_SPAWN_SETPGROUP: ::c_short = 0x1;
+pub const POSIX_SPAWN_SETSIGMASK: ::c_short = 0x2;
+pub const POSIX_SPAWN_SETSIGDEF: ::c_short = 0x4;
+pub const POSIX_SPAWN_SETSCHEDULER: ::c_short = 0x8;
+pub const POSIX_SPAWN_SETSCHEDPARAM: ::c_short = 0x10;
+pub const POSIX_SPAWN_RESETIDS: ::c_short = 0x20;
+pub const POSIX_SPAWN_FORK_HANDLERS: ::c_short = 0x1000;
 
 // stdio.h
 pub const EOF: ::c_int = -1;

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -4895,13 +4895,13 @@ pub const MNT_SNAPSHOT: ::c_int = 0x40000000;
 pub const MNT_NOBLOCK: ::c_int = 0x00020000;
 
 // sys/spawn.h:
-pub const POSIX_SPAWN_RESETIDS: ::c_int = 0x0001;
-pub const POSIX_SPAWN_SETPGROUP: ::c_int = 0x0002;
-pub const POSIX_SPAWN_SETSIGDEF: ::c_int = 0x0004;
-pub const POSIX_SPAWN_SETSIGMASK: ::c_int = 0x0008;
-pub const POSIX_SPAWN_SETEXEC: ::c_int = 0x0040;
-pub const POSIX_SPAWN_START_SUSPENDED: ::c_int = 0x0080;
-pub const POSIX_SPAWN_CLOEXEC_DEFAULT: ::c_int = 0x4000;
+pub const POSIX_SPAWN_RESETIDS: ::c_short = 0x0001;
+pub const POSIX_SPAWN_SETPGROUP: ::c_short = 0x0002;
+pub const POSIX_SPAWN_SETSIGDEF: ::c_short = 0x0004;
+pub const POSIX_SPAWN_SETSIGMASK: ::c_short = 0x0008;
+pub const POSIX_SPAWN_SETEXEC: ::c_short = 0x0040;
+pub const POSIX_SPAWN_START_SUSPENDED: ::c_short = 0x0080;
+pub const POSIX_SPAWN_CLOEXEC_DEFAULT: ::c_short = 0x4000;
 
 // sys/ipc.h:
 pub const IPC_CREAT: ::c_int = 0x200;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -3891,12 +3891,12 @@ pub const RTP_PRIO_REALTIME: ::c_ushort = 2;
 pub const RTP_PRIO_NORMAL: ::c_ushort = 3;
 pub const RTP_PRIO_IDLE: ::c_ushort = 4;
 
-pub const POSIX_SPAWN_RESETIDS: ::c_int = 0x01;
-pub const POSIX_SPAWN_SETPGROUP: ::c_int = 0x02;
-pub const POSIX_SPAWN_SETSCHEDPARAM: ::c_int = 0x04;
-pub const POSIX_SPAWN_SETSCHEDULER: ::c_int = 0x08;
-pub const POSIX_SPAWN_SETSIGDEF: ::c_int = 0x10;
-pub const POSIX_SPAWN_SETSIGMASK: ::c_int = 0x20;
+pub const POSIX_SPAWN_RESETIDS: ::c_short = 0x01;
+pub const POSIX_SPAWN_SETPGROUP: ::c_short = 0x02;
+pub const POSIX_SPAWN_SETSCHEDPARAM: ::c_short = 0x04;
+pub const POSIX_SPAWN_SETSCHEDULER: ::c_short = 0x08;
+pub const POSIX_SPAWN_SETSIGDEF: ::c_short = 0x10;
+pub const POSIX_SPAWN_SETSIGMASK: ::c_short = 0x20;
 
 // Flags for chflags(2)
 pub const UF_SYSTEM: ::c_ulong = 0x00000080;

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -364,12 +364,12 @@ pub const POSIX_MADV_SEQUENTIAL: ::c_int = 2;
 pub const POSIX_MADV_WILLNEED: ::c_int = 3;
 pub const POSIX_MADV_DONTNEED: ::c_int = 4;
 
-pub const POSIX_SPAWN_RESETIDS: ::c_int = 0x01;
-pub const POSIX_SPAWN_SETPGROUP: ::c_int = 0x02;
-pub const POSIX_SPAWN_SETSCHEDPARAM: ::c_int = 0x04;
-pub const POSIX_SPAWN_SETSCHEDULER: ::c_int = 0x08;
-pub const POSIX_SPAWN_SETSIGDEF: ::c_int = 0x10;
-pub const POSIX_SPAWN_SETSIGMASK: ::c_int = 0x20;
+pub const POSIX_SPAWN_RESETIDS: ::c_short = 0x01;
+pub const POSIX_SPAWN_SETPGROUP: ::c_short = 0x02;
+pub const POSIX_SPAWN_SETSCHEDPARAM: ::c_short = 0x04;
+pub const POSIX_SPAWN_SETSCHEDULER: ::c_short = 0x08;
+pub const POSIX_SPAWN_SETSIGDEF: ::c_short = 0x10;
+pub const POSIX_SPAWN_SETSIGMASK: ::c_short = 0x20;
 
 pub const PTHREAD_CREATE_JOINABLE: ::c_int = 0;
 pub const PTHREAD_CREATE_DETACHED: ::c_int = 1;

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2330,7 +2330,7 @@ pub const PT_LWPNEXT: ::c_int = 25;
 pub const PT_SET_SIGPASS: ::c_int = 26;
 pub const PT_GET_SIGPASS: ::c_int = 27;
 pub const PT_FIRSTMACH: ::c_int = 32;
-pub const POSIX_SPAWN_RETURNERROR: ::c_int = 0x40;
+pub const POSIX_SPAWN_RETURNERROR: ::c_short = 0x40;
 
 // Flags for chflags(2)
 pub const SF_APPEND: ::c_ulong = 0x00040000;

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -1474,11 +1474,11 @@ pub const LOG_PERROR: ::c_int = 32 << 12;
 pub const LOG_NOWAIT: ::c_int = 64 << 12;
 
 // spawn.h
-pub const POSIX_SPAWN_RESETIDS: ::c_int = 0x01;
-pub const POSIX_SPAWN_SETPGROUP: ::c_int = 0x02;
-pub const POSIX_SPAWN_SETSIGDEF: ::c_int = 0x10;
-pub const POSIX_SPAWN_SETSIGMASK: ::c_int = 0x20;
-pub const POSIX_SPAWN_SETSID: ::c_int = 0x40;
+pub const POSIX_SPAWN_RESETIDS: ::c_short = 0x01;
+pub const POSIX_SPAWN_SETPGROUP: ::c_short = 0x02;
+pub const POSIX_SPAWN_SETSIGDEF: ::c_short = 0x10;
+pub const POSIX_SPAWN_SETSIGMASK: ::c_short = 0x20;
+pub const POSIX_SPAWN_SETSID: ::c_short = 0x40;
 
 const_fn! {
     {const} fn CMSG_ALIGN(len: usize) -> usize {

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -2761,8 +2761,8 @@ pub const MCL_CURRENT: ::c_int = 0x0001;
 pub const MCL_FUTURE: ::c_int = 0x0002;
 
 // spawn.h
-pub const POSIX_SPAWN_USEVFORK: ::c_int = 64;
-pub const POSIX_SPAWN_SETSID: ::c_int = 128;
+pub const POSIX_SPAWN_USEVFORK: ::c_short = 64;
+pub const POSIX_SPAWN_SETSID: ::c_short = 128;
 
 // sys/syslog.h
 pub const LOG_CRON: ::c_int = 9 << 3;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -2237,8 +2237,8 @@ pub const POSIX_MADV_NORMAL: ::c_int = 0;
 pub const POSIX_MADV_RANDOM: ::c_int = 1;
 pub const POSIX_MADV_SEQUENTIAL: ::c_int = 2;
 pub const POSIX_MADV_WILLNEED: ::c_int = 3;
-pub const POSIX_SPAWN_USEVFORK: ::c_int = 64;
-pub const POSIX_SPAWN_SETSID: ::c_int = 128;
+pub const POSIX_SPAWN_USEVFORK: ::c_short = 64;
+pub const POSIX_SPAWN_SETSID: ::c_short = 128;
 
 pub const S_IEXEC: mode_t = 0o0100;
 pub const S_IWRITE: mode_t = 0o0200;
@@ -2992,12 +2992,12 @@ pub const ETH_P_PHONET: ::c_int = 0x00F5;
 pub const ETH_P_IEEE802154: ::c_int = 0x00F6;
 pub const ETH_P_CAIF: ::c_int = 0x00F7;
 
-pub const POSIX_SPAWN_RESETIDS: ::c_int = 0x01;
-pub const POSIX_SPAWN_SETPGROUP: ::c_int = 0x02;
-pub const POSIX_SPAWN_SETSIGDEF: ::c_int = 0x04;
-pub const POSIX_SPAWN_SETSIGMASK: ::c_int = 0x08;
-pub const POSIX_SPAWN_SETSCHEDPARAM: ::c_int = 0x10;
-pub const POSIX_SPAWN_SETSCHEDULER: ::c_int = 0x20;
+pub const POSIX_SPAWN_RESETIDS: ::c_short = 0x01;
+pub const POSIX_SPAWN_SETPGROUP: ::c_short = 0x02;
+pub const POSIX_SPAWN_SETSIGDEF: ::c_short = 0x04;
+pub const POSIX_SPAWN_SETSIGMASK: ::c_short = 0x08;
+pub const POSIX_SPAWN_SETSCHEDPARAM: ::c_short = 0x10;
+pub const POSIX_SPAWN_SETSCHEDULER: ::c_short = 0x20;
 
 pub const NLMSG_NOOP: ::c_int = 0x1;
 pub const NLMSG_ERROR: ::c_int = 0x2;

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -1609,12 +1609,12 @@ pub const ITIMER_REAL: ::c_int = 0;
 pub const ITIMER_VIRTUAL: ::c_int = 1;
 pub const ITIMER_PROF: ::c_int = 2;
 
-pub const POSIX_SPAWN_RESETIDS: ::c_int = 0x00000010;
-pub const POSIX_SPAWN_SETPGROUP: ::c_int = 0x00000001;
-pub const POSIX_SPAWN_SETSIGDEF: ::c_int = 0x00000004;
-pub const POSIX_SPAWN_SETSIGMASK: ::c_int = 0x00000002;
-pub const POSIX_SPAWN_SETSCHEDPARAM: ::c_int = 0x00000400;
-pub const POSIX_SPAWN_SETSCHEDULER: ::c_int = 0x00000040;
+pub const POSIX_SPAWN_RESETIDS: ::c_short = 0x0010;
+pub const POSIX_SPAWN_SETPGROUP: ::c_short = 0x0001;
+pub const POSIX_SPAWN_SETSIGDEF: ::c_short = 0x0004;
+pub const POSIX_SPAWN_SETSIGMASK: ::c_short = 0x0002;
+pub const POSIX_SPAWN_SETSCHEDPARAM: ::c_short = 0x0400;
+pub const POSIX_SPAWN_SETSCHEDULER: ::c_short = 0x0040;
 
 pub const IPTOS_ECN_NOT_ECT: u8 = 0x00;
 


### PR DESCRIPTION
Changing the type from `c_int` to `c_short` will likely not break existing programs. It might introduce warnings about no-longer needed conversions to `c_short` though.

Fixes #3627