### PR TITLE
[0.2] Require rust >= 1.19 and drop libc_union conditional

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,7 +28,6 @@ const ALLOWED_CFGS: &'static [&'static str] = &[
     "libc_ptr_addr_of",
     "libc_thread_local",
     "libc_underscore_const_names",
-    "libc_union",
     "libc_ctest",
 ];
 
@@ -96,11 +95,6 @@ fn main() {
     // On CI: deny all warnings
     if libc_ci {
         set_cfg("libc_deny_warnings");
-    }
-
-    // Rust >= 1.19 supports unions:
-    if rustc_minor_ver >= 19 || rustc_dep_of_std {
-        set_cfg("libc_union");
     }
 
     // Rust >= 1.24 supports const mem::size_of:

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -68,7 +68,6 @@ fn do_ctest() {
 fn ctest_cfg() -> ctest::TestGenerator {
     let mut cfg = ctest::TestGenerator::new();
     let libc_cfgs = [
-        "libc_union",
         "libc_const_size_of",
         "libc_align",
         "libc_core_cvoid",

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -90,19 +90,15 @@ macro_rules! s_no_extra_traits {
         s_no_extra_traits!(it: $(#[$attr])* pub $t $i { $($field)* });
     )*);
     (it: $(#[$attr:meta])* pub union $i:ident { $($field:tt)* }) => (
-        cfg_if! {
-            if #[cfg(libc_union)] {
-                __item! {
-                    #[repr(C)]
-                    $(#[$attr])*
-                    pub union $i { $($field)* }
-                }
+        __item! {
+            #[repr(C)]
+            $(#[$attr])*
+            pub union $i { $($field)* }
+        }
 
-                impl ::Copy for $i {}
-                impl ::Clone for $i {
-                    fn clone(&self) -> $i { *self }
-                }
-            }
+        impl ::Copy for $i {}
+        impl ::Clone for $i {
+            fn clone(&self) -> $i { *self }
         }
     );
     (it: $(#[$attr:meta])* pub struct $i:ident { $($field:tt)* }) => (

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -534,20 +534,17 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[cfg(libc_union)]
     pub union __sigaction_sa_union {
         pub __su_handler: extern fn(c: ::c_int),
         pub __su_sigaction: extern fn(c: ::c_int, info: *mut siginfo_t, ptr: *mut ::c_void),
     }
 
     pub struct sigaction {
-        #[cfg(libc_union)]
         pub sa_union: __sigaction_sa_union,
         pub sa_mask: sigset_t,
         pub sa_flags: ::c_int,
     }
 
-    #[cfg(libc_union)]
     pub union __poll_ctl_ext_u {
         pub addr: *mut ::c_void,
         pub data32: u32,
@@ -559,7 +556,6 @@ s_no_extra_traits! {
         pub command: u8,
         pub events: ::c_short,
         pub fd: ::c_int,
-        #[cfg(libc_union)]
         pub u: __poll_ctl_ext_u,
         pub reversed64: [u64; 6],
     }
@@ -567,7 +563,6 @@ s_no_extra_traits! {
 
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
-        #[cfg(libc_union)]
         impl PartialEq for __sigaction_sa_union {
             fn eq(&self, other: &__sigaction_sa_union) -> bool {
                 unsafe {
@@ -576,9 +571,7 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl Eq for __sigaction_sa_union {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __sigaction_sa_union {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("__sigaction_sa_union")
@@ -587,7 +580,6 @@ cfg_if! {
                     .finish()
             }
         }
-        #[cfg(libc_union)]
         impl ::hash::Hash for __sigaction_sa_union {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
@@ -599,36 +591,29 @@ cfg_if! {
 
         impl PartialEq for sigaction {
             fn eq(&self, other: &sigaction) -> bool {
-                #[cfg(libc_union)]
-                let union_eq = self.sa_union == other.sa_union;
-                #[cfg(not(libc_union))]
-                let union_eq = true;
                 self.sa_mask == other.sa_mask
                     && self.sa_flags == other.sa_flags
-                    && union_eq
+                    && self.sa_union == other.sa_union
             }
         }
         impl Eq for sigaction {}
         impl ::fmt::Debug for sigaction {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                let mut struct_formatter = f.debug_struct("sigaction");
-                #[cfg(libc_union)]
-                struct_formatter.field("sa_union", &self.sa_union);
-                struct_formatter.field("sa_mask", &self.sa_mask);
-                struct_formatter.field("sa_flags", &self.sa_flags);
-                struct_formatter.finish()
+                f.debug_struct("sigaction")
+                    .field("sa_union", &self.sa_union)
+                    .field("sa_mask", &self.sa_mask)
+                    .field("sa_flags", &self.sa_flags)
+                    .finish()
             }
         }
         impl ::hash::Hash for sigaction {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                #[cfg(libc_union)]
                 self.sa_union.hash(state);
                 self.sa_mask.hash(state);
                 self.sa_flags.hash(state);
             }
         }
 
-        #[cfg(libc_union)]
         impl PartialEq for __poll_ctl_ext_u {
             fn eq(&self, other: &__poll_ctl_ext_u) -> bool {
                 unsafe {
@@ -638,9 +623,7 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl Eq for __poll_ctl_ext_u {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __poll_ctl_ext_u {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("__poll_ctl_ext_u")
@@ -650,7 +633,6 @@ cfg_if! {
                     .finish()
             }
         }
-        #[cfg(libc_union)]
         impl ::hash::Hash for __poll_ctl_ext_u {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
@@ -663,30 +645,25 @@ cfg_if! {
 
         impl PartialEq for poll_ctl_ext {
             fn eq(&self, other: &poll_ctl_ext) -> bool {
-                #[cfg(libc_union)]
-                let union_eq = self.u == other.u;
-                #[cfg(not(libc_union))]
-                let union_eq = true;
                 self.version == other.version
                     && self.command == other.command
                     && self.events == other.events
                     && self.fd == other.fd
                     && self.reversed64 == other.reversed64
-                    && union_eq
+                    && self.u == other.u
             }
         }
         impl Eq for poll_ctl_ext {}
         impl ::fmt::Debug for poll_ctl_ext {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                let mut struct_formatter = f.debug_struct("poll_ctl_ext");
-                struct_formatter.field("version", &self.version);
-                struct_formatter.field("command", &self.command);
-                struct_formatter.field("events", &self.events);
-                struct_formatter.field("fd", &self.fd);
-                #[cfg(libc_union)]
-                struct_formatter.field("u", &self.u);
-                struct_formatter.field("reversed64", &self.reversed64);
-                struct_formatter.finish()
+                f.debug_struct("poll_ctl_ext")
+                    .field("version", &self.version)
+                    .field("command", &self.command)
+                    .field("events", &self.events)
+                    .field("fd", &self.fd)
+                    .field("u", &self.u)
+                    .field("reversed64", &self.reversed64)
+                    .finish()
             }
         }
         impl ::hash::Hash for poll_ctl_ext {
@@ -695,7 +672,6 @@ cfg_if! {
                 self.command.hash(state);
                 self.events.hash(state);
                 self.fd.hash(state);
-                #[cfg(libc_union)]
                 self.u.hash(state);
                 self.reversed64.hash(state);
             }

--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -199,7 +199,6 @@ s_no_extra_traits! {
         pub __pad: [::c_int; 3],
     }
 
-    #[cfg(libc_union)]
     pub union _kernel_simple_lock {
         pub _slock: ::c_long,
         // Should be pointer to 'lock_data_instrumented'
@@ -228,9 +227,7 @@ s_no_extra_traits! {
         pub f_dir_off: ::c_long,
         // Should be pointer to 'cred'
         pub f_cred: *mut ::c_void,
-        #[cfg(libc_union)]
         pub f_lock: _kernel_simple_lock,
-        #[cfg(libc_union)]
         pub f_offset_lock: _kernel_simple_lock,
         pub f_vinfo: ::caddr_t,
         pub f_ops: *mut fileops_t,
@@ -239,7 +236,6 @@ s_no_extra_traits! {
         pub f_fdata: [::c_char; 160],
     }
 
-    #[cfg(libc_union)]
     pub union __ld_info_file {
         pub _ldinfo_fd: ::c_int,
         pub _ldinfo_fp: *mut file,
@@ -249,7 +245,6 @@ s_no_extra_traits! {
     pub struct ld_info {
         pub ldinfo_next: ::c_uint,
         pub ldinfo_flags: ::c_uint,
-        #[cfg(libc_union)]
         pub _file: __ld_info_file,
         pub ldinfo_textorg: *mut ::c_void,
         pub ldinfo_textsize: ::c_ulong,
@@ -258,7 +253,6 @@ s_no_extra_traits! {
         pub ldinfo_filename: [::c_char; 2],
     }
 
-    #[cfg(libc_union)]
     pub union __pollfd_ext_u {
         pub addr: *mut ::c_void,
         pub data32: u32,
@@ -269,7 +263,6 @@ s_no_extra_traits! {
         pub fd: ::c_int,
         pub events: ::c_ushort,
         pub revents: ::c_ushort,
-        #[cfg(libc_union)]
         pub data: __pollfd_ext_u,
     }
 }
@@ -300,10 +293,6 @@ cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         impl PartialEq for siginfo_t {
             fn eq(&self, other: &siginfo_t) -> bool {
-                #[cfg(libc_union)]
-                let value_eq = self.si_value == other.si_value;
-                #[cfg(not(libc_union))]
-                let value_eq = true;
                 self.si_signo == other.si_signo
                     && self.si_errno == other.si_errno
                     && self.si_code == other.si_code
@@ -313,25 +302,24 @@ cfg_if! {
                     && self.si_addr == other.si_addr
                     && self.si_band == other.si_band
                     && self.__si_flags == other.__si_flags
-                    && value_eq
+                    && self.si_value == other.si_value
             }
         }
         impl Eq for siginfo_t {}
         impl ::fmt::Debug for siginfo_t {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                let mut struct_formatter = f.debug_struct("siginfo_t");
-                struct_formatter.field("si_signo", &self.si_signo);
-                struct_formatter.field("si_errno", &self.si_errno);
-                struct_formatter.field("si_code", &self.si_code);
-                struct_formatter.field("si_pid", &self.si_pid);
-                struct_formatter.field("si_uid", &self.si_uid);
-                struct_formatter.field("si_status", &self.si_status);
-                struct_formatter.field("si_addr", &self.si_addr);
-                struct_formatter.field("si_band", &self.si_band);
-                #[cfg(libc_union)]
-                struct_formatter.field("si_value", &self.si_value);
-                struct_formatter.field("__si_flags", &self.__si_flags);
-                struct_formatter.finish()
+                f.debug_struct("siginfo_t")
+                    .field("si_signo", &self.si_signo)
+                    .field("si_errno", &self.si_errno)
+                    .field("si_code", &self.si_code)
+                    .field("si_pid", &self.si_pid)
+                    .field("si_uid", &self.si_uid)
+                    .field("si_status", &self.si_status)
+                    .field("si_addr", &self.si_addr)
+                    .field("si_band", &self.si_band)
+                    .field("si_value", &self.si_value)
+                    .field("__si_flags", &self.__si_flags)
+                    .finish()
             }
         }
         impl ::hash::Hash for siginfo_t {
@@ -344,13 +332,11 @@ cfg_if! {
                 self.si_status.hash(state);
                 self.si_addr.hash(state);
                 self.si_band.hash(state);
-                #[cfg(libc_union)]
                 self.si_value.hash(state);
                 self.__si_flags.hash(state);
             }
         }
 
-        #[cfg(libc_union)]
         impl PartialEq for _kernel_simple_lock {
             fn eq(&self, other: &_kernel_simple_lock) -> bool {
                 unsafe {
@@ -359,9 +345,7 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl Eq for _kernel_simple_lock {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for _kernel_simple_lock {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("_kernel_simple_lock")
@@ -370,7 +354,6 @@ cfg_if! {
                     .finish()
             }
         }
-        #[cfg(libc_union)]
         impl ::hash::Hash for _kernel_simple_lock {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
@@ -413,11 +396,6 @@ cfg_if! {
 
         impl PartialEq for file {
             fn eq(&self, other: &file) -> bool {
-                #[cfg(libc_union)]
-                let lock_eq = self.f_lock == other.f_lock
-                    && self.f_offset_lock == other.f_offset_lock;
-                #[cfg(not(libc_union))]
-                let lock_eq = true;
                 self.f_flag == other.f_flag
                     && self.f_count == other.f_count
                     && self.f_options == other.f_options
@@ -431,31 +409,30 @@ cfg_if! {
                     && self.f_parentp == other.f_parentp
                     && self.f_fnamep == other.f_fnamep
                     && self.f_fdata == other.f_fdata
-                    && lock_eq
+                    && self.f_lock == other.f_lock
+                    && self.f_offset_lock == other.f_offset_lock;
             }
         }
         impl Eq for file {}
         impl ::fmt::Debug for file {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                let mut struct_formatter = f.debug_struct("file");
-                struct_formatter.field("f_flag", &self.f_flag);
-                struct_formatter.field("f_count", &self.f_count);
-                struct_formatter.field("f_options", &self.f_options);
-                struct_formatter.field("f_type", &self.f_type);
-                struct_formatter.field("f_data", &self.f_data);
-                struct_formatter.field("f_offset", &self.f_offset);
-                struct_formatter.field("f_dir_off", &self.f_dir_off);
-                struct_formatter.field("f_cred", &self.f_cred);
-                #[cfg(libc_union)]
-                struct_formatter.field("f_lock", &self.f_lock);
-                #[cfg(libc_union)]
-                struct_formatter.field("f_offset_lock", &self.f_offset_lock);
-                struct_formatter.field("f_vinfo", &self.f_vinfo);
-                struct_formatter.field("f_ops", &self.f_ops);
-                struct_formatter.field("f_parentp", &self.f_parentp);
-                struct_formatter.field("f_fnamep", &self.f_fnamep);
-                struct_formatter.field("f_fdata", &self.f_fdata);
-                struct_formatter.finish()
+                f.debug_struct("file")
+                    .field("f_flag", &self.f_flag)
+                    .field("f_count", &self.f_count)
+                    .field("f_options", &self.f_options)
+                    .field("f_type", &self.f_type)
+                    .field("f_data", &self.f_data)
+                    .field("f_offset", &self.f_offset)
+                    .field("f_dir_off", &self.f_dir_off)
+                    .field("f_cred", &self.f_cred)
+                    .field("f_lock", &self.f_lock)
+                    .field("f_offset_lock", &self.f_offset_lock)
+                    .field("f_vinfo", &self.f_vinfo)
+                    .field("f_ops", &self.f_ops)
+                    .field("f_parentp", &self.f_parentp)
+                    .field("f_fnamep", &self.f_fnamep)
+                    .field("f_fdata", &self.f_fdata)
+                    .finish()
             }
         }
         impl ::hash::Hash for file {
@@ -468,9 +445,7 @@ cfg_if! {
                 self.f_offset.hash(state);
                 self.f_dir_off.hash(state);
                 self.f_cred.hash(state);
-                #[cfg(libc_union)]
                 self.f_lock.hash(state);
-                #[cfg(libc_union)]
                 self.f_offset_lock.hash(state);
                 self.f_vinfo.hash(state);
                 self.f_ops.hash(state);
@@ -480,7 +455,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl PartialEq for __ld_info_file {
             fn eq(&self, other: &__ld_info_file) -> bool {
                 unsafe {
@@ -490,9 +464,7 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl Eq for __ld_info_file {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __ld_info_file {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("__ld_info_file")
@@ -502,7 +474,6 @@ cfg_if! {
                     .finish()
             }
         }
-        #[cfg(libc_union)]
         impl ::hash::Hash for __ld_info_file {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
@@ -515,10 +486,6 @@ cfg_if! {
 
         impl PartialEq for ld_info {
             fn eq(&self, other: &ld_info) -> bool {
-                #[cfg(libc_union)]
-                let file_eq = self._file == other._file;
-                #[cfg(not(libc_union))]
-                let file_eq = true;
                 self.ldinfo_next == other.ldinfo_next
                     && self.ldinfo_flags == other.ldinfo_flags
                     && self.ldinfo_textorg == other.ldinfo_textorg
@@ -526,23 +493,22 @@ cfg_if! {
                     && self.ldinfo_dataorg == other.ldinfo_dataorg
                     && self.ldinfo_datasize == other.ldinfo_datasize
                     && self.ldinfo_filename == other.ldinfo_filename
-                    && file_eq
+                    && self._file == other._file
             }
         }
         impl Eq for ld_info {}
         impl ::fmt::Debug for ld_info {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                let mut struct_formatter = f.debug_struct("ld_info");
-                struct_formatter.field("ldinfo_next", &self.ldinfo_next);
-                struct_formatter.field("ldinfo_flags", &self.ldinfo_flags);
-                struct_formatter.field("ldinfo_textorg", &self.ldinfo_textorg);
-                struct_formatter.field("ldinfo_textsize", &self.ldinfo_textsize);
-                struct_formatter.field("ldinfo_dataorg", &self.ldinfo_dataorg);
-                struct_formatter.field("ldinfo_datasize", &self.ldinfo_datasize);
-                struct_formatter.field("ldinfo_filename", &self.ldinfo_filename);
-                #[cfg(libc_union)]
-                struct_formatter.field("_file", &self._file);
-                struct_formatter.finish()
+                f.debug_struct("ld_info")
+                    .field("ldinfo_next", &self.ldinfo_next)
+                    .field("ldinfo_flags", &self.ldinfo_flags)
+                    .field("ldinfo_textorg", &self.ldinfo_textorg)
+                    .field("ldinfo_textsize", &self.ldinfo_textsize)
+                    .field("ldinfo_dataorg", &self.ldinfo_dataorg)
+                    .field("ldinfo_datasize", &self.ldinfo_datasize)
+                    .field("ldinfo_filename", &self.ldinfo_filename)
+                    .field("_file", &self._file)
+                    .finish()
             }
         }
         impl ::hash::Hash for ld_info {
@@ -554,12 +520,10 @@ cfg_if! {
                 self.ldinfo_dataorg.hash(state);
                 self.ldinfo_datasize.hash(state);
                 self.ldinfo_filename.hash(state);
-                #[cfg(libc_union)]
                 self._file.hash(state);
             }
         }
 
-        #[cfg(libc_union)]
         impl PartialEq for __pollfd_ext_u {
             fn eq(&self, other: &__pollfd_ext_u) -> bool {
                 unsafe {
@@ -569,9 +533,7 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl Eq for __pollfd_ext_u {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __pollfd_ext_u {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("__pollfd_ext_u")
@@ -581,7 +543,6 @@ cfg_if! {
                     .finish()
             }
         }
-        #[cfg(libc_union)]
         impl ::hash::Hash for __pollfd_ext_u {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
@@ -594,26 +555,21 @@ cfg_if! {
 
         impl PartialEq for pollfd_ext {
             fn eq(&self, other: &pollfd_ext) -> bool {
-                #[cfg(libc_union)]
-                let data_eq = self.data == other.data;
-                #[cfg(not(libc_union))]
-                let data_eq = true;
                 self.fd == other.fd
                     && self.events == other.events
                     && self.revents == other.revents
-                    && data_eq
+                    && self.data == other.data
             }
         }
         impl Eq for pollfd_ext {}
         impl ::fmt::Debug for pollfd_ext {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                let mut struct_formatter = f.debug_struct("pollfd_ext");
-                struct_formatter.field("fd", &self.fd);
-                struct_formatter.field("events", &self.events);
-                struct_formatter.field("revents", &self.revents);
-                #[cfg(libc_union)]
-                struct_formatter.field("data", &self.data);
-                struct_formatter.finish()
+                f.debug_struct("pollfd_ext")
+                    .field("fd", &self.fd)
+                    .field("events", &self.events)
+                    .field("revents", &self.revents)
+                    .field("data", &self.data)
+                    .finish()
             }
         }
         impl ::hash::Hash for pollfd_ext {
@@ -621,7 +577,6 @@ cfg_if! {
                 self.fd.hash(state);
                 self.events.hash(state);
                 self.revents.hash(state);
-                #[cfg(libc_union)]
                 self.data.hash(state);
             }
         }

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1196,10 +1196,7 @@ s_no_extra_traits! {
     #[cfg_attr(libc_packedN, repr(packed(4)))]
     pub struct ifconf {
         pub ifc_len: ::c_int,
-        #[cfg(libc_union)]
         pub ifc_ifcu: __c_anonymous_ifc_ifcu,
-        #[cfg(not(libc_union))]
-        pub ifc_ifcu: *mut ifreq,
     }
 
     #[cfg_attr(libc_packedN, repr(packed(4)))]
@@ -1496,7 +1493,6 @@ s_no_extra_traits! {
         pub ifdm_max: ::c_int,
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_ifk_data {
         pub ifk_ptr: *mut ::c_void,
         pub ifk_value: ::c_int,
@@ -1506,11 +1502,9 @@ s_no_extra_traits! {
     pub struct ifkpi {
         pub ifk_module_id: ::c_uint,
         pub ifk_type: ::c_uint,
-        #[cfg(libc_union)]
         pub ifk_data: __c_anonymous_ifk_data,
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_ifr_ifru {
         pub ifru_addr: ::sockaddr,
         pub ifru_dstaddr: ::sockaddr,
@@ -1532,13 +1526,9 @@ s_no_extra_traits! {
 
     pub struct ifreq {
         pub ifr_name: [::c_char; ::IFNAMSIZ],
-        #[cfg(libc_union)]
         pub ifr_ifru: __c_anonymous_ifr_ifru,
-        #[cfg(not(libc_union))]
-        pub ifr_ifru: ::sockaddr,
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_ifc_ifcu {
         pub ifcu_buf: *mut ::c_char,
         pub ifcu_req: *mut ifreq,
@@ -1579,37 +1569,33 @@ impl siginfo_t {
     }
 }
 
+s_no_extra_traits! {
+    pub union semun {
+        pub val: ::c_int,
+        pub buf: *mut semid_ds,
+        pub array: *mut ::c_ushort,
+    }
+}
+
 cfg_if! {
-    if #[cfg(libc_union)] {
-        s_no_extra_traits! {
-            pub union semun {
-                pub val: ::c_int,
-                pub buf: *mut semid_ds,
-                pub array: *mut ::c_ushort,
+    if #[cfg(feature = "extra_traits")] {
+        impl PartialEq for semun {
+            fn eq(&self, other: &semun) -> bool {
+                unsafe { self.val == other.val }
             }
         }
-
-        cfg_if! {
-            if #[cfg(feature = "extra_traits")] {
-                impl PartialEq for semun {
-                    fn eq(&self, other: &semun) -> bool {
-                        unsafe { self.val == other.val }
-                    }
-                }
-                impl Eq for semun {}
-                impl ::fmt::Debug for semun {
-                    fn fmt(&self, f: &mut ::fmt::Formatter)
-                           -> ::fmt::Result {
-                        f.debug_struct("semun")
-                            .field("val", unsafe { &self.val })
-                            .finish()
-                    }
-                }
-                impl ::hash::Hash for semun {
-                    fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                        unsafe { self.val.hash(state) };
-                    }
-                }
+        impl Eq for semun {}
+        impl ::fmt::Debug for semun {
+            fn fmt(&self, f: &mut ::fmt::Formatter)
+                   -> ::fmt::Result {
+                f.debug_struct("semun")
+                    .field("val", unsafe { &self.val })
+                    .finish()
+            }
+        }
+        impl ::hash::Hash for semun {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                unsafe { self.val.hash(state) };
             }
         }
     }
@@ -2947,7 +2933,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous_ifk_data {
             fn eq(&self, other: &__c_anonymous_ifk_data) -> bool {
                 unsafe {
@@ -2957,10 +2942,8 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous_ifk_data {}
 
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_ifk_data {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("__c_anonymous_ifk_data")
@@ -2969,7 +2952,6 @@ cfg_if! {
                     .finish()
             }
         }
-        #[cfg(libc_union)]
         impl ::hash::Hash for __c_anonymous_ifk_data {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
@@ -3004,7 +2986,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous_ifr_ifru {
             fn eq(&self, other: &__c_anonymous_ifr_ifru) -> bool {
                 unsafe {
@@ -3028,10 +3009,8 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous_ifr_ifru {}
 
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_ifr_ifru {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("__c_anonymous_ifr_ifru")
@@ -3055,7 +3034,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl ::hash::Hash for __c_anonymous_ifr_ifru {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
@@ -3104,10 +3082,8 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous_ifc_ifcu {}
 
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous_ifc_ifcu {
             fn eq(&self, other: &__c_anonymous_ifc_ifcu) -> bool {
                 unsafe {
@@ -3117,7 +3093,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_ifc_ifcu {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("ifc_ifcu")
@@ -3127,7 +3102,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl ::hash::Hash for __c_anonymous_ifc_ifcu {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe { self.ifcu_buf.hash(state) };

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -970,10 +970,7 @@ s! {
 
     pub struct ifconf {
         pub ifc_len: ::c_int,
-        #[cfg(libc_union)]
         pub ifc_ifcu: __c_anonymous_ifc_ifcu,
-        #[cfg(not(libc_union))]
-        pub ifc_ifcu: *mut ifreq,
     }
 
     pub struct au_mask_t {
@@ -1358,7 +1355,6 @@ s_no_extra_traits! {
         pub __ut_spare: [::c_char; 64],
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_cr_pid {
         __cr_unused: *mut ::c_void,
         pub cr_pid: ::pid_t,
@@ -1369,10 +1365,7 @@ s_no_extra_traits! {
         pub cr_uid: ::uid_t,
         pub cr_ngroups: ::c_short,
         pub cr_groups: [::gid_t; 16],
-        #[cfg(libc_union)]
         pub cr_pid__c_anonymous_union: __c_anonymous_cr_pid,
-        #[cfg(not(libc_union))]
-        __cr_unused1: *mut ::c_void,
     }
 
     pub struct sockaddr_dl {
@@ -1414,24 +1407,20 @@ s_no_extra_traits! {
         pub devname: [::c_char; SPECNAMELEN as usize + 1],
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_elf32_auxv_union {
         pub a_val: ::c_int,
     }
 
     pub struct Elf32_Auxinfo {
         pub a_type: ::c_int,
-        #[cfg(libc_union)]
         pub a_un: __c_anonymous_elf32_auxv_union,
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_ifi_epoch {
         pub tt: ::time_t,
         pub ph: u64,
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_ifi_lastchange {
         pub tv: ::timeval,
         pub ph: __c_anonymous_ph,
@@ -1485,20 +1474,11 @@ s_no_extra_traits! {
         /// HW offload capabilities, see IFCAP
         pub ifi_hwassist: u64,
         /// uptime at attach or stat reset
-        #[cfg(libc_union)]
         pub __ifi_epoch: __c_anonymous_ifi_epoch,
-        /// uptime at attach or stat reset
-        #[cfg(not(libc_union))]
-        pub __ifi_epoch: u64,
         /// time of last administrative change
-        #[cfg(libc_union)]
         pub __ifi_lastchange: __c_anonymous_ifi_lastchange,
-        /// time of last administrative change
-        #[cfg(not(libc_union))]
-        pub __ifi_lastchange: ::timeval,
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_ifr_ifru {
         pub ifru_addr: ::sockaddr,
         pub ifru_dstaddr: ::sockaddr,
@@ -1520,13 +1500,9 @@ s_no_extra_traits! {
     pub struct ifreq {
         /// if name, e.g. "en0"
         pub ifr_name: [::c_char; ::IFNAMSIZ],
-        #[cfg(libc_union)]
         pub ifr_ifru: __c_anonymous_ifr_ifru,
-        #[cfg(not(libc_union))]
-        pub ifr_ifru: ::sockaddr,
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_ifc_ifcu {
         pub ifcu_buf: ::caddr_t,
         pub ifcu_req: *mut ifreq,
@@ -1715,15 +1691,12 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous_cr_pid {
             fn eq(&self, other: &__c_anonymous_cr_pid) -> bool {
                 unsafe { self.cr_pid == other.cr_pid}
             }
         }
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous_cr_pid {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_cr_pid {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("cr_pid")
@@ -1731,7 +1704,6 @@ cfg_if! {
                     .finish()
             }
         }
-        #[cfg(libc_union)]
         impl ::hash::Hash for __c_anonymous_cr_pid {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe { self.cr_pid.hash(state) };
@@ -1740,17 +1712,11 @@ cfg_if! {
 
         impl PartialEq for xucred {
             fn eq(&self, other: &xucred) -> bool {
-                #[cfg(libc_union)]
-                let equal_cr_pid = self.cr_pid__c_anonymous_union
-                    == other.cr_pid__c_anonymous_union;
-                #[cfg(not(libc_union))]
-                let equal_cr_pid = self.__cr_unused1 == other.__cr_unused1;
-
                 self.cr_version == other.cr_version
                     && self.cr_uid == other.cr_uid
                     && self.cr_ngroups == other.cr_ngroups
                     && self.cr_groups == other.cr_groups
-                    && equal_cr_pid
+                    && self.cr_pid__c_anonymous_union == other.cr_pid__c_anonymous_union
             }
         }
         impl Eq for xucred {}
@@ -1761,7 +1727,6 @@ cfg_if! {
                 struct_formatter.field("cr_uid", &self.cr_uid);
                 struct_formatter.field("cr_ngroups", &self.cr_ngroups);
                 struct_formatter.field("cr_groups", &self.cr_groups);
-                #[cfg(libc_union)]
                 struct_formatter.field(
                     "cr_pid__c_anonymous_union",
                     &self.cr_pid__c_anonymous_union
@@ -1775,10 +1740,7 @@ cfg_if! {
                 self.cr_uid.hash(state);
                 self.cr_ngroups.hash(state);
                 self.cr_groups.hash(state);
-                #[cfg(libc_union)]
                 self.cr_pid__c_anonymous_union.hash(state);
-                #[cfg(not(libc_union))]
-                self.__cr_unused1.hash(state);
             }
         }
 
@@ -1912,15 +1874,12 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous_elf32_auxv_union {
             fn eq(&self, other: &__c_anonymous_elf32_auxv_union) -> bool {
                 unsafe { self.a_val == other.a_val}
             }
         }
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous_elf32_auxv_union {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_elf32_auxv_union {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("a_val")
@@ -1928,13 +1887,6 @@ cfg_if! {
                     .finish()
             }
         }
-        #[cfg(not(libc_union))]
-        impl PartialEq for Elf32_Auxinfo {
-            fn eq(&self, other: &Elf32_Auxinfo) -> bool {
-                self.a_type == other.a_type
-            }
-        }
-        #[cfg(libc_union)]
         impl PartialEq for Elf32_Auxinfo {
             fn eq(&self, other: &Elf32_Auxinfo) -> bool {
                 self.a_type == other.a_type
@@ -1942,15 +1894,6 @@ cfg_if! {
             }
         }
         impl Eq for Elf32_Auxinfo {}
-        #[cfg(not(libc_union))]
-        impl ::fmt::Debug for Elf32_Auxinfo {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                f.debug_struct("Elf32_Auxinfo")
-                    .field("a_type", &self.a_type)
-                    .finish()
-            }
-        }
-        #[cfg(libc_union)]
         impl ::fmt::Debug for Elf32_Auxinfo {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("Elf32_Auxinfo")
@@ -1960,7 +1903,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous_ifr_ifru {
             fn eq(&self, other: &__c_anonymous_ifr_ifru) -> bool {
                 unsafe {
@@ -1982,9 +1924,7 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous_ifr_ifru {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_ifr_ifru {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("ifr_ifru")
@@ -2006,7 +1946,6 @@ cfg_if! {
                     .finish()
             }
         }
-        #[cfg(libc_union)]
         impl ::hash::Hash for __c_anonymous_ifr_ifru {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe { self.ifru_addr.hash(state) };
@@ -2048,10 +1987,8 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous_ifc_ifcu {}
 
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous_ifc_ifcu {
             fn eq(&self, other: &__c_anonymous_ifc_ifcu) -> bool {
                 unsafe {
@@ -2061,7 +1998,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_ifc_ifcu {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("ifc_ifcu")
@@ -2071,7 +2007,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl ::hash::Hash for __c_anonymous_ifc_ifcu {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe { self.ifcu_buf.hash(state) };
@@ -2174,7 +2109,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous_ifi_epoch {
             fn eq(&self, other: &__c_anonymous_ifi_epoch) -> bool {
                 unsafe {
@@ -2183,9 +2117,7 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous_ifi_epoch {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_ifi_epoch {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("__c_anonymous_ifi_epoch")
@@ -2194,7 +2126,6 @@ cfg_if! {
                     .finish()
             }
         }
-        #[cfg(libc_union)]
         impl ::hash::Hash for __c_anonymous_ifi_epoch {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
@@ -2204,7 +2135,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous_ifi_lastchange {
             fn eq(&self, other: &__c_anonymous_ifi_lastchange) -> bool {
                 unsafe {
@@ -2213,9 +2143,7 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous_ifi_lastchange {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_ifi_lastchange {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("__c_anonymous_ifi_lastchange")
@@ -2224,7 +2152,6 @@ cfg_if! {
                     .finish()
             }
         }
-        #[cfg(libc_union)]
         impl ::hash::Hash for __c_anonymous_ifi_lastchange {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -82,7 +82,6 @@ s_no_extra_traits! {
         pub xmm_pad: [u8; 224],
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_elf64_auxv_union {
         pub a_val: ::c_long,
         pub a_ptr: *mut ::c_void,
@@ -91,7 +90,6 @@ s_no_extra_traits! {
 
     pub struct Elf64_Auxinfo {
         pub a_type: ::c_long,
-        #[cfg(libc_union)]
         pub a_un: __c_anonymous_elf64_auxv_union,
     }
 }
@@ -188,7 +186,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous_elf64_auxv_union {
             fn eq(&self, other: &__c_anonymous_elf64_auxv_union) -> bool {
                 unsafe { self.a_val == other.a_val
@@ -196,9 +193,7 @@ cfg_if! {
                         || self.a_fcn == other.a_fcn }
             }
         }
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous_elf64_auxv_union {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_elf64_auxv_union {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("a_val")
@@ -206,13 +201,6 @@ cfg_if! {
                     .finish()
             }
         }
-        #[cfg(not(libc_union))]
-        impl PartialEq for Elf64_Auxinfo {
-            fn eq(&self, other: &Elf64_Auxinfo) -> bool {
-                self.a_type == other.a_type
-            }
-        }
-        #[cfg(libc_union)]
         impl PartialEq for Elf64_Auxinfo {
             fn eq(&self, other: &Elf64_Auxinfo) -> bool {
                 self.a_type == other.a_type
@@ -220,15 +208,6 @@ cfg_if! {
             }
         }
         impl Eq for Elf64_Auxinfo {}
-        #[cfg(not(libc_union))]
-        impl ::fmt::Debug for Elf64_Auxinfo {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                f.debug_struct("Elf64_Auxinfo")
-                    .field("a_type", &self.a_type)
-                    .finish()
-            }
-        }
-        #[cfg(libc_union)]
         impl ::fmt::Debug for Elf64_Auxinfo {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("Elf64_Auxinfo")

--- a/src/unix/bsd/netbsdlike/netbsd/aarch64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/aarch64.rs
@@ -8,7 +8,6 @@ pub type __cpu_simple_lock_nv_t = ::c_uchar;
 
 s! {
     pub struct __fregset {
-        #[cfg(libc_union)]
         pub __qregs: [__c_anonymous__freg; 32],
         pub __fpcr: u32,
         pub __fpsr: u32,
@@ -30,7 +29,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[cfg(libc_union)]
     #[repr(align(16))]
     pub union __c_anonymous__freg {
         pub __b8: [u8; 16],
@@ -43,7 +41,6 @@ s_no_extra_traits! {
 
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous__freg {
             fn eq(&self, other: &__c_anonymous__freg) -> bool {
                 unsafe {
@@ -55,9 +52,7 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous__freg {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous__freg {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
@@ -71,7 +66,6 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl ::hash::Hash for __c_anonymous__freg {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -688,14 +688,12 @@ s! {
     pub struct posix_spawn_file_actions_entry_t {
         pub fae_action: fae_action,
         pub fae_fildes: ::c_int,
-        #[cfg(libc_union)]
         pub fae_data: __c_anonymous_posix_spawn_fae,
     }
 
     pub struct posix_spawn_file_actions_t {
         pub size: ::c_uint,
         pub len: ::c_uint,
-        #[cfg(libc_union)]
         pub fae: *mut posix_spawn_file_actions_entry_t,
     }
 
@@ -734,7 +732,6 @@ s! {
 
     pub struct ifconf {
         pub ifc_len: ::c_int,
-        #[cfg(libc_union)]
         pub ifc_ifcu: __c_anonymous_ifc_ifcu,
     }
 
@@ -893,13 +890,11 @@ s_no_extra_traits! {
         pub sigev_notify_attributes: *mut ::c_void
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_posix_spawn_fae {
         pub open: __c_anonymous_posix_spawn_fae_open,
         pub dup2: __c_anonymous_posix_spawn_fae_dup2,
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_ifc_ifcu {
         pub ifcu_buf: *mut ::c_void,
         pub ifcu_req: *mut ifreq,
@@ -1332,10 +1327,8 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous_posix_spawn_fae {}
 
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous_posix_spawn_fae {
             fn eq(&self, other: &__c_anonymous_posix_spawn_fae) -> bool {
                 unsafe {
@@ -1345,7 +1338,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_posix_spawn_fae {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
@@ -1357,7 +1349,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl ::hash::Hash for __c_anonymous_posix_spawn_fae {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
@@ -1367,10 +1358,8 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous_ifc_ifcu {}
 
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous_ifc_ifcu {
             fn eq(&self, other: &__c_anonymous_ifc_ifcu) -> bool {
                 unsafe {
@@ -1380,7 +1369,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_ifc_ifcu {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
@@ -1392,7 +1380,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl ::hash::Hash for __c_anonymous_ifc_ifcu {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
@@ -2915,6 +2902,9 @@ extern "C" {
         ntargets: ::size_t,
         hint: *const ::c_void,
     ) -> ::c_int;
+
+    pub fn getmntinfo(mntbufp: *mut *mut ::statvfs, flags: ::c_int) -> ::c_int;
+    pub fn getvfsstat(buf: *mut statvfs, bufsize: ::size_t, flags: ::c_int) -> ::c_int;
 }
 
 #[link(name = "rt")]
@@ -3136,16 +3126,6 @@ extern "C" {
         fd: ::c_int,
         fmt: *const ::c_char,
     ) -> ::c_int;
-}
-
-cfg_if! {
-    if #[cfg(libc_union)] {
-        extern {
-            // these functions use statvfs:
-            pub fn getmntinfo(mntbufp: *mut *mut ::statvfs, flags: ::c_int) -> ::c_int;
-            pub fn getvfsstat(buf: *mut statvfs, bufsize: ::size_t, flags: ::c_int) -> ::c_int;
-        }
-    }
 }
 
 cfg_if! {

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -540,10 +540,7 @@ s! {
 
     pub struct ifreq {
         pub ifr_name: [::c_char; ::IFNAMSIZ],
-        #[cfg(libc_union)]
         pub ifr_ifru: __c_anonymous_ifr_ifru,
-        #[cfg(not(libc_union))]
-        pub ifr_ifru: ::sockaddr,
     }
 
     pub struct tcp_info {
@@ -716,7 +713,6 @@ s_no_extra_traits! {
         align: [::c_char; 160],
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_ifr_ifru {
         pub ifru_addr: ::sockaddr,
         pub ifru_dstaddr: ::sockaddr,
@@ -935,7 +931,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous_ifr_ifru {
             fn eq(&self, other: &__c_anonymous_ifr_ifru) -> bool {
                 unsafe {
@@ -952,10 +947,8 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous_ifr_ifru {}
 
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_ifr_ifru {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("__c_anonymous_ifr_ifru")
@@ -972,7 +965,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl ::hash::Hash for __c_anonymous_ifr_ifru {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
@@ -991,135 +983,131 @@ cfg_if! {
     }
 }
 
+s_no_extra_traits! {
+    // This type uses the union mount_info:
+    pub struct statfs {
+        pub f_flags: u32,
+        pub f_bsize: u32,
+        pub f_iosize: u32,
+        pub f_blocks: u64,
+        pub f_bfree: u64,
+        pub f_bavail: i64,
+        pub f_files: u64,
+        pub f_ffree: u64,
+        pub f_favail: i64,
+        pub f_syncwrites: u64,
+        pub f_syncreads: u64,
+        pub f_asyncwrites: u64,
+        pub f_asyncreads: u64,
+        pub f_fsid: ::fsid_t,
+        pub f_namemax: u32,
+        pub f_owner: ::uid_t,
+        pub f_ctime: u64,
+        pub f_fstypename: [::c_char; 16],
+        pub f_mntonname: [::c_char; 90],
+        pub f_mntfromname: [::c_char; 90],
+        pub f_mntfromspec: [::c_char; 90],
+        pub mount_info: mount_info,
+    }
+}
+
 cfg_if! {
-    if #[cfg(libc_union)] {
-        s_no_extra_traits! {
-            // This type uses the union mount_info:
-            pub struct statfs {
-                pub f_flags: u32,
-                pub f_bsize: u32,
-                pub f_iosize: u32,
-                pub f_blocks: u64,
-                pub f_bfree: u64,
-                pub f_bavail: i64,
-                pub f_files: u64,
-                pub f_ffree: u64,
-                pub f_favail: i64,
-                pub f_syncwrites: u64,
-                pub f_syncreads: u64,
-                pub f_asyncwrites: u64,
-                pub f_asyncreads: u64,
-                pub f_fsid: ::fsid_t,
-                pub f_namemax: u32,
-                pub f_owner: ::uid_t,
-                pub f_ctime: u64,
-                pub f_fstypename: [::c_char; 16],
-                pub f_mntonname: [::c_char; 90],
-                pub f_mntfromname: [::c_char; 90],
-                pub f_mntfromspec: [::c_char; 90],
-                pub mount_info: mount_info,
+    if #[cfg(feature = "extra_traits")] {
+        impl PartialEq for statfs {
+            fn eq(&self, other: &statfs) -> bool {
+                self.f_flags == other.f_flags
+                    && self.f_bsize == other.f_bsize
+                    && self.f_iosize == other.f_iosize
+                    && self.f_blocks == other.f_blocks
+                    && self.f_bfree == other.f_bfree
+                    && self.f_bavail == other.f_bavail
+                    && self.f_files == other.f_files
+                    && self.f_ffree == other.f_ffree
+                    && self.f_favail == other.f_favail
+                    && self.f_syncwrites == other.f_syncwrites
+                    && self.f_syncreads == other.f_syncreads
+                    && self.f_asyncwrites == other.f_asyncwrites
+                    && self.f_asyncreads == other.f_asyncreads
+                    && self.f_fsid == other.f_fsid
+                    && self.f_namemax == other.f_namemax
+                    && self.f_owner == other.f_owner
+                    && self.f_ctime == other.f_ctime
+                    && self.f_fstypename
+                    .iter()
+                    .zip(other.f_fstypename.iter())
+                    .all(|(a,b)| a == b)
+                    && self.f_mntonname
+                    .iter()
+                    .zip(other.f_mntonname.iter())
+                    .all(|(a,b)| a == b)
+                    && self.f_mntfromname
+                    .iter()
+                    .zip(other.f_mntfromname.iter())
+                    .all(|(a,b)| a == b)
+                    && self.f_mntfromspec
+                    .iter()
+                    .zip(other.f_mntfromspec.iter())
+                    .all(|(a,b)| a == b)
+                    && self.mount_info == other.mount_info
             }
         }
 
-        cfg_if! {
-            if #[cfg(feature = "extra_traits")] {
-                impl PartialEq for statfs {
-                    fn eq(&self, other: &statfs) -> bool {
-                        self.f_flags == other.f_flags
-                            && self.f_bsize == other.f_bsize
-                            && self.f_iosize == other.f_iosize
-                            && self.f_blocks == other.f_blocks
-                            && self.f_bfree == other.f_bfree
-                            && self.f_bavail == other.f_bavail
-                            && self.f_files == other.f_files
-                            && self.f_ffree == other.f_ffree
-                            && self.f_favail == other.f_favail
-                            && self.f_syncwrites == other.f_syncwrites
-                            && self.f_syncreads == other.f_syncreads
-                            && self.f_asyncwrites == other.f_asyncwrites
-                            && self.f_asyncreads == other.f_asyncreads
-                            && self.f_fsid == other.f_fsid
-                            && self.f_namemax == other.f_namemax
-                            && self.f_owner == other.f_owner
-                            && self.f_ctime == other.f_ctime
-                            && self.f_fstypename
-                            .iter()
-                            .zip(other.f_fstypename.iter())
-                            .all(|(a,b)| a == b)
-                            && self.f_mntonname
-                            .iter()
-                            .zip(other.f_mntonname.iter())
-                            .all(|(a,b)| a == b)
-                            && self.f_mntfromname
-                            .iter()
-                            .zip(other.f_mntfromname.iter())
-                            .all(|(a,b)| a == b)
-                            && self.f_mntfromspec
-                            .iter()
-                            .zip(other.f_mntfromspec.iter())
-                            .all(|(a,b)| a == b)
-                            && self.mount_info == other.mount_info
-                    }
-                }
+        impl Eq for statfs { }
 
-                impl Eq for statfs { }
+        impl ::fmt::Debug for statfs {
+            fn fmt(&self, f: &mut ::fmt::Formatter)
+                   -> ::fmt::Result {
+                f.debug_struct("statfs")
+                    .field("f_flags", &self.f_flags)
+                    .field("f_bsize", &self.f_bsize)
+                    .field("f_iosize", &self.f_iosize)
+                    .field("f_blocks", &self.f_blocks)
+                    .field("f_bfree", &self.f_bfree)
+                    .field("f_bavail", &self.f_bavail)
+                    .field("f_files", &self.f_files)
+                    .field("f_ffree", &self.f_ffree)
+                    .field("f_favail", &self.f_favail)
+                    .field("f_syncwrites", &self.f_syncwrites)
+                    .field("f_syncreads", &self.f_syncreads)
+                    .field("f_asyncwrites", &self.f_asyncwrites)
+                    .field("f_asyncreads", &self.f_asyncreads)
+                    .field("f_fsid", &self.f_fsid)
+                    .field("f_namemax", &self.f_namemax)
+                    .field("f_owner", &self.f_owner)
+                    .field("f_ctime", &self.f_ctime)
+                // FIXME: .field("f_fstypename", &self.f_fstypename)
+                // FIXME: .field("f_mntonname", &self.f_mntonname)
+                // FIXME: .field("f_mntfromname", &self.f_mntfromname)
+                // FIXME: .field("f_mntfromspec", &self.f_mntfromspec)
+                    .field("mount_info", &self.mount_info)
+                    .finish()
+            }
+        }
 
-                impl ::fmt::Debug for statfs {
-                    fn fmt(&self, f: &mut ::fmt::Formatter)
-                           -> ::fmt::Result {
-                        f.debug_struct("statfs")
-                            .field("f_flags", &self.f_flags)
-                            .field("f_bsize", &self.f_bsize)
-                            .field("f_iosize", &self.f_iosize)
-                            .field("f_blocks", &self.f_blocks)
-                            .field("f_bfree", &self.f_bfree)
-                            .field("f_bavail", &self.f_bavail)
-                            .field("f_files", &self.f_files)
-                            .field("f_ffree", &self.f_ffree)
-                            .field("f_favail", &self.f_favail)
-                            .field("f_syncwrites", &self.f_syncwrites)
-                            .field("f_syncreads", &self.f_syncreads)
-                            .field("f_asyncwrites", &self.f_asyncwrites)
-                            .field("f_asyncreads", &self.f_asyncreads)
-                            .field("f_fsid", &self.f_fsid)
-                            .field("f_namemax", &self.f_namemax)
-                            .field("f_owner", &self.f_owner)
-                            .field("f_ctime", &self.f_ctime)
-                        // FIXME: .field("f_fstypename", &self.f_fstypename)
-                        // FIXME: .field("f_mntonname", &self.f_mntonname)
-                        // FIXME: .field("f_mntfromname", &self.f_mntfromname)
-                        // FIXME: .field("f_mntfromspec", &self.f_mntfromspec)
-                            .field("mount_info", &self.mount_info)
-                            .finish()
-                    }
-                }
-
-                impl ::hash::Hash for statfs {
-                    fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                        self.f_flags.hash(state);
-                        self.f_bsize.hash(state);
-                        self.f_iosize.hash(state);
-                        self.f_blocks.hash(state);
-                        self.f_bfree.hash(state);
-                        self.f_bavail.hash(state);
-                        self.f_files.hash(state);
-                        self.f_ffree.hash(state);
-                        self.f_favail.hash(state);
-                        self.f_syncwrites.hash(state);
-                        self.f_syncreads.hash(state);
-                        self.f_asyncwrites.hash(state);
-                        self.f_asyncreads.hash(state);
-                        self.f_fsid.hash(state);
-                        self.f_namemax.hash(state);
-                        self.f_owner.hash(state);
-                        self.f_ctime.hash(state);
-                        self.f_fstypename.hash(state);
-                        self.f_mntonname.hash(state);
-                        self.f_mntfromname.hash(state);
-                        self.f_mntfromspec.hash(state);
-                        self.mount_info.hash(state);
-                    }
-                }
+        impl ::hash::Hash for statfs {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                self.f_flags.hash(state);
+                self.f_bsize.hash(state);
+                self.f_iosize.hash(state);
+                self.f_blocks.hash(state);
+                self.f_bfree.hash(state);
+                self.f_bavail.hash(state);
+                self.f_files.hash(state);
+                self.f_ffree.hash(state);
+                self.f_favail.hash(state);
+                self.f_syncwrites.hash(state);
+                self.f_syncreads.hash(state);
+                self.f_asyncwrites.hash(state);
+                self.f_asyncreads.hash(state);
+                self.f_fsid.hash(state);
+                self.f_namemax.hash(state);
+                self.f_owner.hash(state);
+                self.f_ctime.hash(state);
+                self.f_fstypename.hash(state);
+                self.f_mntonname.hash(state);
+                self.f_mntfromname.hash(state);
+                self.f_mntfromspec.hash(state);
+                self.mount_info.hash(state);
             }
         }
     }
@@ -2201,6 +2189,11 @@ extern "C" {
     pub fn mimmutable(addr: *mut ::c_void, len: ::size_t) -> ::c_int;
 
     pub fn reboot(mode: ::c_int) -> ::c_int;
+
+    pub fn statfs(path: *const ::c_char, buf: *mut statfs) -> ::c_int;
+    pub fn fstatfs(fd: ::c_int, buf: *mut statfs) -> ::c_int;
+    pub fn getmntinfo(mntbufp: *mut *mut ::statfs, flags: ::c_int) -> ::c_int;
+    pub fn getfsstat(buf: *mut statfs, bufsize: ::size_t, flags: ::c_int) -> ::c_int;
 }
 
 #[link(name = "execinfo")]
@@ -2217,18 +2210,6 @@ extern "C" {
         len: ::size_t,
         fmt: *const ::c_char,
     ) -> *mut *mut ::c_char;
-}
-
-cfg_if! {
-    if #[cfg(libc_union)] {
-        extern {
-            // these functions use statfs which uses the union mount_info:
-            pub fn statfs(path: *const ::c_char, buf: *mut statfs) -> ::c_int;
-            pub fn fstatfs(fd: ::c_int, buf: *mut statfs) -> ::c_int;
-            pub fn getmntinfo(mntbufp: *mut *mut ::statfs, flags: ::c_int) -> ::c_int;
-            pub fn getfsstat(buf: *mut statfs, bufsize: ::size_t, flags: ::c_int) -> ::c_int;
-        }
-    }
 }
 
 cfg_if! {

--- a/src/unix/haiku/native.rs
+++ b/src/unix/haiku/native.rs
@@ -460,7 +460,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[cfg(libc_union)]
     pub union cpuid_info {
         pub eax_0: __c_anonymous_eax_0,
         pub eax_1: __c_anonymous_eax_1,
@@ -470,7 +469,6 @@ s_no_extra_traits! {
         pub regs: __c_anonymous_regs,
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_cpu_topology_info_data {
         pub root: cpu_topology_root_info,
         pub package: cpu_topology_package_info,
@@ -481,16 +479,12 @@ s_no_extra_traits! {
         pub id: u32,
         pub type_: topology_level_type,
         pub level: u32,
-        #[cfg(libc_union)]
         pub data: __c_anonymous_cpu_topology_info_data,
-        #[cfg(not(libc_union))]
-        pub data: cpu_topology_core_info,
     }
 }
 
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
-        #[cfg(libc_union)]
         impl PartialEq for cpuid_info {
             fn eq(&self, other: &cpuid_info) -> bool {
                 unsafe {
@@ -503,9 +497,7 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl Eq for cpuid_info {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for cpuid_info {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
@@ -521,7 +513,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous_cpu_topology_info_data {
             fn eq(&self, other: &__c_anonymous_cpu_topology_info_data) -> bool {
                 unsafe {
@@ -531,9 +522,7 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous_cpu_topology_info_data {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_cpu_topology_info_data {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
@@ -1339,14 +1328,8 @@ extern "C" {
         pathString: *mut ::c_char,
         length: i32,
     ) -> status_t;
-}
 
-cfg_if! {
-    if #[cfg(libc_union)] {
-        extern "C" {
-            pub fn get_cpuid(info: *mut cpuid_info, eaxRegister: u32, cpuNum: u32) -> status_t;
-        }
-    }
+    pub fn get_cpuid(info: *mut cpuid_info, eaxRegister: u32, cpuNum: u32) -> status_t;
 }
 
 // The following functions are defined as macros in C/C++

--- a/src/unix/linux_like/android/b32/arm.rs
+++ b/src/unix/linux_like/android/b32/arm.rs
@@ -29,119 +29,115 @@ s! {
     }
 }
 
+s_no_extra_traits! {
+    pub struct __c_anonymous_uc_sigmask_with_padding {
+        pub uc_sigmask: ::sigset_t,
+        /* Android has a wrong (smaller) sigset_t on x86. */
+        __padding_rt_sigset: u32,
+    }
+
+    pub union __c_anonymous_uc_sigmask {
+        uc_sigmask: __c_anonymous_uc_sigmask_with_padding,
+        uc_sigmask64: ::sigset64_t,
+    }
+
+    pub struct ucontext_t {
+        pub uc_flags: ::c_ulong,
+        pub uc_link: *mut ucontext_t,
+        pub uc_stack: ::stack_t,
+        pub uc_mcontext: mcontext_t,
+        pub uc_sigmask__c_anonymous_union: __c_anonymous_uc_sigmask,
+        /* The kernel adds extra padding after uc_sigmask to match
+         * glibc sigset_t on ARM. */
+        __padding: [c_char; 120],
+        __align: [::c_longlong; 0],
+        uc_regspace: [::c_ulong; 128],
+    }
+}
+
 cfg_if! {
-    if #[cfg(libc_union)] {
-        s_no_extra_traits! {
-            pub struct __c_anonymous_uc_sigmask_with_padding {
-                pub uc_sigmask: ::sigset_t,
-                /* Android has a wrong (smaller) sigset_t on x86. */
-                __padding_rt_sigset: u32,
+    if #[cfg(feature = "extra_traits")] {
+        impl PartialEq for __c_anonymous_uc_sigmask_with_padding {
+            fn eq(
+                &self, other: &__c_anonymous_uc_sigmask_with_padding
+            ) -> bool {
+                self.uc_sigmask == other.uc_sigmask
+                    // Ignore padding
             }
-
-            pub union __c_anonymous_uc_sigmask {
-                uc_sigmask: __c_anonymous_uc_sigmask_with_padding,
-                uc_sigmask64: ::sigset64_t,
+        }
+        impl Eq for __c_anonymous_uc_sigmask_with_padding {}
+        impl ::fmt::Debug for __c_anonymous_uc_sigmask_with_padding {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("uc_sigmask_with_padding")
+                    .field("uc_sigmask_with_padding", &self.uc_sigmask)
+                    // Ignore padding
+                    .finish()
             }
-
-            pub struct ucontext_t {
-                pub uc_flags: ::c_ulong,
-                pub uc_link: *mut ucontext_t,
-                pub uc_stack: ::stack_t,
-                pub uc_mcontext: mcontext_t,
-                pub uc_sigmask__c_anonymous_union: __c_anonymous_uc_sigmask,
-                /* The kernel adds extra padding after uc_sigmask to match
-                 * glibc sigset_t on ARM. */
-                __padding: [c_char; 120],
-                __align: [::c_longlong; 0],
-                uc_regspace: [::c_ulong; 128],
+        }
+        impl ::hash::Hash for __c_anonymous_uc_sigmask_with_padding {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                self.uc_sigmask.hash(state)
+                    // Ignore padding
             }
         }
 
-        cfg_if! {
-            if #[cfg(feature = "extra_traits")] {
-                impl PartialEq for __c_anonymous_uc_sigmask_with_padding {
-                    fn eq(
-                        &self, other: &__c_anonymous_uc_sigmask_with_padding
-                    ) -> bool {
-                        self.uc_sigmask == other.uc_sigmask
-                            // Ignore padding
-                    }
-                }
-                impl Eq for __c_anonymous_uc_sigmask_with_padding {}
-                impl ::fmt::Debug for __c_anonymous_uc_sigmask_with_padding {
-                    fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                        f.debug_struct("uc_sigmask_with_padding")
-                            .field("uc_sigmask_with_padding", &self.uc_sigmask)
-                            // Ignore padding
-                            .finish()
-                    }
-                }
-                impl ::hash::Hash for __c_anonymous_uc_sigmask_with_padding {
-                    fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                        self.uc_sigmask.hash(state)
-                            // Ignore padding
-                    }
-                }
+        impl PartialEq for __c_anonymous_uc_sigmask {
+            fn eq(&self, other: &__c_anonymous_uc_sigmask) -> bool {
+                unsafe { self.uc_sigmask == other.uc_sigmask }
+            }
+        }
+        impl Eq for __c_anonymous_uc_sigmask {}
+        impl ::fmt::Debug for __c_anonymous_uc_sigmask {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("uc_sigmask")
+                    .field("uc_sigmask", unsafe { &self.uc_sigmask })
+                    .finish()
+            }
+        }
+        impl ::hash::Hash for __c_anonymous_uc_sigmask {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                unsafe { self.uc_sigmask.hash(state) }
+            }
+        }
 
-                impl PartialEq for __c_anonymous_uc_sigmask {
-                    fn eq(&self, other: &__c_anonymous_uc_sigmask) -> bool {
-                        unsafe { self.uc_sigmask == other.uc_sigmask }
-                    }
-                }
-                impl Eq for __c_anonymous_uc_sigmask {}
-                impl ::fmt::Debug for __c_anonymous_uc_sigmask {
-                    fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                        f.debug_struct("uc_sigmask")
-                            .field("uc_sigmask", unsafe { &self.uc_sigmask })
-                            .finish()
-                    }
-                }
-                impl ::hash::Hash for __c_anonymous_uc_sigmask {
-                    fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                        unsafe { self.uc_sigmask.hash(state) }
-                    }
-                }
-
-                impl PartialEq for ucontext_t {
-                    fn eq(&self, other: &Self) -> bool {
-                        self.uc_flags == other.uc_flags
-                            && self.uc_link == other.uc_link
-                            && self.uc_stack == other.uc_stack
-                            && self.uc_mcontext == other.uc_mcontext
-                            && self.uc_sigmask__c_anonymous_union
-                                == other.uc_sigmask__c_anonymous_union
-                            && &self.uc_regspace[..] == &other.uc_regspace[..]
-                            // Ignore padding field
-                    }
-                }
-                impl Eq for ucontext_t {}
-                impl ::fmt::Debug for ucontext_t {
-                    fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                        f.debug_struct("ucontext_t")
-                            .field("uc_flags", &self.uc_flags)
-                            .field("uc_link", &self.uc_link)
-                            .field("uc_stack", &self.uc_stack)
-                            .field("uc_mcontext", &self.uc_mcontext)
-                            .field(
-                                "uc_sigmask__c_anonymous_union",
-                                &self.uc_sigmask__c_anonymous_union
-                            )
-                            .field("uc_regspace", &&self.uc_regspace[..])
-                            // Ignore padding field
-                            .finish()
-                    }
-                }
-                impl ::hash::Hash for ucontext_t {
-                    fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                        self.uc_flags.hash(state);
-                        self.uc_link.hash(state);
-                        self.uc_stack.hash(state);
-                        self.uc_mcontext.hash(state);
-                        self.uc_sigmask__c_anonymous_union.hash(state);
-                        self.uc_regspace[..].hash(state);
-                        // Ignore padding field
-                    }
-                }
+        impl PartialEq for ucontext_t {
+            fn eq(&self, other: &Self) -> bool {
+                self.uc_flags == other.uc_flags
+                    && self.uc_link == other.uc_link
+                    && self.uc_stack == other.uc_stack
+                    && self.uc_mcontext == other.uc_mcontext
+                    && self.uc_sigmask__c_anonymous_union
+                        == other.uc_sigmask__c_anonymous_union
+                    && &self.uc_regspace[..] == &other.uc_regspace[..]
+                    // Ignore padding field
+            }
+        }
+        impl Eq for ucontext_t {}
+        impl ::fmt::Debug for ucontext_t {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("ucontext_t")
+                    .field("uc_flags", &self.uc_flags)
+                    .field("uc_link", &self.uc_link)
+                    .field("uc_stack", &self.uc_stack)
+                    .field("uc_mcontext", &self.uc_mcontext)
+                    .field(
+                        "uc_sigmask__c_anonymous_union",
+                        &self.uc_sigmask__c_anonymous_union
+                    )
+                    .field("uc_regspace", &&self.uc_regspace[..])
+                    // Ignore padding field
+                    .finish()
+            }
+        }
+        impl ::hash::Hash for ucontext_t {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                self.uc_flags.hash(state);
+                self.uc_link.hash(state);
+                self.uc_stack.hash(state);
+                self.uc_mcontext.hash(state);
+                self.uc_sigmask__c_anonymous_union.hash(state);
+                self.uc_regspace[..].hash(state);
+                // Ignore padding field
             }
         }
     }

--- a/src/unix/linux_like/android/b32/x86/mod.rs
+++ b/src/unix/linux_like/android/b32/x86/mod.rs
@@ -28,113 +28,109 @@ s! {
     }
 }
 
+s_no_extra_traits! {
+    pub struct __c_anonymous_uc_sigmask_with_padding {
+        pub uc_sigmask: ::sigset_t,
+        /* Android has a wrong (smaller) sigset_t on x86. */
+        __padding_rt_sigset: u32,
+    }
+
+    pub union __c_anonymous_uc_sigmask {
+        uc_sigmask: __c_anonymous_uc_sigmask_with_padding,
+        uc_sigmask64: ::sigset64_t,
+    }
+
+    pub struct ucontext_t {
+        pub uc_flags: ::c_ulong,
+        pub uc_link: *mut ucontext_t,
+        pub uc_stack: ::stack_t,
+        pub uc_mcontext: mcontext_t,
+        pub uc_sigmask__c_anonymous_union: __c_anonymous_uc_sigmask,
+        __padding_rt_sigset: u32,
+        __fpregs_mem: _libc_fpstate,
+    }
+}
+
 cfg_if! {
-    if #[cfg(libc_union)] {
-        s_no_extra_traits! {
-            pub struct __c_anonymous_uc_sigmask_with_padding {
-                pub uc_sigmask: ::sigset_t,
-                /* Android has a wrong (smaller) sigset_t on x86. */
-                __padding_rt_sigset: u32,
+    if #[cfg(feature = "extra_traits")] {
+        impl PartialEq for __c_anonymous_uc_sigmask_with_padding {
+            fn eq(
+                &self, other: &__c_anonymous_uc_sigmask_with_padding
+            ) -> bool {
+                self.uc_sigmask == other.uc_sigmask
+                    // Ignore padding
             }
-
-            pub union __c_anonymous_uc_sigmask {
-                uc_sigmask: __c_anonymous_uc_sigmask_with_padding,
-                uc_sigmask64: ::sigset64_t,
+        }
+        impl Eq for __c_anonymous_uc_sigmask_with_padding {}
+        impl ::fmt::Debug for __c_anonymous_uc_sigmask_with_padding {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("uc_sigmask_with_padding")
+                    .field("uc_sigmask_with_padding", &self.uc_sigmask)
+                    // Ignore padding
+                    .finish()
             }
-
-            pub struct ucontext_t {
-                pub uc_flags: ::c_ulong,
-                pub uc_link: *mut ucontext_t,
-                pub uc_stack: ::stack_t,
-                pub uc_mcontext: mcontext_t,
-                pub uc_sigmask__c_anonymous_union: __c_anonymous_uc_sigmask,
-                __padding_rt_sigset: u32,
-                __fpregs_mem: _libc_fpstate,
+        }
+        impl ::hash::Hash for __c_anonymous_uc_sigmask_with_padding {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                self.uc_sigmask.hash(state)
+                    // Ignore padding
             }
         }
 
-        cfg_if! {
-            if #[cfg(feature = "extra_traits")] {
-                impl PartialEq for __c_anonymous_uc_sigmask_with_padding {
-                    fn eq(
-                        &self, other: &__c_anonymous_uc_sigmask_with_padding
-                    ) -> bool {
-                        self.uc_sigmask == other.uc_sigmask
-                            // Ignore padding
-                    }
-                }
-                impl Eq for __c_anonymous_uc_sigmask_with_padding {}
-                impl ::fmt::Debug for __c_anonymous_uc_sigmask_with_padding {
-                    fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                        f.debug_struct("uc_sigmask_with_padding")
-                            .field("uc_sigmask_with_padding", &self.uc_sigmask)
-                            // Ignore padding
-                            .finish()
-                    }
-                }
-                impl ::hash::Hash for __c_anonymous_uc_sigmask_with_padding {
-                    fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                        self.uc_sigmask.hash(state)
-                            // Ignore padding
-                    }
-                }
+        impl PartialEq for __c_anonymous_uc_sigmask {
+            fn eq(&self, other: &__c_anonymous_uc_sigmask) -> bool {
+                unsafe { self.uc_sigmask == other.uc_sigmask }
+            }
+        }
+        impl Eq for __c_anonymous_uc_sigmask {}
+        impl ::fmt::Debug for __c_anonymous_uc_sigmask {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("uc_sigmask")
+                    .field("uc_sigmask", unsafe { &self.uc_sigmask })
+                    .finish()
+            }
+        }
+        impl ::hash::Hash for __c_anonymous_uc_sigmask {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                unsafe { self.uc_sigmask.hash(state) }
+            }
+        }
 
-                impl PartialEq for __c_anonymous_uc_sigmask {
-                    fn eq(&self, other: &__c_anonymous_uc_sigmask) -> bool {
-                        unsafe { self.uc_sigmask == other.uc_sigmask }
-                    }
-                }
-                impl Eq for __c_anonymous_uc_sigmask {}
-                impl ::fmt::Debug for __c_anonymous_uc_sigmask {
-                    fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                        f.debug_struct("uc_sigmask")
-                            .field("uc_sigmask", unsafe { &self.uc_sigmask })
-                            .finish()
-                    }
-                }
-                impl ::hash::Hash for __c_anonymous_uc_sigmask {
-                    fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                        unsafe { self.uc_sigmask.hash(state) }
-                    }
-                }
-
-                impl PartialEq for ucontext_t {
-                    fn eq(&self, other: &Self) -> bool {
-                        self.uc_flags == other.uc_flags
-                            && self.uc_link == other.uc_link
-                            && self.uc_stack == other.uc_stack
-                            && self.uc_mcontext == other.uc_mcontext
-                            && self.uc_sigmask__c_anonymous_union
-                                == other.uc_sigmask__c_anonymous_union
-                            // Ignore padding field
-                    }
-                }
-                impl Eq for ucontext_t {}
-                impl ::fmt::Debug for ucontext_t {
-                    fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                        f.debug_struct("ucontext_t")
-                            .field("uc_flags", &self.uc_flags)
-                            .field("uc_link", &self.uc_link)
-                            .field("uc_stack", &self.uc_stack)
-                            .field("uc_mcontext", &self.uc_mcontext)
-                            .field(
-                                "uc_sigmask__c_anonymous_union",
-                                &self.uc_sigmask__c_anonymous_union
-                            )
-                            // Ignore padding field
-                            .finish()
-                    }
-                }
-                impl ::hash::Hash for ucontext_t {
-                    fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                        self.uc_flags.hash(state);
-                        self.uc_link.hash(state);
-                        self.uc_stack.hash(state);
-                        self.uc_mcontext.hash(state);
-                        self.uc_sigmask__c_anonymous_union.hash(state);
-                        // Ignore padding field
-                    }
-                }
+        impl PartialEq for ucontext_t {
+            fn eq(&self, other: &Self) -> bool {
+                self.uc_flags == other.uc_flags
+                    && self.uc_link == other.uc_link
+                    && self.uc_stack == other.uc_stack
+                    && self.uc_mcontext == other.uc_mcontext
+                    && self.uc_sigmask__c_anonymous_union
+                        == other.uc_sigmask__c_anonymous_union
+                    // Ignore padding field
+            }
+        }
+        impl Eq for ucontext_t {}
+        impl ::fmt::Debug for ucontext_t {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("ucontext_t")
+                    .field("uc_flags", &self.uc_flags)
+                    .field("uc_link", &self.uc_link)
+                    .field("uc_stack", &self.uc_stack)
+                    .field("uc_mcontext", &self.uc_mcontext)
+                    .field(
+                        "uc_sigmask__c_anonymous_union",
+                        &self.uc_sigmask__c_anonymous_union
+                    )
+                    // Ignore padding field
+                    .finish()
+            }
+        }
+        impl ::hash::Hash for ucontext_t {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                self.uc_flags.hash(state);
+                self.uc_link.hash(state);
+                self.uc_stack.hash(state);
+                self.uc_mcontext.hash(state);
+                self.uc_sigmask__c_anonymous_union.hash(state);
+                // Ignore padding field
             }
         }
     }

--- a/src/unix/linux_like/android/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/android/b64/x86_64/mod.rs
@@ -104,35 +104,31 @@ s! {
 
 }
 
+s_no_extra_traits! {
+    pub union __c_anonymous_uc_sigmask {
+        uc_sigmask: ::sigset_t,
+        uc_sigmask64: ::sigset64_t,
+    }
+}
+
 cfg_if! {
-    if #[cfg(libc_union)] {
-        s_no_extra_traits! {
-            pub union __c_anonymous_uc_sigmask {
-                uc_sigmask: ::sigset_t,
-                uc_sigmask64: ::sigset64_t,
+    if #[cfg(feature = "extra_traits")] {
+        impl PartialEq for __c_anonymous_uc_sigmask {
+            fn eq(&self, other: &__c_anonymous_uc_sigmask) -> bool {
+                unsafe { self.uc_sigmask == other.uc_sigmask }
             }
         }
-
-        cfg_if! {
-            if #[cfg(feature = "extra_traits")] {
-                impl PartialEq for __c_anonymous_uc_sigmask {
-                    fn eq(&self, other: &__c_anonymous_uc_sigmask) -> bool {
-                        unsafe { self.uc_sigmask == other.uc_sigmask }
-                    }
-                }
-                impl Eq for __c_anonymous_uc_sigmask {}
-                impl ::fmt::Debug for __c_anonymous_uc_sigmask {
-                    fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                        f.debug_struct("uc_sigmask")
-                            .field("uc_sigmask", unsafe { &self.uc_sigmask })
-                            .finish()
-                    }
-                }
-                impl ::hash::Hash for __c_anonymous_uc_sigmask {
-                    fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                        unsafe { self.uc_sigmask.hash(state) }
-                    }
-                }
+        impl Eq for __c_anonymous_uc_sigmask {}
+        impl ::fmt::Debug for __c_anonymous_uc_sigmask {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                f.debug_struct("uc_sigmask")
+                    .field("uc_sigmask", unsafe { &self.uc_sigmask })
+                    .finish()
+            }
+        }
+        impl ::hash::Hash for __c_anonymous_uc_sigmask {
+            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+                unsafe { self.uc_sigmask.hash(state) }
             }
         }
     }

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -612,7 +612,6 @@ s_no_extra_traits! {
         __value: [[::c_char; 4]; 23],
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_ifr_ifru {
         pub ifru_addr: ::sockaddr,
         pub ifru_dstaddr: ::sockaddr,
@@ -632,13 +631,9 @@ s_no_extra_traits! {
     pub struct ifreq {
         /// interface name, e.g. "en0"
         pub ifr_name: [::c_char; ::IFNAMSIZ],
-        #[cfg(libc_union)]
         pub ifr_ifru: __c_anonymous_ifr_ifru,
-        #[cfg(not(libc_union))]
-        pub ifr_ifru: ::sockaddr,
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_ifc_ifcu {
         pub ifcu_buf: *mut ::c_char,
         pub ifcu_req: *mut ::ifreq,
@@ -649,10 +644,7 @@ s_no_extra_traits! {
     networks accessible).  */
     pub struct ifconf {
         pub ifc_len: ::c_int,       /* Size of buffer.  */
-        #[cfg(libc_union)]
         pub ifc_ifcu: __c_anonymous_ifc_ifcu,
-        #[cfg(not(libc_union))]
-        pub ifc_ifcu: *mut ::ifreq,
     }
 
 }
@@ -1002,7 +994,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_ifr_ifru {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("ifr_ifru")
@@ -1031,7 +1022,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_ifc_ifcu {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("ifr_ifru")
@@ -4190,64 +4180,60 @@ impl siginfo_t {
     }
 }
 
-cfg_if! {
-    if #[cfg(libc_union)] {
-        // Internal, for casts to access union fields
-        #[repr(C)]
-        struct sifields_sigchld {
-            si_pid: ::pid_t,
-            si_uid: ::uid_t,
-            si_status: ::c_int,
-            si_utime: ::c_long,
-            si_stime: ::c_long,
-        }
-        impl ::Copy for sifields_sigchld {}
-        impl ::Clone for sifields_sigchld {
-            fn clone(&self) -> sifields_sigchld {
-                *self
-            }
-        }
+// Internal, for casts to access union fields
+#[repr(C)]
+struct sifields_sigchld {
+    si_pid: ::pid_t,
+    si_uid: ::uid_t,
+    si_status: ::c_int,
+    si_utime: ::c_long,
+    si_stime: ::c_long,
+}
+impl ::Copy for sifields_sigchld {}
+impl ::Clone for sifields_sigchld {
+    fn clone(&self) -> sifields_sigchld {
+        *self
+    }
+}
 
-        // Internal, for casts to access union fields
-        #[repr(C)]
-        union sifields {
-            _align_pointer: *mut ::c_void,
-            sigchld: sifields_sigchld,
-        }
+// Internal, for casts to access union fields
+#[repr(C)]
+union sifields {
+    _align_pointer: *mut ::c_void,
+    sigchld: sifields_sigchld,
+}
 
-        // Internal, for casts to access union fields. Note that some variants
-        // of sifields start with a pointer, which makes the alignment of
-        // sifields vary on 32-bit and 64-bit architectures.
-        #[repr(C)]
-        struct siginfo_f {
-            _siginfo_base: [::c_int; 3],
-            sifields: sifields,
-        }
+// Internal, for casts to access union fields. Note that some variants
+// of sifields start with a pointer, which makes the alignment of
+// sifields vary on 32-bit and 64-bit architectures.
+#[repr(C)]
+struct siginfo_f {
+    _siginfo_base: [::c_int; 3],
+    sifields: sifields,
+}
 
-        impl siginfo_t {
-            unsafe fn sifields(&self) -> &sifields {
-                &(*(self as *const siginfo_t as *const siginfo_f)).sifields
-            }
+impl siginfo_t {
+    unsafe fn sifields(&self) -> &sifields {
+        &(*(self as *const siginfo_t as *const siginfo_f)).sifields
+    }
 
-            pub unsafe fn si_pid(&self) -> ::pid_t {
-                self.sifields().sigchld.si_pid
-            }
+    pub unsafe fn si_pid(&self) -> ::pid_t {
+        self.sifields().sigchld.si_pid
+    }
 
-            pub unsafe fn si_uid(&self) -> ::uid_t {
-                self.sifields().sigchld.si_uid
-            }
+    pub unsafe fn si_uid(&self) -> ::uid_t {
+        self.sifields().sigchld.si_uid
+    }
 
-            pub unsafe fn si_status(&self) -> ::c_int {
-                self.sifields().sigchld.si_status
-            }
+    pub unsafe fn si_status(&self) -> ::c_int {
+        self.sifields().sigchld.si_status
+    }
 
-            pub unsafe fn si_utime(&self) -> ::c_long {
-                self.sifields().sigchld.si_utime
-            }
+    pub unsafe fn si_utime(&self) -> ::c_long {
+        self.sifields().sigchld.si_utime
+    }
 
-            pub unsafe fn si_stime(&self) -> ::c_long {
-                self.sifields().sigchld.si_stime
-            }
-        }
+    pub unsafe fn si_stime(&self) -> ::c_long {
+        self.sifields().sigchld.si_stime
     }
 }

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -353,7 +353,6 @@ s! {
         pub arch: ::__u32,
         pub instruction_pointer: ::__u64,
         pub stack_pointer: ::__u64,
-        #[cfg(libc_union)]
         pub u: __c_anonymous_ptrace_syscall_info_data,
     }
 
@@ -531,77 +530,73 @@ impl siginfo_t {
     }
 }
 
-cfg_if! {
-    if #[cfg(libc_union)] {
-        // Internal, for casts to access union fields
-        #[repr(C)]
-        struct sifields_sigchld {
-            si_pid: ::pid_t,
-            si_uid: ::uid_t,
-            si_status: ::c_int,
-            si_utime: ::c_long,
-            si_stime: ::c_long,
-        }
-        impl ::Copy for sifields_sigchld {}
-        impl ::Clone for sifields_sigchld {
-            fn clone(&self) -> sifields_sigchld {
-                *self
-            }
-        }
+// Internal, for casts to access union fields
+#[repr(C)]
+struct sifields_sigchld {
+    si_pid: ::pid_t,
+    si_uid: ::uid_t,
+    si_status: ::c_int,
+    si_utime: ::c_long,
+    si_stime: ::c_long,
+}
+impl ::Copy for sifields_sigchld {}
+impl ::Clone for sifields_sigchld {
+    fn clone(&self) -> sifields_sigchld {
+        *self
+    }
+}
 
-        // Internal, for casts to access union fields
-        #[repr(C)]
-        union sifields {
-            _align_pointer: *mut ::c_void,
-            sigchld: sifields_sigchld,
-        }
+// Internal, for casts to access union fields
+#[repr(C)]
+union sifields {
+    _align_pointer: *mut ::c_void,
+    sigchld: sifields_sigchld,
+}
 
-        // Internal, for casts to access union fields. Note that some variants
-        // of sifields start with a pointer, which makes the alignment of
-        // sifields vary on 32-bit and 64-bit architectures.
-        #[repr(C)]
-        struct siginfo_f {
-            _siginfo_base: [::c_int; 3],
-            sifields: sifields,
-        }
+// Internal, for casts to access union fields. Note that some variants
+// of sifields start with a pointer, which makes the alignment of
+// sifields vary on 32-bit and 64-bit architectures.
+#[repr(C)]
+struct siginfo_f {
+    _siginfo_base: [::c_int; 3],
+    sifields: sifields,
+}
 
-        impl siginfo_t {
-            unsafe fn sifields(&self) -> &sifields {
-                &(*(self as *const siginfo_t as *const siginfo_f)).sifields
-            }
+impl siginfo_t {
+    unsafe fn sifields(&self) -> &sifields {
+        &(*(self as *const siginfo_t as *const siginfo_f)).sifields
+    }
 
-            pub unsafe fn si_pid(&self) -> ::pid_t {
-                self.sifields().sigchld.si_pid
-            }
+    pub unsafe fn si_pid(&self) -> ::pid_t {
+        self.sifields().sigchld.si_pid
+    }
 
-            pub unsafe fn si_uid(&self) -> ::uid_t {
-                self.sifields().sigchld.si_uid
-            }
+    pub unsafe fn si_uid(&self) -> ::uid_t {
+        self.sifields().sigchld.si_uid
+    }
 
-            pub unsafe fn si_status(&self) -> ::c_int {
-                self.sifields().sigchld.si_status
-            }
+    pub unsafe fn si_status(&self) -> ::c_int {
+        self.sifields().sigchld.si_status
+    }
 
-            pub unsafe fn si_utime(&self) -> ::c_long {
-                self.sifields().sigchld.si_utime
-            }
+    pub unsafe fn si_utime(&self) -> ::c_long {
+        self.sifields().sigchld.si_utime
+    }
 
-            pub unsafe fn si_stime(&self) -> ::c_long {
-                self.sifields().sigchld.si_stime
-            }
-        }
+    pub unsafe fn si_stime(&self) -> ::c_long {
+        self.sifields().sigchld.si_stime
+    }
+}
 
-        pub union __c_anonymous_ptrace_syscall_info_data {
-            pub entry: __c_anonymous_ptrace_syscall_info_entry,
-            pub exit: __c_anonymous_ptrace_syscall_info_exit,
-            pub seccomp: __c_anonymous_ptrace_syscall_info_seccomp,
-        }
-        impl ::Copy for __c_anonymous_ptrace_syscall_info_data {}
-        impl ::Clone for __c_anonymous_ptrace_syscall_info_data {
-            fn clone(&self) -> __c_anonymous_ptrace_syscall_info_data {
-                *self
-            }
-        }
+pub union __c_anonymous_ptrace_syscall_info_data {
+    pub entry: __c_anonymous_ptrace_syscall_info_entry,
+    pub exit: __c_anonymous_ptrace_syscall_info_exit,
+    pub seccomp: __c_anonymous_ptrace_syscall_info_seccomp,
+}
+impl ::Copy for __c_anonymous_ptrace_syscall_info_data {}
+impl ::Clone for __c_anonymous_ptrace_syscall_info_data {
+    fn clone(&self) -> __c_anonymous_ptrace_syscall_info_data {
+        *self
     }
 }
 
@@ -705,7 +700,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous_ptrace_syscall_info_data {
             fn eq(&self, other: &__c_anonymous_ptrace_syscall_info_data) -> bool {
                 unsafe {
@@ -716,10 +710,8 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous_ptrace_syscall_info_data {}
 
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_ptrace_syscall_info_data {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
@@ -732,7 +724,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl ::hash::Hash for __c_anonymous_ptrace_syscall_info_data {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -969,7 +969,6 @@ s_no_extra_traits! {
         pad: [::c_long; 4],
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_ifr_ifru {
         pub ifru_addr: ::sockaddr,
         pub ifru_dstaddr: ::sockaddr,
@@ -989,13 +988,9 @@ s_no_extra_traits! {
     pub struct ifreq {
         /// interface name, e.g. "en0"
         pub ifr_name: [::c_char; ::IFNAMSIZ],
-        #[cfg(libc_union)]
         pub ifr_ifru: __c_anonymous_ifr_ifru,
-        #[cfg(not(libc_union))]
-        pub ifr_ifru: ::sockaddr,
     }
 
-    #[cfg(libc_union)]
     pub union __c_anonymous_ifc_ifcu {
         pub ifcu_buf: *mut ::c_char,
         pub ifcu_req: *mut ::ifreq,
@@ -1006,10 +1001,7 @@ s_no_extra_traits! {
     networks accessible).  */
     pub struct ifconf {
         pub ifc_len: ::c_int,       /* Size of buffer.  */
-        #[cfg(libc_union)]
         pub ifc_ifcu: __c_anonymous_ifc_ifcu,
-        #[cfg(not(libc_union))]
-        pub ifc_ifcu: *mut ::ifreq,
     }
 
     pub struct hwtstamp_config {
@@ -1037,20 +1029,17 @@ s_no_extra_traits! {
         pub sched_period: ::__u64,
     }
 
-    #[cfg(libc_union)]
     #[allow(missing_debug_implementations)]
     pub union tpacket_req_u {
         pub req: ::tpacket_req,
         pub req3: ::tpacket_req3,
     }
 
-    #[cfg(libc_union)]
     #[allow(missing_debug_implementations)]
     pub union tpacket_bd_header_u {
         pub bh1: ::tpacket_hdr_v1,
     }
 
-    #[cfg(libc_union)]
     #[allow(missing_debug_implementations)]
     pub struct tpacket_block_desc {
         pub version: ::__u32,
@@ -1068,23 +1057,19 @@ s_no_extra_traits! {
     }
 }
 
-cfg_if! {
-    if #[cfg(libc_union)] {
-        s_no_extra_traits! {
-            // linux/can.h
-            #[allow(missing_debug_implementations)]
-            pub union __c_anonymous_sockaddr_can_can_addr {
-                pub tp: __c_anonymous_sockaddr_can_tp,
-                pub j1939: __c_anonymous_sockaddr_can_j1939,
-            }
+s_no_extra_traits! {
+    // linux/can.h
+    #[allow(missing_debug_implementations)]
+    pub union __c_anonymous_sockaddr_can_can_addr {
+        pub tp: __c_anonymous_sockaddr_can_tp,
+        pub j1939: __c_anonymous_sockaddr_can_j1939,
+    }
 
-            #[allow(missing_debug_implementations)]
-            pub struct sockaddr_can {
-                pub can_family: ::sa_family_t,
-                pub can_ifindex: ::c_int,
-                pub can_addr: __c_anonymous_sockaddr_can_can_addr,
-            }
-        }
+    #[allow(missing_debug_implementations)]
+    pub struct sockaddr_can {
+        pub can_family: ::sa_family_t,
+        pub can_ifindex: ::c_int,
+        pub can_addr: __c_anonymous_sockaddr_can_can_addr,
     }
 }
 
@@ -1452,7 +1437,6 @@ cfg_if! {
                 self.mq_curmsgs.hash(state);
             }
         }
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_ifr_ifru {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("ifr_ifru")
@@ -1481,7 +1465,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_ifc_ifcu {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("ifr_ifru")

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -58,65 +58,61 @@ impl siginfo_t {
     }
 }
 
-cfg_if! {
-    if #[cfg(libc_union)] {
-        // Internal, for casts to access union fields
-        #[repr(C)]
-        struct sifields_sigchld {
-            si_pid: ::pid_t,
-            si_uid: ::uid_t,
-            si_status: ::c_int,
-            si_utime: ::c_long,
-            si_stime: ::c_long,
-        }
-        impl ::Copy for sifields_sigchld {}
-        impl ::Clone for sifields_sigchld {
-            fn clone(&self) -> sifields_sigchld {
-                *self
-            }
-        }
+// Internal, for casts to access union fields
+#[repr(C)]
+struct sifields_sigchld {
+    si_pid: ::pid_t,
+    si_uid: ::uid_t,
+    si_status: ::c_int,
+    si_utime: ::c_long,
+    si_stime: ::c_long,
+}
+impl ::Copy for sifields_sigchld {}
+impl ::Clone for sifields_sigchld {
+    fn clone(&self) -> sifields_sigchld {
+        *self
+    }
+}
 
-        // Internal, for casts to access union fields
-        #[repr(C)]
-        union sifields {
-            _align_pointer: *mut ::c_void,
-            sigchld: sifields_sigchld,
-        }
+// Internal, for casts to access union fields
+#[repr(C)]
+union sifields {
+    _align_pointer: *mut ::c_void,
+    sigchld: sifields_sigchld,
+}
 
-        // Internal, for casts to access union fields. Note that some variants
-        // of sifields start with a pointer, which makes the alignment of
-        // sifields vary on 32-bit and 64-bit architectures.
-        #[repr(C)]
-        struct siginfo_f {
-            _siginfo_base: [::c_int; 3],
-            sifields: sifields,
-        }
+// Internal, for casts to access union fields. Note that some variants
+// of sifields start with a pointer, which makes the alignment of
+// sifields vary on 32-bit and 64-bit architectures.
+#[repr(C)]
+struct siginfo_f {
+    _siginfo_base: [::c_int; 3],
+    sifields: sifields,
+}
 
-        impl siginfo_t {
-            unsafe fn sifields(&self) -> &sifields {
-                &(*(self as *const siginfo_t as *const siginfo_f)).sifields
-            }
+impl siginfo_t {
+    unsafe fn sifields(&self) -> &sifields {
+        &(*(self as *const siginfo_t as *const siginfo_f)).sifields
+    }
 
-            pub unsafe fn si_pid(&self) -> ::pid_t {
-                self.sifields().sigchld.si_pid
-            }
+    pub unsafe fn si_pid(&self) -> ::pid_t {
+        self.sifields().sigchld.si_pid
+    }
 
-            pub unsafe fn si_uid(&self) -> ::uid_t {
-                self.sifields().sigchld.si_uid
-            }
+    pub unsafe fn si_uid(&self) -> ::uid_t {
+        self.sifields().sigchld.si_uid
+    }
 
-            pub unsafe fn si_status(&self) -> ::c_int {
-                self.sifields().sigchld.si_status
-            }
+    pub unsafe fn si_status(&self) -> ::c_int {
+        self.sifields().sigchld.si_status
+    }
 
-            pub unsafe fn si_utime(&self) -> ::c_long {
-                self.sifields().sigchld.si_utime
-            }
+    pub unsafe fn si_utime(&self) -> ::c_long {
+        self.sifields().sigchld.si_utime
+    }
 
-            pub unsafe fn si_stime(&self) -> ::c_long {
-                self.sifields().sigchld.si_stime
-            }
-        }
+    pub unsafe fn si_stime(&self) -> ::c_long {
+        self.sifields().sigchld.si_stime
     }
 }
 

--- a/src/unix/nto/x86_64.rs
+++ b/src/unix/nto/x86_64.rs
@@ -34,10 +34,7 @@ s! {
     #[repr(align(8))]
     pub struct mcontext_t {
         pub cpu: x86_64_cpu_registers,
-        #[cfg(libc_union)]
         pub fpu: x86_64_fpu_registers,
-        #[cfg(not(libc_union))]
-        __reserved: [u8; 1024],
     }
 
     pub struct stack_t {
@@ -80,7 +77,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[cfg(libc_union)]
     pub union x86_64_fpu_registers {
         pub fsave_area: fsave_area_64,
         pub fxsave_area: fxsave_area_64,
@@ -91,10 +87,8 @@ s_no_extra_traits! {
 
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
-        #[cfg(libc_union)]
         impl Eq for x86_64_fpu_registers {}
 
-        #[cfg(libc_union)]
         impl PartialEq for x86_64_fpu_registers {
             fn eq(&self, other: &x86_64_fpu_registers) -> bool {
                 unsafe {
@@ -105,7 +99,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl ::fmt::Debug for x86_64_fpu_registers {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
@@ -118,7 +111,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl ::hash::Hash for x86_64_fpu_registers {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -555,14 +555,12 @@ s_no_extra_traits! {
         __sigev_pad2: ::c_int,
     }
 
-    #[cfg(libc_union)]
     #[cfg_attr(libc_align, repr(align(16)))]
     pub union pad128_t {
         // pub _q in this structure would be a "long double", of 16 bytes
         pub _l: [i32; 4],
     }
 
-    #[cfg(libc_union)]
     #[cfg_attr(libc_align, repr(align(16)))]
     pub union upad128_t {
         // pub _q in this structure would be a "long double", of 16 bytes
@@ -849,7 +847,6 @@ cfg_if! {
             }
         }
 
-        #[cfg(libc_union)]
         impl PartialEq for pad128_t {
             fn eq(&self, other: &pad128_t) -> bool {
                 unsafe {
@@ -858,9 +855,7 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl Eq for pad128_t {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for pad128_t {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
@@ -871,7 +866,6 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl ::hash::Hash for pad128_t {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
@@ -880,7 +874,6 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl PartialEq for upad128_t {
             fn eq(&self, other: &upad128_t) -> bool {
                 unsafe {
@@ -889,9 +882,7 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl Eq for upad128_t {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for upad128_t {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
@@ -902,7 +893,6 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl ::hash::Hash for upad128_t {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {

--- a/src/unix/solarish/x86_64.rs
+++ b/src/unix/solarish/x86_64.rs
@@ -60,7 +60,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[cfg(libc_union)]
     pub union __c_anonymous_fp_reg_set {
         pub fpchip_state: __c_anonymous_fpchip_state,
         pub f_fpregs: [[u32; 13]; 10],
@@ -96,7 +95,6 @@ s_no_extra_traits! {
 
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
-        #[cfg(libc_union)]
         impl PartialEq for __c_anonymous_fp_reg_set {
             fn eq(&self, other: &__c_anonymous_fp_reg_set) -> bool {
                 unsafe {
@@ -109,9 +107,7 @@ cfg_if! {
                 }
             }
         }
-        #[cfg(libc_union)]
         impl Eq for __c_anonymous_fp_reg_set {}
-        #[cfg(libc_union)]
         impl ::fmt::Debug for __c_anonymous_fp_reg_set {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {


### PR DESCRIPTION
Mostly taken from <https://github.com/rust-lang/libc/pull/2845>, I just updated to remove all new `libc_union` uses.