### PR TITLE
Remove the `wasm32-wasi` target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,6 @@ targets = [
     "thumbv7neon-unknown-linux-gnueabihf",
     "wasm32-unknown-emscripten",
     "wasm32-unknown-unknown",
-    "wasm32-wasi",
     "x86_64-apple-darwin",
     "x86_64-apple-ios",
     "x86_64-fortanix-unknown-sgx",

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -136,7 +136,6 @@ armv5te-unknown-linux-gnueabi \
 armv5te-unknown-linux-musleabi \
 i686-pc-windows-gnu \
 riscv64gc-unknown-linux-gnu \
-wasm32-wasi \
 x86_64-fortanix-unknown-sgx \
 x86_64-unknown-fuchsia \
 x86_64-pc-solaris \


### PR DESCRIPTION
Since [1], the `wasm32-wasi` target is no longer supported (replaced by `wasm32-wasip1` and `wasm32-wasip2`). This has made it into the latest nightly, so remove it from our testing.

[1]: https://github.com/rust-lang/rust/pull/132562