### PR TITLE
Add `release-plz` for the 0.2 branch

### DIFF
--- a/.github/workflows/publish_0.2.yml
+++ b/.github/workflows/publish_0.2.yml
@@ -1,0 +1,30 @@
+# release-plz for the stable 0.2 branch
+
+name: Release-plz v0.2
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - libc-0.2
+
+jobs:
+  release-plz:
+    name: Release-plz v0.2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust (rustup)
+        run: rustup update stable --no-self-update && rustup default stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,0 +1,2 @@
+[workspace]
+git_tag_name = "v{{ version }}"

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
+publish = false
 repository = "https://github.com/rust-lang/libc"
 homepage = "https://github.com/rust-lang/libc"
 description = """


### PR DESCRIPTION
This only enables the release PRs. We can enable publish once we verify that the results look correct.