### PR TITLE
[0.2] Add SIG constants to espidf

### DIFF
--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -89,6 +89,16 @@ pub const MSG_EOR: ::c_int = 0x08;
 
 pub const PTHREAD_STACK_MIN: ::size_t = 768;
 
+pub const SIGABRT: ::size_t = 1;
+pub const SIGFPE: ::size_t = 1;
+pub const SIGILL: ::size_t = 1;
+pub const SIGINT: ::size_t = 1;
+pub const SIGSEGV: ::size_t = 1;
+pub const SIGTERM: ::size_t = 1;
+pub const SIGHUP: ::size_t = 1;
+pub const SIGQUIT: ::size_t = 1;
+pub const NSIG: ::size_t = 2;
+
 extern "C" {
     pub fn pthread_create(
         native: *mut ::pthread_t,

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -511,6 +511,8 @@ pub const SOCK_CLOEXEC: ::c_int = O_CLOEXEC;
 
 pub const INET_ADDRSTRLEN: ::c_int = 16;
 
+pub const SIGABRT: ::c_int = 1;
+
 // https://github.com/bminor/newlib/blob/HEAD/newlib/libc/sys/linux/include/net/if.h#L121
 pub const IFF_UP: ::c_int = 0x1; // interface is up
 pub const IFF_BROADCAST: ::c_int = 0x2; // broadcast address valid

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -511,8 +511,6 @@ pub const SOCK_CLOEXEC: ::c_int = O_CLOEXEC;
 
 pub const INET_ADDRSTRLEN: ::c_int = 16;
 
-pub const SIGABRT: ::c_int = 1;
-
 // https://github.com/bminor/newlib/blob/HEAD/newlib/libc/sys/linux/include/net/if.h#L121
 pub const IFF_UP: ::c_int = 0x1; // interface is up
 pub const IFF_BROADCAST: ::c_int = 0x2; // broadcast address valid


### PR DESCRIPTION
Added missing constants from [signals](https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/include/sys/signal.h;h=96bf9781ae9313e4181d0b3c65df1105f1ac79df;hb=HEAD#l258).

Resolves #3615. When rust-analyzer is running rust/library/test/src/test_results.rs [this](https://github.com/rust-lang/rust-analyzer/issues/16552) error is occurring, because of missing SIGABRT const.