### PR TITLE
Backport #3537 to libc-0.2

### DIFF
--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -107,6 +107,64 @@ impl siginfo_t {
     }
 }
 
+// Internal, for casts to access union fields
+#[repr(C)]
+struct sifields_sigchld {
+    si_pid: ::pid_t,
+    si_uid: ::uid_t,
+    si_status: ::c_int,
+    si_utime: ::c_long,
+    si_stime: ::c_long,
+}
+impl ::Copy for sifields_sigchld {}
+impl ::Clone for sifields_sigchld {
+    fn clone(&self) -> sifields_sigchld {
+        *self
+    }
+}
+
+// Internal, for casts to access union fields
+#[repr(C)]
+union sifields {
+    _align_pointer: *mut ::c_void,
+    sigchld: sifields_sigchld,
+}
+
+// Internal, for casts to access union fields. Note that some variants
+// of sifields start with a pointer, which makes the alignment of
+// sifields vary on 32-bit and 64-bit architectures.
+#[repr(C)]
+struct siginfo_f {
+    _siginfo_base: [::c_int; 3],
+    sifields: sifields,
+}
+
+impl siginfo_t {
+    unsafe fn sifields(&self) -> &sifields {
+        &(*(self as *const siginfo_t as *const siginfo_f)).sifields
+    }
+
+    pub unsafe fn si_pid(&self) -> ::pid_t {
+        self.sifields().sigchld.si_pid
+    }
+
+    pub unsafe fn si_uid(&self) -> ::uid_t {
+        self.sifields().sigchld.si_uid
+    }
+
+    pub unsafe fn si_status(&self) -> ::c_int {
+        self.sifields().sigchld.si_status
+    }
+
+    pub unsafe fn si_utime(&self) -> ::c_long {
+        self.sifields().sigchld.si_utime
+    }
+
+    pub unsafe fn si_stime(&self) -> ::c_long {
+        self.sifields().sigchld.si_stime
+    }
+}
+
 pub const MCL_CURRENT: ::c_int = 0x0001;
 pub const MCL_FUTURE: ::c_int = 0x0002;
 pub const MCL_ONFAULT: ::c_int = 0x0004;


### PR DESCRIPTION
Backporting changes from #3537 to fix the following errors when building Rust `std` on Linux uClibc targets.

```
error[E0599]: no method named `si_pid` found for struct `siginfo_t` in the current scope
   --> /home/operutka/.rustup/toolchains/nightly-2024-06-05-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/pal/unix/process/process_unix.rs:870:33
    |
870 |             if unsafe { siginfo.si_pid() } == 0 {
    |                                 ^^^^^^ method not found in `siginfo_t`

error[E0599]: no method named `si_status` found for struct `siginfo_t` in the current scope
   --> /home/operutka/.rustup/toolchains/nightly-2024-06-05-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/pal/unix/process/process_unix.rs:908:39
    |
908 |         let status = unsafe { siginfo.si_status() };
    |                                       ^^^^^^^^^ method not found in `siginfo_t`
```