### PR TITLE
semver/linux-musl: Remove outdated "TODO: musl" comment

### DIFF
--- a/libc-test/semver/linux-musl.txt
+++ b/libc-test/semver/linux-musl.txt
@@ -1,4 +1,3 @@
-# TODO: musl.
 AF_IB
 AF_MPLS
 AF_XDP


### PR DESCRIPTION
# Description

The comment was there since the file was otherwise empty, but it has outlived its purpose.

# Sources

_not applicable_

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
