### PR TITLE
[0.2] Set `rust-version` to 1.63

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["libc", "ffi", "bindings", "operating", "system"]
 categories = ["external-ffi-bindings", "no-std", "os"]
 build = "build.rs"
 exclude = ["/ci/*", "/.github/*", "/.cirrus.yml", "/triagebot.toml"]
-rust-version = "1.19"
+rust-version = "1.63"
 description = """
 Raw FFI bindings to platform libraries like libc.
 """


### PR DESCRIPTION
With the change to MSRV in [1], update Cargo.toml `rust-version` to match.

[1]: https://github.com/rust-lang/libc/pull/4040