### PR TITLE
Revert "Upgrade Docker images to Ubuntu 23.10" on sparc64

### DIFF
--- a/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl ca-certificates \

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3862,6 +3862,9 @@ fn test_linux(target: &str) {
             | "SW_CNT"
                 if ppc64 || riscv64 => true,
 
+            // FIXME: requires more recent kernel headers on CI
+            "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV" if sparc64 => true,
+
             // FIXME: Not currently available in headers on ARM and musl.
             "NETLINK_GET_STRICT_CHK" if arm || musl => true,
 


### PR DESCRIPTION
This partially reverts commit 946c348bc7ce61fb8b92c27ea8328c8fbbcecf72.

The test binaries were getting a symbol version for `GLIBC_2.38`, but the debian-11 image used for qemu doesn't have that new of glibc.