### PR TITLE
CI: reduce verbosity of build.sh

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -11,6 +11,7 @@ set -ex
 : "${OS?The OS environment variable must be set.}"
 
 RUST=${TOOLCHAIN}
+VERBOSE=-v
 
 echo "Testing Rust ${RUST} on ${OS}"
 
@@ -41,50 +42,50 @@ test_target() {
 
     # Test that libc builds without any default features (no std)
     if [ "${NO_STD}" != "1" ]; then
-        cargo "+${RUST}" "${BUILD_CMD}" -vv --no-default-features --target "${TARGET}"
+        cargo "+${RUST}" "${BUILD_CMD}" "$VERBOSE" --no-default-features --target "${TARGET}"
     else
         # FIXME: With `build-std` feature, `compiler_builtins` emits a lof of lint warnings.
         RUSTFLAGS="-A improper_ctypes_definitions" cargo "+${RUST}" "${BUILD_CMD}" \
-            -Z build-std=core,alloc -vv --no-default-features --target "${TARGET}"
+            -Z build-std=core,alloc "$VERBOSE" --no-default-features --target "${TARGET}"
     fi
     # Test that libc builds with default features (e.g. std)
     # if the target supports std
     if [ "$NO_STD" != "1" ]; then
-        cargo "+${RUST}" "${BUILD_CMD}" -vv --target "${TARGET}"
+        cargo "+${RUST}" "${BUILD_CMD}" "$VERBOSE" --target "${TARGET}"
     else
         RUSTFLAGS="-A improper_ctypes_definitions" cargo "+${RUST}" "${BUILD_CMD}" \
-            -Z build-std=core,alloc -vv --target "${TARGET}"
+            -Z build-std=core,alloc "$VERBOSE" --target "${TARGET}"
     fi
 
     # Test that libc builds with the `extra_traits` feature
     if [ "${NO_STD}" != "1" ]; then
-        cargo "+${RUST}" "${BUILD_CMD}" -vv --no-default-features --target "${TARGET}" \
+        cargo "+${RUST}" "${BUILD_CMD}" "$VERBOSE" --no-default-features --target "${TARGET}" \
             --features extra_traits
     else
         RUSTFLAGS="-A improper_ctypes_definitions" cargo "+${RUST}" "${BUILD_CMD}" \
-            -Z build-std=core,alloc -vv --no-default-features \
+            -Z build-std=core,alloc "$VERBOSE" --no-default-features \
             --target "${TARGET}" --features extra_traits
     fi
 
     # Test the 'const-extern-fn' feature on nightly
     if [ "${RUST}" = "nightly" ]; then
         if [ "${NO_STD}" != "1" ]; then
-            cargo "+${RUST}" "${BUILD_CMD}" -vv --no-default-features --target "${TARGET}" \
+            cargo "+${RUST}" "${BUILD_CMD}" "$VERBOSE" --no-default-features --target "${TARGET}" \
                 --features const-extern-fn
         else
             RUSTFLAGS="-A improper_ctypes_definitions" cargo "+${RUST}" "${BUILD_CMD}" \
-                -Z build-std=core,alloc -vv --no-default-features \
+                -Z build-std=core,alloc "$VERBOSE" --no-default-features \
                 --target "${TARGET}" --features const-extern-fn
         fi
     fi
 
     # Also test that it builds with `extra_traits` and default features:
     if [ "$NO_STD" != "1" ]; then
-        cargo "+${RUST}" "${BUILD_CMD}" -vv --target "${TARGET}" \
+        cargo "+${RUST}" "${BUILD_CMD}" "$VERBOSE" --target "${TARGET}" \
             --features extra_traits
     else
         RUSTFLAGS="-A improper_ctypes_definitions" cargo "+${RUST}" "${BUILD_CMD}" \
-            -Z build-std=core,alloc -vv --target "${TARGET}" \
+            -Z build-std=core,alloc "$VERBOSE" --target "${TARGET}" \
             --features extra_traits
     fi
 }


### PR DESCRIPTION
`-vv` produces lots of unrelated warnings in other crates when building
with `-Zbuild-std`. That makes it hard to load and see errors when tests fail.

A single `-v` is enough for most testing purposes.

Build log size before and after:

Before: ~12 MB ([raw build log](https://productionresultssa13.blob.core.windows.net/actions-results/9c133a6c-7102-4722-904b-14015b27f096/workflow-job-run-35264dad-c771-5372-33bb-799f8ac9da2e/logs/job/job-logs.txt?rsct=text%2Fplain&se=2024-05-19T19%3A49%3A01Z&sig=RSyXgGLkTEfNqJtHgGzYNOl83Xj5sqFFi9w5MPSgPTY%3D&sp=r&spr=https&sr=b&st=2024-05-19T19%3A38%3A56Z&sv=2021-12-02))
After: 2,127.86 KB ([raw build log](https://productionresultssa1.blob.core.windows.net/actions-results/5c109e58-eac4-4bc5-8125-47c4123fc36b/workflow-job-run-35264dad-c771-5372-33bb-799f8ac9da2e/logs/job/job-logs.txt?rsct=text%2Fplain&se=2024-05-19T20%3A47%3A23Z&sig=Ly9B1EbsAkwIr5CDwJRp2W14F4OuFlIIG1%2FVGtr9%2FNA%3D&sp=r&spr=https&sr=b&st=2024-05-19T20%3A37%3A18Z&sv=2021-12-02))