### PR TITLE
Add POSIX confstr API

### DIFF
--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -511,6 +511,9 @@ XSK_UNALIGNED_BUF_ADDR_MASK
 XDP_PKT_CONTD
 XENFS_SUPER_MAGIC
 XFS_SUPER_MAGIC
+_CS_GNU_LIBC_VERSION
+_CS_GNU_LIBPTHREAD_VERSION
+_CS_PATH
 _SC_2_C_VERSION
 _SC_BASE
 _SC_CHARCLASS_NAME_MAX
@@ -611,6 +614,7 @@ aio_write
 aiocb
 backtrace
 clock_adjtime
+confstr
 copy_file_range
 ctermid
 dlinfo

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -826,6 +826,9 @@ pub const TMP_MAX: ::c_uint = 238328;
 pub const FOPEN_MAX: ::c_uint = 16;
 pub const FILENAME_MAX: ::c_uint = 4096;
 pub const POSIX_MADV_DONTNEED: ::c_int = 4;
+pub const _CS_GNU_LIBC_VERSION: ::c_int = 2;
+pub const _CS_GNU_LIBPTHREAD_VERSION: ::c_int = 3;
+pub const _CS_PATH: ::c_int = 0;
 pub const _SC_EQUIV_CLASS_MAX: ::c_int = 41;
 pub const _SC_CHARCLASS_NAME_MAX: ::c_int = 45;
 pub const _SC_PII: ::c_int = 53;
@@ -1485,6 +1488,7 @@ extern "C" {
     ) -> ::size_t;
     pub fn strptime(s: *const ::c_char, format: *const ::c_char, tm: *mut ::tm) -> *mut ::c_char;
 
+    pub fn confstr(name: ::c_int, buf: *mut ::c_char, len: ::size_t) -> ::size_t;
     pub fn dirname(path: *mut ::c_char) -> *mut ::c_char;
     /// POSIX version of `basename(3)`, defined in `libgen.h`.
     #[link_name = "__xpg_basename"]


### PR DESCRIPTION
Fixes #3767 

Some notes for reviewers:
* This PR was successfully tested with my Rust `getconf` util implementation at https://github.com/rustcoreutils/posixutils-rs
* It would be ideal, and seemingly appropriate, to add the `confstr(3)` API `unix`, because it is POSIX standard, just like `sysconf(3)`, and originates from libc, just like `sysconf(3)`.  This failed to due a single platform, arm-android.
* Therefore, an ideal future patch would populate other unix platforms with `confstr`.

This patch chooses the more limited path of focusing on linux-gnu, given that the symbols (not the function!) are glibc-specific.