### PR TITLE
illumos: expose `PIPE_BUF` constant

### DIFF
--- a/libc-test/semver/solarish.txt
+++ b/libc-test/semver/solarish.txt
@@ -1,0 +1,1 @@
+PIPE_BUF

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1265,6 +1265,7 @@ pub const FOPEN_MAX: ::c_uint = 20;
 pub const FILENAME_MAX: ::c_uint = 1024;
 pub const L_tmpnam: ::c_uint = 25;
 pub const TMP_MAX: ::c_uint = 17576;
+pub const PIPE_BUF: ::c_int = 5120;
 
 pub const GRND_NONBLOCK: ::c_uint = 0x0001;
 pub const GRND_RANDOM: ::c_uint = 0x0002;


### PR DESCRIPTION
Expose the `PIPE_BUF` constant on Solaris/illumos. We have verified that these values are the same between the two variants of the system.