### PR TITLE
Lower the MSRV to 1.63

### DIFF
--- a/.github/workflows/full_ci.yml
+++ b/.github/workflows/full_ci.yml
@@ -154,7 +154,7 @@ jobs:
           stable,
           beta,
           nightly,
-          1.71.0,
+          1.63.0,
         ]
     steps:
       - uses: actions/checkout@v4
@@ -179,7 +179,7 @@ jobs:
           - { toolchain: stable, os: macos-14 }
           - { toolchain: beta, os: macos-14 }
           - { toolchain: nightly, os: macos-14 }
-          - { toolchain: 1.71.0, os: macos-14 }
+          - { toolchain: 1.63.0, os: macos-14 }
     runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v4
@@ -200,7 +200,7 @@ jobs:
       fail-fast: true
       matrix:
         toolchain: [
-          1.71.0,
+          1.63.0,
           stable,
         ]
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["/ci/*", "/.github/*", "/.cirrus.yml", "/triagebot.toml"]
 description = """
 Raw FFI bindings to platform libraries like libc.
 """
-rust-version = "1.71.0"
+rust-version = "1.63.0"
 
 [package.metadata.docs.rs]
 features = ["const-extern-fn", "extra_traits"]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ libc = "0.2"
 
 ## Rust version support
 
-The minimum supported Rust toolchain version is currently **Rust 1.71.0**
+The minimum supported Rust toolchain version is currently **Rust 1.63.0**
 (libc does not currently have any policy regarding changes to the minimum
 supported Rust version; such policy is a work in progress).
 

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1089,12 +1089,6 @@ s! {
         pub nativeattr: attribute_set_t,
     }
 
-    #[repr(packed(4))]
-    pub struct ifconf {
-        pub ifc_len: ::c_int,
-        pub ifc_ifcu: __c_anonymous_ifc_ifcu,
-    }
-
     #[repr(align(8))]
     pub struct tcp_connection_info {
         pub tcpi_state: u8,
@@ -1211,6 +1205,12 @@ s! {
 }
 
 s_no_extra_traits! {
+    #[repr(packed(4))]
+    pub struct ifconf {
+        pub ifc_len: ::c_int,
+        pub ifc_ifcu: __c_anonymous_ifc_ifcu,
+    }
+
     #[repr(packed(4))]
     pub struct kevent {
         pub ident: ::uintptr_t,
@@ -3086,30 +3086,15 @@ cfg_if! {
             }
         }
 
-        impl Eq for __c_anonymous_ifc_ifcu {}
-
-        impl PartialEq for __c_anonymous_ifc_ifcu {
-            fn eq(&self, other: &__c_anonymous_ifc_ifcu) -> bool {
-                unsafe {
-                    self.ifcu_buf == other.ifcu_buf &&
-                    self.ifcu_req == other.ifcu_req
-                }
+        impl ::fmt::Debug for ifconf{
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("ifconf").finish_non_exhaustive()
             }
         }
 
         impl ::fmt::Debug for __c_anonymous_ifc_ifcu {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                f.debug_struct("ifc_ifcu")
-                    .field("ifcu_buf", unsafe { &self.ifcu_buf })
-                    .field("ifcu_req", unsafe { &self.ifcu_req })
-                    .finish()
-            }
-        }
-
-        impl ::hash::Hash for __c_anonymous_ifc_ifcu {
-            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                unsafe { self.ifcu_buf.hash(state) };
-                unsafe { self.ifcu_req.hash(state) };
+                f.debug_struct("ifc_ifcu").finish_non_exhaustive()
             }
         }
 


### PR DESCRIPTION
This will get us compatibility with Debian stable.

If this turns out to be problematic, we can always raise it back in the time before 1.0 is released.