### PR TITLE
haiku: add getentropy

### DIFF
--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -2093,6 +2093,8 @@ extern "C" {
         length: ::size_t,
         locale: ::locale_t,
     ) -> ::c_int;
+
+    pub fn getentropy(buf: *mut ::c_void, buflen: ::size_t) -> ::c_int;
 }
 
 #[link(name = "bsd")]


### PR DESCRIPTION
no man page so far but
https://github.com/haiku/haiku/blob/e4a557f372b21b348e0c6a2ae7157c1b73e0d738/src/system/libroot/posix/unistd/getentropy.c#L13
