### PR TITLE
NuttX: add pthread_[get/set]name_np functions

### DIFF
--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -551,5 +551,7 @@ extern "C" {
     pub fn futimens(fd: i32, times: *const timespec) -> i32;
     pub fn pthread_condattr_setclock(attr: *mut pthread_condattr_t, clock_id: clockid_t) -> i32;
     pub fn pthread_set_name_np(thread: pthread_t, name: *const c_char) -> i32;
+    pub fn pthread_setname_np(thread: pthread_t, name: *const c_char) -> i32;
+    pub fn pthread_getname_np(thread: pthread_t, name: *mut c_char, len: usize) -> i32;
     pub fn getrandom(buf: *mut c_void, buflen: usize, flags: u32) -> isize;
 }


### PR DESCRIPTION
# Description

The pull request adds `pthread_getname_np` and `pthred_setname_np` functions to NuttX as they are supported since version `10.3.0`.

# Sources

The commit which added it to NuttX: https://github.com/apache/nuttx/commit/4ee5ff81ddac608900f342a2c18029a804ea36d

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
