### PR TITLE
Add missing definitions on NetBSD

### DIFF
--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -136,6 +136,8 @@ CLD_EXITED
 CLD_KILLED
 CLD_STOPPED
 CLD_TRAPPED
+CLOCK_PROCESS_CPUTIME_ID
+CLOCK_THREAD_CPUTIME_ID
 CMSG_DATA
 CMSG_FIRSTHDR
 CMSG_LEN
@@ -1567,6 +1569,7 @@ sync
 syscall
 sysctl
 sysctlbyname
+sysctlnametomib
 sysctldesc
 tcp_info
 telldir

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1873,6 +1873,8 @@ pub const MNT_NOWAIT: ::c_int = 2;
 pub const MNT_LAZY: ::c_int = 3;
 
 //<sys/timex.h>
+pub const CLOCK_PROCESS_CPUTIME_ID: ::clockid_t = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: ::clockid_t = 4;
 pub const NTP_API: ::c_int = 4;
 pub const MAXPHASE: ::c_long = 500000000;
 pub const MAXFREQ: ::c_long = 500000;
@@ -2645,6 +2647,11 @@ extern "C" {
         oldlenp: *mut ::size_t,
         newp: *const ::c_void,
         newlen: ::size_t,
+    ) -> ::c_int;
+    pub fn sysctlnametomib(
+        sname: *const ::c_char,
+        name: *mut ::c_int,
+        namelenp: *mut ::size_t,
     ) -> ::c_int;
     #[link_name = "__kevent50"]
     pub fn kevent(


### PR DESCRIPTION
This PR adds support for:
  CLOCK_PROCESS_CPUTIME_ID
  CLOCK_THREAD_CPUTIME_ID
  sysctlnametomib

It replaces the following closed PRs:
https://github.com/rust-lang/libc/pull/3926
https://github.com/rust-lang/libc/pull/3923

Sorry for the back and forward actions.