### PR TITLE
Add getentropy to RTEMS

### DIFF
--- a/src/unix/newlib/rtems/mod.rs
+++ b/src/unix/newlib/rtems/mod.rs
@@ -137,5 +137,7 @@ extern "C" {
         clock_id: ::clockid_t,
     ) -> ::c_int;
 
+    pub fn getentropy(buf: *mut ::c_void, buflen: ::size_t) -> ::c_int;
+
     pub fn setgroups(ngroups: ::c_int, grouplist: *const ::gid_t) -> ::c_int;
 }


### PR DESCRIPTION
# Description

With the newest updates in the compiler the `getentropy` method is needed and not exposed for RTEMS.
This PR adds the function prototype to the rtems module

# Sources

* Having the `getentropy` method is mandatory for all RTEMS board support packages according to the [RTEMS BSP documentation](https://docs.rtems.org/branches/master/bsp-howto/getentropy.html).
* The method itself is declared in `unistd.h`

# Checklist

- [x ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
