### PR TITLE
ci: add support for loongarch64-unknown-linux-gnu

### DIFF
--- a/.github/workflows/full_ci.yml
+++ b/.github/workflows/full_ci.yml
@@ -163,6 +163,7 @@ jobs:
           - arm-unknown-linux-musleabihf
           - i686-linux-android
           - i686-unknown-linux-musl
+          - loongarch64-unknown-linux-gnu
           - powerpc-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
           - powerpc64le-unknown-linux-gnu

--- a/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gcc libc6-dev qemu-user ca-certificates \
+        gcc-14-loongarch64-linux-gnu libc6-dev-loong64-cross \
+        linux-headers-generic
+
+ENV CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER=loongarch64-linux-gnu-gcc-14 \
+    CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_RUNNER="qemu-loongarch64 -L /usr/loongarch64-linux-gnu" \
+    CC_loongarch64_unknown_linux_gnu=loongarch64-linux-gnu-gcc-14 \
+    CFLAGS_loongarch64_unknown_linux_gnu="-mabi=lp64d -fPIC" \
+    PATH=$PATH:/rust/bin


### PR DESCRIPTION
# Description

Add support for `loongarch64-unknown-linux-gnu` target in CI.

# Source

None.

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
