### PR TITLE
VxWorks: Add some functions from `vxCpuLib.h` and `taskLib.h`

### DIFF
--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -1813,6 +1813,10 @@ extern "C" {
     pub fn taskIdSelf() -> ::TASK_ID;
     pub fn taskDelay(ticks: ::_Vx_ticks_t) -> ::c_int;
 
+    // taskLib.h
+    pub fn taskNameSet(task_id: ::TASK_ID, task_name: *mut ::c_char) -> ::c_int;
+    pub fn taskNameGet(task_id: ::TASK_ID, buf_name: *mut ::c_char, bufsize: ::size_t) -> ::c_int;
+
     // rtpLibCommon.h
     pub fn rtpInfoGet(rtpId: ::RTP_ID, rtpStruct: *mut ::RTP_DESC) -> ::c_int;
     pub fn rtpSpawn(
@@ -1872,6 +1876,10 @@ extern "C" {
     ) -> ::c_int;
     pub fn mq_getattr(mqd: ::mqd_t, attr: *mut ::mq_attr) -> ::c_int;
     pub fn mq_setattr(mqd: ::mqd_t, newattr: *const ::mq_attr, oldattr: *mut ::mq_attr) -> ::c_int;
+
+    // vxCpuLib.h
+    fn vxCpuEnabledGet() -> ::cpuset_t; // Get set of running CPU's in the system
+    fn vxCpuConfiguredGet() -> ::cpuset_t; // Get set of Configured CPU's in the system
 }
 
 //Dummy functions, these don't really exist in VxWorks.


### PR DESCRIPTION
Add functions
1. `vxCpuConfiguredGet()`  set of CPU's configured in the system.
2. `vxCpuEnabledGet()` to get set of CPU's running in the system.
3. `taskNameSet()` to set name of any task.
4. `taskNameGet()` to get name of any task.