### PR TITLE
Modify QNX NTO `dl_iterate_phdr` to toke `* mut`

### DIFF
--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -3340,7 +3340,10 @@ extern "C" {
     pub fn dl_iterate_phdr(
         callback: ::Option<
             unsafe extern "C" fn(
-                info: *const dl_phdr_info,
+                // The original .h file declares this as *const, but for consistency with other platforms,
+                // changing this to *mut to make it easier to use.
+                // Maybe in v0.3 all platforms should use this as a *const.
+                info: *mut dl_phdr_info,
                 size: ::size_t,
                 data: *mut ::c_void,
             ) -> ::c_int,


### PR DESCRIPTION
All other platforms use `* mut`, and while this is technically a breaking change, most likely noone is using it directly.

See also https://github.com/rust-lang/backtrace-rs/pull/648

r? @joshtriplett 