### PR TITLE
[0.2] Explicitly set the edition to 2015

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.164"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+edition = "2015"
 repository = "https://github.com/rust-lang/libc"
 homepage = "https://github.com/rust-lang/libc"
 documentation = "https://docs.rs/libc/"


### PR DESCRIPTION
This just suppresses a warning. Ideally this should go to 2021 but that requires quite a bit of refactoring, so hold off until the rest of the 0.2 cleanup is complete.