### PR TITLE
[0.2] Document the MSRV of the stable channel as 1.63

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,21 +55,13 @@ libc = "0.2"
 
 ## Rust version support
 
-The minimum supported Rust toolchain version is currently **Rust 1.13.0**. (libc
-does not currently have any policy regarding changes to the minimum supported
-Rust version; such policy is a work in progress.) APIs requiring newer Rust
-features are only available on newer Rust toolchains:
+The minimum supported Rust toolchain version is currently **Rust 1.63**.
 
-| Feature              | Version |
-| -------------------- | ------- |
-| `union`              | 1.19.0  |
-| `const mem::size_of` | 1.24.0  |
-| `repr(align)`        | 1.25.0  |
-| `extra_traits`       | 1.25.0  |
-| `core::ffi::c_void`  | 1.30.0  |
-| `repr(packed(N))`    | 1.33.0  |
-| `cfg(target_vendor)` | 1.33.0  |
-| `const-extern-fn`    | 1.62.0  |
+Increases to the MSRV are allowed to change without a major (i.e. semver-
+breaking) release in order to avoid a ripple effect in the ecosystem.
+
+`libc` may continue to compile with Rust versions older than the current MSRV
+but this is not guaranteed.
 
 ## Platform support
 


### PR DESCRIPTION
Currently this crate maintains the `main` branch (future 1.0) alongside `libc-0.2` (current stable release). PRs are made against `main` then cherry picked as applicable to `libc-0.2`.

Usually this flow works okay, but there is a substantial difference in minimum supported versions: libc-0.2 is tested down to 1.19 and main is tested with 1.63. This means that supported features differ quite a bit and as a result, cherry picks get conflict-heavy (e.g. `repr(align)`, `union`, and `const fn` cannot be used on `libc-0.2`).

In order to make it easier to keep these branches in sync and get us close to a 1.0 release, raise the MSRV on `libc-0.2` to 1.63. This means both branches can run the exact same tests.

Future Changes
==============

This still does not establish a MSRV policy, which has been discussed at great length in [1]. For the purpose of unsticking us this selects 1.63 as the MSRV, which is the version currently available on Debian stable (a commonly requested reference point in [1], and about the oldest specific version mentioned).

This is a documentation-only change to keep things simple, cleanup can follow. Further increases and official policy are not precluded.

History
======

An attempt to raise the MSRV to 1.57 in 2022 was approved at one point [2], but never merged due to various failures. Making this a documentation-only change hopes to avoid this problem.

I brought up a 0.3 release to increase versions in [3], but consensus there was that we should be able to increase the MSRV in the existing 0.2 release without a semver-breaking change.

Link: https://github.com/rust-lang/libs-team/issues/72 [1]
Link: https://github.com/rust-lang/libc/pull/2845 [2]
Link: https://github.com/rust-lang/libs-team/issues/463 [3]