### PR TITLE
fix: use c_char from crate root

### DIFF
--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -128,7 +128,7 @@ s_no_extra_traits! {
     pub struct sockaddr_un {
         pub sun_len: u8,
         pub sun_family: sa_family_t,
-        pub sun_path: [c_char; 104]
+        pub sun_path: [::c_char; 104]
     }
 
     pub struct utsname {


### PR DESCRIPTION
Most likely this is a typo and c_char from crate root should be used. If this is intentional and there must be an unsigned char, then it may be better to specify u8 instead of c_char.