### PR TITLE
Don't pass -lc to Emscripten, it breaks

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -389,8 +389,8 @@ cfg_if! {
                    link(name = "c", cfg(not(target_feature = "crt-static"))))]
         extern {}
     } else if #[cfg(target_os = "emscripten")] {
-        #[link(name = "c")]
-        extern {}
+        // Don't pass -lc to Emscripten, it breaks. See:
+        // https://github.com/emscripten-core/emscripten/issues/22758
     } else if #[cfg(all(target_os = "android", feature = "rustc-dep-of-std"))] {
         #[link(name = "c", kind = "static", modifiers = "-bundle",
             cfg(target_feature = "crt-static"))]


### PR DESCRIPTION
Before this patch,
```
echo "fn main(){}" > a.rs
rustc -Copt-level=z a.rs -o a.js --target=wasm32-unknown-emscripten
```
fails with:
```
error: undefined symbol: _emscripten_memcpy_js (referenced by root reference (e.g. compiled C/C++ code))
warning: To disable errors for undefined symbols use `-sERROR_ON_UNDEFINED_SYMBOLS=0`
warning: __emscripten_memcpy_js may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library
Error: Aborting compilation due to previous errors
emcc: error: '/home/rchatham/Documents/programming/emsdk/node/18.20.3_64bit/bin/node /home/rchatham/Documents/programming/emsdk/upstream/emscripten/src/compiler.mjs /tmp/tmpogw1glcz.json' failed (returned 1)          
```
There are quite a few other sets of linker arguments that trigger this problem, but this is the shortest. Applying this patch to rust-libc and overriding the version of libc used in `library/Crates.toml` to use the patched version, I have verified locally that the crash goes away.

See:
https://github.com/emscripten-core/emscripten/issues/22742 
https://github.com/emscripten-core/emscripten/issues/16680 
https://github.com/rust-lang/rust/issues/98155
https://github.com/rust-lang/rust/pull/98303
https://github.com/rust-lang/rust/pull/131885


cc @workingjubilee @sbc100