### PR TITLE
hurd: fix definition of utsname struct

### DIFF
--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -872,12 +872,11 @@ s! {
     }
 
     pub struct utsname {
-        pub sysname: [::c_char; 65],
-        pub nodename: [::c_char; 65],
-        pub release: [::c_char; 65],
-        pub version: [::c_char; 65],
-        pub machine: [::c_char; 65],
-        pub domainname: [::c_char; 65]
+        pub sysname: [::c_char; _UTSNAME_LENGTH],
+        pub nodename: [::c_char; _UTSNAME_LENGTH],
+        pub release: [::c_char; _UTSNAME_LENGTH],
+        pub version: [::c_char; _UTSNAME_LENGTH],
+        pub machine: [::c_char; _UTSNAME_LENGTH],
     }
 
     pub struct rlimit64 {
@@ -3435,6 +3434,9 @@ pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
     __data: 0i64 as *mut ::c_void,
 };
 pub const PTHREAD_STACK_MIN: ::size_t = 0;
+
+// Non-public helper constants
+const _UTSNAME_LENGTH: usize = 1024;
 
 const_fn! {
     {const} fn CMSG_ALIGN(len: usize) -> usize {


### PR DESCRIPTION
- drop the `domainname` field, as it is not actually used
- add a private `_UTSNAME_LENGTH` constant matching the helper libc one, to ease declaring the struct
- bump the size of the other fields to `_UTSNAME_LENGTH`