### PR TITLE
Correct types of mode bit constants on Fuchsia

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -1334,9 +1334,9 @@ pub const GRPQUOTA: ::c_int = 1;
 
 pub const SIGIOT: ::c_int = 6;
 
-pub const S_ISUID: ::c_int = 0x800;
-pub const S_ISGID: ::c_int = 0x400;
-pub const S_ISVTX: ::c_int = 0x200;
+pub const S_ISUID: ::mode_t = 0x800;
+pub const S_ISGID: ::mode_t = 0x400;
+pub const S_ISVTX: ::mode_t = 0x200;
 
 pub const IF_NAMESIZE: ::size_t = 16;
 pub const IFNAMSIZ: ::size_t = IF_NAMESIZE;

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -1334,9 +1334,9 @@ pub const GRPQUOTA: ::c_int = 1;
 
 pub const SIGIOT: ::c_int = 6;
 
-pub const S_ISUID: ::mode_t = 0x800;
-pub const S_ISGID: ::mode_t = 0x400;
-pub const S_ISVTX: ::mode_t = 0x200;
+pub const S_ISUID: ::mode_t = 0o4000;
+pub const S_ISGID: ::mode_t = 0o2000;
+pub const S_ISVTX: ::mode_t = 0o1000;
 
 pub const IF_NAMESIZE: ::size_t = 16;
 pub const IFNAMSIZ: ::size_t = IF_NAMESIZE;


### PR DESCRIPTION
Fuchsia's definitions of these constants were split from the unix impls before #503, and so S_ISUID, S_ISGID, and S_ISVTX are all incorrectly typed as c_int instead of mode_t. This applies the same fix to Fuchsia's constant definitions to bring them in line with the rest of libc.

This is a breaking change since `c_int` is `i32` on Fuchsia and `mode_t` is `u32`, but it's a good breaking change.