### PR TITLE
pthread constants and functions for VxWorks

### DIFF
--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -253,7 +253,7 @@ s! {
     }
 
     // b_struct__Sched_param.h
-    pub struct _Sched_param {
+    pub struct sched_param {
         pub sched_priority: ::c_int, /* scheduling priority */
         pub sched_ss_low_priority: ::c_int,    /* low scheduling priority */
         pub sched_ss_repl_period: ::_Timespec, /* replenishment period */
@@ -274,7 +274,7 @@ s! {
         pub threadAttrSchedpolicy     : ::c_int,
         pub threadAttrName            : *mut ::c_char,
         pub threadAttrOptions         : ::c_int,
-        pub threadAttrSchedparam      : ::_Sched_param,
+        pub threadAttrSchedparam      : ::sched_param,
     }
 
     // signal.h
@@ -612,6 +612,19 @@ pub const PTHREAD_MUTEX_RECURSIVE: ::c_int = 2;
 pub const PTHREAD_MUTEX_DEFAULT: ::c_int = PTHREAD_MUTEX_NORMAL;
 pub const PTHREAD_STACK_MIN: usize = 4096;
 pub const _PTHREAD_SHARED_SEM_NAME_MAX: usize = 30;
+
+//sched.h
+pub const SCHED_FIFO: ::c_int = 0x01;
+pub const SCHED_RR: ::c_int = 0x02;
+pub const SCHED_OTHER: ::c_int = 0x04;
+pub const SCHED_SPORADIC: ::c_int = 0x08;
+pub const PRIO_PROCESS: ::c_uint = 0;
+pub const SCHED_FIFO_HIGH_PRI: ::c_int = 255;
+pub const SCHED_FIFO_LOW_PRI: ::c_int = 0;
+pub const SCHED_RR_HIGH_PRI: ::c_int = 255;
+pub const SCHED_RR_LOW_PRI: ::c_int = 0;
+pub const SCHED_SPORADIC_HIGH_PRI: ::c_int = 255;
+pub const SCHED_SPORADIC_LOW_PRI: ::c_int = 0;
 
 // ERRNO STUFF
 pub const ERROR: ::c_int = -1;
@@ -1388,6 +1401,29 @@ extern "C" {
         value: *mut ::c_void,
     ) -> ::c_int;
 
+    //pthread.h
+    pub fn pthread_setschedparam(
+        native: ::pthread_t,
+        policy: ::c_int,
+        param: *const ::sched_param,
+    ) -> ::c_int;
+
+    //pthread.h
+    pub fn pthread_getschedparam(
+        native: ::pthread_t,
+        policy: *mut ::c_int,
+        param: *mut ::sched_param,
+    ) -> ::c_int;
+
+    //pthread.h
+    pub fn pthread_attr_setinheritsched(
+        attr: *mut ::pthread_attr_t,
+        inheritsched: ::c_int,
+    ) -> ::c_int;
+
+    //pthread.h
+    pub fn pthread_attr_setschedpolicy(attr: *mut ::pthread_attr_t, policy: ::c_int) -> ::c_int;
+
     // pthread.h
     pub fn pthread_attr_destroy(thread: *mut ::pthread_attr_t) -> ::c_int;
 
@@ -1400,6 +1436,7 @@ extern "C" {
         parent: ::Option<unsafe extern "C" fn()>,
         child: ::Option<unsafe extern "C" fn()>,
     ) -> ::c_int;
+
     // stat.h
     pub fn fstat(fildes: ::c_int, buf: *mut stat) -> ::c_int;
 
@@ -1753,6 +1790,31 @@ extern "C" {
 
     // dirent.h
     pub fn closedir(ptr: *mut ::DIR) -> ::c_int;
+
+    //sched.h
+    pub fn sched_get_priority_max(policy: ::c_int) -> ::c_int;
+
+    //sched.h
+    pub fn sched_get_priority_min(policy: ::c_int) -> ::c_int;
+
+    //sched.h
+    pub fn sched_setparam(pid: ::pid_t, param: *const ::sched_param) -> ::c_int;
+
+    //sched.h
+    pub fn sched_getparam(pid: ::pid_t, param: *mut ::sched_param) -> ::c_int;
+
+    //sched.h
+    pub fn sched_setscheduler(
+        pid: ::pid_t,
+        policy: ::c_int,
+        param: *const ::sched_param,
+    ) -> ::c_int;
+
+    //sched.h
+    pub fn sched_getscheduler(pid: ::pid_t) -> ::c_int;
+
+    //sched.h
+    pub fn sched_rr_get_interval(pid: ::pid_t, tp: *mut ::timespec) -> ::c_int;
 
     // sched.h
     pub fn sched_yield() -> ::c_int;


### PR DESCRIPTION
Changes made are supporting changes for https://github.com/iddm/thread-priority/pull/45
1. Changes name of sched_param in VxWorks so that it matches unix platforms
2. Add pthread constants and functions required for thread-priority.

Requesting for stable nomination.

r? @tgross35 

Thank you,
B I Mohammed Abbas