### PR TITLE
Add `AT_EACCESS` to emscripten

### DIFF
--- a/libc-test/semver/emscripten.txt
+++ b/libc-test/semver/emscripten.txt
@@ -1,2 +1,3 @@
+AT_EACCESS
 getentropy
 posix_fallocate64

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -775,6 +775,8 @@ pub const POSIX_MADV_RANDOM: ::c_int = 1;
 pub const POSIX_MADV_SEQUENTIAL: ::c_int = 2;
 pub const POSIX_MADV_WILLNEED: ::c_int = 3;
 
+pub const AT_EACCESS: ::c_int = 0x200;
+
 pub const S_IEXEC: mode_t = 0o0100;
 pub const S_IWRITE: mode_t = 0o0200;
 pub const S_IREAD: mode_t = 0o0400;


### PR DESCRIPTION

Header source:
[AT_EACCESS](https://github.com/emscripten-core/emscripten/blob/3073806d3fde4320c81cb2dc7cf0e00378f52df1/system/lib/libc/musl/include/fcntl.h#L68)