### PR TITLE
[0.2] Change signal constants to c_int on espidf

### DIFF
--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -89,14 +89,14 @@ pub const MSG_EOR: ::c_int = 0x08;
 
 pub const PTHREAD_STACK_MIN: ::size_t = 768;
 
-pub const SIGABRT: ::size_t = 1;
-pub const SIGFPE: ::size_t = 1;
-pub const SIGILL: ::size_t = 1;
-pub const SIGINT: ::size_t = 1;
-pub const SIGSEGV: ::size_t = 1;
-pub const SIGTERM: ::size_t = 1;
-pub const SIGHUP: ::size_t = 1;
-pub const SIGQUIT: ::size_t = 1;
+pub const SIGABRT: ::c_int = 1;
+pub const SIGFPE: ::c_int = 1;
+pub const SIGILL: ::c_int = 1;
+pub const SIGINT: ::c_int = 1;
+pub const SIGSEGV: ::c_int = 1;
+pub const SIGTERM: ::c_int = 1;
+pub const SIGHUP: ::c_int = 1;
+pub const SIGQUIT: ::c_int = 1;
 pub const NSIG: ::size_t = 2;
 
 extern "C" {


### PR DESCRIPTION
(backport <https://github.com/rust-lang/libc/pull/3895>)
(cherry picked from commit a6f4694237042e0fc5616782c2f8bbb516c27e4d)