### PR TITLE
Linux: epoll: add busy polling parameters

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3839,6 +3839,9 @@ fn test_linux(target: &str) {
             // kernel so we can drop this and test the type once this new version is used in CI.
             "sched_attr" => true,
 
+            // FIXME: Requires >= 6.9 kernel headers.
+            "epoll_params" => true,
+
             _ => false,
         }
     });
@@ -4286,6 +4289,10 @@ fn test_linux(target: &str) {
             | "SCHED_FLAG_KEEP_ALL"
             | "SCHED_FLAG_UTIL_CLAMP"
             | "SCHED_FLAG_ALL" if musl => true, // Needs more recent linux headers.
+
+            // FIXME: Requires >= 6.9 kernel headers.
+            "EPIOCSPARAMS"
+            | "EPIOCGPARAMS" => true,
 
             _ => false,
         }

--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -556,6 +556,8 @@ ENOTSUP
 ENOTUNIQ
 EOF
 EOWNERDEAD
+EPIOCGPARAMS
+EPIOCSPARAMS
 EPOLLERR
 EPOLLET
 EPOLLEXCLUSIVE
@@ -3532,6 +3534,7 @@ epoll_create
 epoll_create1
 epoll_ctl
 epoll_event
+epoll_params
 epoll_pwait
 epoll_wait
 erand48

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1036,6 +1036,15 @@ s! {
         pub get_args: __u16,
         pub name: [c_char; ::IFNAMSIZ],
     }
+
+    // #include <linux/eventpoll.h>
+
+    pub struct epoll_params {
+        pub busy_poll_usecs: u32,
+        pub busy_poll_budget: u16,
+        pub prefer_busy_poll: u8,
+        pub __pad: u8, // Must be zero
+    }
 }
 
 cfg_if! {
@@ -5171,6 +5180,10 @@ pub const SCHED_FLAG_ALL: ::c_int = SCHED_FLAG_RESET_ON_FORK
     | SCHED_FLAG_DL_OVERRUN
     | SCHED_FLAG_KEEP_ALL
     | SCHED_FLAG_UTIL_CLAMP;
+
+// ioctl_eventpoll: added in Linux 6.9
+pub const EPIOCSPARAMS: ::Ioctl = 0x40088a01;
+pub const EPIOCGPARAMS: ::Ioctl = 0x80088a02;
 
 f! {
     pub fn NLA_ALIGN(len: ::c_int) -> ::c_int {


### PR DESCRIPTION
In Linux 6.9 a new ioctl for epoll was added:
https://man.archlinux.org/man/ioctl_eventpoll.2.en

It's used for busy polling sockets
