### PR TITLE
Fix ESP-IDF constants and structs

### DIFF
--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -89,15 +89,15 @@ pub const MSG_EOR: ::c_int = 0x08;
 
 pub const PTHREAD_STACK_MIN: ::size_t = 768;
 
-pub const SIGABRT: ::c_int = 1;
-pub const SIGFPE: ::c_int = 1;
-pub const SIGILL: ::c_int = 1;
-pub const SIGINT: ::c_int = 1;
-pub const SIGSEGV: ::c_int = 1;
-pub const SIGTERM: ::c_int = 1;
+pub const SIGABRT: ::c_int = 6;
+pub const SIGFPE: ::c_int = 8;
+pub const SIGILL: ::c_int = 4;
+pub const SIGINT: ::c_int = 2;
+pub const SIGSEGV: ::c_int = 11;
+pub const SIGTERM: ::c_int = 15;
 pub const SIGHUP: ::c_int = 1;
-pub const SIGQUIT: ::c_int = 1;
-pub const NSIG: ::size_t = 2;
+pub const SIGQUIT: ::c_int = 3;
+pub const NSIG: ::size_t = 32;
 
 extern "C" {
     pub fn pthread_create(

--- a/src/unix/newlib/generic.rs
+++ b/src/unix/newlib/generic.rs
@@ -2,7 +2,10 @@
 
 s! {
     pub struct sigset_t {
+        #[cfg(target_os = "horizon")]
         __val: [::c_ulong; 16],
+        #[cfg(not(target_os = "horizon"))]
+        __val: u32,
     }
 
     pub struct stat {

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -42,7 +42,13 @@ cfg_if! {
 pub type socklen_t = u32;
 pub type speed_t = u32;
 pub type suseconds_t = i32;
-pub type tcflag_t = ::c_uint;
+cfg_if! {
+    if #[cfg(target_os = "espidf")] {
+        pub type tcflag_t = u16;
+    } else {
+        pub type tcflag_t = ::c_uint;
+    }
+}
 pub type useconds_t = u32;
 
 cfg_if! {
@@ -241,7 +247,14 @@ pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = pthread_cond_t {
 pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
     size: [__PTHREAD_INITIALIZER_BYTE; __SIZEOF_PTHREAD_RWLOCK_T],
 };
-pub const NCCS: usize = 32;
+
+cfg_if! {
+    if #[cfg(target_os = "espidf")] {
+        pub const NCCS: usize = 11;
+    } else {
+        pub const NCCS: usize = 32;
+    }
+}
 
 cfg_if! {
     if #[cfg(target_os = "espidf")] {
@@ -410,7 +423,13 @@ pub const O_SYNC: ::c_int = 8192;
 pub const O_NONBLOCK: ::c_int = 16384;
 
 pub const O_ACCMODE: ::c_int = 3;
-pub const O_CLOEXEC: ::c_int = 0x80000;
+cfg_if! {
+    if #[cfg(target_os = "espidf")] {
+        pub const O_CLOEXEC: ::c_int = 0x40000;
+    } else {
+        pub const O_CLOEXEC: ::c_int = 0x80000;
+    }
+}
 
 pub const RTLD_LAZY: ::c_int = 0x1;
 
@@ -452,7 +471,13 @@ pub const SOL_TCP: ::c_int = 6;
 
 pub const PF_UNSPEC: ::c_int = 0;
 pub const PF_INET: ::c_int = 2;
-pub const PF_INET6: ::c_int = 23;
+cfg_if! {
+    if #[cfg(target_os = "espidf")] {
+        pub const PF_INET6: ::c_int = 10;
+    } else {
+        pub const PF_INET6: ::c_int = 23;
+    }
+}
 
 pub const AF_UNSPEC: ::c_int = 0;
 pub const AF_INET: ::c_int = 2;
@@ -537,6 +562,9 @@ cfg_if! {
     if #[cfg(target_os = "vita")] {
         pub const TCP_NODELAY: ::c_int = 1;
         pub const TCP_MAXSEG: ::c_int = 2;
+    } else if #[cfg(target_os = "espidf")] {
+        pub const TCP_NODELAY: ::c_int = 1;
+        pub const TCP_MAXSEG: ::c_int = 8194;
     } else {
         pub const TCP_NODELAY: ::c_int = 8193;
         pub const TCP_MAXSEG: ::c_int = 8194;
@@ -545,13 +573,23 @@ cfg_if! {
 
 pub const TCP_NOPUSH: ::c_int = 4;
 pub const TCP_NOOPT: ::c_int = 8;
-pub const TCP_KEEPIDLE: ::c_int = 256;
-pub const TCP_KEEPINTVL: ::c_int = 512;
-pub const TCP_KEEPCNT: ::c_int = 1024;
+cfg_if! {
+    if #[cfg(target_os = "espidf")] {
+        pub const TCP_KEEPIDLE: ::c_int = 3;
+        pub const TCP_KEEPINTVL: ::c_int = 4;
+        pub const TCP_KEEPCNT: ::c_int = 5;
+    } else {
+        pub const TCP_KEEPIDLE: ::c_int = 256;
+        pub const TCP_KEEPINTVL: ::c_int = 512;
+        pub const TCP_KEEPCNT: ::c_int = 1024;
+    }
+}
 
 cfg_if! {
     if #[cfg(target_os = "horizon")] {
         pub const IP_TOS: ::c_int = 7;
+    } else if #[cfg(target_os = "espidf")] {
+        pub const IP_TOS: ::c_int = 1;
     } else {
         pub const IP_TOS: ::c_int = 3;
     }
@@ -559,55 +597,107 @@ cfg_if! {
 cfg_if! {
     if #[cfg(target_os = "vita")] {
         pub const IP_TTL: ::c_int = 4;
+    } else if #[cfg(target_os = "espidf")] {
+        pub const IP_TTL: ::c_int = 2;
     } else {
         pub const IP_TTL: ::c_int = 8;
     }
 }
-pub const IP_MULTICAST_IF: ::c_int = 9;
-pub const IP_MULTICAST_TTL: ::c_int = 10;
-pub const IP_MULTICAST_LOOP: ::c_int = 11;
+
+cfg_if! {
+    if #[cfg(target_os = "espidf")] {
+        pub const IP_MULTICAST_IF: ::c_int = 6;
+        pub const IP_MULTICAST_TTL: ::c_int = 5;
+        pub const IP_MULTICAST_LOOP: ::c_int = 7;
+    } else {
+        pub const IP_MULTICAST_IF: ::c_int = 9;
+        pub const IP_MULTICAST_TTL: ::c_int = 10;
+        pub const IP_MULTICAST_LOOP: ::c_int = 11;
+    }
+}
+
 cfg_if! {
     if #[cfg(target_os = "vita")] {
         pub const IP_ADD_MEMBERSHIP: ::c_int = 12;
         pub const IP_DROP_MEMBERSHIP: ::c_int = 13;
+    } else if #[cfg(target_os = "espidf")] {
+        pub const IP_ADD_MEMBERSHIP: ::c_int = 3;
+        pub const IP_DROP_MEMBERSHIP: ::c_int = 4;
     } else {
         pub const IP_ADD_MEMBERSHIP: ::c_int = 11;
         pub const IP_DROP_MEMBERSHIP: ::c_int = 12;
     }
 }
 pub const IPV6_UNICAST_HOPS: ::c_int = 4;
