### PR TITLE
[0.2] Specify `rust-version = "1.19"` in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["libc", "ffi", "bindings", "operating", "system"]
 categories = ["external-ffi-bindings", "no-std", "os"]
 build = "build.rs"
 exclude = ["/ci/*", "/.github/*", "/.cirrus.yml", "/triagebot.toml"]
+rust-version = "1.19"
 description = """
 Raw FFI bindings to platform libraries like libc.
 """


### PR DESCRIPTION
The `libc-0.2` branch currently tests down to version 1.19. Document this in Cargo.toml to give an obvious point of reference when this changes.