### PR TITLE
Add mach_error_string (and mach_error_t)

### DIFF
--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -1913,6 +1913,8 @@ lockf
 log2phys
 login_tty
 lutimes
+mach_error_string
+mach_error_t
 madvise
 malloc_default_zone
 malloc_good_size

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -58,6 +58,7 @@ pub type thread_inspect_t = ::mach_port_t;
 pub type thread_act_t = ::mach_port_t;
 pub type thread_act_array_t = *mut ::thread_act_t;
 pub type policy_t = ::c_int;
+pub type mach_error_t = ::kern_return_t;
 pub type mach_vm_address_t = u64;
 pub type mach_vm_offset_t = u64;
 pub type mach_vm_size_t = u64;
@@ -6208,6 +6209,8 @@ extern "C" {
     pub fn copyfile_state_alloc() -> copyfile_state_t;
     pub fn copyfile_state_get(s: copyfile_state_t, flags: u32, dst: *mut ::c_void) -> ::c_int;
     pub fn copyfile_state_set(s: copyfile_state_t, flags: u32, src: *const ::c_void) -> ::c_int;
+
+    pub fn mach_error_string(error_value: ::mach_error_t) -> *mut ::c_char;
 
     // Added in macOS 10.13
     // ISO/IEC 9899:2011 ("ISO C11") K.3.7.4.1


### PR DESCRIPTION
`mach_error_string` is defined in `/usr/include/mach/mach_error.h`
It is not referenced in the documentation Apple website.

```
char            *mach_error_string(
/*
 *  Returns a string appropriate to the error argument given
 */
    mach_error_t error_value
    );
```

`mach_error_t` is defined in `/usr/include/mach/error.h`
https://developer.apple.com/documentation/kernel/mach_error_t

```
typedef kern_return_t   mach_error_t;
```