### PR TITLE
[0.2] Remove array size hacks for Rust < 1.47

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -398,8 +398,7 @@ fn test_apple(target: &str) {
             // FIXME: the array size has been changed since macOS 10.15 ([8] -> [7]).
             ("statfs", "f_reserved") => true,
             ("__darwin_arm_neon_state64", "__v") => true,
-            // MAXPATHLEN is too big for auto-derive traits on arrays.
-            ("vnode_info_path", "vip_path") => true,
+
             ("ifreq", "ifr_ifru") => true,
             ("ifkpi", "ifk_data") => true,
             ("ifconf", "ifc_ifcu") => true,
@@ -2744,8 +2743,6 @@ fn test_freebsd(target: &str) {
             ("umutex", "m_owner") => true,
             // c_has_waiters field is a volatile int32_t
             ("ucond", "c_has_waiters") => true,
-            // is PATH_MAX long but tests can't accept multi array as equivalent.
-            ("kinfo_vmentry", "kve_path") => true,
 
             // a_un field is a union
             ("Elf32_Auxinfo", "a_un") => true,
@@ -2773,10 +2770,6 @@ fn test_freebsd(target: &str) {
 
             // Anonymous type.
             ("filestat", "next") => true,
-
-            // We ignore this field because we needed to use a hack in order to make rust 1.19
-            // happy...
-            ("kinfo_proc", "ki_sparestrings") => true,
 
             // `__sem_base` is a private struct field
             ("semid_ds", "__sem_base") => true,

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -946,9 +946,7 @@ s! {
 
     pub struct vnode_info_path {
         pub vip_vi: vnode_info,
-        // Normally it's `vip_path: [::c_char; MAXPATHLEN]` but because libc supports an old rustc
-        // version, we go around this limitation like this.
-        pub vip_path: [[::c_char; 32]; 32],
+        pub vip_path: [::c_char; ::MAXPATHLEN as usize],
     }
 
     pub struct proc_vnodepathinfo {

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -517,7 +517,7 @@ s_no_extra_traits! {
         pub mc_ownedfp: ::c_uint,
         __reserved: ::c_uint,
         __unused: [::c_uint; 8],
-        pub mc_fpregs: [[::c_uint; 8]; 32],
+        pub mc_fpregs: [::c_uint; 256],
     }
 
     pub struct ucontext_t {
@@ -786,8 +786,7 @@ cfg_if! {
                 self.mc_len == other.mc_len &&
                 self.mc_fpformat == other.mc_fpformat &&
                 self.mc_ownedfp == other.mc_ownedfp &&
-                self.mc_fpregs.iter().zip(other.mc_fpregs.iter()).
-                all(|(a, b)| a == b)
+                self.mc_fpregs == other.mc_fpregs
             }
         }
         impl Eq for mcontext_t {}

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
@@ -166,7 +166,7 @@ s! {
         /// More thread name.
         pub ki_moretdname: [::c_char; ::MAXCOMLEN - ::TDNAMLEN + 1],
         /// Spare string space.
-        pub ki_sparestrings: [[::c_char; 23]; 2], // little hack to allow PartialEq
+        pub ki_sparestrings: [::c_char; 46],
         /// Spare room for growth.
         pub ki_spareints: [::c_int; ::KI_NSPARE_INT],
         /// Which cpu we are on.

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -173,7 +173,7 @@ s! {
         /// More thread name.
         pub ki_moretdname: [::c_char; ::MAXCOMLEN - ::TDNAMLEN + 1],
         /// Spare string space.
-        pub ki_sparestrings: [[::c_char; 23]; 2], // little hack to allow PartialEq
+        pub ki_sparestrings: [::c_char; 46],
         /// Spare room for growth.
         pub ki_spareints: [::c_int; ::KI_NSPARE_INT],
         /// Controlling tty dev.

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -183,7 +183,7 @@ s! {
         /// More thread name.
         pub ki_moretdname: [::c_char; ::MAXCOMLEN - ::TDNAMLEN + 1],
         /// Spare string space.
-        pub ki_sparestrings: [[::c_char; 23]; 2], // little hack to allow PartialEq
+        pub ki_sparestrings: [::c_char; 46],
         /// Spare room for growth.
         pub ki_spareints: [::c_int; ::KI_NSPARE_INT],
         /// Controlling tty dev.

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -183,7 +183,7 @@ s! {
         /// More thread name.
         pub ki_moretdname: [::c_char; ::MAXCOMLEN - ::TDNAMLEN + 1],
         /// Spare string space.
-        pub ki_sparestrings: [[::c_char; 23]; 2], // little hack to allow PartialEq
+        pub ki_sparestrings: [::c_char; 46],
         /// Spare room for growth.
         pub ki_spareints: [::c_int; ::KI_NSPARE_INT],
         /// Controlling tty dev.

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
@@ -183,7 +183,7 @@ s! {
         /// More thread name.
         pub ki_moretdname: [::c_char; ::MAXCOMLEN - ::TDNAMLEN + 1],
         /// Spare string space.
-        pub ki_sparestrings: [[::c_char; 23]; 2], // little hack to allow PartialEq
+        pub ki_sparestrings: [::c_char; 46],
         /// Spare room for growth.
         pub ki_spareints: [::c_int; ::KI_NSPARE_INT],
         /// Controlling tty dev.

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1145,7 +1145,7 @@ s! {
         pub sinfo_assoc_id: ::sctp_assoc_t,
         pub sinfo_keynumber: u16,
         pub sinfo_keynumber_valid: u16,
-        pub __reserve_pad: [[u8; 23]; 4],
+        pub __reserve_pad: [u8; SCTP_ALIGN_RESV_PAD],
     }
 
     pub struct sctp_extrcvinfo {
@@ -1165,7 +1165,7 @@ s! {
         pub serinfo_next_ppid: u32,
         pub sinfo_keynumber: u16,
         pub sinfo_keynumber_valid: u16,
-        pub __reserve_pad: [[u8; 19]; 4],
+        pub __reserve_pad: [u8; SCTP_ALIGN_RESV_PAD_SHORT],
     }
 
     pub struct sctp_sndinfo {
@@ -4873,6 +4873,11 @@ pub const SCTP_ASSOC_RESET_FAILED: ::c_int = 0x0008;
 
 pub const SCTP_STREAM_CHANGE_DENIED: ::c_int = 0x0004;
 pub const SCTP_STREAM_CHANGE_FAILED: ::c_int = 0x0008;
+
+// sctp_uio.h
+
+pub const SCTP_ALIGN_RESV_PAD: usize = 92;
+pub const SCTP_ALIGN_RESV_PAD_SHORT: usize = 76;
 
 pub const KENV_DUMP_LOADER: ::c_int = 4;
 pub const KENV_DUMP_STATIC: ::c_int = 5;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -458,7 +458,7 @@ s! {
         _kve_is_spare: [::c_int; 8],
         #[cfg(freebsd11)]
         _kve_is_spare: [::c_int; 12],
-        pub kve_path: [[::c_char; 32]; 32],
+        pub kve_path: [::c_char; ::PATH_MAX as usize],
     }
 
     pub struct __c_anonymous_filestat {

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -284,7 +284,7 @@ s! {
 
     pub struct accept_filter_arg {
         pub af_name: [::c_char; 16],
-        af_arg: [[::c_char; 10]; 24],
+        af_arg: [::c_char; 240],
     }
 
     pub struct ptrace_io_desc {

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -512,7 +512,7 @@ s! {
 
     pub struct accept_filter_arg {
         pub af_name: [::c_char; 16],
-        af_arg: [[::c_char; 10]; 24],
+        pub af_arg: [::c_char; 256 - 16],
     }
 
     pub struct ki_sigset_t {

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -663,7 +663,7 @@ s! {
         pub kve_vn_rdev: u64,
         pub kve_vn_type: u32,
         pub kve_vn_mode: u32,
-        pub kve_path: [[::c_char; 32]; 32],
+        pub kve_path: [::c_char; ::PATH_MAX as usize],
     }
 
     pub struct __c_anonymous_posix_spawn_fae_open {

--- a/src/unix/linux_like/android/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/android/b64/aarch64/mod.rs
@@ -71,9 +71,7 @@ s! {
         pub sp: ::c_ulonglong,
         pub pc: ::c_ulonglong,
         pub pstate: ::c_ulonglong,
-        // nested arrays to get the right size/length while being able to
-        // auto-derive traits like Debug
-        __reserved: [[u64; 32]; 16],
+        __reserved: [u64; 512],
     }
 
     pub struct user_fpsimd_struct {

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -609,7 +609,7 @@ s_no_extra_traits! {
     pub struct prop_info {
         __name: [::c_char; 32],
         __serial: ::c_uint,
-        __value: [[::c_char; 4]; 23],
+        __value: [::c_char; 92],
     }
 
     pub union __c_anonymous_ifr_ifru {

--- a/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
@@ -212,9 +212,7 @@ s! {
         pub sp: ::c_ulonglong,
         pub pc: ::c_ulonglong,
         pub pstate: ::c_ulonglong,
-        // nested arrays to get the right size/length while being able to
-        // auto-derive traits like Debug
-        __reserved: [[u64; 32]; 16],
+        __reserved: [u64; 512],
     }
 
     pub struct user_fpsimd_struct {

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -84,7 +84,7 @@ s! {
         pub sp: ::c_ulong,
         pub pc: ::c_ulong,
         pub pstate: ::c_ulong,
-        __reserved: [[u64; 32]; 16],
+        __reserved: [u64; 512],
     }
 
     #[repr(align(8))]


### PR DESCRIPTION
Rust >= 1.47 supports traits for arrays of arbitrary size, so remove the various hacks using nested arrays when the native platform definition uses a single array.

Cherry picked from https://github.com/rust-lang/libc/pull/2845