### PR TITLE
Add dns api

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -436,6 +436,19 @@ fn test_apple(target: &str) {
         "uuid_t" | "vol_capabilities_set_t" => true,
         _ => false,
     });
+
+    // dnsinfo.h isn't available via the SDK https://opensource.apple.com/source/configd/configd-1109.140.1/dnsinfo/dnsinfo.h.auto.html
+    cfg.skip_struct(move |s| match s {
+        "dns_sortaddr_t" | "dns_resolver_t" | "dns_config_t" => true,
+        _ => false,
+    });
+    cfg.skip_fn(move |s| match s {
+        "dns_configuration_copy"
+        | "dns_configuration_free"
+        | "dns_configuration_notify_key"
+        | "_dns_configuration_ack" => true,
+        _ => false,
+    });
     cfg.generate("../src/lib.rs", "main.rs");
 }
 

--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -2284,3 +2284,10 @@ wait4
 waitid
 xsw_usage
 xucred
+dns_config_t
+dns_resolver_t
+dns_sortaddr_t
+dns_configuration_notify_key
+dns_configuration_copy
+dns_configuration_free
+_dns_configuration_ack

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1525,6 +1525,40 @@ s_no_extra_traits! {
         pub ifcu_buf: *mut ::c_char,
         pub ifcu_req: *mut ifreq,
     }
+
+    #[repr(C, align(4))]
+    pub struct dns_sortaddr_t {
+        pub address: in_addr,
+        pub mask: in_addr,
+    }
+
+    #[repr(C, align(4))]
+    pub struct dns_resolver_t {
+        pub domain: *mut ::c_char,
+        pub n_nameserver: i32,
+        pub nameserver: *mut *mut ::sockaddr,
+        pub port: u16,
+        pub n_search: i32,
+        pub search: *mut *mut ::c_char,
+        pub n_sortaddr: i32,
+        pub sortaddr: *mut *mut dns_sortaddr_t,
+        pub options: *mut ::c_char,
+        pub timeout: u32,
+        pub search_order: u32,
+        pub if_index: u32,
+        pub flags: u32,
+        pub reach_flags: u32,
+        pub reserved: [u32; 5],
+    }
+
+    pub struct dns_config_t {
+        pub n_resolver: i32,
+        pub resolver: *mut *mut dns_resolver_t,
+        pub n_scoped_resolver: i32,
+        pub scoped_resolver: *mut *mut dns_resolver_t,
+        pub reserved: [u32; 5],
+    }
+
 }
 
 impl siginfo_t {
@@ -6461,6 +6495,10 @@ extern "C" {
         search_path: *const ::c_char,
         argv: *const *mut ::c_char,
     ) -> ::c_int;
+    pub fn dns_configuration_notify_key() -> *const ::c_char;
+    pub fn dns_configuration_copy() -> *mut dns_config_t;
+    pub fn dns_configuration_free(config: *mut dns_config_t);
+    pub fn _dns_configuration_ack(config: *mut dns_config_t, bundle_id: *const ::c_char);
 }
 
 pub unsafe fn mach_task_self() -> ::mach_port_t {


### PR DESCRIPTION
Adding structs and functions defined in `dnsinfo.h` which is private, so no libc tests (or any idea for a workaround?)
The functions are exported via libSystem.dylib so symbol resolution should be okay.
Closes #3666 