### PR TITLE
Use `#[derive]` for `Copy`/`Clone` in `s!` and friends

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4503,11 +4503,11 @@ fn test_linux(target: &str) {
             true
         }
 
-        // The `inotify_event` and `cmsghdr` types contain Flexible Array Member fields (the
-        // `name` and `data` fields respectively) which have unspecified calling convention.
-        // The roundtripping tests deliberately pass the structs by value to check "by value"
-        // layout consistency, but this would be UB for the these types.
+        // The following types contain Flexible Array Member fields which have unspecified calling
+        // convention. The roundtripping tests deliberately pass the structs by value to check "by
+        // value" layout consistency, but this would be UB for the these types.
         "inotify_event" => true,
+        "fanotify_event_info_fid" => true,
         "cmsghdr" => true,
 
         // FIXME: the call ABI of max_align_t is incorrect on these platforms:

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -82,15 +82,10 @@ macro_rules! s {
         __item! {
             #[repr(C)]
             #[cfg_attr(feature = "extra_traits", derive(Debug, Eq, Hash, PartialEq))]
+            #[derive(Copy, Clone)]
             #[allow(deprecated)]
             $(#[$attr])*
             pub struct $i { $($field)* }
-        }
-        #[allow(deprecated)]
-        impl ::Copy for $i {}
-        #[allow(deprecated)]
-        impl ::Clone for $i {
-            fn clone(&self) -> $i { *self }
         }
     );
 }
@@ -106,12 +101,9 @@ macro_rules! s_paren {
     )*) => ($(
         __item! {
             #[cfg_attr(feature = "extra_traits", derive(Debug, Eq, Hash, PartialEq))]
+            #[derive(Copy, Clone)]
             $(#[$attr])*
             pub struct $i ( $($field)* );
-        }
-        impl ::Copy for $i {}
-        impl ::Clone for $i {
-            fn clone(&self) -> $i { *self }
         }
     )*);
 }
@@ -130,27 +122,18 @@ macro_rules! s_no_extra_traits {
     (it: $(#[$attr:meta])* pub union $i:ident { $($field:tt)* }) => (
         __item! {
             #[repr(C)]
+            #[derive(Copy, Clone)]
             $(#[$attr])*
             pub union $i { $($field)* }
-        }
-
-        impl ::Copy for $i {}
-        impl ::Clone for $i {
-            fn clone(&self) -> $i { *self }
         }
     );
 
     (it: $(#[$attr:meta])* pub struct $i:ident { $($field:tt)* }) => (
         __item! {
             #[repr(C)]
+            #[derive(Copy, Clone)]
             $(#[$attr])*
             pub struct $i { $($field)* }
-        }
-        #[allow(deprecated)]
-        impl ::Copy for $i {}
-        #[allow(deprecated)]
-        impl ::Clone for $i {
-            fn clone(&self) -> $i { *self }
         }
     );
 }
@@ -177,12 +160,9 @@ macro_rules! e {
     )*) => ($(
         __item! {
             #[cfg_attr(feature = "extra_traits", derive(Debug, Eq, Hash, PartialEq))]
+            #[derive(Copy, Clone)]
             $(#[$attr])*
             pub enum $i { $($field)* }
-        }
-        impl ::Copy for $i {}
-        impl ::Clone for $i {
-            fn clone(&self) -> $i { *self }
         }
     )*);
 }


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Extracted from #3261 as a pre-requisite change.

Allows use of `#[cfg]` to skip items in an `s!` block without creating invalid, orphaned `impl` blocks.

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] ~~Relevant tests in `libc-test/semver` have been updated~~
- [ ] ~~No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))~~
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
