### PR TITLE
Change signal constants to c_int on espidf

### DIFF
--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -89,14 +89,14 @@ pub const MSG_EOR: ::c_int = 0x08;
 
 pub const PTHREAD_STACK_MIN: ::size_t = 768;
 
-pub const SIGABRT: ::size_t = 1;
-pub const SIGFPE: ::size_t = 1;
-pub const SIGILL: ::size_t = 1;
-pub const SIGINT: ::size_t = 1;
-pub const SIGSEGV: ::size_t = 1;
-pub const SIGTERM: ::size_t = 1;
-pub const SIGHUP: ::size_t = 1;
-pub const SIGQUIT: ::size_t = 1;
+pub const SIGABRT: ::c_int = 1;
+pub const SIGFPE: ::c_int = 1;
+pub const SIGILL: ::c_int = 1;
+pub const SIGINT: ::c_int = 1;
+pub const SIGSEGV: ::c_int = 1;
+pub const SIGTERM: ::c_int = 1;
+pub const SIGHUP: ::c_int = 1;
+pub const SIGQUIT: ::c_int = 1;
 pub const NSIG: ::size_t = 2;
 
 extern "C" {


### PR DESCRIPTION
The espidf targets cannot build libtest because the types of these signal constants disagree with all the other cfg(unix) targets. Since they're of course macros on the C side https://github.com/espressif/newlib-esp32/blob/7cdcb0b0848a5d909e906834fe81903ba9466c90/newlib/libc/include/sys/signal.h#L259-L269 I think `c_int` is a more reasonable type to use. Without this change, attempting to build libtest will produce this error:
```
error[E0308]: mismatched types
   --> /home/ben/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/test_result.rs:108:18
    |
107 |         None => match status.signal() {
    |                       --------------- this expression has type `std::option::Option<i32>`
108 |             Some(libc::SIGABRT) => TestResult::TrFailed,
    |                  ^^^^^^^^^^^^^ expected `i32`, found `usize`
```
It's not entirely clear to me why the conversation on https://github.com/rust-lang/libc/issues/3615 and the issues from there petered out. I'm a bit concerned that the users just configured their editors to suppress the error and moved on. That's certainly what it looks like.

I've checked that this fixes the problem by pointing my rust-lang/rust checkout to my libc branch and running
```
MIRI_LIB_SRC=/home/ben/rust/library cargo +nightly miri setup --target riscv32imafc-esp-espidf
```
or
```
x check library/test --target riscv32imafc-esp-espidf
```