### PR TITLE
Fix tests on FreeBSD x86

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1462,6 +1462,7 @@ pub const TIOCISPTMASTER: ::c_ulong = 0x20007455;
 pub const TIOCMODG: ::c_ulong = 0x40047403;
 pub const TIOCMODS: ::c_ulong = 0x80047404;
 pub const TIOCREMOTE: ::c_ulong = 0x80047469;
+pub const TIOCTIMESTAMP: ::c_ulong = 0x40107459;
 
 // Constants used by "at" family of system calls.
 pub const AT_FDCWD: ::c_int = 0xFFFAFDCD; // invalid file descriptor

--- a/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
@@ -135,3 +135,4 @@ cfg_if! {
 
 pub const MAP_32BIT: ::c_int = 0x00080000;
 pub const MINSIGSTKSZ: ::size_t = 4096; // 1024 * 4
+pub const TIOCTIMESTAMP: ::c_ulong = 0x40107459;

--- a/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
@@ -133,6 +133,8 @@ cfg_if! {
     }
 }
 
+pub const BIOCSRTIMEOUT: ::c_ulong = 0x8010426d;
+pub const BIOCGRTIMEOUT: ::c_ulong = 0x4010426e;
 pub const MAP_32BIT: ::c_int = 0x00080000;
 pub const MINSIGSTKSZ: ::size_t = 4096; // 1024 * 4
 pub const TIOCTIMESTAMP: ::c_ulong = 0x40107459;

--- a/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
@@ -1,6 +1,7 @@
 pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
+pub type clock_t = i32;
 pub type wchar_t = u32;
 pub type time_t = i64;
 pub type suseconds_t = i64;

--- a/src/unix/bsd/freebsdlike/freebsd/arm.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/arm.rs
@@ -1,6 +1,7 @@
 pub type c_char = u8;
 pub type c_long = i32;
 pub type c_ulong = u32;
+pub type clock_t = u32;
 pub type wchar_t = u32;
 pub type time_t = i64;
 pub type suseconds_t = i32;

