### PR TITLE
Added ucontext_t for powerpc64-linux

### DIFF
--- a/src/unix/linux_like/linux/gnu/b64/powerpc64/align.rs
+++ b/src/unix/linux_like/linux/gnu/b64/powerpc64/align.rs
@@ -5,3 +5,86 @@ s_no_extra_traits! {
         priv_: [i64; 4]
     }
 }
+
+s! {
+    pub struct ucontext_t {
+        pub uc_flags: ::c_ulong,
+        pub uc_link: *mut ucontext_t,
+        pub uc_stack: ::stack_t,
+        pub uc_sigmask: ::sigset_t,
+        pub uc_mcontext: mcontext_t,
+    }
+
+    pub struct pt_regs {
+        pub gpr: [::c_ulong; 32],
+        pub nip: ::c_ulong,
+        pub msr: ::c_ulong,
+        pub orig_gpr3: ::c_ulong,
+        pub ctr: ::c_ulong,
+        pub link: ::c_ulong,
+        pub xer: ::c_ulong,
+        pub ccr: ::c_ulong,
+        pub softe: ::c_ulong,
+        pub trap: ::c_ulong,
+        pub dar: ::c_ulong,
+        pub dsisr: ::c_ulong,
+        pub result: ::c_ulong,
+    }
+
+    #[repr(align(16))]
+    pub struct mcontext_t {
+        __glibc_reserved: [::c_ulong; 4],
+        pub signal: ::c_int,
+        __pad0: ::c_int,
+        pub handler: ::c_ulong,
+        pub oldmask: ::c_ulong,
+        pub regs: *mut pt_regs,
+        pub gp_regs: [::c_ulong; 48], // # define __NGREG	48
+        pub fp_regs: [::c_double; 33], // # define __NFPREG	33
+        pub v_regs: *mut vrregset_t,
+        pub vmx_reserve: [::c_long; 69], // # define __NVRREG	34 (34*2+1)
+    }
+
+    #[repr(align(16))]
+    pub struct vrregset_t {
+        pub vrregs: [[::c_uint; 4]; 32],
+        pub vscr: vscr_t,
+        pub vrsave: ::c_uint,
+        __pad: [::c_uint; 3],
+    }
+
+    #[repr(align(16))]
+    pub struct vscr_t {
+        #[cfg(target_endian = "big")]
+        __pad: [::c_uint; 3],
+        #[cfg(target_endian = "big")]
+        pub vscr_word: ::c_uint,
+
+        #[cfg(target_endian = "little")]
+        pub vscr_word: ::c_uint,
+        #[cfg(target_endian = "little")]
+        __pad: [::c_uint; 3],
+    }
+
+    #[repr(align(8))]
+    pub struct clone_args {
+        pub flags: ::c_ulonglong,
+        pub pidfd: ::c_ulonglong,
+        pub child_tid: ::c_ulonglong,
+        pub parent_tid: ::c_ulonglong,
+        pub exit_signal: ::c_ulonglong,
+        pub stack: ::c_ulonglong,
+        pub stack_size: ::c_ulonglong,
+        pub tls: ::c_ulonglong,
+        pub set_tid: ::c_ulonglong,
+        pub set_tid_size: ::c_ulonglong,
+        pub cgroup: ::c_ulonglong,
+    }
+}
+
+extern "C" {
+    pub fn getcontext(ucp: *mut ucontext_t) -> ::c_int;
+    pub fn setcontext(ucp: *const ucontext_t) -> ::c_int;
+    pub fn makecontext(ucp: *mut ucontext_t, func: extern "C" fn(), argc: ::c_int, ...);
+    pub fn swapcontext(uocp: *mut ucontext_t, ucp: *const ucontext_t) -> ::c_int;
+}


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

This PR will add `ucontext_t` to powerpc64le-unknown-linux-gnu

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

Testing throws an error, but that is not related to this PR as far as I can see. Even without the patch I see an error in the main branch

```bash
[...]
  cargo:warning=57833 |             }
  cargo:warning=      |             ^
  cargo:warning=/root/git/libc/target/powerpc64le-unknown-linux-gnu/debug/build/libc-test-0e970a92698d6386/out/main.c: In function ‘__test_fn_epoll_pwait2’:
  cargo:warning=/root/git/libc/target/powerpc64le-unknown-linux-gnu/debug/build/libc-test-0e970a92698d6386/out/main.c:57858:13: error: control reaches end of non-void function [-Werror=return-type]
  cargo:warning=57858 |             }
  cargo:warning=      |             ^
  cargo:warning=At top level:
  cargo:warning=cc1: note: unrecognized command-line option ‘-Wno-unknown-warning-option’ may have been intended to silence earlier diagnostics
  cargo:warning=cc1: all warnings being treated as errors

  --- stderr
  rust version: 1.84.0-nightly


  error occurred: Command "cc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64" "-Wall" "-Wextra" "-Wall" "-Wextra" "-Werror" "-Wno-unused-parameter" "-Wno-type-limits" "-Wno-address-of-packed-member" "-Wno-unknown-warning-option" "-Wno-deprecated-declarations" "-D_GNU_SOURCE" "-D__GLIBC_USE_DEPRECATED_SCANF" "-o" "/root/git/libc/target/powerpc64le-unknown-linux-gnu/debug/build/libc-test-0e970a92698d6386/out/4d9447838b1b2e62-main.o" "-c" "/root/git/libc/target/powerpc64le-unknown-linux-gnu/debug/build/libc-test-0e970a92698d6386/out/main.c" with args cc did not execute successfully (status code exit status: 1).
```
