### PR TITLE
Fix configuration for AIX

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -395,7 +395,7 @@ cfg_if! {
         #[cfg_attr(feature = "rustc-dep-of-std",
                    link(name = "c", cfg(not(target_feature = "crt-static"))))]
         extern {}
-    } else if #[cfg(target_env = "aix")] {
+    } else if #[cfg(target_os = "aix")] {
         #[link(name = "c")]
         #[link(name = "m")]
         #[link(name = "bsd")]


### PR DESCRIPTION
Should use `target_os` rather than `target_env`, so that correct libraries are linked.