### PR TITLE
Remove linking the MSVC CRT

### DIFF
--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -254,12 +254,6 @@ pub const SIG_GET: ::sighandler_t = 2;
 pub const SIG_SGE: ::sighandler_t = 3;
 pub const SIG_ACK: ::sighandler_t = 4;
 
-// inline comment below appeases style checker
-#[cfg(all(target_env = "msvc", feature = "rustc-dep-of-std"))] // " if "
-#[link(name = "msvcrt", cfg(not(target_feature = "crt-static")))]
-#[link(name = "libcmt", cfg(target_feature = "crt-static"))]
-extern "C" {}
-
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum FILE {}
 impl ::Copy for FILE {}


### PR DESCRIPTION
This is now done in rust-lang/rust repo https://github.com/rust-lang/rust/pull/122268
