### PR TITLE
hurd: Fix st_dev name

### DIFF
--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -476,7 +476,7 @@ s! {
 
     pub struct stat64 {
         pub st_fstype: ::c_int,
-        pub st_fsid: __fsid_t,
+        pub st_dev: __fsid_t, /* Actually st_fsid */
         pub st_ino: __ino64_t,
         pub st_gen: ::c_uint,
         pub st_rdev: __dev_t,


### PR DESCRIPTION
The real GNU name is st_fsid, but the more commonly known name is st_dev, so better use it to avoid having to fix various rust package.

This also aligns on the existing struct stat field name.