### PR TITLE
build.rs: always use freebsd12 when rustc_dep_of_std is set

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -44,14 +44,21 @@ fn main() {
     //
     // On CI, we detect the actual FreeBSD version and match its ABI exactly,
     // running tests to ensure that the ABI is correct.
-    match which_freebsd() {
-        Some(10) if libc_ci => set_cfg("freebsd10"),
-        Some(11) if libc_ci => set_cfg("freebsd11"),
-        Some(12) if libc_ci || rustc_dep_of_std => set_cfg("freebsd12"),
-        Some(13) if libc_ci => set_cfg("freebsd13"),
-        Some(14) if libc_ci => set_cfg("freebsd14"),
-        Some(15) if libc_ci => set_cfg("freebsd15"),
-        Some(_) | None => set_cfg("freebsd11"),
+    let which_freebsd = if libc_ci {
+        which_freebsd().unwrap_or(11)
+    } else if rustc_dep_of_std {
+        12
+    } else {
+        11
+    };
+    match which_freebsd {
+        x if x < 10 => panic!("FreeBSD older than 10 is not supported"),
+        10 => set_cfg("freebsd10"),
+        11 => set_cfg("freebsd11"),
+        12 => set_cfg("freebsd12"),
+        13 => set_cfg("freebsd13"),
+        14 => set_cfg("freebsd14"),
+        _ => set_cfg("freebsd15"),
     }
 
     match emcc_version_code() {


### PR DESCRIPTION
Currently, when rustc_dep_of_std is set, the freebsd version used depends on the return value of `which_freebsd()`:
- if it is `Some(12)`, it uses `freebsd12`
- otherwise it uses `freebsd11`

That does not seem intended? It is certainly rather odd that when building on FreeBSD 13 we'd get the freebsd11 API, but when building on FreeBSD 12 we get freebsd12. This also causes some "fun" for Miri when cross-building the freebsd std on other targets: `which_freebsd()` then returns `None`, so std uses different symbols than it does in the std that is shipped by rustup.

I assume the intention of https://github.com/rust-lang/libc/pull/3434 was to force std to use freebsd12 when rustc_dep_of_std is set (at least that's what the comments seem to say), so let's implement that.