### PR TITLE
Solaris: Add CI, fix: confstr, uc_lwpid is missing from Solaris 11.4 …

### DIFF
--- a/.github/workflows/full_ci.yml
+++ b/.github/workflows/full_ci.yml
@@ -187,6 +187,33 @@ jobs:
       - name: Execute run-docker.sh
         run: sh ./ci/run-docker.sh ${{ matrix.target }}
 
+  solaris:
+    name: Solaris
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
+          - x86_64-pc-solaris
+    steps:
+      - uses: actions/checkout@v4
+      - name: test on Solaris
+        uses: vmactions/solaris-vm@v1
+        with:
+          release: "11.4-gcc"
+          usesh: true
+          mem: 4096
+          copyback: false
+          prepare: |
+            source <(curl -s https://raw.githubusercontent.com/psumbera/solaris-rust/refs/heads/main/sh.rust-web-install)
+            echo "~~~~ rustc --version ~~~~"
+            rustc --version
+            echo "~~~~ Solaris-version ~~~~"
+            uname -a
+          run: |
+            export PATH=$HOME/.rust_solaris/bin:$PATH
+            bash ./ci/run.sh ${{ matrix.target }}
+            
   check_cfg:
     name: "Check #[cfg]s"
     runs-on: ubuntu-22.04
@@ -207,6 +234,7 @@ jobs:
       - docker_linux_tier2
       - macos
       - windows
+      - solaris
       - style_check
       - build_channels_linux
       - build_channels_macos

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1485,6 +1485,9 @@ cfg_if! {
                 all(target_os = "macos", target_arch = "x86"),
                 link_name = "confstr$UNIX2003"
             )]
+            #[cfg_attr(target_os = "solaris",
+                link_name = "__confstr_xpg7"
+            )]
             pub fn confstr(name: ::c_int, buf: *mut ::c_char, len: ::size_t) -> ::size_t;
         }
     }

--- a/src/unix/solarish/x86_64.rs
+++ b/src/unix/solarish/x86_64.rs
@@ -89,9 +89,7 @@ s_no_extra_traits! {
         #[cfg(target_os = "solaris")]
         pub uc_xrs: solaris::xrs_t,
         #[cfg(target_os = "solaris")]
-        pub uc_lwpid: ::c_uint,
-        #[cfg(target_os = "solaris")]
-        pub uc_filler: [::c_long; 2],
+        pub uc_filler: [::c_long; 3],
     }
 }
 


### PR DESCRIPTION
Note that while `uc_lwpid` is available in latest Solaris 11.4 SRU,. it's not yet available in Solaris 11.4.42 CBE release (the only freely available version for FOSS testing).