### PR TITLE
Add `getpwnam_r` and `getpwuid_r` to emscripten

### DIFF
--- a/libc-test/semver/emscripten.txt
+++ b/libc-test/semver/emscripten.txt
@@ -1,2 +1,4 @@
 getentropy
 posix_fallocate64
+getpwnam_r
+getpwuid_r

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1774,6 +1774,21 @@ extern "C" {
     ) -> ::c_int;
 
     pub fn getentropy(buf: *mut ::c_void, buflen: ::size_t) -> ::c_int;
+
+    pub fn getpwnam_r(
+        name: *const ::c_char,
+        pwd: *mut passwd,
+        buf: *mut ::c_char,
+        buflen: ::size_t,
+        result: *mut *mut passwd,
+    ) -> ::c_int;
+    pub fn getpwuid_r(
+        uid: ::uid_t,
+        pwd: *mut passwd,
+        buf: *mut ::c_char,
+        buflen: ::size_t,
+        result: *mut *mut passwd,
+    ) -> ::c_int;
 }
 
 // Alias <foo> to <foo>64 to mimic glibc's LFS64 support


### PR DESCRIPTION
`getpwnam` and `getpwuid` exist, but `*_r` functions do not exist for Emscripten, so I added them.

Header sources:
[getpwnam_r](https://github.com/emscripten-core/emscripten/blob/127fb03dad7288a71f51bd46be49f1da8bdb0fa8/system/lib/libc/musl/include/pwd.h#L39)
[getpwuid_r](https://github.com/emscripten-core/emscripten/blob/127fb03dad7288a71f51bd46be49f1da8bdb0fa8/system/lib/libc/musl/include/pwd.h#L38)