--- a/src/unix/bsd/freebsdlike/freebsd/arm.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/arm.rs
@@ -52,3 +52,4 @@ cfg_if! {
 pub(crate) const _ALIGNBYTES: usize = ::mem::size_of::<::c_int>() - 1;
 pub const MAP_32BIT: ::c_int = 0x00080000;
 pub const MINSIGSTKSZ: ::size_t = 4096; // 1024 * 4
+pub const TIOCTIMESTAMP: ::c_ulong = 0x40107459;

--- a/src/unix/bsd/freebsdlike/freebsd/arm.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/arm.rs
@@ -50,6 +50,8 @@ cfg_if! {
 }
 
 pub(crate) const _ALIGNBYTES: usize = ::mem::size_of::<::c_int>() - 1;
+pub const BIOCSRTIMEOUT: ::c_ulong = 0x8010426d;
+pub const BIOCGRTIMEOUT: ::c_ulong = 0x4010426e;
 pub const MAP_32BIT: ::c_int = 0x00080000;
 pub const MINSIGSTKSZ: ::size_t = 4096; // 1024 * 4
 pub const TIOCTIMESTAMP: ::c_ulong = 0x40107459;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -41,7 +41,10 @@ s! {
     }
 
     pub struct __c_anonymous_domainset {
-        _priv: [::uintptr_t; 4],
+        #[cfg(target_pointer_width = "64")]
+        _priv: [::c_ulong; 4],
+        #[cfg(target_pointer_width = "32")]
+        _priv: [::c_ulong; 8],
     }
 
     pub struct kinfo_proc {

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -41,7 +41,10 @@ s! {
     }
 
     pub struct __c_anonymous_domainset {
-        _priv: [::uintptr_t; 4],
+        #[cfg(target_pointer_width = "64")]
+        _priv: [::c_ulong; 4],
+        #[cfg(target_pointer_width = "32")]
+        _priv: [::c_ulong; 8],
     }
 
     pub struct kinfo_proc {

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
@@ -41,7 +41,10 @@ s! {
     }
 
     pub struct __c_anonymous_domainset {
-        _priv: [::uintptr_t; 4],
+        #[cfg(target_pointer_width = "64")]
+        _priv: [::c_ulong; 4],
+        #[cfg(target_pointer_width = "32")]
+        _priv: [::c_ulong; 8],
     }
 
     pub struct kinfo_proc {

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -3152,7 +3152,14 @@ cfg_if! {
     }
 }
 
-pub const FIODGNAME: ::c_ulong = 0x80106678;
+cfg_if! {
+    if #[cfg(target_pointer_width = "64")] {
+        pub const FIODGNAME: ::c_ulong = 0x80106678;
+    } else {
+        pub const FIODGNAME: ::c_ulong = 0x80086678;
+    }
+}
+
 pub const FIONWRITE: ::c_ulong = 0x40046677;
 pub const FIONSPACE: ::c_ulong = 0x40046676;
 pub const FIOSEEKDATA: ::c_ulong = 0xc0086661;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -3145,7 +3145,13 @@ pub const H4DISC: ::c_int = 0x7;
 
 pub const VM_TOTAL: ::c_int = 1;
 
-pub const BIOCSETFNR: ::c_ulong = 0x80104282;
+cfg_if! {
+    if #[cfg(target_pointer_width = "64")] {
+        pub const BIOCSETFNR: ::c_ulong = 0x80104282;
+    } else {
+        pub const BIOCSETFNR: ::c_ulong = 0x80084282;
+    }
+}
 
 pub const FIODGNAME: ::c_ulong = 0x80106678;
 pub const FIONWRITE: ::c_ulong = 0x40046677;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1629,7 +1629,7 @@ s_no_extra_traits! {
         pub kf_flags: ::c_int,
         _kf_pad0: ::c_int,
         pub kf_offset: i64,
-        _priv: [::uintptr_t; 38], // FIXME if needed
+        _priv: [u8; 304],   // FIXME: this is really a giant union
         pub kf_status: u16,
         _kf_pad1: u16,
         _kf_ispare0: ::c_int,

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1,5 +1,4 @@
 pub type fflags_t = u32;
-pub type clock_t = i32;
 
 pub type vm_prot_t = u_char;
 pub type kvaddr_t = u64;

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
@@ -69,6 +69,8 @@ cfg_if! {
 }
 
 pub(crate) const _ALIGNBYTES: usize = ::mem::size_of::<::c_int>() - 1;
+pub const BIOCSRTIMEOUT: ::c_ulong = 0x8010426d;
+pub const BIOCGRTIMEOUT: ::c_ulong = 0x4010426e;
 pub const MAP_32BIT: ::c_int = 0x00080000;
 pub const MINSIGSTKSZ: ::size_t = 2048; // 512 * 4
 pub const TIOCTIMESTAMP: ::c_ulong = 0x40107459;

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
@@ -71,3 +71,4 @@ cfg_if! {
 pub(crate) const _ALIGNBYTES: usize = ::mem::size_of::<::c_int>() - 1;
 pub const MAP_32BIT: ::c_int = 0x00080000;
 pub const MINSIGSTKSZ: ::size_t = 2048; // 512 * 4
+pub const TIOCTIMESTAMP: ::c_ulong = 0x40107459;

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
@@ -1,6 +1,7 @@
 pub type c_char = u8;
 pub type c_long = i32;
 pub type c_ulong = u32;
+pub type clock_t = u32;
 pub type wchar_t = i32;
 pub type time_t = i64;
 pub type suseconds_t = i32;

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
@@ -71,3 +71,4 @@ cfg_if! {
 pub(crate) const _ALIGNBYTES: usize = ::mem::size_of::<::c_long>() - 1;
 pub const MAP_32BIT: ::c_int = 0x00080000;
 pub const MINSIGSTKSZ: ::size_t = 2048; // 512 * 4
+pub const TIOCTIMESTAMP: ::c_ulong = 0x40107459;

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
@@ -69,6 +69,8 @@ cfg_if! {
 }
 
 pub(crate) const _ALIGNBYTES: usize = ::mem::size_of::<::c_long>() - 1;
+pub const BIOCSRTIMEOUT: ::c_ulong = 0x8010426d;
+pub const BIOCGRTIMEOUT: ::c_ulong = 0x4010426e;
 pub const MAP_32BIT: ::c_int = 0x00080000;
 pub const MINSIGSTKSZ: ::size_t = 2048; // 512 * 4
 pub const TIOCTIMESTAMP: ::c_ulong = 0x40107459;

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
@@ -1,6 +1,7 @@
 pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
+pub type clock_t = u32;
 pub type wchar_t = i32;
 pub type time_t = i64;
 pub type suseconds_t = i64;

--- a/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
@@ -143,3 +143,4 @@ cfg_if! {
 
 pub const MAP_32BIT: ::c_int = 0x00080000;
 pub const MINSIGSTKSZ: ::size_t = 4096; // 1024 * 4
+pub const TIOCTIMESTAMP: ::c_ulong = 0x40107459;

--- a/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
@@ -1,6 +1,7 @@
 pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
+pub type clock_t = i32;
 pub type wchar_t = ::c_int;
 pub type time_t = i64;
 pub type suseconds_t = ::c_long;

--- a/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
@@ -141,6 +141,8 @@ cfg_if! {
     }
 }
 
+pub const BIOCSRTIMEOUT: ::c_ulong = 0x8010426d;
+pub const BIOCGRTIMEOUT: ::c_ulong = 0x4010426e;
 pub const MAP_32BIT: ::c_int = 0x00080000;
 pub const MINSIGSTKSZ: ::size_t = 4096; // 1024 * 4
 pub const TIOCTIMESTAMP: ::c_ulong = 0x40107459;

--- a/src/unix/bsd/freebsdlike/freebsd/x86.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86.rs
@@ -156,5 +156,7 @@ cfg_if! {
 
 pub const MINSIGSTKSZ: ::size_t = 2048; // 512 * 4
 
+pub const BIOCSRTIMEOUT: ::c_ulong = 0x8008426d;
+pub const BIOCGRTIMEOUT: ::c_ulong = 0x4008426e;
 pub const KINFO_FILE_SIZE: ::c_int = 1392;
 pub const TIOCTIMESTAMP: ::c_ulong = 0x40087459;

--- a/src/unix/bsd/freebsdlike/freebsd/x86.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86.rs
@@ -32,7 +32,7 @@ s_no_extra_traits! {
         pub mc_fpformat: ::c_int,
         pub mc_ownedfp: ::c_int,
         pub mc_flags: register_t,
-        pub mc_fpstate: [[::c_int; 32]; 4],
+        pub mc_fpstate: [::c_int; 128],
         pub mc_fsbase: register_t,
         pub mc_gsbase: register_t,
         pub mc_xfpustate: register_t,

--- a/src/unix/bsd/freebsdlike/freebsd/x86.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86.rs
@@ -1,6 +1,7 @@
 pub type c_char = i8;
 pub type c_long = i32;
 pub type c_ulong = u32;
+pub type clock_t = ::c_ulong;
 pub type wchar_t = i32;
 pub type time_t = i32;
 pub type suseconds_t = i32;

--- a/src/unix/bsd/freebsdlike/freebsd/x86.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86.rs
@@ -7,6 +7,7 @@ pub type suseconds_t = i32;
 pub type register_t = i32;
 
 s_no_extra_traits! {
+    #[repr(align(16))]
     pub struct mcontext_t {
         pub mc_onstack: register_t,
         pub mc_gs: register_t,

--- a/src/unix/bsd/freebsdlike/freebsd/x86.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86.rs
@@ -157,3 +157,4 @@ cfg_if! {
 pub const MINSIGSTKSZ: ::size_t = 2048; // 512 * 4
 
 pub const KINFO_FILE_SIZE: ::c_int = 1392;
+pub const TIOCTIMESTAMP: ::c_ulong = 0x40087459;

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -1,6 +1,7 @@
 pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
+pub type clock_t = i32;
 pub type wchar_t = i32;
 pub type time_t = i64;
 pub type suseconds_t = i64;

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -220,6 +220,9 @@ cfg_if! {
 
 pub(crate) const _ALIGNBYTES: usize = ::mem::size_of::<::c_long>() - 1;
 
+pub const BIOCSRTIMEOUT: ::c_ulong = 0x8010426d;
+pub const BIOCGRTIMEOUT: ::c_ulong = 0x4010426e;
+
 pub const MAP_32BIT: ::c_int = 0x00080000;
 pub const MINSIGSTKSZ: ::size_t = 2048; // 512 * 4
 

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -236,5 +236,7 @@ pub const _MC_FPOWNED_PCB: c_long = 0x20002;
 
 pub const KINFO_FILE_SIZE: ::c_int = 1392;
 
+pub const TIOCTIMESTAMP: ::c_ulong = 0x40107459;
+
 mod align;
 pub use self::align::*;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1224,7 +1224,6 @@ pub const TIOCGETD: ::c_ulong = 0x4004741a;
 pub const TIOCSETD: ::c_ulong = 0x8004741b;
 pub const TIOCGDRAINWAIT: ::c_ulong = 0x40047456;
 pub const TIOCSDRAINWAIT: ::c_ulong = 0x80047457;
-pub const TIOCTIMESTAMP: ::c_ulong = 0x40107459;
 pub const TIOCMGDTRWAIT: ::c_ulong = 0x4004745a;
 pub const TIOCMSDTRWAIT: ::c_ulong = 0x8004745b;
 pub const TIOCDRAIN: ::c_ulong = 0x2000745e;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1278,10 +1278,15 @@ pub const BIOCSRSIG: ::c_ulong = 0x80044273;
 pub const BIOCSDLT: ::c_ulong = 0x80044278;
 pub const BIOCGSEESENT: ::c_ulong = 0x40044276;
 pub const BIOCSSEESENT: ::c_ulong = 0x80044277;
-pub const BIOCSETF: ::c_ulong = 0x80104267;
-pub const BIOCGDLTLIST: ::c_ulong = 0xc0104279;
-pub const BIOCSRTIMEOUT: ::c_ulong = 0x8010426d;
-pub const BIOCGRTIMEOUT: ::c_ulong = 0x4010426e;
+cfg_if! {
+    if #[cfg(target_pointer_width = "64")] {
+        pub const BIOCGDLTLIST: ::c_ulong = 0xc0104279;
+        pub const BIOCSETF: ::c_ulong = 0x80104267;
+    } else if #[cfg(target_pointer_width = "32")] {
+        pub const BIOCGDLTLIST: ::c_ulong = 0xc0084279;
+        pub const BIOCSETF: ::c_ulong = 0x80084267;
+    }
+}
 
 pub const FIODTYPE: ::c_ulong = 0x4004667a;
 pub const FIOGETLBA: ::c_ulong = 0x40046679;


### PR DESCRIPTION
This PR fixes the tests on FreeBSD 15 x86.  Many of the symbols were wrong for all 32-bit architectures.  All of these symbols are fairly obscure, so no real users are known to have encountered problems with them.  The discrepancies were never caught because we do CI only on FreeBSD x86_64.

Note: this PR must be rebased after #3946 merges.  That PR is much more important since it involves "struct stat", whereas this PR only concerns more obscure symbols.