### PR TITLE
Update version to `0.2.155`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-test"
-version = "0.2.154"
+version = "0.2.155"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
@@ -12,7 +12,7 @@ A test crate for the libc crate.
 
 [dependencies.libc]
 path = ".."
-version = "0.2.154"
+version = "0.2.155"
 default-features = false
 
 [build-dependencies]


### PR DESCRIPTION
Motivation: Allow [updating `libc` in the standard library](https://github.com/rust-lang/rust/pull/124560). `0.2.154` was broken by https://github.com/rust-lang/libc/issues/3608, I don't _think_ there are more issues now, though I'm sure bors will prove me wrong.

Related: Maybe consider yanking `0.2.154` after this, as consumers of the posix APIs that require `posix_spawn_file_actions_t` are unsound in that version.