### PR TITLE
armv7-unknown-freebsd: fix test errors regarding __gregset_t

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2701,6 +2701,13 @@ fn test_freebsd(target: &str) {
             _ => false,
         }
     });
+    if target.contains("arm") {
+        cfg.skip_roundtrip(move |s| match s {
+            // Can't return an array from a C function.
+            "__gregset_t" => true,
+            _ => false,
+        });
+    }
 
     cfg.generate("../src/lib.rs", "main.rs");
 }


### PR DESCRIPTION
We must skip roundtrip tests for __gregset_t, because C functions cannot return arrays.