### PR TITLE
[illumos] add pthread stack functions

### DIFF
--- a/libc-test/semver/illumos.txt
+++ b/libc-test/semver/illumos.txt
@@ -1,0 +1,3 @@
+pthread_attr_get_np
+pthread_attr_getstackaddr
+pthread_attr_setstack

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -81,6 +81,21 @@ extern "C" {
     ) -> ::c_int;
     pub fn pset_getloadavg(pset: ::psetid_t, load: *mut ::c_double, num: ::c_int) -> ::c_int;
 
+    pub fn pthread_attr_get_np(thread: ::pthread_t, attr: *mut ::pthread_attr_t) -> ::c_int;
+    pub fn pthread_attr_getstackaddr(
+        attr: *const ::pthread_attr_t,
+        stackaddr: *mut *mut ::c_void,
+    ) -> ::c_int;
+    pub fn pthread_attr_setstack(
+        attr: *mut ::pthread_attr_t,
+        stackaddr: *mut ::c_void,
+        stacksize: ::size_t,
+    ) -> ::c_int;
+    pub fn pthread_attr_setstackaddr(
+        attr: *mut ::pthread_attr_t,
+        stackaddr: *mut ::c_void,
+    ) -> ::c_int;
+
     pub fn preadv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t) -> ::ssize_t;
     pub fn pwritev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t)
         -> ::ssize_t;


### PR DESCRIPTION
The goal of this change is to make the following improvements possible:

* https://github.com/rust-lang/stacker/pull/88
* https://github.com/rust-lang/rust/issues/128568

Add some pthread stack functions:

* [`pthread_attr_get_np`](https://illumos.org/man/3C/pthread_attr_get_np)
* [`pthread_attr_getstackaddr`](https://illumos.org/man/3C/pthread_attr_getstackaddr)
* [`pthread_attr_setstack`](https://illumos.org/man/3C/pthread_attr_setstack)
* [`pthread_attr_setstackaddr`](https://illumos.org/man/3C/pthread_attr_setstackaddr)

I've verified that these functions exist and do the right thing.

Note that there doesn't appear to be a file like `linux.txt` for illumos specifically.

Another note: `cd libc-test && cargo test` currently fails on illumos with:

```
     Running test/main.rs (/home/rain/dev/libc/target/debug/deps/main-6329db179eb2b631)
RUNNING ALL TESTS
bad PTHREAD_MUTEX_DEFAULT value at byte 0: rust: 0 (0x0) != c 8 (0x8)
thread 'main' panicked at /home/rain/dev/libc/target/debug/build/libc-test-cefbf7853a50b4e4/out/main.rs:12:21:
some tests failed
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: test failed, to rerun pass `--test main`
```

But it also fails on main with the same error, so this isn't a regression.