### PR TITLE
[0.2] Add RUSTC_WRAPPER support to build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -196,8 +196,17 @@ fn rustc_minor_nightly() -> (u32, bool) {
         };
     }
 
-    let rustc = otry!(env::var_os("RUSTC"));
-    let output = Command::new(rustc)
+    let rustc = env::var_os("RUSTC").expect("Failed to get rustc version: missing RUSTC env");
+    let mut cmd = match env::var_os("RUSTC_WRAPPER").as_ref() {
+        Some(wrapper) if !wrapper.is_empty() => {
+            let mut cmd = Command::new(wrapper);
+            cmd.arg(rustc);
+            cmd
+        }
+        _ => Command::new(rustc),
+    };
+
+    let output = cmd
         .arg("--version")
         .output()
         .ok()


### PR DESCRIPTION
(backport <https://github.com/rust-lang/libc/pull/3842>)
(cherry picked from commit 8dba4a03d23ff979eba11afac4ff0b605267cddb)