### PR TITLE
WASI: fix missing `Iterator` with `rustc-dep-of-std`

### DIFF
--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -1,4 +1,5 @@
 use super::{Send, Sync};
+use core::iter::Iterator;
 
 pub use ffi::c_void;
 


### PR DESCRIPTION
(backport <https://github.com/rust-lang/libc/pull/3854>)
(cherry picked from commit df33cf9f41d3092e39947e010440101c813439f7)