### PR TITLE
Expose the "epoll_pwait2()" function

### DIFF
--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -712,3 +712,4 @@ putpwent
 putgrent
 execveat
 close_range
+epoll_pwait2

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1534,6 +1534,14 @@ extern "C" {
     pub fn close_range(first: ::c_uint, last: ::c_uint, flags: ::c_int) -> ::c_int;
 
     pub fn mq_notify(mqdes: ::mqd_t, sevp: *const ::sigevent) -> ::c_int;
+
+    pub fn epoll_pwait2(
+        epfd: ::c_int,
+        events: *mut ::epoll_event,
+        maxevents: ::c_int,
+        timeout: *const ::timespec,
+        sigmask: *const ::sigset_t,
+    ) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
Hello everyone!

I propose exposing the ```epoll_pwait2()``` function. Epoll is a event polling/waiting feature in Linux. It is similar to ```poll()```, but while ```poll()``` requires passing an event list on each call, epoll works by creating a file descriptor which can be filled with events on file descriptors and then be waited/polled multiple times. File descriptors and events can be added, modified and deleted during epoll fd lifetime, which is good for server applications -- they can watch the listening socket and register connection sockets for watching.

Polling and waiting happens by calling ```epoll_wait()```, ```epoll_pwait()``` or ```epoll_pwait2()```. The first system call implements only millisecond precision of wait timeout and does not provide a way to atomically alter the signal mask during wait. The second system call accepts a signal mask that will be the signal mask of the waiting thread until the system call returns. The third system call also allows setting the timeout with nanosecond precision. The libc crates exposes the first two but not the third one.

[Related man-page](https://man.archlinux.org/man/epoll_pwait2.2.en)