### PR TITLE
Ensure that calls to `sort` do not depend on locale

### DIFF
--- a/ci/style.sh
+++ b/ci/style.sh
@@ -18,6 +18,9 @@ else
     exit 1
 fi
 
+# Ensure that `sort` output is not locale-dependent
+export LC_ALL=C
+
 for file in libc-test/semver/*.txt; do
     case "$file" in 
       *TODO*) continue ;;


### PR DESCRIPTION
Fixes: https://github.com/rust-lang/libc/pull/3934#issuecomment-2462301527