### PR TITLE
[0.2] Backport #3654 "Correct types of mode bit constants on Fuchsia"

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -1334,9 +1334,9 @@ pub const GRPQUOTA: ::c_int = 1;
 
 pub const SIGIOT: ::c_int = 6;
 
-pub const S_ISUID: ::c_int = 0x800;
-pub const S_ISGID: ::c_int = 0x400;
-pub const S_ISVTX: ::c_int = 0x200;
+pub const S_ISUID: ::mode_t = 0x800;
+pub const S_ISGID: ::mode_t = 0x400;
+pub const S_ISVTX: ::mode_t = 0x200;
 
 pub const IF_NAMESIZE: ::size_t = 16;
 pub const IFNAMSIZ: ::size_t = IF_NAMESIZE;

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -1334,9 +1334,9 @@ pub const GRPQUOTA: ::c_int = 1;
 
 pub const SIGIOT: ::c_int = 6;
 
-pub const S_ISUID: ::mode_t = 0x800;
-pub const S_ISGID: ::mode_t = 0x400;
-pub const S_ISVTX: ::mode_t = 0x200;
+pub const S_ISUID: ::mode_t = 0o4000;
+pub const S_ISGID: ::mode_t = 0o2000;
+pub const S_ISVTX: ::mode_t = 0o1000;
 
 pub const IF_NAMESIZE: ::size_t = 16;
 pub const IFNAMSIZ: ::size_t = IF_NAMESIZE;


### PR DESCRIPTION
These commits were fixes to problems that predate the branch for 0.3, so they should be good candidates for a backport. See #3654 for more context.