### PR TITLE
Add `wasm32-wasip2` to the test matrix on CI

### DIFF
--- a/.github/workflows/full_ci.yml
+++ b/.github/workflows/full_ci.yml
@@ -119,6 +119,7 @@ jobs:
           s390x-unknown-linux-gnu,
           riscv64gc-unknown-linux-gnu,
           wasm32-wasip1,
+          wasm32-wasip2,
           sparc64-unknown-linux-gnu,
           wasm32-unknown-emscripten,
           x86_64-linux-android,

--- a/ci/docker/wasm32-wasip1/Dockerfile
+++ b/ci/docker/wasm32-wasip1/Dockerfile
@@ -1,23 +1,7 @@
 FROM ubuntu:24.04
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    clang \
-    xz-utils
-
-# Wasmtime is used to execute tests and wasi-sdk is used to compile tests.
-# Download appropriate versions here and configure various flags below.
-ENV WASMTIME 24.0.0
-ENV WASI_SDK 24
-
-RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v$WASMTIME/wasmtime-v$WASMTIME-x86_64-linux.tar.xz | \
-  tar xJf -
-ENV PATH=$PATH:/wasmtime-v$WASMTIME-x86_64-linux
-
-RUN curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$WASI_SDK/wasi-sdk-$WASI_SDK.0-x86_64-linux.deb
-RUN dpkg -i ./wasi-sdk-*.deb
+COPY wasi.sh /
+RUN bash /wasi.sh
 
 # Note that `-D_WASI_EMULATED_PROCESS_CLOCKS` is used to enable access to
 # clock-related defines even though they're emulated. Also note that the usage
@@ -29,4 +13,4 @@ ENV CARGO_TARGET_WASM32_WASIP1_RUNNER=wasmtime \
     CARGO_TARGET_WASM32_WASIP1_RUSTFLAGS="-lwasi-emulated-process-clocks -Ctarget-feature=-crt-static" \
     CC_wasm32_wasip1=/opt/wasi-sdk/bin/clang \
     CFLAGS_wasm32_wasip1=-D_WASI_EMULATED_PROCESS_CLOCKS \
-    PATH=$PATH:/rust/bin
+    PATH=$PATH:/rust/bin:/wasmtime

--- a/ci/docker/wasm32-wasip2/Dockerfile
+++ b/ci/docker/wasm32-wasip2/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:24.04
+
+COPY wasi.sh /
+RUN bash /wasi.sh
+
+# Note that most of these are copied from `wasm32-wasip1/Dockerfile`
+#
+# FIXME: the `-Clink-arg` to export `cabi_realloc` is a bug in the target
+# itself, this should be fixed upstream.
+ENV CARGO_TARGET_WASM32_WASIP2_RUNNER=wasmtime \
+    CARGO_TARGET_WASM32_WASIP2_LINKER=/opt/wasi-sdk/bin/clang \
+    CARGO_TARGET_WASM32_WASIP2_RUSTFLAGS="-lwasi-emulated-process-clocks -Ctarget-feature=-crt-static -Clink-arg=-Wl,--export,cabi_realloc" \
+    CC_wasm32_wasip2=/opt/wasi-sdk/bin/clang \
+    CFLAGS_wasm32_wasip2=-D_WASI_EMULATED_PROCESS_CLOCKS \
+    PATH=$PATH:/rust/bin:/wasmtime

--- a/ci/wasi.sh
+++ b/ci/wasi.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -ex
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    clang \
+    xz-utils
+
+# Wasmtime is used to execute tests and wasi-sdk is used to compile tests.
+# Download appropriate versions here and configure various flags below.
+#
+# At the time of this writing wasmtime 24.0.0 is the latest release and
+# wasi-sdk-24 is the latest release, that these numbers match is just
+# coincidence.
+wasmtime=24.0.0
+wasi_sdk=24
+
+curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v$wasmtime/wasmtime-v$wasmtime-x86_64-linux.tar.xz | \
+  tar xJf -
+mv wasmtime-v$wasmtime-x86_64-linux wasmtime
+
+# The pre-built `*.deb` files for wasi-sdk install to `/opt/wasi-sdk`
+curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$wasi_sdk/wasi-sdk-$wasi_sdk.0-x86_64-linux.deb
+dpkg -i ./wasi-sdk-*.deb


### PR DESCRIPTION
This is similar to #3869 except that it adds tests for `wasm32-wasip2` in addition to `wasm32-wasip1`. This is intended to eventually empower definitions from rust-lang/rust#129638 to move into this repository.
