### PR TITLE
add `pthread_equal`

### DIFF
--- a/libc-test/semver/unix.txt
+++ b/libc-test/semver/unix.txt
@@ -687,6 +687,7 @@ pthread_condattr_init
 pthread_condattr_t
 pthread_create
 pthread_detach
+pthread_equal
 pthread_exit
 pthread_getspecific
 pthread_join

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1030,6 +1030,7 @@ extern "C" {
     pub fn times(buf: *mut ::tms) -> ::clock_t;
 
     pub fn pthread_self() -> ::pthread_t;
+    pub fn pthread_equal(t1: ::pthread_t, t2: ::pthread_t) -> ::c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "pthread_join$UNIX2003"


### PR DESCRIPTION
From its [documentation](https://man7.org/linux/man-pages/man3/pthread_equal.3.html):
> The `pthread_equal()` function is necessary because thread IDs should be considered opaque: there is no portable way for applications to directly compare two `pthread_t` values.