### PR TITLE
fix: Remove macOS 11 usage on CI

### DIFF
--- a/.github/workflows/full_ci.yml
+++ b/.github/workflows/full_ci.yml
@@ -227,14 +227,6 @@ jobs:
           - { toolchain: stable, os: macos-13 }
           - { toolchain: beta, os: macos-13 }
           - { toolchain: nightly, os: macos-13 }
-          # Use macOS 11 for older toolchains as newer Xcode donesn't work well.
-          # FIXME: Disabled due to:
-          # error: failed to parse registry's information for: serde
-          #- { toolchain: 1.13.0, os: macos-11 }
-          - { toolchain: 1.19.0, os: macos-11 }
-          - { toolchain: 1.24.0, os: macos-11 }
-          - { toolchain: 1.25.0, os: macos-11 }
-          - { toolchain: 1.30.0, os: macos-11 }
     runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
...as CI now says:
> This is a scheduled macOS-11 brownout. The macOS-11 environment is deprecated and will be removed on June 28th, 2024.