### PR TITLE
[0.2] Backport bsd fix

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -322,6 +322,7 @@ cfg_if! {
         target_os = "macos",
         target_os = "freebsd",
         target_os = "android",
+        target_os = "openbsd",
     ))] {
         pub const FNM_PATHNAME: c_int = 1 << 1;
         pub const FNM_NOESCAPE: c_int = 1 << 0;


### PR DESCRIPTION
fix FNM_PATHNAME and FNM_NOESCAPE values.

(backport <https://github.com/rust-lang/libc/pull/3983>)
(cherry picked from commit 1f687923ce2fddb87ee8d39552afef7649ed4bb5)