### PR TITLE
Temporarily disable CI on FreeBSD 15

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,9 +7,13 @@ task:
     - name: nightly freebsd-14
       freebsd_instance:
         image: freebsd-14-1-release-amd64-ufs
-    - name: nightly freebsd-15
-      freebsd_instance:
-        image_family: freebsd-15-0-snap
+    # Temporarily disable CI on FreeBSD 15.0-CURRENT until the libmd solib
+    # fallout is cleaned up.
+    # FIXME https://github.com/rust-lang/libc/issues/3967
+    # https://github.com/rust-lang/libc/issues/3967
+    #- name: nightly freebsd-15
+    # freebsd_instance:
+    # image_family: freebsd-15-0-snap
   setup_script:
     - pkg install -y libnghttp2 curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh


### PR DESCRIPTION
FreeBSD 15 is the unstable development release.  Currently its GCE images available to Cirrus CI don't work because the solib version of libmd was just bumped, and the package builders haven't yet caught up.

Issue #3967