### PR TITLE
Fix the definition of sigevent on FreeBSD and Linux

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -16,24 +16,6 @@ cfg_if! {
 }
 
 s! {
-    pub struct aiocb {
-        pub aio_fildes: ::c_int,
-        pub aio_lio_opcode: ::c_int,
-        pub aio_reqprio: ::c_int,
-        pub aio_buf: *mut ::c_void,
-        pub aio_nbytes: ::size_t,
-        pub aio_sigevent: ::sigevent,
-        __next_prio: *mut aiocb,
-        __abs_prio: ::c_int,
-        __policy: ::c_int,
-        __error_code: ::c_int,
-        __return_value: ::ssize_t,
-        pub aio_offset: off_t,
-        #[cfg(all(not(target_arch = "x86_64"), target_pointer_width = "32"))]
-        __unused1: [::c_char; 4],
-        __glibc_reserved: [::c_char; 32],
-    }
-
     pub struct __exit_status {
         pub e_termination: ::c_short,
         pub e_exit: ::c_short,
@@ -507,6 +489,28 @@ impl siginfo_t {
             si_sigval: ::sigval,
         }
         (*(self as *const siginfo_t as *const siginfo_timer)).si_sigval
+    }
+}
+
+s_no_extra_traits! {
+    #[cfg_attr(feature = "extra_traits", derive(Debug))]
+    pub struct aiocb {
+        pub aio_fildes: ::c_int,
+        pub aio_lio_opcode: ::c_int,
+        pub aio_reqprio: ::c_int,
+        pub aio_buf: *mut ::c_void,
+        pub aio_nbytes: ::size_t,
+        pub aio_sigevent: ::sigevent,
+        __next_prio: *mut aiocb,
+        __abs_prio: ::c_int,
+        __policy: ::c_int,
+        __error_code: ::c_int,
+        __return_value: ::ssize_t,
+        // FIXME(off64): visible fields depend on __USE_FILE_OFFSET64
+        pub aio_offset: off_t,
+        #[cfg(all(not(target_arch = "x86_64"), target_pointer_width = "32"))]
+        __pad: [::c_char; 4],
+        __glibc_reserved: [::c_char; 32],
     }
 }
 

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -119,26 +119,6 @@ impl siginfo_t {
 }
 
 s! {
-    pub struct aiocb {
-        pub aio_fildes: ::c_int,
-        pub aio_lio_opcode: ::c_int,
-        pub aio_reqprio: ::c_int,
-        pub aio_buf: *mut ::c_void,
-        pub aio_nbytes: ::size_t,
-        pub aio_sigevent: ::sigevent,
-        __td: *mut ::c_void,
-        __lock: [::c_int; 2],
-        __err: ::c_int,
-        __ret: ::ssize_t,
-        pub aio_offset: off_t,
-        __next: *mut ::c_void,
-        __prev: *mut ::c_void,
-        #[cfg(target_pointer_width = "32")]
-        __dummy4: [::c_char; 24],
-        #[cfg(target_pointer_width = "64")]
-        __dummy4: [::c_char; 16],
-    }
-
     pub struct sigaction {
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: ::sigset_t,
@@ -496,6 +476,28 @@ s! {
 }
 
 s_no_extra_traits! {
+    #[cfg_attr(feature = "extra_traits", derive(Debug))]
+    pub struct aiocb {
+        pub aio_fildes: ::c_int,
+        pub aio_lio_opcode: ::c_int,
+        pub aio_reqprio: ::c_int,
+        pub aio_buf: *mut ::c_void,
+        pub aio_nbytes: ::size_t,
+        pub aio_sigevent: ::sigevent,
+        __td: *mut ::c_void,
+        __lock: [::c_int; 2],
+        __err: ::c_int,
+        __ret: ::ssize_t,
+        pub aio_offset: off_t,
+        __next: *mut ::c_void,
+        __prev: *mut ::c_void,
+        // FIXME(ctest): length should be `32 - 2 * core::mem::size_of::<*const ()>()`
+        #[cfg(target_pointer_width = "32")]
+        __dummy4: [::c_char; 24],
+        #[cfg(target_pointer_width = "64")]
+        __dummy4: [::c_char; 16],
+    }
+
     pub struct sysinfo {
         pub uptime: ::c_ulong,
         pub loads: [::c_ulong; 3],


### PR DESCRIPTION
It was originally defined back before rust could represent C unions.  So instead of defining the union field correctly, it simply defined that union's most useful field.  Define it correctly now.

Remove traits that can't be safely implemented on a union: PartialEq, Eq, and Hash.  Define Debug, but exclude the union field.  Leave Clone in place.

This PR is a rebase of #2813 that eschews all of the backwards-compatibility parts.