### PR TITLE
Apple: add `host_cpu_load_info`

### DIFF
--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -1890,6 +1890,9 @@ getxattr
 glob
 glob_t
 globfree
+host_cpu_load_info
+host_cpu_load_info_data_t
+host_cpu_load_info_t
 icmp6_ifstat
 iconv_t
 id_t

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -74,6 +74,11 @@ pub type ledger_array_t = *mut ::ledger_t;
 
 pub type iconv_t = *mut ::c_void;
 
+// mach/host_info.h
+pub type host_cpu_load_info_t = *mut host_cpu_load_info;
+pub type host_cpu_load_info_data_t = host_cpu_load_info;
+
+// mach/processor_info.h
 pub type processor_cpu_load_info_t = *mut processor_cpu_load_info;
 pub type processor_cpu_load_info_data_t = processor_cpu_load_info;
 pub type processor_basic_info_t = *mut processor_basic_info;
@@ -1207,6 +1212,11 @@ s! {
         pub ifs6_out_mldquery: ::u_quad_t,
         pub ifs6_out_mldreport: ::u_quad_t,
         pub ifs6_out_mlddone: ::u_quad_t,
+    }
+
+    // mach/host_info.h
+    pub struct host_cpu_load_info {
+        pub cpu_ticks: [::natural_t; CPU_STATE_MAX as usize],
     }
 }
 


### PR DESCRIPTION
Snippet from `host_info.h`:

```
struct host_cpu_load_info {             /* number of ticks while running... */
    natural_t       cpu_ticks[CPU_STATE_MAX]; /* ... in the given mode */
};

typedef struct host_cpu_load_info       host_cpu_load_info_data_t;
typedef struct host_cpu_load_info       *host_cpu_load_info_t;
```