### PR TITLE
Update esp-idf time flag

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ use std::str;
 // make sure to add it to this list as well.
 const ALLOWED_CFGS: &'static [&'static str] = &[
     "emscripten_new_stat_abi",
-    "espidf_time64",
+    "espidf_time32",
     "freebsd10",
     "freebsd11",
     "freebsd12",

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -52,7 +52,7 @@ cfg_if! {
 pub type useconds_t = u32;
 
 cfg_if! {
-    if #[cfg(any(target_os = "horizon", all(target_os = "espidf", espidf_time64)))] {
+    if #[cfg(any(target_os = "horizon", all(target_os = "espidf", not(espidf_time32))))] {
         pub type time_t = ::c_longlong;
     } else {
         pub type time_t = i32;


### PR DESCRIPTION
# Description

This PR updates the ESP-IDF time flag, instead of having a `espidf_time64`, we will have a `espidf_time32` flag. `espidf_time64` was enabling support for ESP-IDF 5 (latest stable), while `espidf_time32` enables support for ESP-IDF 4 (which is now end of life). So making ESP-IDF 4 the opt-in and having ESP-IDF 5 enabled by default makes sense.

See https://github.com/esp-rs/esp-idf-sys/discussions/306#discussioncomment-9537457 for more information.

cc: @ivmarkov 

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
