### PR TITLE
[0.2] Expose the "epoll_pwait2()" function

### DIFF
--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -711,3 +711,4 @@ putpwent
 putgrent
 execveat
 close_range
+epoll_pwait2

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1542,6 +1542,14 @@ extern "C" {
     pub fn close_range(first: ::c_uint, last: ::c_uint, flags: ::c_int) -> ::c_int;
 
     pub fn mq_notify(mqdes: ::mqd_t, sevp: *const ::sigevent) -> ::c_int;
+
+    pub fn epoll_pwait2(
+        epfd: ::c_int,
+        events: *mut ::epoll_event,
+        maxevents: ::c_int,
+        timeout: *const ::timespec,
+        sigmask: *const ::sigset_t,
+    ) -> ::c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
The ```epoll_pwait2()``` function has been moved to linux/gnu

(backport <https://github.com/rust-lang/libc/pull/3868>)
(cherry picked from commit f3756b90e8605ec07d49fc041ef685be8582bf5d)
