### PR TITLE
adding new illumos ptsname_r call.

### DIFF
--- a/libc-test/semver/illumos.txt
+++ b/libc-test/semver/illumos.txt
@@ -1,3 +1,4 @@
 pthread_attr_get_np
 pthread_attr_getstackaddr
 pthread_attr_setstack
+ptsname_r

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -100,4 +100,6 @@ extern "C" {
     pub fn pwritev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int, offset: ::off_t)
         -> ::ssize_t;
     pub fn getpagesizes2(pagesize: *mut ::size_t, nelem: ::c_int) -> ::c_int;
+
+    pub fn ptsname_r(fildes: ::c_int, name: *mut ::c_char, namelen: ::size_t) -> ::c_int;
 }

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2154,7 +2154,7 @@ pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
 pub const PTHREAD_MUTEX_NORMAL: ::c_int = 0;
 pub const PTHREAD_MUTEX_ERRORCHECK: ::c_int = 2;
 pub const PTHREAD_MUTEX_RECURSIVE: ::c_int = 4;
-pub const PTHREAD_MUTEX_DEFAULT: ::c_int = PTHREAD_MUTEX_NORMAL;
+pub const PTHREAD_MUTEX_DEFAULT: ::c_int = ::PTHREAD_MUTEX_NORMAL;
 
 pub const RTLD_NEXT: *mut ::c_void = -1isize as *mut ::c_void;
 pub const RTLD_DEFAULT: *mut ::c_void = -2isize as *mut ::c_void;


### PR DESCRIPTION
while at it, fixing PTHREAD_MUTEX_DEFAULT which differs from solaris.

[man page](https://github.com/illumos/illumos-gate/blob/f1131be9159d3bbfbff616a59d26504ef672b1f2/usr/src/man/man3c/ptsname.3c#L100)