### PR TITLE
Add `getgrgid`, `getgrnam`, `getgrnam_r` and `getgrgid_r` for emscripten

### DIFF
--- a/libc-test/semver/emscripten.txt
+++ b/libc-test/semver/emscripten.txt
@@ -1,5 +1,9 @@
 AT_EACCESS
 getentropy
+getgrgid
+getgrnam
+getgrnam_r
+getgrgid_r
 posix_fallocate64
 getpwnam_r
 getpwuid_r

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1791,6 +1791,24 @@ extern "C" {
         buflen: ::size_t,
         result: *mut *mut passwd,
     ) -> ::c_int;
+
+    // grp.h
+    pub fn getgrgid(gid: ::gid_t) -> *mut ::group;
+    pub fn getgrnam(name: *const ::c_char) -> *mut ::group;
+    pub fn getgrnam_r(
+        name: *const ::c_char,
+        grp: *mut ::group,
+        buf: *mut ::c_char,
+        buflen: ::size_t,
+        result: *mut *mut ::group,
+    ) -> ::c_int;
+    pub fn getgrgid_r(
+        gid: ::gid_t,
+        grp: *mut ::group,
+        buf: *mut ::c_char,
+        buflen: ::size_t,
+        result: *mut *mut ::group,
+    ) -> ::c_int;
 }
 
 // Alias <foo> to <foo>64 to mimic glibc's LFS64 support


### PR DESCRIPTION
I added `getgrgid`, `getgrnam`, `getgrnam_r` and `getgrgid_r` for emscripten.

Header sources:
[getgrgid](https://github.com/emscripten-core/emscripten/blob/3073806d3fde4320c81cb2dc7cf0e00378f52df1/system/lib/libc/musl/include/grp.h#L26)
[getgrnam](https://github.com/emscripten-core/emscripten/blob/3073806d3fde4320c81cb2dc7cf0e00378f52df1/system/lib/libc/musl/include/grp.h#L27)
[getgrgid_r](https://github.com/emscripten-core/emscripten/blob/127fb03dad7288a71f51bd46be49f1da8bdb0fa8/system/lib/libc/musl/include/grp.h#L29)
[getgrnam_r](https://github.com/emscripten-core/emscripten/blob/127fb03dad7288a71f51bd46be49f1da8bdb0fa8/system/lib/libc/musl/include/grp.h#L30)

