### PR TITLE
Add optional zerocopy crate derives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ cargo-args = ["-Zbuild-std=core"]
 
 [dependencies]
 rustc-std-workspace-core = { version = "1.0.0", optional = true }
+zerocopy_0_8 = { package = "zerocopy", version = "0.8.0-alpha.21", optional = true, features = ["derive"] }
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,9 @@
 #![cfg_attr(feature = "rustc-dep-of-std", no_core)]
 #![cfg_attr(libc_const_extern_fn_unstable, feature(const_extern_fn))]
 
+#[cfg(feature = "zerocopy_0_8")]
+extern crate zerocopy_0_8 as zerocopy;
+
 #[macro_use]
 mod macros;
 

--- a/src/unix/bsd/apple/b64/aarch64/mod.rs
+++ b/src/unix/bsd/apple/b64/aarch64/mod.rs
@@ -1,6 +1,7 @@
 pub type boolean_t = ::c_int;
 
 s! {
+    #[cfg_attr(feature = "zerocopy_0_8", derive(zerocopy_0_8::FromBytes))]
     pub struct malloc_zone_t {
         __private: [::uintptr_t; 18], // FIXME: needs arm64 auth pointers support
     }


### PR DESCRIPTION
This is not ready for merging until zerocopy publishes a stable 0.8 release (currently it only has 0.8 alpha releases). I'm putting this up now to test out CI and get the ball rolling in case there are fixes required.