### PR TITLE
hurd: Add missing struct __timeval for 64bit support

### DIFF
--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -449,6 +449,11 @@ s! {
         pub tv_nsec: __syscall_slong_t,
     }
 
+    pub struct __timeval {
+        pub tv_sec: i32,
+        pub tv_usec: i32,
+    }
+
     pub struct __locale_data {
         pub _address: u8,
     }


### PR DESCRIPTION
This is the same as linux_like/linux/gnu's __timeval for ut_tv for 64bit architectures.