### PR TITLE
adding aligned_alloc support for the following:

### DIFF
--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -1836,6 +1836,7 @@ aio_return
 aio_suspend
 aio_write
 aiocb
+aligned_alloc
 arc4random
 arc4random_buf
 arc4random_uniform

--- a/libc-test/semver/dragonfly.txt
+++ b/libc-test/semver/dragonfly.txt
@@ -1246,6 +1246,7 @@ aio_suspend
 aio_waitcomplete
 aio_write
 aiocb
+aligned_alloc
 arc4random
 arc4random_buf
 arc4random_uniform

--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -1703,6 +1703,7 @@ aio_suspend
 aio_waitcomplete
 aio_write
 aiocb
+aligned_alloc
 arc4random
 arc4random_buf
 arc4random_uniform

--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -609,6 +609,7 @@ aio_return
 aio_suspend
 aio_write
 aiocb
+aligned_alloc
 backtrace
 clock_adjtime
 copy_file_range

--- a/libc-test/semver/linux-musl.txt
+++ b/libc-test/semver/linux-musl.txt
@@ -56,6 +56,7 @@ aio_return
 aio_suspend
 aio_write
 aiocb
+aligned_alloc
 clock_adjtime
 copy_file_range
 ctermid

--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -1202,6 +1202,7 @@ aio_return
 aio_suspend
 aio_write
 aiocb
+aligned_alloc
 arc4random
 arc4random_buf
 arc4random_uniform

--- a/libc-test/semver/openbsd.txt
+++ b/libc-test/semver/openbsd.txt
@@ -1007,6 +1007,7 @@ __errno
 abs
 accept4
 acct
+aligned_alloc
 arc4random
 arc4random_buf
 arc4random_uniform

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -915,6 +915,7 @@ extern "C" {
         timeptr: *const ::tm,
         locale: ::locale_t,
     ) -> ::size_t;
+    pub fn aligned_alloc(alignment: ::size_t, size: ::size_t) -> *mut ::c_void;
 }
 
 cfg_if! {

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1537,6 +1537,9 @@ extern "C" {
 
     // Added in `glibc` 2.34
     pub fn close_range(first: ::c_uint, last: ::c_uint, flags: ::c_int) -> ::c_int;
+
+    // Added in `glibc` 2.16
+    pub fn aligned_alloc(alignment: ::size_t, size: ::size_t) -> *mut ::c_void;
 }
 
 cfg_if! {

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -885,6 +885,7 @@ extern "C" {
 
     pub fn dirname(path: *mut ::c_char) -> *mut ::c_char;
     pub fn basename(path: *mut ::c_char) -> *mut ::c_char;
+    pub fn aligned_alloc(alignment: ::size_t, size: ::size_t) -> *mut ::c_void;
 }
 
 // Alias <foo> to <foo>64 to mimic glibc's LFS64 support

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -3212,6 +3212,7 @@ extern "C" {
     pub fn __major(version: ::c_int, devnum: ::dev_t) -> ::major_t;
     pub fn __minor(version: ::c_int, devnum: ::dev_t) -> ::minor_t;
     pub fn __makedev(version: ::c_int, majdev: ::major_t, mindev: ::minor_t) -> ::dev_t;
+    pub fn aligned_alloc(alignment: ::size_t, size: ::size_t) -> *mut ::c_void;
 }
 
 #[link(name = "sendfile")]


### PR DESCRIPTION
- linux glibc/musl.
- all supported BSD implements it.
- apple.
- solarish.

close #3689