### PR TITLE
WASI: fix missing `Iterator` with `rustc-dep-of-std`

### DIFF
--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -2,6 +2,7 @@
 // `wasi-libc` project provides multiple libraries including emulated features, but we list only basic features with `libc.a` here.
 
 use super::{Send, Sync};
+use core::iter::Iterator;
 
 pub use ffi::c_void;
 


### PR DESCRIPTION
https://github.com/rust-lang/libc/pull/3681#issuecomment-2295428691

@tgross35 How can I correctly run local test of this build? I tried `cargo build --target wasm32-wasip1 --features rustc-dep-of-std --no-default-features` but it causes multiple patch-unrelated errors

```
❯ cargo build --target wasm32-wasip1 --features rustc-dep-of-std --no-default-features
error[E0432]: unresolved import `core::clone`
  --> src/lib.rs:46:11
   |
46 | use core::clone::Clone;
   |           ^^^^^ could not find `clone` in `core`

error[E0432]: unresolved import `core::ffi`
  --> src/lib.rs:48:5
   |
48 | use core::ffi;
   |     ^^^^^^^^^ no `ffi` in the root
```