### PR TITLE
Add getpid in wasi

### DIFF
--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -730,6 +730,8 @@ extern "C" {
     pub fn getcwd(buf: *mut c_char, size: ::size_t) -> *mut c_char;
     pub fn chdir(dir: *const c_char) -> ::c_int;
 
+    pub fn getpid() -> pid_t;
+
     pub fn nl_langinfo(item: ::nl_item) -> *mut ::c_char;
     pub fn nl_langinfo_l(item: ::nl_item, loc: ::locale_t) -> *mut ::c_char;
 


### PR DESCRIPTION
<!--
Thanks for considering submitting a PR!

We have the [contribution guide](https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md). Please read it if you're new here!

Here's a checklist for things that will be checked during review or continuous integration.

- \[ ] Edit corresponding file(s) under `libc-test/semver` when you add/remove item(s), e.g. edit `linux.txt` if you add an item to `src/unix/linux_like/linux/mod.rs`
- \[x] Your PR doesn't contain any private or *unstable* values like `*LAST` or `*MAX` (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- \[x] If your PR has a breaking change, please clarify it
- \[x] If your PR increments version number, it must NOT contain any other changes (otherwise a release could be delayed)
- \[x] Make sure `ci/style.sh` passes
- \[ ] `cd libc-test && cargo test`
  - (this might fail on your env due to environment difference between your env and CI. Ignore failures if you are not sure)

Delete this line and everything above before opening your PR.
-->

Add `getpid` from wasi-libc. `getpid` in wasi itself doesn't make sense, but `wasi-libc` defines an emulated function which returns a constant value.

I found `semver/wasi.txt` doesn't exist. Do I need to create it?
 