### PR TITLE
Fix CI by ignoring `rmx_state` on Apple platforms

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -408,6 +408,9 @@ fn test_apple(target: &str) {
             ("ifreq", "ifr_ifru") => true,
             ("ifkpi", "ifk_data") => true,
             ("ifconf", "ifc_ifcu") => true,
+            // FIXME: this field has been incorporated into a resized `rmx_filler` array.
+            ("rt_metrics", "rmx_state") => true,
+            ("rt_metrics", "rmx_filler") => true,
             _ => false,
         }
     });

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -509,6 +509,8 @@ s! {
         pub rmx_rtt: u32,
         pub rmx_rttvar: u32,
         pub rmx_pksent: u32,
+        /// This field does not exist anymore, the u32 is now part of a resized
+        /// `rmx_filler` array.
         pub rmx_state: u32,
         pub rmx_filler: [u32; 3],
     }

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -366,7 +366,7 @@ pub const _SC_PAGE_SIZE: ::c_int = _SC_PAGESIZE;
 pub const _SC_IOV_MAX: c_int = 60;
 pub const _SC_SYMLOOP_MAX: c_int = 173;
 
-#[allow(unused_unsafe)] // `addr_of!(EXTERN_STATIC)` is now considered safe
+#[allow(unused_unsafe)] // `addr_of!(EXTERN_STATIC)` is now safe; remove `unsafe` when MSRV >= 1.82
 pub static CLOCK_MONOTONIC: clockid_t = unsafe { clockid_t(ptr_addr_of!(_CLOCK_MONOTONIC)) };
 #[allow(unused_unsafe)]
 pub static CLOCK_PROCESS_CPUTIME_ID: clockid_t =

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -366,10 +366,14 @@ pub const _SC_PAGE_SIZE: ::c_int = _SC_PAGESIZE;
 pub const _SC_IOV_MAX: c_int = 60;
 pub const _SC_SYMLOOP_MAX: c_int = 173;
 
+#[allow(unused_unsafe)] // `addr_of!(EXTERN_STATIC)` is now considered safe
 pub static CLOCK_MONOTONIC: clockid_t = unsafe { clockid_t(ptr_addr_of!(_CLOCK_MONOTONIC)) };
+#[allow(unused_unsafe)]
 pub static CLOCK_PROCESS_CPUTIME_ID: clockid_t =
     unsafe { clockid_t(ptr_addr_of!(_CLOCK_PROCESS_CPUTIME_ID)) };
+#[allow(unused_unsafe)]
 pub static CLOCK_REALTIME: clockid_t = unsafe { clockid_t(ptr_addr_of!(_CLOCK_REALTIME)) };
+#[allow(unused_unsafe)]
 pub static CLOCK_THREAD_CPUTIME_ID: clockid_t =
     unsafe { clockid_t(ptr_addr_of!(_CLOCK_THREAD_CPUTIME_ID)) };
 


### PR DESCRIPTION
`rmx_state` has been removed in https://github.com/apple-oss-distributions/xnu/commit/94d3b452840153a99b38a3a9659680b2a006908e (macOS version 14.4) in favour of an expanded `rmx_filler` field. Just ignore it in CI.