### PR TITLE
hurd: cleanups

### DIFF
--- a/src/unix/hurd/align.rs
+++ b/src/unix/hurd/align.rs
@@ -1,1 +1,0 @@
-// Placeholder file

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -72,7 +72,6 @@ pub type __ptrdiff_t = __sword_type;
 pub type __socklen_t = __u32_type;
 pub type __sig_atomic_t = ::c_int;
 pub type __time64_t = __int64_t;
-pub type ssize_t = __ssize_t;
 pub type wchar_t = ::c_int;
 pub type wint_t = ::c_uint;
 pub type gid_t = __gid_t;

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -4671,9 +4671,6 @@ safe_f! {
     }
 }
 
-mod align;
-pub use self::align::*;
-
 cfg_if! {
     if #[cfg(target_pointer_width = "64")] {
         mod b64;


### PR DESCRIPTION
# Description

This cleans a couple of details in the hurd port: ssize_t and align are currently not actually used

# Checklist

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
