### PR TITLE
[libc 1.0] Put a big warning to Linux's dirent docs

### DIFF
--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1061,6 +1061,7 @@ s_no_extra_traits! {
         pub nl_groups: u32
     }
 
+    /// CRITICAL WARNING! "256" is a lie here. File name can be longer or shorter than 256 bytes. So extra care is needed when dealing with this structure. It is very hard to avoid undefined behavior. See <https://github.com/rust-lang/rust/blob/96eaf553e547e36003e235a9de26c11460712231/library/std/src/sys/pal/unix/fs.rs#L732> and <https://github.com/rust-lang/libc/issues/2669>
     pub struct dirent {
         pub d_ino: ::ino_t,
         pub d_off: ::off_t,
@@ -1163,6 +1164,7 @@ s_no_extra_traits! {
         pub rx_filter: ::c_int,
     }
 
+    /// CRITICAL WARNING! "256" is a lie here. File name can be longer or shorter than 256 bytes. So extra care is needed when dealing with this structure. It is very hard to avoid undefined behavior. See <https://github.com/rust-lang/rust/blob/96eaf553e547e36003e235a9de26c11460712231/library/std/src/sys/pal/unix/fs.rs#L732> and <https://github.com/rust-lang/libc/issues/2669>
     pub struct dirent64 {
         pub d_ino: ::ino64_t,
         pub d_off: ::off64_t,

--- a/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
@@ -269,6 +269,7 @@ s! {
 }
 
 s_no_extra_traits! {
+    /// CRITICAL WARNING! "256" is a lie here. File name can be longer or shorter than 256 bytes. So extra care is needed when dealing with this structure. It is very hard to avoid undefined behavior. See <https://github.com/rust-lang/rust/blob/96eaf553e547e36003e235a9de26c11460712231/library/std/src/sys/pal/unix/fs.rs#L732> and <https://github.com/rust-lang/libc/issues/2669>
     #[allow(missing_debug_implementations)]
     pub struct dirent {
         pub d_ino: ::ino64_t,


### PR DESCRIPTION
This fixes my bug https://github.com/rust-lang/libc/issues/2669 .

We cannot change type for `d_name` field, because this will break tests. So the only thing we can do is to document `dirent` behavior.

The question remains what are exact rules for dealing with `dirent`, but this is left to Rust specification