### PR TITLE
Make VxWorks shims `unsafe`

### DIFF
--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -1867,11 +1867,16 @@ safe_f! {
     }
 }
 
-pub fn pread(_fd: ::c_int, _buf: *mut ::c_void, _count: ::size_t, _offset: off64_t) -> ::ssize_t {
+pub unsafe fn pread(
+    _fd: ::c_int,
+    _buf: *mut ::c_void,
+    _count: ::size_t,
+    _offset: off64_t,
+) -> ::ssize_t {
     -1
 }
 
-pub fn pwrite(
+pub unsafe fn pwrite(
     _fd: ::c_int,
     _buf: *const ::c_void,
     _count: ::size_t,
@@ -1879,7 +1884,12 @@ pub fn pwrite(
 ) -> ::ssize_t {
     -1
 }
-pub fn posix_memalign(memptr: *mut *mut ::c_void, align: ::size_t, size: ::size_t) -> ::c_int {
+
+pub unsafe fn posix_memalign(
+    memptr: *mut *mut ::c_void,
+    align: ::size_t,
+    size: ::size_t,
+) -> ::c_int {
     // check to see if align is a power of 2 and if align is a multiple
     //  of sizeof(void *)
     if (align & align - 1 != 0) || (align as usize % size_of::<::size_t>() != 0) {


### PR DESCRIPTION
`pread` and `pwrite` don't technically need to be `unsafe`, but it is consistent and more convenient for avoiding the `unused_unsafe` warning across targets.

`posix_memalign` must be `unsafe` since it writes to the ptr arg `memptr`.

This is a breaking change.