### PR TITLE
Disable `libregex` for QNX 7.0

### DIFF
--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -2865,9 +2865,9 @@ safe_f! {
 
 // Network related functions are provided by libsocket and regex
 // functions are provided by libregex.
+// Note that in QNX <=7.0, libregex functions were included it in libc itself.
 #[link(name = "socket")]
-#[link(name = "regex")]
-
+#[cfg_attr(not(target_env = "nto70"), link(name = "regex"))]
 extern "C" {
     pub fn sem_destroy(sem: *mut sem_t) -> ::c_int;
     pub fn sem_init(sem: *mut sem_t, pshared: ::c_int, value: ::c_uint) -> ::c_int;

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -2865,7 +2865,7 @@ safe_f! {
 
 // Network related functions are provided by libsocket and regex
 // functions are provided by libregex.
-// Note that in QNX <=7.0, libregex functions were included it in libc itself.
+// In QNX <=7.0, libregex functions were included in libc itself.
 #[link(name = "socket")]
 #[cfg_attr(not(target_env = "nto70"), link(name = "regex"))]
 extern "C" {


### PR DESCRIPTION
`libregex` did not exist until QNX 7.1. Before that, the regex functions were part of the libc. At the moment, this is a NOOP because `nto70` only supports `no_std`. I am working on backporting `std` support to 7.0, and hit this bug.  See https://github.com/rust-lang/rust/pull/127897

In order to pass CI, this PR is based on #3776 - so it should build and merge cleanly once 3776 is merged.