### PR TITLE
[0.2] Apple: add `_NSGetArgv`, `_NSGetArgc` and `_NSGetProgname`

### DIFF
--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -1695,8 +1695,11 @@ _CS_PATH
 _IOFBF
 _IOLBF
 _IONBF
+_NSGetArgc
+_NSGetArgv
 _NSGetEnviron
 _NSGetExecutablePath
+_NSGetProgname
 _POSIX_VDISABLE
 _PTHREAD_COND_SIG_init
 _PTHREAD_MUTEX_SIG_init

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -6377,7 +6377,12 @@ extern "C" {
     pub fn getentropy(buf: *mut ::c_void, buflen: ::size_t) -> ::c_int;
 
     pub fn _NSGetExecutablePath(buf: *mut ::c_char, bufsize: *mut u32) -> ::c_int;
+
+    // crt_externs.h
+    pub fn _NSGetArgv() -> *mut *mut *mut ::c_char;
+    pub fn _NSGetArgc() -> *mut ::c_int;
     pub fn _NSGetEnviron() -> *mut *mut *mut ::c_char;
+    pub fn _NSGetProgname() -> *mut *mut ::c_char;
 
     pub fn mach_vm_map(
         target_task: ::vm_map_t,


### PR DESCRIPTION
Available in the headers on all Apple platforms.

(backport <https://github.com/rust-lang/libc/pull/3702>)
(cherry picked from commit 4333c2f1de640379ec5ecbbc79219bef799b5bd0)