### PR TITLE
Add wasi select, FD_SET, FD_ZERO, FD_ISSET

### DIFF
--- a/libc-test/semver/wasi.txt
+++ b/libc-test/semver/wasi.txt
@@ -1,0 +1,5 @@
+fd_set
+FD_SET
+FD_ZERO
+FD_ISSET
+select

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -178,6 +178,11 @@ s! {
         pub st_ctim: timespec,
         __reserved: [c_longlong; 3],
     }
+
+    pub struct fd_set {
+        __nfds: usize,
+        __fds: [c_int; FD_SETSIZE as usize],
+    }
 }
 
 // Declare dirent outside of s! so that it doesn't implement Copy, Eq, Hash,
@@ -445,6 +450,28 @@ pub const YESEXPR: ::nl_item = 0x50000;
 pub const NOEXPR: ::nl_item = 0x50001;
 pub const YESSTR: ::nl_item = 0x50002;
 pub const NOSTR: ::nl_item = 0x50003;
+
+f! {
+    pub fn FD_ISSET(fd: ::c_int, set: *const fd_set) -> bool {
+        let set = &*set;
+        let n = set.__nfds;
+        return set.__fds[..n].iter().any(|p| *p == fd)
+    }
+
+    pub fn FD_SET(fd: ::c_int, set: *mut fd_set) -> () {
+        let set = &mut *set;
+        let n = set.__nfds;
+        if !set.__fds[..n].iter().any(|p| *p == fd) {
+            set.__nfds = n + 1;
+            set.__fds[n] = fd;
+        }
+    }
+
+    pub fn FD_ZERO(set: *mut fd_set) -> () {
+        (*set).__nfds = 0;
+        return
+    }
+}
 
 #[cfg_attr(
     feature = "rustc-dep-of-std",
@@ -740,6 +767,14 @@ extern "C" {
 
     pub fn nl_langinfo(item: ::nl_item) -> *mut ::c_char;
     pub fn nl_langinfo_l(item: ::nl_item, loc: ::locale_t) -> *mut ::c_char;
+
+    pub fn select(
+        nfds: c_int,
+        readfds: *mut fd_set,
+        writefds: *mut fd_set,
+        errorfds: *mut fd_set,
+        timeout: *const timeval,
+    ) -> c_int;
 
     pub fn __wasilibc_register_preopened_fd(fd: c_int, path: *const c_char) -> c_int;
     pub fn __wasilibc_fd_renumber(fd: c_int, newfd: c_int) -> c_int;


### PR DESCRIPTION
<!--
Thanks for considering submitting a PR!

We have the [contribution guide](https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md). Please read it if you're new here!

Here's a checklist for things that will be checked during review or continuous integration.

- \[ ] Edit corresponding file(s) under `libc-test/semver` when you add/remove item(s), e.g. edit `linux.txt` if you add an item to `src/unix/linux_like/linux/mod.rs`
- \[ ] Your PR doesn't contain any private or *unstable* values like `*LAST` or `*MAX` (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- \[ ] If your PR has a breaking change, please clarify it
- \[ ] If your PR increments version number, it must NOT contain any other changes (otherwise a release could be delayed)
- \[ ] Make sure `ci/style.sh` passes
- \[ ] `cd libc-test && cargo test`
  - (this might fail on your env due to environment difference between your env and CI. Ignore failures if you are not sure)

Delete this line and everything above before opening your PR.
-->

Please check if it fits in the project policy.

This is port of wasi-libc type definitions and functions. wasi-libc has different `fd_set` design to widely used one.