### PR TITLE
linux_like: Unify statx definitions

### DIFF
--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -515,39 +515,6 @@ s! {
         pub ifr6_prefixlen: u32,
         pub ifr6_ifindex: ::c_int,
     }
-
-    pub struct statx {
-        pub stx_mask: ::__u32,
-        pub stx_blksize: ::__u32,
-        pub stx_attributes: ::__u64,
-        pub stx_nlink: ::__u32,
-        pub stx_uid: ::__u32,
-        pub stx_gid: ::__u32,
-        pub stx_mode: ::__u16,
-        __statx_pad1: [::__u16; 1],
-        pub stx_ino: ::__u64,
-        pub stx_size: ::__u64,
-        pub stx_blocks: ::__u64,
-        pub stx_attributes_mask: ::__u64,
-        pub stx_atime: ::statx_timestamp,
-        pub stx_btime: ::statx_timestamp,
-        pub stx_ctime: ::statx_timestamp,
-        pub stx_mtime: ::statx_timestamp,
-        pub stx_rdev_major: ::__u32,
-        pub stx_rdev_minor: ::__u32,
-        pub stx_dev_major: ::__u32,
-        pub stx_dev_minor: ::__u32,
-        pub stx_mnt_id: ::__u64,
-        pub stx_dio_mem_align: ::__u32,
-        pub stx_dio_offset_align: ::__u32,
-        __statx_pad3: [::__u64; 12],
-    }
-
-    pub struct statx_timestamp {
-        pub tv_sec: ::__s64,
-        pub tv_nsec: ::__u32,
-        pub __reserved: ::__s32,
-    }
 }
 
 s_no_extra_traits! {
@@ -4162,13 +4129,6 @@ extern "C" {
         newdirfd: ::c_int,
         newpath: *const ::c_char,
         flags: ::c_uint,
-    ) -> ::c_int;
-    pub fn statx(
-        dirfd: ::c_int,
-        pathname: *const c_char,
-        flags: ::c_int,
-        mask: ::c_uint,
-        statxbuf: *mut statx,
     ) -> ::c_int;
 }
 

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -16,39 +16,6 @@ cfg_if! {
 }
 
 s! {
-    pub struct statx {
-        pub stx_mask: u32,
-        pub stx_blksize: u32,
-        pub stx_attributes: u64,
-        pub stx_nlink: u32,
-        pub stx_uid: u32,
-        pub stx_gid: u32,
-        pub stx_mode: u16,
-        __statx_pad1: [u16; 1],
-        pub stx_ino: u64,
-        pub stx_size: u64,
-        pub stx_blocks: u64,
-        pub stx_attributes_mask: u64,
-        pub stx_atime: ::statx_timestamp,
-        pub stx_btime: ::statx_timestamp,
-        pub stx_ctime: ::statx_timestamp,
-        pub stx_mtime: ::statx_timestamp,
-        pub stx_rdev_major: u32,
-        pub stx_rdev_minor: u32,
-        pub stx_dev_major: u32,
-        pub stx_dev_minor: u32,
-        pub stx_mnt_id: u64,
-        pub stx_dio_mem_align: u32,
-        pub stx_dio_offset_align: u32,
-        __statx_pad3: [u64; 12],
-    }
-
-    pub struct statx_timestamp {
-        pub tv_sec: i64,
-        pub tv_nsec: u32,
-        pub __statx_timestamp_pad1: [i32; 1],
-    }
-
     pub struct aiocb {
         pub aio_fildes: ::c_int,
         pub aio_lio_opcode: ::c_int,
@@ -1168,37 +1135,6 @@ pub const M_PERTURB: ::c_int = -6;
 pub const M_ARENA_TEST: ::c_int = -7;
 pub const M_ARENA_MAX: ::c_int = -8;
 
-pub const AT_STATX_SYNC_TYPE: ::c_int = 0x6000;
-pub const AT_STATX_SYNC_AS_STAT: ::c_int = 0x0000;
-pub const AT_STATX_FORCE_SYNC: ::c_int = 0x2000;
-pub const AT_STATX_DONT_SYNC: ::c_int = 0x4000;
-pub const STATX_TYPE: ::c_uint = 0x0001;
-pub const STATX_MODE: ::c_uint = 0x0002;
-pub const STATX_NLINK: ::c_uint = 0x0004;
-pub const STATX_UID: ::c_uint = 0x0008;
-pub const STATX_GID: ::c_uint = 0x0010;
-pub const STATX_ATIME: ::c_uint = 0x0020;
-pub const STATX_MTIME: ::c_uint = 0x0040;
-pub const STATX_CTIME: ::c_uint = 0x0080;
-pub const STATX_INO: ::c_uint = 0x0100;
-pub const STATX_SIZE: ::c_uint = 0x0200;
-pub const STATX_BLOCKS: ::c_uint = 0x0400;
-pub const STATX_BASIC_STATS: ::c_uint = 0x07ff;
-pub const STATX_BTIME: ::c_uint = 0x0800;
-pub const STATX_MNT_ID: ::c_uint = 0x1000;
-pub const STATX_DIOALIGN: ::c_uint = 0x2000;
-pub const STATX_ALL: ::c_uint = 0x0fff;
-pub const STATX__RESERVED: ::c_int = 0x80000000;
-pub const STATX_ATTR_COMPRESSED: ::c_int = 0x0004;
-pub const STATX_ATTR_IMMUTABLE: ::c_int = 0x0010;
-pub const STATX_ATTR_APPEND: ::c_int = 0x0020;
-pub const STATX_ATTR_NODUMP: ::c_int = 0x0040;
-pub const STATX_ATTR_ENCRYPTED: ::c_int = 0x0800;
-pub const STATX_ATTR_AUTOMOUNT: ::c_int = 0x1000;
-pub const STATX_ATTR_MOUNT_ROOT: ::c_int = 0x2000;
-pub const STATX_ATTR_VERITY: ::c_int = 0x00100000;
-pub const STATX_ATTR_DAX: ::c_int = 0x00200000;
-
 pub const SOMAXCONN: ::c_int = 4096;
 
 // linux/mount.h
@@ -1404,13 +1340,6 @@ extern "C" {
     pub fn getpt() -> ::c_int;
     pub fn mallopt(param: ::c_int, value: ::c_int) -> ::c_int;
     pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::timezone) -> ::c_int;
-    pub fn statx(
-        dirfd: ::c_int,
-        pathname: *const c_char,
-        flags: ::c_int,
-        mask: ::c_uint,
-        statxbuf: *mut statx,
-    ) -> ::c_int;
     pub fn getentropy(buf: *mut ::c_void, buflen: ::size_t) -> ::c_int;
     pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
     pub fn getauxval(type_: ::c_ulong) -> ::c_ulong;

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -205,6 +205,45 @@ s! {
     }
 }
 
+cfg_if! {
+    if #[cfg(any(target_env = "gnu", target_os = "android"))] {
+        s! {
+            pub struct statx {
+                pub stx_mask: ::__u32,
+                pub stx_blksize: ::__u32,
+                pub stx_attributes: ::__u64,
+                pub stx_nlink: ::__u32,
+                pub stx_uid: ::__u32,
+                pub stx_gid: ::__u32,
+                pub stx_mode: ::__u16,
+                __statx_pad1: [::__u16; 1],
+                pub stx_ino: ::__u64,
+                pub stx_size: ::__u64,
+                pub stx_blocks: ::__u64,
+                pub stx_attributes_mask: ::__u64,
+                pub stx_atime: statx_timestamp,
+                pub stx_btime: statx_timestamp,
+                pub stx_ctime: statx_timestamp,
+                pub stx_mtime: statx_timestamp,
+                pub stx_rdev_major: ::__u32,
+                pub stx_rdev_minor: ::__u32,
+                pub stx_dev_major: ::__u32,
+                pub stx_dev_minor: ::__u32,
+                pub stx_mnt_id: ::__u64,
+                pub stx_dio_mem_align: ::__u32,
+                pub stx_dio_offset_align: ::__u32,
+                __statx_pad3: [::__u64; 12],
+            }
+
+            pub struct statx_timestamp {
+                pub tv_sec: ::__s64,
+                pub tv_nsec: ::__u32,
+                __statx_timestamp_pad1: [::__s32; 1],
+            }
+        }
+    }
+}
+
 s_no_extra_traits! {
     #[cfg_attr(
         any(
@@ -1529,6 +1568,41 @@ cfg_if! {
     }
 }
 
+cfg_if! {
+    if #[cfg(any(target_env = "gnu", target_os = "android"))] {
+        pub const AT_STATX_SYNC_TYPE: ::c_int = 0x6000;
+        pub const AT_STATX_SYNC_AS_STAT: ::c_int = 0x0000;
+        pub const AT_STATX_FORCE_SYNC: ::c_int = 0x2000;
+        pub const AT_STATX_DONT_SYNC: ::c_int = 0x4000;
+        pub const STATX_TYPE: ::c_uint = 0x0001;
+        pub const STATX_MODE: ::c_uint = 0x0002;
+        pub const STATX_NLINK: ::c_uint = 0x0004;
+        pub const STATX_UID: ::c_uint = 0x0008;
+        pub const STATX_GID: ::c_uint = 0x0010;
+        pub const STATX_ATIME: ::c_uint = 0x0020;
+        pub const STATX_MTIME: ::c_uint = 0x0040;
+        pub const STATX_CTIME: ::c_uint = 0x0080;
+        pub const STATX_INO: ::c_uint = 0x0100;
+        pub const STATX_SIZE: ::c_uint = 0x0200;
+        pub const STATX_BLOCKS: ::c_uint = 0x0400;
+        pub const STATX_BASIC_STATS: ::c_uint = 0x07ff;
+        pub const STATX_BTIME: ::c_uint = 0x0800;
+        pub const STATX_ALL: ::c_uint = 0x0fff;
+        pub const STATX_MNT_ID: ::c_uint = 0x1000;
+        pub const STATX_DIOALIGN: ::c_uint = 0x2000;
+        pub const STATX__RESERVED: ::c_int = 0x80000000;
+        pub const STATX_ATTR_COMPRESSED: ::c_int = 0x0004;
+        pub const STATX_ATTR_IMMUTABLE: ::c_int = 0x0010;
+        pub const STATX_ATTR_APPEND: ::c_int = 0x0020;
+        pub const STATX_ATTR_NODUMP: ::c_int = 0x0040;
+        pub const STATX_ATTR_ENCRYPTED: ::c_int = 0x0800;
+        pub const STATX_ATTR_AUTOMOUNT: ::c_int = 0x1000;
+        pub const STATX_ATTR_MOUNT_ROOT: ::c_int = 0x2000;
+        pub const STATX_ATTR_VERITY: ::c_int = 0x100000;
+        pub const STATX_ATTR_DAX: ::c_int = 0x200000;
+    }
+}
+
 const_fn! {
     {const} fn CMSG_ALIGN(len: usize) -> usize {
         len + ::mem::size_of::<usize>() - 1 & !(::mem::size_of::<usize>() - 1)
@@ -1883,6 +1957,21 @@ cfg_if! {
                 name: *mut ::c_char,
                 termp: *const termios,
                 winp: *const ::winsize,
+            ) -> ::c_int;
+        }
+    }
+}
+
+// The statx syscall, available on some libcs.
+cfg_if! {
+    if #[cfg(any(target_env = "gnu", target_os = "android"))] {
+        extern "C" {
+            pub fn statx(
+                dirfd: ::c_int,
+                pathname: *const ::c_char,
+                flags: ::c_int,
+                mask: ::c_uint,
+                statxbuf: *mut statx,
             ) -> ::c_int;
         }
     }


### PR DESCRIPTION
# Description

The statx system call and corresponding constants are defined by the Linux kernel and don't depend on the libc or architecture. The only difference is whether a libc exports the statx syscall wrapper or not.

We can thus unify the statx definitions for all Linux "like" platforms: GNU (glibc), Android (bionic), and (in a later commit) musl.

The statx struct is in a separate file because the style check doesn't allow multiple s! macros in one file, and #[cfg()] doesn't work in s!.

Plain u64 (or uint64_t in C) can't be used for the statx fields because bionic defines them as __u64, and provides incompatible definitions of uint64_t and __u64.

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->

_none_

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI (failed due to unrelated error, linux/errqueue.h)
