### PR TITLE
[0.2] Revert "Upgrade Docker images to Ubuntu 23.10" on sparc64

### DIFF
--- a/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl ca-certificates \

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3909,6 +3909,9 @@ fn test_linux(target: &str) {
             | "SW_CNT"
                 if ppc64 || riscv64 => true,
 
+            // FIXME: requires more recent kernel headers on CI
+            "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV" if sparc64 => true,
+
             // FIXME: Not currently available in headers on ARM and musl.
             "NETLINK_GET_STRICT_CHK" if arm || musl => true,
 

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3910,7 +3910,10 @@ fn test_linux(target: &str) {
                 if ppc64 || riscv64 => true,
 
             // FIXME: requires more recent kernel headers on CI
-            "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV" if sparc64 => true,
+            | "MFD_EXEC"
+            | "MFD_NOEXEC_SEAL"
+            | "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV"
+                if sparc64 => true,
 
             // FIXME: Not currently available in headers on ARM and musl.
             "NETLINK_GET_STRICT_CHK" if arm || musl => true,


### PR DESCRIPTION
This is a cherry-pick of #3707 on `libc-0.2`.