### PR TITLE
Fix out-of-bounds pointer arithmetic in CMSG_NXTHDR

### DIFF
--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -4650,7 +4650,7 @@ f! {
             as *mut cmsghdr;
         let max = (*mhdr).msg_control as usize
             + (*mhdr).msg_controllen as usize;
-        if (next.offset(1)) as usize > max ||
+        if (next.wrapping_offset(1)) as usize > max ||
             next as usize + super::CMSG_ALIGN((*next).cmsg_len as usize) > max
         {
             0 as *mut cmsghdr


### PR DESCRIPTION
This fixes a bug Miri found in a program that uses UNIX-domain sockets via nix:

```
error: Undefined Behavior: out-of-bounds pointer arithmetic: 0x3cf148[noalloc] is a dangling pointer (it has no provenance)
    --> /home/purplesyringa/.cargo/git/checkouts/libc-d1297d136f47e864/3939453/src/unix/linux_like/linux/mod.rs:4653:12
     |
4653 |         if (next.offset(1)) as usize > max ||
     |            ^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: 0x3cf148[noalloc] is a dangling pointer (it has no provenance)
     |
     = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
     = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
     = note: BACKTRACE on thread `test_rx`:
     = note: inside `libc::unix::linux_like::linux::CMSG_NXTHDR` at /home/purplesyringa/.cargo/git/checkouts/libc-d1297d136f47e864/3939453/src/unix/linux_like/linux/mod.rs:4653:12: 4653:28
     = note: inside `nix::sys::socket::pack_mhdr_to_send::<'_, &[std::io::IoSlice<'_>], &[nix::sys::socket::ControlMessage<'_>], ()>` at /home/purplesyringa/.cargo/git/checkouts/nix-b3212349c9ce0b13/c6ff94a/src/sys/socket/mod.rs:1899:26: 1899:68
...
```

`wrapping_offset` seems to be what was actually intended here.