### PR TITLE
Add QNX NTO platform support

### DIFF
--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -469,13 +469,14 @@ s! {
         // to false. So I'm just removing these, and if uClibc changes
         // the #if block in the future to include the following fields, these
         // will probably need including here. tsidea, skrap
-        #[cfg(not(target_env = "uclibc"))]
+        // QNX (NTO) platform does not define these fields
+        #[cfg(not(any(target_env = "uclibc", target_os = "nto")))]
         pub dlpi_adds: ::c_ulonglong,
-        #[cfg(not(target_env = "uclibc"))]
+        #[cfg(not(any(target_env = "uclibc", target_os = "nto")))]
         pub dlpi_subs: ::c_ulonglong,
-        #[cfg(not(target_env = "uclibc"))]
+        #[cfg(not(any(target_env = "uclibc", target_os = "nto")))]
         pub dlpi_tls_modid: ::size_t,
-        #[cfg(not(target_env = "uclibc"))]
+        #[cfg(not(any(target_env = "uclibc", target_os = "nto")))]
         pub dlpi_tls_data: *mut ::c_void,
     }
 

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -3339,7 +3339,10 @@ extern "C" {
     pub fn dl_iterate_phdr(
         callback: ::Option<
             unsafe extern "C" fn(
-                info: *const dl_phdr_info,
+                // The original .h file declares this as *const, but for consistency with other platforms,
+                // changing this to *mut to make it easier to use.
+                // Maybe in v0.3 all platforms should use this as a *const.
+                info: *mut dl_phdr_info,
                 size: ::size_t,
                 data: *mut ::c_void,
             ) -> ::c_int,


### PR DESCRIPTION
This PR contains changes from #3790 and #3792 applied to the main branch per @tgross35 request

NTO does not define last four fields of the `dl_phdr_info`, so might as well exclude them for cleanliness.

v7.0: [link](https://www.qnx.com/developers/docs/7.0.0/index.html#com.qnx.doc.neutrino.lib_ref/topic/d/dl_iterate_phdr.html)
v7.1: [link](https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.lib_ref/topic/d/dl_iterate_phdr.html)
v8.0: [link](https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.lib_ref/topic/d/dl_iterate_phdr.html?hl=dl_phdr_info)