### PR TITLE
Fix hidden lifetime parameter

### DIFF
--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -574,7 +574,7 @@ cfg_if! {
         }
         impl Eq for __sigaction_sa_union {}
         impl ::fmt::Debug for __sigaction_sa_union {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter<'_>) -> ::fmt::Result {
                 f.debug_struct("__sigaction_sa_union")
                     .field("__su_handler", unsafe { &self.__su_handler })
                     .field("__su_sigaction", unsafe { &self.__su_sigaction })
@@ -600,7 +600,7 @@ cfg_if! {
         }
         impl Eq for sigaction {}
         impl ::fmt::Debug for sigaction {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter<'_>) -> ::fmt::Result {
                 let mut struct_formatter = f.debug_struct("sigaction");
                 struct_formatter.field("sa_union", &self.sa_union);
                 struct_formatter.field("sa_mask", &self.sa_mask);
@@ -627,7 +627,7 @@ cfg_if! {
         }
         impl Eq for __poll_ctl_ext_u {}
         impl ::fmt::Debug for __poll_ctl_ext_u {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter<'_>) -> ::fmt::Result {
                 f.debug_struct("__poll_ctl_ext_u")
                     .field("addr", unsafe { &self.addr })
                     .field("data32", unsafe { &self.data32 })
@@ -658,7 +658,7 @@ cfg_if! {
         }
         impl Eq for poll_ctl_ext {}
         impl ::fmt::Debug for poll_ctl_ext {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter<'_>) -> ::fmt::Result {
                 let mut struct_formatter = f.debug_struct("poll_ctl_ext");
                 struct_formatter.field("version", &self.version);
                 struct_formatter.field("command", &self.command);

--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -307,7 +307,7 @@ cfg_if! {
         }
         impl Eq for siginfo_t {}
         impl ::fmt::Debug for siginfo_t {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter<'_>) -> ::fmt::Result {
                 let mut struct_formatter = f.debug_struct("siginfo_t");
                 struct_formatter.field("si_signo", &self.si_signo);
                 struct_formatter.field("si_errno", &self.si_errno);
@@ -347,7 +347,7 @@ cfg_if! {
         }
         impl Eq for _kernel_simple_lock {}
         impl ::fmt::Debug for _kernel_simple_lock {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter<'_>) -> ::fmt::Result {
                 f.debug_struct("_kernel_simple_lock")
                     .field("_slock", unsafe { &self._slock })
                     .field("_slockp", unsafe { &self._slockp })
@@ -374,7 +374,7 @@ cfg_if! {
         }
         impl Eq for fileops_t {}
         impl ::fmt::Debug for fileops_t {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter<'_>) -> ::fmt::Result {
                 let mut struct_formatter = f.debug_struct("fileops_t");
                 struct_formatter.field("fo_rw", &self.fo_rw);
                 struct_formatter.field("fo_ioctl", &self.fo_ioctl);
@@ -415,7 +415,7 @@ cfg_if! {
         }
         impl Eq for file {}
         impl ::fmt::Debug for file {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter<'_>) -> ::fmt::Result {
                 let mut struct_formatter = f.debug_struct("file");
                 struct_formatter.field("f_flag", &self.f_flag);
                 struct_formatter.field("f_count", &self.f_count);
@@ -466,7 +466,7 @@ cfg_if! {
         }
         impl Eq for __ld_info_file {}
         impl ::fmt::Debug for __ld_info_file {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter<'_>) -> ::fmt::Result {
                 f.debug_struct("__ld_info_file")
                     .field("_ldinfo_fd", unsafe { &self._ldinfo_fd })
                     .field("_ldinfo_fp", unsafe { &self._ldinfo_fp })
@@ -498,7 +498,7 @@ cfg_if! {
         }
         impl Eq for ld_info {}
         impl ::fmt::Debug for ld_info {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter<'_>) -> ::fmt::Result {
                 let mut struct_formatter = f.debug_struct("ld_info");
                 struct_formatter.field("ldinfo_next", &self.ldinfo_next);
                 struct_formatter.field("ldinfo_flags", &self.ldinfo_flags);
@@ -535,7 +535,7 @@ cfg_if! {
         }
         impl Eq for __pollfd_ext_u {}
         impl ::fmt::Debug for __pollfd_ext_u {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter<'_>) -> ::fmt::Result {
                 f.debug_struct("__pollfd_ext_u")
                     .field("addr", unsafe { &self.addr })
                     .field("data32", unsafe { &self.data32 })
@@ -563,7 +563,7 @@ cfg_if! {
         }
         impl Eq for pollfd_ext {}
         impl ::fmt::Debug for pollfd_ext {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter<'_>) -> ::fmt::Result {
                 let mut struct_formatter = f.debug_struct("pollfd_ext");
                 struct_formatter.field("fd", &self.fd);
                 struct_formatter.field("events", &self.events);


### PR DESCRIPTION
Hidden lifetime parameter is not allowed in newer version of rust.