-pub const IPV6_MULTICAST_IF: ::c_int = 9;
-pub const IPV6_MULTICAST_HOPS: ::c_int = 10;
-pub const IPV6_MULTICAST_LOOP: ::c_int = 11;
+cfg_if! {
+    if #[cfg(target_os = "espidf")] {
+        pub const IPV6_MULTICAST_IF: ::c_int = 768;
+        pub const IPV6_MULTICAST_HOPS: ::c_int = 769;
+        pub const IPV6_MULTICAST_LOOP: ::c_int = 770;
+    } else {
+        pub const IPV6_MULTICAST_IF: ::c_int = 9;
+        pub const IPV6_MULTICAST_HOPS: ::c_int = 10;
+        pub const IPV6_MULTICAST_LOOP: ::c_int = 11;
+    }
+}
 pub const IPV6_V6ONLY: ::c_int = 27;
 pub const IPV6_JOIN_GROUP: ::c_int = 12;
 pub const IPV6_LEAVE_GROUP: ::c_int = 13;
 pub const IPV6_ADD_MEMBERSHIP: ::c_int = 12;
 pub const IPV6_DROP_MEMBERSHIP: ::c_int = 13;
 
-pub const HOST_NOT_FOUND: ::c_int = 1;
-pub const NO_DATA: ::c_int = 2;
+cfg_if! {
+    if #[cfg(target_os = "espidf")] {
+        pub const HOST_NOT_FOUND: ::c_int = 210;
+        pub const NO_DATA: ::c_int = 211;
+        pub const NO_RECOVERY: ::c_int = 212;
+        pub const TRY_AGAIN: ::c_int = 213;
+
+    } else {
+        pub const HOST_NOT_FOUND: ::c_int = 1;
+        pub const NO_DATA: ::c_int = 2;
+        pub const NO_RECOVERY: ::c_int = 3;
+        pub const TRY_AGAIN: ::c_int = 4;
+    }
+}
 pub const NO_ADDRESS: ::c_int = 2;
