### PR TITLE
unbreak OpenBSD after #3937

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -329,6 +329,7 @@ cfg_if! {
         target_os = "macos",
         target_os = "freebsd",
         target_os = "android",
+        target_os = "openbsd",
     ))] {
         pub const FNM_PATHNAME: c_int = 1 << 1;
         pub const FNM_NOESCAPE: c_int = 1 << 0;


### PR DESCRIPTION
fix `FNM_PATHNAME` and `FNM_NOESCAPE` values.
