### PR TITLE
Update documentation with the 0.2/1.0 workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,6 @@ Here's a checklist for things that will be checked during review or continuous i
 - \[ ] If your PR increments version number, it must NOT contain any other changes (otherwise a release could be delayed)
 - \[ ] Make sure `ci/style.sh` passes
 - \[ ] `cd libc-test && cargo test`
-  - (this might fail on your env due to environment difference between your env and CI. Ignore failures if you are not sure)
+  - (this might fail on your env due to environment difference between your env and CI. Ignore local failures if you are not sure)
 
 Delete this line and everything above before opening your PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,41 @@
 Welcome! If you are reading this document, it means you are interested in contributing
 to the `libc` crate.
 
-## v0.2 changes
+## v1.0 Roadmap
 
-If you want to add your changes to v0.2, please submit them to the `libc-0.2` branch.
-If you want to add any breaking changes, it should be submitted to the main branch,
-which has changes for v0.3.
-We will support and make a new release for v0.2 until we make the first release of v0.3.
+`libc` has two active branches: `main` and `libc-0.2`. `main` is for active
+development of the upcoming v1.0 release, and should be the target of all pull
+requests. `libc-0.2` is for updates to the currently released version.
+
+If a pull request to `main` is a good candidate for inclusion in an `0.2.x`
+release, include `@rustbot label stable-nominated` in a comment to propose this.
+Good candidates will usually meet the following:
+
+1. The included changes are non-breaking.
+2. The change applies cleanly to both branches.
+3. There is a usecase that justifies inclusion in a stable release (all
+   additions should always have a usecase, hopefully).
+
+Once a `stable-nominated` PR targeting `main` has merged, it can be cherry
+picked to the `libc-0.2` branch. A maintainer will likely do these cherry
+picks in a batch.
+
+Alternatively, you can start this process yourself by creating a new branch
+based on `libc-0.2` and running `git cherry-pick -xe commit-sha-on-main` (`git
+cherry-pick -xe start-sha^..end-sha` if a range of commits is needed). `git`
+will automatically add the "cherry picked from commit" note, but try to add a
+backport note so the original PR gets crosslinked:
+
+```
+# ... original commit message ...
+
+(backport <https://github.com/rust-lang/libc/pull/1234>)             # add manually
+(cherry picked from commit 104b6a4ae31c726814c36318dc718470cc96e167) # added by git
+```
+
+Once the cherry-pick is complete, open a PR targeting `libc-0.2`.
+
+See the [tracking issue](https://github.com/rust-lang/libc/issues/3248) for details.
 
 ## Adding an API
 
@@ -51,7 +80,7 @@ With that in mind, the steps for adding a new API are:
 5. Wait for a merge!
 
 <sup>1</sup>: Note that this list has nothing to do with any Unix or Posix
-standard, it's just a list shared between all OSs that declare `#[cfg(unix)]`.
+standard, it's just a list shared among all OSs that declare `#[cfg(unix)]`.
 
 ## Test before you commit
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,17 @@ More detailed information about the design of this library can be found in its
 
 [rfc]: https://github.com/rust-lang/rfcs/blob/HEAD/text/1291-promote-libc.md
 
-## v0.3 Roadmap
+## v1.0 Roadmap
 
-The main branch is now for v0.3 which has some breaking changes.
+Currently, `libc` has two active branches: `main` for the upcoming v1.0 release,
+and `libc-0.2` for the currently published version. By default all pull requests
+should target `main`; once reviewed, they can be cherry picked to the `libc-0.2`
+branch if needed.
 
-For v0.2, please submit PRs to the `libc-0.2` branch instead.
-We will stop making new v0.2 releases once we release v0.3 on crates.io.
+We will stop making new v0.2 releases once v1.0 is released.
 
-See the [tracking issue](https://github.com/rust-lang/libc/issues/3248) for details.
+See the section in [CONTRIBUTING.md](CONTRIBUTING.md#v10-roadmap) for more
+details.
 
 ## Usage
 


### PR DESCRIPTION
Clarify that PRs should be to `main` then cherry picked to 0.2 after review, in order to keep things from getting too out of sync or needing to conduct the same review in multiple places.