### PR TITLE
Unix: add `IN6ADDR_ANY_INIT`, `IN6ADDR_LOOPBACK_INIT`, `in6addr_any`, `in6addr_loopback`

### DIFF
--- a/libc-test/semver/unix.txt
+++ b/libc-test/semver/unix.txt
@@ -152,6 +152,8 @@ IF_NAMESIZE
 IGNBRK
 IGNCR
 IGNPAR
+IN6ADDR_ANY_INIT
+IN6ADDR_LOOPBACK_INIT
 INADDR_ANY
 INADDR_BROADCAST
 INADDR_LOOPBACK
@@ -586,6 +588,8 @@ hstrerror
 if_indextoname
 if_nametoindex
 in6_addr
+in6addr_any
+in6addr_loopback
 in_addr
 in_addr_t
 in_port_t

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -305,6 +305,13 @@ pub const INADDR_ANY: in_addr_t = 0;
 pub const INADDR_BROADCAST: in_addr_t = 4294967295;
 pub const INADDR_NONE: in_addr_t = 4294967295;
 
+pub const IN6ADDR_LOOPBACK_INIT: in6_addr = in6_addr {
+    s6_addr: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+};
+pub const IN6ADDR_ANY_INIT: in6_addr = in6_addr {
+    s6_addr: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+};
+
 pub const ARPOP_REQUEST: u16 = 1;
 pub const ARPOP_REPLY: u16 = 2;
 
@@ -312,6 +319,11 @@ pub const ATF_COM: ::c_int = 0x02;
 pub const ATF_PERM: ::c_int = 0x04;
 pub const ATF_PUBL: ::c_int = 0x08;
 pub const ATF_USETRAILERS: ::c_int = 0x10;
+
+extern "C" {
+    pub static in6addr_loopback: in6_addr;
+    pub static in6addr_any: in6_addr;
+}
 
 cfg_if! {
     if #[cfg(any(target_os = "l4re", target_os = "espidf"))] {


### PR DESCRIPTION
This is not breaking change.

Note that this PR adds global variables (statics) `in6addr_any` and `in6addr_loopback`. But this is okay, because:
- We already have global variables in crate libc: https://docs.rs/libc/0.2.154/aarch64-apple-darwin/libc/index.html#statics
- `ctest2` knows how to test global variables: https://docs.rs/ctest2/0.4.8/ctest2/struct.TestGenerator.html#method.skip_static

This PR closes https://github.com/rust-lang/libc/issues/1950

Also I suggest merging this PR for ctest2: https://github.com/JohnTitor/ctest2/pull/56 , it removes annoying warnings produced by ctest2 in presence of statics. And also fixes CI for ctest2. I recommend merging https://github.com/JohnTitor/ctest2/pull/56 , but this is not required