### PR TITLE
Fix `which is not FFI-safe` warning

### DIFF
--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -60,6 +60,7 @@ pub type posix_spawn_file_actions_t = *mut ::c_char;
 pub type iconv_t = *mut ::c_void;
 
 e! {
+    #[repr(u32)]
     pub enum uio_rw {
         UIO_READ = 0,
         UIO_WRITE,


### PR DESCRIPTION
Fix warning
```
warning: `extern` fn uses type `aix::uio_rw`, which is not FFI-safe
   --> src/unix/aix/powerpc64.rs:209:20
    |
209 |           pub fo_rw: extern fn(file: *mut file, rw: ::uio_rw, io: *mut ::c_void, ext: ::c_long,
    |  ____________________^
210 | |                              secattr: *mut ::c_void) -> ::c_int,
    | |_______________________________________________________________^ not FFI-safe
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
note: the type is defined here
   --> src/macros.rs:130:13
    |
130 |               pub enum $i { $($field)* }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/unix/aix/mod.rs:62:1
    |
62  | / e! {
63  | |     pub enum uio_rw {
64  | |         UIO_READ = 0,
65  | |         UIO_WRITE,
...   |
69  | |     }
70  | | }
    | |_- in this macro invocation
    = note: `#[warn(improper_ctypes_definitions)]` on by default
    = note: this warning originates in the macro `e` (in Nightly builds, run with -Z macro-backtrace for more info)
```
In `sys/uio.h`, the type is defined as
```
enum  uio_rw { UIO_READ, UIO_WRITE, UIO_READ_NO_MOVE, UIO_WRITE_NO_MOVE,
     UIO_PWRITE };
```
```