### PR TITLE
Adding constant SOMAXCONN to vxworks

### DIFF
--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -768,6 +768,7 @@ pub const S_IRWXO: ::c_int = 0o0007;
 
 // socket.h
 pub const SOL_SOCKET: ::c_int = 0xffff;
+pub const SOMAXCONN: ::c_int = 128;
 
 pub const SO_DEBUG: ::c_int = 0x0001;
 pub const SO_REUSEADDR: ::c_int = 0x0004;


### PR DESCRIPTION
Hi all, I'm just adding the SOMAXCONN variable that was missing in the VxWorks Rust libc. I've checked the libraries, and this is the correct value for the constant.