### PR TITLE
Add missing getauxval for Linux uClibc targets

### DIFF
--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -374,6 +374,7 @@ extern "C" {
     pub fn setrlimit(resource: ::__rlimit_resource_t, rlim: *const ::rlimit) -> ::c_int;
     pub fn getpriority(which: ::__priority_which_t, who: ::id_t) -> ::c_int;
     pub fn setpriority(which: ::__priority_which_t, who: ::id_t, prio: ::c_int) -> ::c_int;
+    pub fn getauxval(type_: ::c_ulong) -> ::c_ulong;
 }
 
 cfg_if! {


### PR DESCRIPTION
This should fix the following error when building Rust `std` on Linux uClibc targets.

```
error[E0425]: cannot find function `getauxval` in crate `libc`
   --> /home/operutka/.rustup/toolchains/nightly-2024-06-05-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/pal/unix/stack_overflow.rs:237:47
    |
237 |         let dynamic_sigstksz = unsafe { libc::getauxval(AT_MINSIGSTKSZ) };
    |                                               ^^^^^^^^^ not found in `libc`
```