### PR TITLE
[musl] add posix_spawn chdir functions

### DIFF
--- a/libc-test/semver/linux-musl.txt
+++ b/libc-test/semver/linux-musl.txt
@@ -80,6 +80,8 @@ getutxline
 lio_listio
 ntptimeval
 open_wmemstream
+posix_spawn_file_actions_addchdir_np
+posix_spawn_file_actions_addfchdir_np
 preadv2
 preadv64
 prlimit

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -968,6 +968,17 @@ extern "C" {
     pub fn dirname(path: *mut ::c_char) -> *mut ::c_char;
     pub fn basename(path: *mut ::c_char) -> *mut ::c_char;
 
+    // Added in `musl` 1.1.24
+    pub fn posix_spawn_file_actions_addchdir_np(
+        actions: *mut ::posix_spawn_file_actions_t,
+        path: *const ::c_char,
+    ) -> ::c_int;
+    // Added in `musl` 1.1.24
+    pub fn posix_spawn_file_actions_addfchdir_np(
+        actions: *mut ::posix_spawn_file_actions_t,
+        fd: ::c_int,
+    ) -> ::c_int;
+
     pub fn getutxent() -> *mut utmpx;
     pub fn getutxid(ut: *const utmpx) -> *mut utmpx;
     pub fn getutxline(ut: *const utmpx) -> *mut utmpx;


### PR DESCRIPTION
Add `posix_spawn_file_actions_add[f]chdir_np`, as present in musl 1.1.24 and above ([reference]).

[reference]: https://git.musl-libc.org/cgit/musl/commit/?id=74244e5b3ed4a61d99c5fc0967b69e5c9a753456
