### PR TITLE
freebsd moving the kinfo_file type to general use.

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2311,6 +2311,12 @@ fn test_freebsd(target: &str) {
             // should've been used anywhere anyway.
             "TDF_UNUSED23" => true,
 
+            // Removed in FreeBSD 15
+            "TDF_CANSWAP" | "TDF_SWAPINREQ" => true,
+
+            // Unaccessible in FreeBSD 15
+            "TDI_SWAPPED" | "P_SWAPPINGOUT" | "P_SWAPPINGIN" => true,
+
             // Removed in FreeBSD 14 (git a6b55ee6be1)
             "IFF_KNOWSEPOCH" => true,
 

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1637,6 +1637,23 @@ s_no_extra_traits! {
         pub cause: sctp_error_cause,
         pub hmac_id: u16,
     }
+
+    pub struct kinfo_file {
+        pub kf_structsize: ::c_int,
+        pub kf_type: ::c_int,
+        pub kf_fd: ::c_int,
+        pub kf_ref_count: ::c_int,
+        pub kf_flags: ::c_int,
+        _kf_pad0: ::c_int,
+        pub kf_offset: i64,
+        _priv: [::uintptr_t; 38], // FIXME if needed
+        pub kf_status: u16,
+        _kf_pad1: u16,
+        _kf_ispare0: ::c_int,
+        pub kf_cap_rights: ::cap_rights_t,
+        _kf_cap_spare: u64,
+        pub kf_path: [::c_char; ::PATH_MAX as usize],
+    }
 }
 
 cfg_if! {
@@ -2591,6 +2608,52 @@ cfg_if! {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 {self.cause}.hash(state);
                 {self.hmac_id}.hash(state);
+            }
+        }
+
+        impl PartialEq for kinfo_file {
+            fn eq(&self, other: &kinfo_file) -> bool {
+                self.kf_structsize == other.kf_structsize &&
+                    self.kf_type == other.kf_type &&
+                    self.kf_fd == other.kf_fd &&
+                    self.kf_ref_count == other.kf_ref_count &&
+                    self.kf_flags == other.kf_flags &&
+                    self.kf_offset == other.kf_offset &&
+                    self.kf_status == other.kf_status &&
+                    self.kf_cap_rights == other.kf_cap_rights &&
+                    self.kf_path
+                        .iter()
+                        .zip(other.kf_path.iter())
+                        .all(|(a,b)| a == b)
+            }
+        }
+        impl Eq for kinfo_file {}
+        impl ::fmt::Debug for kinfo_file {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("kinfo_file")
+                    .field("kf_structsize", &self.kf_structsize)
+                    .field("kf_type", &self.kf_type)
+                    .field("kf_fd", &self.kf_fd)
+                    .field("kf_ref_count", &self.kf_ref_count)
+                    .field("kf_flags", &self.kf_flags)
+                    .field("kf_offset", &self.kf_offset)
+                    .field("kf_status", &self.kf_status)
+                    .field("kf_cap_rights", &self.kf_cap_rights)
+                    .field("kf_path", &&self.kf_path[..])
+                    .finish()
+            }
+        }
+        impl ::hash::Hash for kinfo_file {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                self.kf_structsize.hash(state);
+                self.kf_type.hash(state);
+                self.kf_fd.hash(state);
+                self.kf_ref_count.hash(state);
+                self.kf_flags.hash(state);
+                self.kf_offset.hash(state);
+                self.kf_status.hash(state);
+                self.kf_cap_rights.hash(state);
+                self.kf_path.hash(state);
             }
         }
     }

--- a/src/unix/bsd/freebsdlike/freebsd/x86.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86.rs
@@ -199,3 +199,5 @@ cfg_if! {
 }
 
 pub const MINSIGSTKSZ: ::size_t = 2048; // 512 * 4
+
+pub const KINFO_FILE_SIZE: ::c_int = 1392;

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -93,23 +93,6 @@ s_no_extra_traits! {
         #[cfg(libc_union)]
         pub a_un: __c_anonymous_elf64_auxv_union,
     }
-
-    pub struct kinfo_file {
-        pub kf_structsize: ::c_int,
-        pub kf_type: ::c_int,
-        pub kf_fd: ::c_int,
-        pub kf_ref_count: ::c_int,
-        pub kf_flags: ::c_int,
-        _kf_pad0: ::c_int,
-        pub kf_offset: i64,
-        _priv: [::uintptr_t; 38], // FIXME if needed
-        pub kf_status: u16,
-        _kf_pad1: u16,
-        _kf_ispare0: ::c_int,
-        pub kf_cap_rights: ::cap_rights_t,
-        _kf_cap_spare: u64,
-        pub kf_path: [::c_char; ::PATH_MAX as usize],
-    }
 }
 
 cfg_if! {
@@ -253,52 +236,6 @@ cfg_if! {
                     .finish()
             }
         }
-
-        impl PartialEq for kinfo_file {
-            fn eq(&self, other: &kinfo_file) -> bool {
-                self.kf_structsize == other.kf_structsize &&
-                    self.kf_type == other.kf_type &&
-                    self.kf_fd == other.kf_fd &&
-                    self.kf_ref_count == other.kf_ref_count &&
-                    self.kf_flags == other.kf_flags &&
-                    self.kf_offset == other.kf_offset &&
-                    self.kf_status == other.kf_status &&
-                    self.kf_cap_rights == other.kf_cap_rights &&
-                    self.kf_path
-                        .iter()
-                        .zip(other.kf_path.iter())
-                        .all(|(a,b)| a == b)
-            }
-        }
-        impl Eq for kinfo_file {}
-        impl ::fmt::Debug for kinfo_file {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                f.debug_struct("kinfo_file")
-                    .field("kf_structsize", &self.kf_structsize)
-                    .field("kf_type", &self.kf_type)
-                    .field("kf_fd", &self.kf_fd)
-                    .field("kf_ref_count", &self.kf_ref_count)
-                    .field("kf_flags", &self.kf_flags)
-                    .field("kf_offset", &self.kf_offset)
-                    .field("kf_status", &self.kf_status)
-                    .field("kf_cap_rights", &self.kf_cap_rights)
-                    .field("kf_path", &&self.kf_path[..])
-                    .finish()
-            }
-        }
-        impl ::hash::Hash for kinfo_file {
-            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                self.kf_structsize.hash(state);
-                self.kf_type.hash(state);
-                self.kf_fd.hash(state);
-                self.kf_ref_count.hash(state);
-                self.kf_flags.hash(state);
-                self.kf_offset.hash(state);
-                self.kf_status.hash(state);
-                self.kf_cap_rights.hash(state);
-                self.kf_path.hash(state);
-            }
-        }
     }
 }
 
@@ -325,6 +262,8 @@ pub const _MC_FPFMT_XMM: c_long = 0x10002;
 pub const _MC_FPOWNED_NONE: c_long = 0x20000;
 pub const _MC_FPOWNED_FPU: c_long = 0x20001;
 pub const _MC_FPOWNED_PCB: c_long = 0x20002;
+
+pub const KINFO_FILE_SIZE: ::c_int = 1392;
 
 cfg_if! {
     if #[cfg(libc_align)] {


### PR DESCRIPTION
but keeping the constant KINFO_FILE_SIZE for intel archs only.