### PR TITLE
Revise network definitions for HorizonOS

### DIFF
--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -21,6 +21,14 @@ pub type sbintime_t = ::c_longlong;
 pub type sigset_t = ::c_ulong;
 
 s! {
+    pub struct hostent {
+        pub h_name: *mut ::c_char,
+        pub h_aliases: *mut *mut ::c_char,
+        pub h_addrtype: u16,
+        pub h_length: u16,
+        pub h_addr_list: *mut *mut ::c_char,
+    }
+
     pub struct sockaddr {
         pub sa_family: ::sa_family_t,
         pub sa_data: [::c_char; 26usize],
@@ -35,6 +43,7 @@ s! {
         pub sin_family: ::sa_family_t,
         pub sin_port: ::in_port_t,
         pub sin_addr: ::in_addr,
+        pub sin_zero: [::c_char; 8],
     }
 
     pub struct sockaddr_in6 {

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -53,6 +53,21 @@ cfg_if! {
     }
 }
 
+cfg_if! {
+    if #[cfg(not(target_os = "horizon"))] {
+        s!{
+            pub struct hostent {
+                pub h_name: *mut ::c_char,
+                pub h_aliases: *mut *mut ::c_char,
+                pub h_addrtype: ::c_int,
+                pub h_length: ::c_int,
+                pub h_addr_list: *mut *mut ::c_char,
+                pub h_addr: *mut ::c_char,
+            }
+        }
+    }
+}
+
 s! {
     // The order of the `ai_addr` field in this struct is crucial
     // for converting between the Rust and C types.
@@ -87,16 +102,7 @@ s! {
     }
 
     pub struct in_addr {
-            pub s_addr: ::in_addr_t,
-    }
-
-    pub struct hostent {
-            pub h_name: *mut ::c_char,
-            pub h_aliases: *mut *mut ::c_char,
-            pub h_addrtype: ::c_int,
-            pub h_length: ::c_int,
-            pub h_addr_list: *mut *mut ::c_char,
-            pub h_addr: *mut ::c_char,
+        pub s_addr: ::in_addr_t,
     }
 
     pub struct pollfd {


### PR DESCRIPTION
@ian-h-chamberlain @FenrirWolf @adryzz

Following some discussion in https://github.com/rust3ds/ctru-rs/issues/174.

The changes include:
- Update to the `hostent` definition for HorizonOS (`armv6k-nintendo-3ds`) following upstream [changes](https://github.com/devkitPro/libctru/commit/6714c04806c1164eef0718191060ee7a38e64d77).

- A step back on the decision to remove the trailing zero bytes from `sockaddr_in` that was made all the way back in https://github.com/rust-lang/libc/pull/2725. This change will require a little work in `std`, but we came to understand it's only right to keep the definitions true to the upstream versions.

Also, should this PR be flagged for release in 0.2.x as well as the 1.0 milestone? Work on tier-3 targets isn't clearly talked about in the new contribution guidelines (not that this PR is of any relevance to the release process).