### PR TITLE
hurd: Fix st_dev name

### DIFF
--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -481,7 +481,7 @@ s! {
 
     pub struct stat64 {
         pub st_fstype: ::c_int,
-        pub st_fsid: __fsid_t,
+        pub st_dev: __fsid_t, /* Actually st_fsid */
         pub st_ino: __ino64_t,
         pub st_gen: ::c_uint,
         pub st_rdev: __dev_t,


### PR DESCRIPTION
Currently struct stat and struct stat64 are not coherent: struct stat is using st_dev, and struct stat64 is using st_fsid.

st_dev is the more commonly-known name, already used by e.g. ~45 rust software in Debian, so better fix st_fsid into st_dev, rather than having to uselessly spend time hand-patching all these software.