### PR TITLE
RTEMS export arc4random

### DIFF
--- a/src/unix/newlib/rtems/mod.rs
+++ b/src/unix/newlib/rtems/mod.rs
@@ -139,5 +139,7 @@ extern "C" {
 
     pub fn getentropy(buf: *mut ::c_void, buflen: ::size_t) -> ::c_int;
 
+    pub fn arc4random_buf(buf: *mut core::ffi::c_void, nbytes: ::size_t);
+
     pub fn setgroups(ngroups: ::c_int, grouplist: *const ::gid_t) -> ::c_int;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Export ´arc4random_buf´ for RTEMS.
Seems to be preferred to the `getentropy` method (see here: https://github.com/rust-lang/rust/pull/131774).

# Sources

https://docs.rtems.org/branches/master/bsp-howto/getentropy.html

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
