### PR TITLE
Bump libc-test to Rust 2021 Edition

### DIFF
--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libc-test"
 version = "0.2.151"
-edition = "2018"
+edition = "2021"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"


### PR DESCRIPTION
`libc-test` was already at 2018 Edition, bumping to 2021 just needs changing it in `Cargo.toml`