### PR TITLE
Fix CI for FreeBSD 15, on libc-0.2 branch

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2338,6 +2338,9 @@ fn test_freebsd(target: &str) {
             // base system anyway.
             "CTL_MAXID" | "KERN_MAXID" | "HW_MAXID" | "USER_MAXID" => true,
 
+            // Deprecated and removed in FreeBSD 15.  It was never actually implemented.
+            "TCP_MAXPEAKRATE" => true,
+
             // FIXME: This is deprecated - remove in a couple of releases.
             // This was removed in FreeBSD 14 (git 1b4701fe1e8) and never
             // should've been used anywhere anyway.
@@ -2363,6 +2366,10 @@ fn test_freebsd(target: &str) {
             | "PRI_MAX_KERN" | "PSWP" | "PVM" | "PINOD" | "PRIBIO" | "PVFS" | "PZERO" | "PSOCK"
             | "PWAIT" | "PLOCK" | "PPAUSE" | "PRI_MIN_TIMESHARE" | "PUSER" | "PI_AV" | "PI_NET"
             | "PI_DISK" | "PI_TTY" | "PI_DULL" | "PI_SOFT" => true,
+
+            // This constant changed in FreeBSD 15 (git 3458bbd397783).  It was never intended to
+            // be stable, and probably shouldn't be bound by libc at all.
+            "RLIM_NLIMITS" => true,
 
             // This symbol changed in FreeBSD 14 (git 051e7d78b03), but the new
             // version should be safe to use on older releases.
@@ -2494,7 +2501,6 @@ fn test_freebsd(target: &str) {
 
             // Flags introduced in FreeBSD 14.
             "TCP_MAXUNACKTIME"
-            | "TCP_MAXPEAKRATE"
             | "TCP_IDLE_REDUCE"
             | "TCP_REMOTE_UDP_ENCAPS_PORT"
             | "TCP_DELACK"

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -3843,6 +3843,7 @@ pub const TCP_INFO: ::c_int = 32;
 pub const TCP_CONGESTION: ::c_int = 64;
 pub const TCP_CCALGOOPT: ::c_int = 65;
 pub const TCP_MAXUNACKTIME: ::c_int = 68;
+#[deprecated(since = "0.2.160", note = "Removed in FreeBSD 15")]
 pub const TCP_MAXPEAKRATE: ::c_int = 69;
 pub const TCP_IDLE_REDUCE: ::c_int = 70;
 pub const TCP_REMOTE_UDP_ENCAPS_PORT: ::c_int = 71;


### PR DESCRIPTION
It was failing for two reasons:

* 87fbd9fc71[^1] removed the TCP_MAXPEAKRATE symbol.
* 3458bbd392[^2] changed the value of RLIM_NLIMITS

Fixes #3947

[^1]: https://github.com/freebsd/freebsd-src/commit/87fbd9fc7fc5f8d79fe5e3dcd13ad02b11a67ef0
[^2]: https://github.com/freebsd/freebsd-src/commit/3458bbd397783f3bb62713c54ae87f19eeb98dc0