### PR TITLE
emscripten: Upgrade emsdk to 3.1.68

### DIFF
--- a/ci/emscripten.sh
+++ b/ci/emscripten.sh
@@ -2,9 +2,9 @@
 
 set -ex
 
-# FIXME: 3.1.21 removed a lot of header files (https://github.com/emscripten-core/emscripten/pull/17704).
-#        We have to tweak libc-test (and deprecate unsupported items, maybe) when updating emsdk.
-EMSDK_VERSION=3.1.20
+# Note: keep in sync with:
+# https://github.com/rust-lang/rust/blob/master/src/ci/docker/scripts/emscripten.sh
+EMSDK_VERSION=3.1.68
 
 git clone https://github.com/emscripten-core/emsdk.git /emsdk-portable
 cd /emsdk-portable

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2779,31 +2779,21 @@ fn test_emscripten(target: &str) {
                "stdio.h",
                "stdlib.h",
                "string.h",
-               "sys/epoll.h",
-               "sys/eventfd.h",
                "sys/file.h",
                "sys/ioctl.h",
                "sys/ipc.h",
                "sys/mman.h",
                "sys/mount.h",
                "sys/msg.h",
-               "sys/personality.h",
-               "sys/prctl.h",
-               "sys/ptrace.h",
-               "sys/quota.h",
-               "sys/reboot.h",
                "sys/resource.h",
                "sys/sem.h",
                "sys/shm.h",
-               "sys/signalfd.h",
                "sys/socket.h",
                "sys/stat.h",
                "sys/statvfs.h",
-               "sys/swap.h",
                "sys/syscall.h",
                "sys/sysinfo.h",
                "sys/time.h",
-               "sys/timerfd.h",
                "sys/times.h",
                "sys/types.h",
                "sys/uio.h",
@@ -2828,8 +2818,6 @@ fn test_emscripten(target: &str) {
         match ty {
             // Just pass all these through, no need for a "struct" prefix
             "FILE" | "fd_set" | "Dl_info" | "DIR" => ty.to_string(),
-
-            "os_unfair_lock" => "struct os_unfair_lock_s".to_string(),
 
             // LFS64 types have been removed in Emscripten 3.1.44+
             // https://github.com/emscripten-core/emscripten/pull/19812
@@ -2867,6 +2855,10 @@ fn test_emscripten(target: &str) {
             // FIXME: is this necessary?
             "sighandler_t" => true,
 
+            // No epoll support
+            // https://github.com/emscripten-core/emscripten/issues/5033
+            ty if ty.starts_with("epoll") => true,
+
             // FIXME: The size has been changed due to musl's time64
             "time_t" => true,
 
@@ -2892,6 +2884,11 @@ fn test_emscripten(target: &str) {
 
             // FIXME: The size has been changed when upgraded to musl 1.2.2
             "pthread_mutex_t" => true,
+
+            // No epoll support
+            // https://github.com/emscripten-core/emscripten/issues/5033
+            ty if ty.starts_with("epoll") => true,
+            ty if ty.starts_with("signalfd") => true,
 
             // FIXME: Lowered from 16 to 8 bytes in
             // llvm/llvm-project@d1a96e9
@@ -2929,9 +2926,29 @@ fn test_emscripten(target: &str) {
             // FIXME: emscripten uses different constants to constructs these
             n if n.contains("__SIZEOF_PTHREAD") => true,
 
+            // No epoll support
+            // https://github.com/emscripten-core/emscripten/issues/5033
+            n if n.starts_with("EPOLL") => true,
+
+            // No ptrace.h
+            // https://github.com/emscripten-core/emscripten/pull/17704
+            n if n.starts_with("PTRACE_") => true,
+
+            // No quota.h
+            // https://github.com/emscripten-core/emscripten/pull/17704
+            n if n.starts_with("QIF_") => true,
+            "USRQUOTA" | "GRPQUOTA" | "Q_GETFMT" | "Q_GETINFO" | "Q_SETINFO" | "Q_SYNC"
+            | "Q_QUOTAON" | "Q_QUOTAOFF" | "Q_GETQUOTA" | "Q_SETQUOTA" => true,
+
             // FIXME: `SYS_gettid` was removed in
             // emscripten-core/emscripten@6d6474e
             "SYS_gettid" => true,
+
+            // No personality.h
+            // https://github.com/emscripten-core/emscripten/pull/17704
+            "ADDR_NO_RANDOMIZE" | "MMAP_PAGE_ZERO" | "ADDR_COMPAT_LAYOUT" | "READ_IMPLIES_EXEC"
+            | "ADDR_LIMIT_32BIT" | "SHORT_INODE" | "WHOLE_SECONDS" | "STICKY_TIMEOUTS"
+            | "ADDR_LIMIT_3GB" => true,
 
             // FIXME: These values have been changed
             | "POSIX_MADV_DONTNEED" // to 4
@@ -2973,17 +2990,6 @@ fn test_emscripten(target: &str) {
         // musl names this __dummy1 but it's still there
         // FIXME: is this necessary?
         (struct_ == "glob_t" && field == "gl_flags") ||
-        // musl seems to define this as an *anonymous* bitfield
-        // FIXME: is this necessary?
-        (struct_ == "statvfs" && field == "__f_unused") ||
-        // sigev_notify_thread_id is actually part of a sigev_un union
-        (struct_ == "sigevent" && field == "sigev_notify_thread_id") ||
-        // signalfd had SIGSYS fields added in Linux 4.18, but no libc release has them yet.
-        (struct_ == "signalfd_siginfo" && (field == "ssi_addr_lsb" ||
-                                           field == "_pad2" ||
-                                           field == "ssi_syscall" ||
-                                           field == "ssi_call_addr" ||
-                                           field == "ssi_arch")) ||
         // FIXME: After musl 1.1.24, it have only one field `sched_priority`,
         // while other fields become reserved.
         (struct_ == "sched_param" && [

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2739,7 +2739,6 @@ fn test_emscripten(target: &str) {
     cfg.define("_GNU_SOURCE", None); // FIXME: ??
 
     headers! { cfg:
-               "aio.h",
                "ctype.h",
                "dirent.h",
                "dlfcn.h",
@@ -2964,10 +2963,7 @@ fn test_emscripten(target: &str) {
         (struct_ == "sigaction" && field == "sa_sigaction") ||
         // sigval is actually a union, but we pretend it's a struct
         // FIXME: is this necessary?
-        (struct_ == "sigevent" && field == "sigev_value") ||
-        // aio_buf is "volatile void*" and Rust doesn't understand volatile
-        // FIXME: is this necessary?
-        (struct_ == "aiocb" && field == "aio_buf")
+        (struct_ == "sigevent" && field == "sigev_value")
     });
 
     cfg.skip_field(move |struct_, field| {

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2890,10 +2890,6 @@ fn test_emscripten(target: &str) {
             ty if ty.starts_with("epoll") => true,
             ty if ty.starts_with("signalfd") => true,
 
-            // FIXME: Lowered from 16 to 8 bytes in
-            // llvm/llvm-project@d1a96e9
-            "max_align_t" => true,
-
             // FIXME: The size has been changed due to time64
             "utimbuf" | "timeval" | "timespec" | "rusage" | "itimerval" | "sched_param"
             | "stat" | "stat64" | "shmid_ds" | "msqid_ds" => true,

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2801,7 +2801,6 @@ fn test_emscripten(target: &str) {
                "sys/statvfs.h",
                "sys/swap.h",
                "sys/syscall.h",
-               "sys/sysctl.h",
                "sys/sysinfo.h",
                "sys/time.h",
                "sys/timerfd.h",

--- a/src/unix/linux_like/emscripten/align.rs
+++ b/src/unix/linux_like/emscripten/align.rs
@@ -38,9 +38,9 @@ macro_rules! expand_align {
             }
 
             #[allow(missing_debug_implementations)]
-            #[repr(align(16))]
+            #[repr(align(8))]
             pub struct max_align_t {
-                priv_: [f64; 4]
+                priv_: [f64; 3]
             }
 
         }

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -16,7 +16,7 @@ pub type loff_t = i64;
 pub type pthread_key_t = ::c_uint;
 
 pub type clock_t = c_long;
-pub type time_t = c_long;
+pub type time_t = i64;
 pub type suseconds_t = c_long;
 pub type ino_t = u64;
 pub type off_t = i64;
@@ -259,11 +259,8 @@ s! {
         pub shm_perm: ::ipc_perm,
         pub shm_segsz: ::size_t,
         pub shm_atime: ::time_t,
-        __unused1: ::c_int,
         pub shm_dtime: ::time_t,
-        __unused2: ::c_int,
         pub shm_ctime: ::time_t,
-        __unused3: ::c_int,
         pub shm_cpid: ::pid_t,
         pub shm_lpid: ::pid_t,
         pub shm_nattch: ::c_ulong,
@@ -274,11 +271,8 @@ s! {
     pub struct msqid_ds {
         pub msg_perm: ::ipc_perm,
         pub msg_stime: ::time_t,
-        __unused1: ::c_int,
         pub msg_rtime: ::time_t,
-        __unused2: ::c_int,
         pub msg_ctime: ::time_t,
-        __unused3: ::c_int,
         __msg_cbytes: ::c_ulong,
         pub msg_qnum: ::msgqnum_t,
         pub msg_qbytes: ::msglen_t,
@@ -1046,11 +1040,11 @@ pub const PTHREAD_STACK_MIN: ::size_t = 2048;
 pub const POSIX_FADV_DONTNEED: ::c_int = 4;
 pub const POSIX_FADV_NOREUSE: ::c_int = 5;
 
-pub const POSIX_MADV_DONTNEED: ::c_int = 0;
+pub const POSIX_MADV_DONTNEED: ::c_int = 4;
 
 pub const RLIM_INFINITY: ::rlim_t = !0;
 #[deprecated(since = "0.2.64", note = "Not stable across OS versions")]
-pub const RLIMIT_NLIMITS: ::c_int = 15;
+pub const RLIMIT_NLIMITS: ::c_int = 16;
 #[allow(deprecated)]
 #[deprecated(since = "0.2.64", note = "Not stable across OS versions")]
 pub const RLIM_NLIMITS: ::c_int = RLIMIT_NLIMITS;
@@ -1065,7 +1059,7 @@ pub const __SIZEOF_PTHREAD_CONDATTR_T: usize = 4;
 pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
 pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: usize = 8;
 
-pub const CPU_SETSIZE: ::c_int = 128;
+pub const CPU_SETSIZE: ::c_int = 1024;
 
 pub const TCSANOW: ::c_int = 0;
 pub const TCSADRAIN: ::c_int = 1;
@@ -1167,14 +1161,14 @@ pub const B3500000: ::speed_t = 0o010016;
 pub const B4000000: ::speed_t = 0o010017;
 
 pub const SO_BINDTODEVICE: ::c_int = 25;
-pub const SO_TIMESTAMP: ::c_int = 29;
+pub const SO_TIMESTAMP: ::c_int = 63;
 pub const SO_MARK: ::c_int = 36;
 pub const SO_RXQ_OVFL: ::c_int = 40;
 pub const SO_PEEK_OFF: ::c_int = 42;
 pub const SO_BUSY_POLL: ::c_int = 46;
 
 pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 32;
-pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 28;
+pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 24;
 
 pub const O_DIRECT: ::c_int = 0x4000;
 pub const O_DIRECTORY: ::c_int = 0x10000;
@@ -1225,7 +1219,7 @@ pub const SOCK_STREAM: ::c_int = 1;
 pub const SOCK_DGRAM: ::c_int = 2;
 pub const SOCK_SEQPACKET: ::c_int = 5;
 
-pub const IPPROTO_MAX: ::c_int = 256;
+pub const IPPROTO_MAX: ::c_int = 263;
 
 pub const SOL_SOCKET: ::c_int = 1;
 
@@ -1242,8 +1236,8 @@ pub const SO_LINGER: ::c_int = 13;
 pub const SO_REUSEPORT: ::c_int = 15;
 pub const SO_RCVLOWAT: ::c_int = 18;
 pub const SO_SNDLOWAT: ::c_int = 19;
-pub const SO_RCVTIMEO: ::c_int = 20;
-pub const SO_SNDTIMEO: ::c_int = 21;
+pub const SO_RCVTIMEO: ::c_int = 66;
+pub const SO_SNDTIMEO: ::c_int = 67;
 pub const SO_ACCEPTCONN: ::c_int = 30;
 
 pub const IPV6_RTHDR_LOOSE: ::c_int = 0;
@@ -1345,7 +1339,7 @@ pub const TIOCM_RNG: ::c_int = 0x080;
 pub const TIOCM_DSR: ::c_int = 0x100;
 pub const TIOCM_CD: ::c_int = TIOCM_CAR;
 pub const TIOCM_RI: ::c_int = TIOCM_RNG;
-pub const O_TMPFILE: ::c_int = 0x400000;
+pub const O_TMPFILE: ::c_int = 0x410000;
 
 pub const MAX_ADDR_LEN: usize = 7;
 pub const ARPD_UPDATE: ::c_ushort = 0x01;

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -103,18 +103,6 @@ s! {
         __f_spare: [::c_int; 6],
     }
 
-    pub struct dqblk {
-        pub dqb_bhardlimit: u64,
-        pub dqb_bsoftlimit: u64,
-        pub dqb_curspace: u64,
-        pub dqb_ihardlimit: u64,
-        pub dqb_isoftlimit: u64,
-        pub dqb_curinodes: u64,
-        pub dqb_btime: u64,
-        pub dqb_itime: u64,
-        pub dqb_valid: u32,
-    }
-
     pub struct signalfd_siginfo {
         pub ssi_signo: u32,
         pub ssi_errno: i32,
@@ -850,22 +838,9 @@ pub const SHM_UNLOCK: ::c_int = 12;
 pub const SHM_HUGETLB: ::c_int = 0o4000;
 pub const SHM_NORESERVE: ::c_int = 0o10000;
 
-pub const QFMT_VFS_OLD: ::c_int = 1;
-pub const QFMT_VFS_V0: ::c_int = 2;
-
-pub const EFD_SEMAPHORE: ::c_int = 0x1;
-
 pub const LOG_NFACILITIES: ::c_int = 24;
 
 pub const SEM_FAILED: *mut ::sem_t = 0 as *mut sem_t;
-
-pub const RB_AUTOBOOT: ::c_int = 0x01234567u32 as i32;
-pub const RB_HALT_SYSTEM: ::c_int = 0xcdef0123u32 as i32;
-pub const RB_ENABLE_CAD: ::c_int = 0x89abcdefu32 as i32;
-pub const RB_DISABLE_CAD: ::c_int = 0x00000000u32 as i32;
-pub const RB_POWER_OFF: ::c_int = 0x4321fedcu32 as i32;
-pub const RB_SW_SUSPEND: ::c_int = 0xd000fce2u32 as i32;
-pub const RB_KEXEC: ::c_int = 0x45584543u32 as i32;
 
 pub const AI_PASSIVE: ::c_int = 0x0001;
 pub const AI_CANONNAME: ::c_int = 0x0002;
@@ -901,127 +876,6 @@ pub const EAI_SYSTEM: ::c_int = -11;
 pub const MREMAP_MAYMOVE: ::c_int = 1;
 pub const MREMAP_FIXED: ::c_int = 2;
 
-pub const PR_SET_PDEATHSIG: ::c_int = 1;
-pub const PR_GET_PDEATHSIG: ::c_int = 2;
-
-pub const PR_GET_DUMPABLE: ::c_int = 3;
-pub const PR_SET_DUMPABLE: ::c_int = 4;
-
-pub const PR_GET_UNALIGN: ::c_int = 5;
-pub const PR_SET_UNALIGN: ::c_int = 6;
-pub const PR_UNALIGN_NOPRINT: ::c_int = 1;
-pub const PR_UNALIGN_SIGBUS: ::c_int = 2;
-
-pub const PR_GET_KEEPCAPS: ::c_int = 7;
-pub const PR_SET_KEEPCAPS: ::c_int = 8;
-
-pub const PR_GET_FPEMU: ::c_int = 9;
-pub const PR_SET_FPEMU: ::c_int = 10;
-pub const PR_FPEMU_NOPRINT: ::c_int = 1;
-pub const PR_FPEMU_SIGFPE: ::c_int = 2;
-
-pub const PR_GET_FPEXC: ::c_int = 11;
-pub const PR_SET_FPEXC: ::c_int = 12;
-pub const PR_FP_EXC_SW_ENABLE: ::c_int = 0x80;
-pub const PR_FP_EXC_DIV: ::c_int = 0x010000;
-pub const PR_FP_EXC_OVF: ::c_int = 0x020000;
-pub const PR_FP_EXC_UND: ::c_int = 0x040000;
-pub const PR_FP_EXC_RES: ::c_int = 0x080000;
-pub const PR_FP_EXC_INV: ::c_int = 0x100000;
-pub const PR_FP_EXC_DISABLED: ::c_int = 0;
-pub const PR_FP_EXC_NONRECOV: ::c_int = 1;
-pub const PR_FP_EXC_ASYNC: ::c_int = 2;
-pub const PR_FP_EXC_PRECISE: ::c_int = 3;
-
-pub const PR_GET_TIMING: ::c_int = 13;
-pub const PR_SET_TIMING: ::c_int = 14;
-pub const PR_TIMING_STATISTICAL: ::c_int = 0;
-pub const PR_TIMING_TIMESTAMP: ::c_int = 1;
-
-pub const PR_SET_NAME: ::c_int = 15;
-pub const PR_GET_NAME: ::c_int = 16;
-
-pub const PR_GET_ENDIAN: ::c_int = 19;
-pub const PR_SET_ENDIAN: ::c_int = 20;
-pub const PR_ENDIAN_BIG: ::c_int = 0;
-pub const PR_ENDIAN_LITTLE: ::c_int = 1;
-pub const PR_ENDIAN_PPC_LITTLE: ::c_int = 2;
-
-pub const PR_GET_SECCOMP: ::c_int = 21;
-pub const PR_SET_SECCOMP: ::c_int = 22;
-
-pub const PR_CAPBSET_READ: ::c_int = 23;
-pub const PR_CAPBSET_DROP: ::c_int = 24;
-
-pub const PR_GET_TSC: ::c_int = 25;
-pub const PR_SET_TSC: ::c_int = 26;
-pub const PR_TSC_ENABLE: ::c_int = 1;
-pub const PR_TSC_SIGSEGV: ::c_int = 2;
-
-pub const PR_GET_SECUREBITS: ::c_int = 27;
-pub const PR_SET_SECUREBITS: ::c_int = 28;
-
-pub const PR_SET_TIMERSLACK: ::c_int = 29;
-pub const PR_GET_TIMERSLACK: ::c_int = 30;
-
-pub const PR_TASK_PERF_EVENTS_DISABLE: ::c_int = 31;
-pub const PR_TASK_PERF_EVENTS_ENABLE: ::c_int = 32;
-
-pub const PR_MCE_KILL: ::c_int = 33;
-pub const PR_MCE_KILL_CLEAR: ::c_int = 0;
-pub const PR_MCE_KILL_SET: ::c_int = 1;
-
-pub const PR_MCE_KILL_LATE: ::c_int = 0;
-pub const PR_MCE_KILL_EARLY: ::c_int = 1;
-pub const PR_MCE_KILL_DEFAULT: ::c_int = 2;
-
-pub const PR_MCE_KILL_GET: ::c_int = 34;
-
-pub const PR_SET_MM: ::c_int = 35;
-pub const PR_SET_MM_START_CODE: ::c_int = 1;
-pub const PR_SET_MM_END_CODE: ::c_int = 2;
-pub const PR_SET_MM_START_DATA: ::c_int = 3;
-pub const PR_SET_MM_END_DATA: ::c_int = 4;
-pub const PR_SET_MM_START_STACK: ::c_int = 5;
-pub const PR_SET_MM_START_BRK: ::c_int = 6;
-pub const PR_SET_MM_BRK: ::c_int = 7;
-pub const PR_SET_MM_ARG_START: ::c_int = 8;
-pub const PR_SET_MM_ARG_END: ::c_int = 9;
-pub const PR_SET_MM_ENV_START: ::c_int = 10;
-pub const PR_SET_MM_ENV_END: ::c_int = 11;
-pub const PR_SET_MM_AUXV: ::c_int = 12;
-pub const PR_SET_MM_EXE_FILE: ::c_int = 13;
-pub const PR_SET_MM_MAP: ::c_int = 14;
-pub const PR_SET_MM_MAP_SIZE: ::c_int = 15;
-
-pub const PR_SET_PTRACER: ::c_int = 0x59616d61;
-pub const PR_SET_PTRACER_ANY: ::c_ulong = 0xffffffffffffffff;
-
-pub const PR_SET_CHILD_SUBREAPER: ::c_int = 36;
-pub const PR_GET_CHILD_SUBREAPER: ::c_int = 37;
-
-pub const PR_SET_NO_NEW_PRIVS: ::c_int = 38;
-pub const PR_GET_NO_NEW_PRIVS: ::c_int = 39;
-
-pub const PR_GET_TID_ADDRESS: ::c_int = 40;
-
-pub const PR_SET_THP_DISABLE: ::c_int = 41;
-pub const PR_GET_THP_DISABLE: ::c_int = 42;
-
-pub const PR_MPX_ENABLE_MANAGEMENT: ::c_int = 43;
-pub const PR_MPX_DISABLE_MANAGEMENT: ::c_int = 44;
-
-pub const PR_SET_FP_MODE: ::c_int = 45;
-pub const PR_GET_FP_MODE: ::c_int = 46;
-pub const PR_FP_MODE_FR: ::c_int = 1 << 0;
-pub const PR_FP_MODE_FRE: ::c_int = 1 << 1;
-
-pub const PR_CAP_AMBIENT: ::c_int = 47;
-pub const PR_CAP_AMBIENT_IS_SET: ::c_int = 1;
-pub const PR_CAP_AMBIENT_RAISE: ::c_int = 2;
-pub const PR_CAP_AMBIENT_LOWER: ::c_int = 3;
-pub const PR_CAP_AMBIENT_CLEAR_ALL: ::c_int = 4;
-
 pub const ITIMER_REAL: ::c_int = 0;
 pub const ITIMER_VIRTUAL: ::c_int = 1;
 pub const ITIMER_PROF: ::c_int = 2;
@@ -1030,11 +884,6 @@ pub const _POSIX_VDISABLE: ::cc_t = 0;
 
 pub const FALLOC_FL_KEEP_SIZE: ::c_int = 0x01;
 pub const FALLOC_FL_PUNCH_HOLE: ::c_int = 0x02;
-
-// On Linux, libc doesn't define this constant, libattr does instead.
-// We still define it for Linux as it's defined by libc on other platforms,
-// and it's mentioned in the man pages for getxattr and setxattr.
-pub const SFD_CLOEXEC: ::c_int = 0x080000;
 
 pub const NCCS: usize = 32;
 
@@ -1184,10 +1033,6 @@ pub const SA_RESETHAND: ::c_int = 0x80000000;
 pub const SA_RESTART: ::c_int = 0x10000000;
 pub const SA_NOCLDSTOP: ::c_int = 0x00000001;
 
-pub const EPOLL_CLOEXEC: ::c_int = 0x80000;
-
-pub const EFD_CLOEXEC: ::c_int = 0x80000;
-
 pub const BUFSIZ: ::c_uint = 1024;
 pub const TMP_MAX: ::c_uint = 10000;
 pub const FOPEN_MAX: ::c_uint = 1000;
@@ -1221,43 +1066,6 @@ pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
 pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: usize = 8;
 
 pub const CPU_SETSIZE: ::c_int = 128;
-
-pub const QFMT_VFS_V1: ::c_int = 4;
-
-pub const PTRACE_TRACEME: ::c_int = 0;
-pub const PTRACE_PEEKTEXT: ::c_int = 1;
-pub const PTRACE_PEEKDATA: ::c_int = 2;
-pub const PTRACE_PEEKUSER: ::c_int = 3;
-pub const PTRACE_POKETEXT: ::c_int = 4;
-pub const PTRACE_POKEDATA: ::c_int = 5;
-pub const PTRACE_POKEUSER: ::c_int = 6;
-pub const PTRACE_CONT: ::c_int = 7;
-pub const PTRACE_KILL: ::c_int = 8;
-pub const PTRACE_SINGLESTEP: ::c_int = 9;
-pub const PTRACE_ATTACH: ::c_int = 16;
-pub const PTRACE_DETACH: ::c_int = 17;
-pub const PTRACE_SYSCALL: ::c_int = 24;
-pub const PTRACE_SETOPTIONS: ::c_int = 0x4200;
-pub const PTRACE_GETEVENTMSG: ::c_int = 0x4201;
-pub const PTRACE_GETSIGINFO: ::c_int = 0x4202;
-pub const PTRACE_SETSIGINFO: ::c_int = 0x4203;
-pub const PTRACE_GETREGSET: ::c_int = 0x4204;
-pub const PTRACE_SETREGSET: ::c_int = 0x4205;
-pub const PTRACE_SEIZE: ::c_int = 0x4206;
-pub const PTRACE_INTERRUPT: ::c_int = 0x4207;
-pub const PTRACE_LISTEN: ::c_int = 0x4208;
-pub const PTRACE_PEEKSIGINFO: ::c_int = 0x4209;
-
-pub const PTRACE_GETFPREGS: ::c_uint = 14;
-pub const PTRACE_SETFPREGS: ::c_uint = 15;
-pub const PTRACE_GETFPXREGS: ::c_uint = 18;
-pub const PTRACE_SETFPXREGS: ::c_uint = 19;
-pub const PTRACE_GETREGS: ::c_uint = 12;
-pub const PTRACE_SETREGS: ::c_uint = 13;
-
-pub const EFD_NONBLOCK: ::c_int = ::O_NONBLOCK;
-
-pub const SFD_NONBLOCK: ::c_int = ::O_NONBLOCK;
 
 pub const TCSANOW: ::c_int = 0;
 pub const TCSADRAIN: ::c_int = 1;

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -171,23 +171,6 @@ s! {
         pub sem_flg: ::c_short,
     }
 
-    pub struct aiocb {
-        pub aio_fildes: ::c_int,
-        pub aio_lio_opcode: ::c_int,
-        pub aio_reqprio: ::c_int,
-        pub aio_buf: *mut ::c_void,
-        pub aio_nbytes: ::size_t,
-        pub aio_sigevent: ::sigevent,
-        __td: *mut ::c_void,
-        __lock: [::c_int; 2],
-        __err: ::c_int,
-        __ret: ::ssize_t,
-        pub aio_offset: off_t,
-        __next: *mut ::c_void,
-        __prev: *mut ::c_void,
-        __dummy4: [::c_char; 24],
-    }
-
     pub struct sigaction {
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: ::sigset_t,
@@ -914,15 +897,6 @@ pub const SYNC_FILE_RANGE_WRITE: ::c_uint = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: ::c_uint = 4;
 
 pub const EAI_SYSTEM: ::c_int = -11;
-
-pub const AIO_CANCELED: ::c_int = 0;
-pub const AIO_NOTCANCELED: ::c_int = 1;
-pub const AIO_ALLDONE: ::c_int = 2;
-pub const LIO_READ: ::c_int = 0;
-pub const LIO_WRITE: ::c_int = 1;
-pub const LIO_NOP: ::c_int = 2;
-pub const LIO_WAIT: ::c_int = 0;
-pub const LIO_NOWAIT: ::c_int = 1;
 
 pub const MREMAP_MAYMOVE: ::c_int = 1;
 pub const MREMAP_FIXED: ::c_int = 2;


### PR DESCRIPTION
In line with commit https://github.com/rust-lang/rust/commit/2c38ecfc9077000db7de14bf501fa5294eeecedd.

Resolves: #3306.
Supersedes: #3569.
Cherry-picks a couple of changes from: #3307.