### PR TITLE
flock for vxworks using ioctl

### DIFF
--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -413,6 +413,14 @@ s! {
         pub mq_flags:   ::c_long,
         pub mq_curmsgs: ::c_long,
     }
+
+    pub struct flock {
+        pub l_type: ::c_short,
+        pub l_whence: ::c_short,
+        pub l_start: ::c_long,
+        pub l_len: ::c_long,
+        pub l_pid: ::c_long,
+    }
 }
 
 s_no_extra_traits! {
@@ -944,6 +952,9 @@ pub const F_GETLK: ::c_int = 7;
 pub const F_SETLK: ::c_int = 8;
 pub const F_SETLKW: ::c_int = 9;
 pub const F_DUPFD_CLOEXEC: ::c_int = 14;
+pub const F_RDLCK: ::c_int = 1;
+pub const F_WRLCK: ::c_int = 2;
+pub const F_UNLCK: ::c_int = 3;
 
 // signal.h
 pub const SIG_DFL: sighandler_t = 0 as sighandler_t;


### PR DESCRIPTION
# Description

Added an implementation for `flock` for vxworks target. Vxworks only supplies `ioctl`, but it does have all `flock` related `#define`s available.

# Sources

Vxworks headers are copyrighted, however this is based on: `ioLib.h` and `sys/fcntlcom.h`

# Checklist

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

Note that testing seems to not be available for the vxworks target