### PR TITLE
[0.2] Add clone_args for riscv64 linux gnu/musl

### DIFF
--- a/src/unix/linux_like/linux/gnu/b64/riscv64/align.rs
+++ b/src/unix/linux_like/linux/gnu/b64/riscv64/align.rs
@@ -42,3 +42,20 @@ s_no_extra_traits! {
         pub __glibc_reserved: [::c_uint; 3],
     }
 }
+
+s! {
+    #[repr(align(8))]
+    pub struct clone_args {
+        pub flags: ::c_ulonglong,
+        pub pidfd: ::c_ulonglong,
+        pub child_tid: ::c_ulonglong,
+        pub parent_tid: ::c_ulonglong,
+        pub exit_signal: ::c_ulonglong,
+        pub stack: ::c_ulonglong,
+        pub stack_size: ::c_ulonglong,
+        pub tls: ::c_ulonglong,
+        pub set_tid: ::c_ulonglong,
+        pub set_tid_size: ::c_ulonglong,
+        pub cgroup: ::c_ulonglong,
+    }
+}

--- a/src/unix/linux_like/linux/musl/b64/riscv64/align.rs
+++ b/src/unix/linux_like/linux/musl/b64/riscv64/align.rs
@@ -42,3 +42,20 @@ s_no_extra_traits! {
         pub __glibc_reserved: [::c_uint; 3],
     }
 }
+
+s! {
+    #[repr(align(8))]
+    pub struct clone_args {
+        pub flags: ::c_ulonglong,
+        pub pidfd: ::c_ulonglong,
+        pub child_tid: ::c_ulonglong,
+        pub parent_tid: ::c_ulonglong,
+        pub exit_signal: ::c_ulonglong,
+        pub stack: ::c_ulonglong,
+        pub stack_size: ::c_ulonglong,
+        pub tls: ::c_ulonglong,
+        pub set_tid: ::c_ulonglong,
+        pub set_tid_size: ::c_ulonglong,
+        pub cgroup: ::c_ulonglong,
+    }
+}


### PR DESCRIPTION
(backport <https://github.com/rust-lang/libc/pull/3757>)
(cherry picked from commit 9fda1f68219ed0d740ea38f967d50efef063219f)