### PR TITLE
Unlock ci: fix wrong cfg emscripten

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,7 @@ use std::string::String;
 // make sure to add it to this list as well.
 const ALLOWED_CFGS: &'static [&'static str] = &[
     "emscripten_new_stat_abi",
+    "espidf_time64",
     "freebsd10",
     "freebsd11",
     "freebsd12",
@@ -51,7 +52,7 @@ fn main() {
     let align_cargo_feature = env::var("CARGO_FEATURE_ALIGN").is_ok();
     let const_extern_fn_cargo_feature = env::var("CARGO_FEATURE_CONST_EXTERN_FN").is_ok();
     let libc_ci = env::var("LIBC_CI").is_ok();
-    let libc_check_cfg = env::var("LIBC_CHECK_CFG").is_ok();
+    let libc_check_cfg = env::var("LIBC_CHECK_CFG").is_ok() || rustc_minor_ver >= 80;
 
     if env::var("CARGO_FEATURE_USE_STD").is_ok() {
         println!(

--- a/ci/switch.json
+++ b/ci/switch.json
@@ -1,7 +1,5 @@
 {
-  "family": "unix",
   "env": "newlib",
-  "target-env": "newlib",
   "target-family": "unix",
   "target-c-int-width": "32",
   "target-endian": "little",
@@ -9,14 +7,6 @@
   "os": "horizon",
   "arch": "aarch64",
   "panic-strategy": "unwind",
-  "abi-blacklist": [
-      "stdcall",
-      "fastcall",
-      "vectorcall",
-      "thiscall",
-      "win64",
-      "sysv64"
-  ],
   "dynamic-linking" : false,
   "features": "+a53,+strict-align",
   "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
@@ -24,7 +14,7 @@
   "position-independent-executables" : true,
   "linker-flavor": "gcc",
   "llvm-target": "aarch64-unknown-none",
-  "has-elf-tls" : false,
+  "has-thread-local": false,
   "linker-is-gnu" : true,
   "disable-redzone" : true,
   "relocation-model" : "pic",

--- a/libc-test/test/makedev.rs
+++ b/libc-test/test/makedev.rs
@@ -79,7 +79,7 @@ mod t {
 
     // These OSes allow 32 bits for both minor and major
     #[cfg(any(
-        target_os = "empscripten",
+        target_os = "emscripten",
         target_os = "freebsd",
         target_os = "fuchsia",
         target_os = "linux",


### PR DESCRIPTION
CI is currently failing: https://github.com/rust-lang/libc/actions/runs/8961351128/job/24608869921

From https://blog.rust-lang.org/2024/05/06/check-cfg.html, cargo for rust 1.80 always enables rust check-cfg.