-pub const NO_RECOVERY: ::c_int = 3;
-pub const TRY_AGAIN: ::c_int = 4;
 
 pub const AI_PASSIVE: ::c_int = 1;
 pub const AI_CANONNAME: ::c_int = 2;
 pub const AI_NUMERICHOST: ::c_int = 4;
-pub const AI_NUMERICSERV: ::c_int = 0;
-pub const AI_ADDRCONFIG: ::c_int = 0;
+cfg_if! {
+    if #[cfg(target_os = "espidf")] {
+        pub const AI_NUMERICSERV: ::c_int = 8;
+        pub const AI_ADDRCONFIG: ::c_int = 64;
+    } else {
+        pub const AI_NUMERICSERV: ::c_int = 0;
+        pub const AI_ADDRCONFIG: ::c_int = 0;
+    }
+}
 
 pub const NI_MAXHOST: ::c_int = 1025;
 pub const NI_MAXSERV: ::c_int = 32;
 pub const NI_NOFQDN: ::c_int = 1;
 pub const NI_NUMERICHOST: ::c_int = 2;
 pub const NI_NAMEREQD: ::c_int = 4;
-pub const NI_NUMERICSERV: ::c_int = 0;
-pub const NI_DGRAM: ::c_int = 0;
+cfg_if! {
+    if #[cfg(target_os = "espidf")] {
+        pub const NI_NUMERICSERV: ::c_int = 8;
+        pub const NI_DGRAM: ::c_int = 16;
+    } else {
+        pub const NI_NUMERICSERV: ::c_int = 0;
+        pub const NI_DGRAM: ::c_int = 0;
+    }
+}
 
 cfg_if! {
     // Defined in vita/mod.rs for "vita"
-    if #[cfg(not(target_os = "vita"))] {
+    if #[cfg(target_os = "espidf")] {
+        pub const EAI_FAMILY: ::c_int = 204;
+        pub const EAI_MEMORY: ::c_int = 203;
+        pub const EAI_NONAME: ::c_int = 200;
+        pub const EAI_SOCKTYPE: ::c_int = 10;
+    } else if #[cfg(not(target_os = "vita"))] {
         pub const EAI_FAMILY: ::c_int = -303;
         pub const EAI_MEMORY: ::c_int = -304;
         pub const EAI_NONAME: ::c_int = -305;

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -203,6 +203,10 @@ s! {
         pub c_lflag: ::tcflag_t,
         pub c_line: ::cc_t,
         pub c_cc: [::cc_t; ::NCCS],
+        #[cfg(target_os = "espidf")]
+        pub c_ispeed: u32,
+        #[cfg(target_os = "espidf")]
+        pub c_ospeed: u32,
     }
 
     pub struct sem_t { // Unverified
@@ -230,7 +234,24 @@ s! {
     }
 
     pub struct pthread_attr_t { // Unverified
-        __size: [u8; __SIZEOF_PTHREAD_ATTR_T]
+        #[cfg(not(target_os = "espidf"))]
+        __size: [u8; __SIZEOF_PTHREAD_ATTR_T],
+        #[cfg(target_os = "espidf")]
+        pub is_initialized: i32,
+        #[cfg(target_os = "espidf")]
+        pub stackaddr: *mut crate::c_void,
+        #[cfg(target_os = "espidf")]
+        pub stacksize: i32,
+        #[cfg(target_os = "espidf")]
+        pub contentionscope: i32,
+        #[cfg(target_os = "espidf")]
+        pub inheritsched: i32,
+        #[cfg(target_os = "espidf")]
+        pub schedpolicy: i32,
+        #[cfg(target_os = "espidf")]
+        pub schedparam: i32,
+        #[cfg(target_os = "espidf")]
+        pub detachstate: i32,
     }
 
     pub struct pthread_rwlockattr_t { // Unverified


### PR DESCRIPTION
This PR fixes some constants and structs which were wrong for ESP-IDF targets. I created an app that compares all the constants in `src/unix/newlib` and `src/unix/newlib/espidf` modules with the ones in ESP-IDF source code (accessed via [`esp_idf_svc::sys`](https://docs.esp-rs.org/esp-idf-svc/esp_idf_svc/sys/index.html)). Here is the app https://github.com/SergioGasquez/libc-checks, using `libc@0.2.158` yields the following errors:
```
E (622) libc_checks: Mismatch detected for constant `SIGABRT`: `esp-idf` 6 | `libc` 1
E (632) libc_checks: Mismatch detected for constant `SIGFPE`: `esp-idf` 8 | `libc` 1
E (642) libc_checks: Mismatch detected for constant `SIGILL`: `esp-idf` 4 | `libc` 1
E (652) libc_checks: Mismatch detected for constant `SIGINT`: `esp-idf` 2 | `libc` 1
E (662) libc_checks: Mismatch detected for constant `SIGSEGV`: `esp-idf` 11 | `libc` 1
E (672) libc_checks: Mismatch detected for constant `SIGTERM`: `esp-idf` 15 | `libc` 1
E (672) libc_checks: Mismatch detected for constant `SIGQUIT`: `esp-idf` 3 | `libc` 1
E (682) libc_checks: Mismatch detected for constant `NSIG`: `esp-idf` 32 | `libc` 2
E (692) libc_checks: Mismatch detected for type `tcflag_t` size: `esp-idf` 2 | `libc` 4
E (702) libc_checks: Mismatch detected for type `tcflag_t` alignment: `esp-idf` 2 | `libc` 4
E (712) libc_checks: Mismatch detected for type `sigaction` size: `esp-idf` 12 | `libc` 72
E (722) libc_checks: Mismatch detected for type `termios` size: `esp-idf` 28 | `libc` 52
E (732) libc_checks: Mismatch detected for type `pthread_attr_t` alignment: `esp-idf` 4 | `libc` 1
E (742) libc_checks: Mismatch detected for constant `NCCS`: `esp-idf` 11 | `libc` 32
E (752) libc_checks: Mismatch detected for constant `O_CLOEXEC`: `esp-idf` 262144 | `libc` 524288
E (762) libc_checks: Mismatch detected for constant `PF_INET6`: `esp-idf` 10 | `libc` 23
E (762) libc_checks: Mismatch detected for constant `SOCK_CLOEXEC`: `esp-idf` 262144 | `libc` 524288
E (772) libc_checks: Mismatch detected for constant `TCP_NODELAY`: `esp-idf` 1 | `libc` 8193
E (782) libc_checks: Mismatch detected for constant `TCP_KEEPIDLE`: `esp-idf` 3 | `libc` 256
E (792) libc_checks: Mismatch detected for constant `TCP_KEEPINTVL`: `esp-idf` 4 | `libc` 512
E (802) libc_checks: Mismatch detected for constant `TCP_KEEPCNT`: `esp-idf` 5 | `libc` 1024
E (812) libc_checks: Mismatch detected for constant `IP_TOS`: `esp-idf` 1 | `libc` 3
E (822) libc_checks: Mismatch detected for constant `IP_TTL`: `esp-idf` 2 | `libc` 8
E (832) libc_checks: Mismatch detected for constant `IP_MULTICAST_IF`: `esp-idf` 6 | `libc` 9
E (842) libc_checks: Mismatch detected for constant `IP_MULTICAST_TTL`: `esp-idf` 5 | `libc` 10
E (842) libc_checks: Mismatch detected for constant `IP_MULTICAST_LOOP`: `esp-idf` 7 | `libc` 11
E (852) libc_checks: Mismatch detected for constant `IP_ADD_MEMBERSHIP`: `esp-idf` 3 | `libc` 11
E (862) libc_checks: Mismatch detected for constant `IP_DROP_MEMBERSHIP`: `esp-idf` 4 | `libc` 12
E (872) libc_checks: Mismatch detected for constant `IPV6_MULTICAST_IF`: `esp-idf` 768 | `libc` 9
E (882) libc_checks: Mismatch detected for constant `IPV6_MULTICAST_HOPS`: `esp-idf` 769 | `libc` 10
E (892) libc_checks: Mismatch detected for constant `IPV6_MULTICAST_LOOP`: `esp-idf` 770 | `libc` 11
E (902) libc_checks: Mismatch detected for constant `HOST_NOT_FOUND`: `esp-idf` 210 | `libc` 1
E (912) libc_checks: Mismatch detected for constant `NO_DATA`: `esp-idf` 211 | `libc` 2
E (922) libc_checks: Mismatch detected for constant `NO_RECOVERY`: `esp-idf` 212 | `libc` 3
E (932) libc_checks: Mismatch detected for constant `TRY_AGAIN`: `esp-idf` 213 | `libc` 4
E (942) libc_checks: Mismatch detected for constant `AI_NUMERICSERV`: `esp-idf` 8 | `libc` 0
E (952) libc_checks: Mismatch detected for constant `AI_ADDRCONFIG`: `esp-idf` 64 | `libc` 0
E (962) libc_checks: Mismatch detected for constant `NI_NUMERICSERV`: `esp-idf` 8 | `libc` 0
E (972) libc_checks: Mismatch detected for constant `NI_DGRAM`: `esp-idf` 16 | `libc` 0
E (972) libc_checks: Mismatch detected for constant `EAI_FAMILY`: `esp-idf` 204 | `libc` -303
E (982) libc_checks: Mismatch detected for constant `EAI_MEMORY`: `esp-idf` 203 | `libc` -304
E (992) libc_checks: Mismatch detected for constant `EAI_NONAME`: `esp-idf` 200 | `libc` -305
E (1002) libc_checks: Mismatch detected for constant `EAI_SOCKTYPE`: `esp-idf` 10 | `libc` -307
```

All those errors are fixed in this PR, if I point the app to use the branch of this PR, no errors appear.

cc and thanks to @ivmarkov!

closes https://github.com/rust-lang/libc/issues/3774