### PR TITLE
[0.2] haiku: add B_APP_IMAGE_SYMBOL definition

### DIFF
--- a/src/unix/haiku/native.rs
+++ b/src/unix/haiku/native.rs
@@ -956,6 +956,7 @@ pub const B_XATTR_TYPE: u32 = haiku_constant!('X', 'A', 'T', 'R');
 pub const B_NETWORK_ADDRESS_TYPE: u32 = haiku_constant!('N', 'W', 'A', 'D');
 pub const B_MIME_STRING_TYPE: u32 = haiku_constant!('M', 'I', 'M', 'S');
 pub const B_ASCII_TYPE: u32 = haiku_constant!('T', 'E', 'X', 'T');
+pub const B_APP_IMAGE_SYMBOL: *const ::c_void = core::ptr::null();
 
 extern "C" {
     // kernel/OS.h


### PR DESCRIPTION
(backport <https://github.com/rust-lang/libc/pull/3743>)
(cherry picked from commit https://github.com/rust-lang/libc/commit/dacde013c44c235a6a16282c7ed82427f1f7ddd3)