### PR TITLE
fix: value of `PTHREAD_MUTEX_DEFAULT` on illumos

### DIFF
--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -256,6 +256,8 @@ pub const PRIV_USER: ::c_uint = PRIV_DEBUG
     | PRIV_AWARE_RESET
     | PRIV_PFEXEC;
 
+pub const PTHREAD_MUTEX_DEFAULT: ::c_int = 8;
+
 pub const LGRP_RSRC_COUNT: ::lgrp_rsrc_t = 2;
 pub const LGRP_RSRC_CPU: ::lgrp_rsrc_t = 0;
 pub const LGRP_RSRC_MEM: ::lgrp_rsrc_t = 1;

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2041,7 +2041,6 @@ pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
 pub const PTHREAD_MUTEX_NORMAL: ::c_int = 0;
 pub const PTHREAD_MUTEX_ERRORCHECK: ::c_int = 2;
 pub const PTHREAD_MUTEX_RECURSIVE: ::c_int = 4;
-pub const PTHREAD_MUTEX_DEFAULT: ::c_int = ::PTHREAD_MUTEX_NORMAL;
 
 pub const RTLD_NEXT: *mut ::c_void = -1isize as *mut ::c_void;
 pub const RTLD_DEFAULT: *mut ::c_void = -2isize as *mut ::c_void;

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -191,6 +191,8 @@ pub const PRIV_USER: ::c_uint = PRIV_DEBUG
     | PRIV_TPD_KILLABLE
     | PRIV_PROC_TPD_RESET;
 
+pub const PTHREAD_MUTEX_DEFAULT: ::c_int = ::PTHREAD_MUTEX_NORMAL;
+
 extern "C" {
     pub fn fexecve(fd: ::c_int, argv: *const *mut ::c_char, envp: *const *mut ::c_char) -> ::c_int;
 


### PR DESCRIPTION
# Description

The value on illumos is different to the one on solaris.

# Sources

https://github.com/illumos/illumos-gate/blob/master/usr/src/head/pthread.h

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
