### PR TITLE
android: add mallinfo2

### DIFF
--- a/libc-test/semver/android.txt
+++ b/libc-test/semver/android.txt
@@ -3454,6 +3454,7 @@ madvise
 major
 makedev
 mallinfo
+mallinfo2
 malloc
 malloc_usable_size
 mcontext_t

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -112,6 +112,20 @@ s! {
         pub keepcost: ::size_t,
     }
 
+    // This is identical to struct mallinfo on Android
+    pub struct mallinfo2 {
+        pub arena: ::size_t,
+        pub ordblks: ::size_t,
+        pub smblks: ::size_t,
+        pub hblks: ::size_t,
+        pub hblkhd: ::size_t,
+        pub usmblks: ::size_t,
+        pub fsmblks: ::size_t,
+        pub uordblks: ::size_t,
+        pub fordblks: ::size_t,
+        pub keepcost: ::size_t,
+    }
+
     pub struct flock {
         pub l_type: ::c_short,
         pub l_whence: ::c_short,
@@ -3744,6 +3758,8 @@ extern "C" {
     pub fn __sched_cpucount(setsize: ::size_t, set: *const cpu_set_t) -> ::c_int;
     pub fn sched_getcpu() -> ::c_int;
     pub fn mallinfo() -> ::mallinfo;
+    #[link_name = "mallinfo"]
+    pub fn mallinfo2() -> ::mallinfo2;
     // available from API 23
     pub fn malloc_info(options: ::c_int, stream: *mut ::FILE) -> ::c_int;
 


### PR DESCRIPTION
It's actually just mallinfo in a funny hat, just like in C; see <https://android-review.googlesource.com/c/platform/bionic/+/1910571> for the review of when they added this to Bionic's malloc.h header.

Since it's actually just mallinfo in dsguise, there is no minimum SDK level (just like for mallinfo).

Unlike in the header, I had to copy and paste the struct, because that's easier than building/borrowing a Rust macro to duplicate the fields. (Sometimes worse really is better.)