### PR TITLE
Revert "openbsd/netbsd factorise getnameinfo."

### DIFF
--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -705,17 +705,6 @@ extern "C" {
         dev: dev_t,
     ) -> ::c_int;
     pub fn mkfifoat(dirfd: ::c_int, pathname: *const ::c_char, mode: ::mode_t) -> ::c_int;
-
-    pub fn getnameinfo(
-        sa: *const ::sockaddr,
-        salen: ::socklen_t,
-        host: *mut ::c_char,
-        hostlen: ::socklen_t,
-        serv: *mut ::c_char,
-        servlen: ::socklen_t,
-        flags: ::c_int,
-    ) -> ::c_int;
-
     pub fn sem_timedwait(sem: *mut sem_t, abstime: *const ::timespec) -> ::c_int;
     pub fn sem_getvalue(sem: *mut sem_t, sval: *mut ::c_int) -> ::c_int;
     pub fn pthread_condattr_setclock(

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2626,6 +2626,15 @@ extern "C" {
     pub fn lutimes(file: *const ::c_char, times: *const ::timeval) -> ::c_int;
     #[link_name = "__gettimeofday50"]
     pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::c_void) -> ::c_int;
+    pub fn getnameinfo(
+        sa: *const ::sockaddr,
+        salen: ::socklen_t,
+        host: *mut ::c_char,
+        hostlen: ::socklen_t,
+        serv: *mut ::c_char,
+        servlen: ::socklen_t,
+        flags: ::c_int,
+    ) -> ::c_int;
     pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
     pub fn sysctl(
         name: *const ::c_int,

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1983,6 +1983,15 @@ extern "C" {
         atflag: ::c_int,
     ) -> ::c_int;
     pub fn dirfd(dirp: *mut ::DIR) -> ::c_int;
+    pub fn getnameinfo(
+        sa: *const ::sockaddr,
+        salen: ::socklen_t,
+        host: *mut ::c_char,
+        hostlen: ::size_t,
+        serv: *mut ::c_char,
+        servlen: ::size_t,
+        flags: ::c_int,
+    ) -> ::c_int;
     pub fn getresgid(rgid: *mut ::gid_t, egid: *mut ::gid_t, sgid: *mut ::gid_t) -> ::c_int;
     pub fn getresuid(ruid: *mut ::uid_t, euid: *mut ::uid_t, suid: *mut ::uid_t) -> ::c_int;
     pub fn kevent(


### PR DESCRIPTION
This reverts commit 5df9fa0db73fea938c3837c811a9ab4d27aadd96.

The change broke builds for OpenBSD. See discussion at <https://github.com/rust-lang/libc/pull/3822#issuecomment-2292907397>.