### PR TITLE
[0.2] Drop the `libc_const_extern_fn` conditional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ Raw FFI bindings to platform libraries like libc.
 """
 
 [package.metadata.docs.rs]
-features = ["const-extern-fn", "extra_traits"]
+features = ["extra_traits"]
 default-target = "x86_64-unknown-linux-gnu"
 targets = [
     "aarch64-apple-darwin",
@@ -141,6 +141,8 @@ default = ["std"]
 std = []
 rustc-dep-of-std = ['align', 'rustc-std-workspace-core']
 extra_traits = []
+
+# `const-extern-function` is deprecated and no longer does anything
 const-extern-fn = []
 
 # `align` is deprecated and no longer does anything

--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ libc = "0.2"
 * `extra_traits`: all `struct`s implemented in `libc` are `Copy` and `Clone`.
   This feature derives `Debug`, `Eq`, `Hash`, and `PartialEq`.
 
-* `const-extern-fn`: Changes some `extern fn`s into `const extern fn`s. If you
-  use Rust >= 1.62, this feature is implicitly enabled. Otherwise it requires a
-  nightly rustc.
+The following features are deprecated:
+
+* `use_std`: this is equivalent to `std`
+* `const-extern-fn`: this is now enabled by default
+* `align`: this is now enabled by default
 
 ## Rust version support
 

--- a/build.rs
+++ b/build.rs
@@ -14,8 +14,6 @@ const ALLOWED_CFGS: &'static [&'static str] = &[
     "freebsd13",
     "freebsd14",
     "freebsd15",
-    "libc_const_extern_fn",
-    "libc_const_extern_fn_unstable",
     "libc_deny_warnings",
     "libc_long_array",
     "libc_thread_local",
@@ -42,9 +40,8 @@ fn main() {
     // Avoid unnecessary re-building.
     println!("cargo:rerun-if-changed=build.rs");
 
-    let (rustc_minor_ver, is_nightly) = rustc_minor_nightly();
+    let (rustc_minor_ver, _is_nightly) = rustc_minor_nightly();
     let rustc_dep_of_std = env::var("CARGO_FEATURE_RUSTC_DEP_OF_STD").is_ok();
-    let const_extern_fn_cargo_feature = env::var("CARGO_FEATURE_CONST_EXTERN_FN").is_ok();
     let libc_ci = env::var("LIBC_CI").is_ok();
     let libc_check_cfg = env::var("LIBC_CHECK_CFG").is_ok() || rustc_minor_ver >= 80;
 
@@ -94,20 +91,6 @@ fn main() {
     // #[thread_local] is currently unstable
     if rustc_dep_of_std {
         set_cfg("libc_thread_local");
-    }
-
-    // Rust >= 1.62.0 allows to use `const_extern_fn` for "Rust" and "C".
-    if rustc_minor_ver >= 62 {
-        set_cfg("libc_const_extern_fn");
-    } else {
-        // Rust < 1.62.0 requires a crate feature and feature gate.
-        if const_extern_fn_cargo_feature {
-            if !is_nightly || rustc_minor_ver < 40 {
-                panic!("const-extern-fn requires a nightly compiler >= 1.40");
-            }
-            set_cfg("libc_const_extern_fn_unstable");
-            set_cfg("libc_const_extern_fn");
-        }
     }
 
     // check-cfg is a nightly cargo/rustc feature to warn when unknown cfgs are used across the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@
 #![deny(missing_copy_implementations, safe_packed_borrows)]
 #![cfg_attr(not(feature = "rustc-dep-of-std"), no_std)]
 #![cfg_attr(feature = "rustc-dep-of-std", no_core)]
-#![cfg_attr(libc_const_extern_fn_unstable, feature(const_extern_fn))]
 
 #[macro_use]
 mod macros;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -214,8 +214,11 @@ macro_rules! e {
 // 1. Avoid ambiguity errors from 'macro_rules!' (which happen when writing '$foo:ident fn'
 // 2. Allow users of this macro to mix 'pub fn foo' and 'pub const fn bar' within the same
 // 'f!' block
+
+// FIXME(ctest): ctest can't handle `const extern` functions, we should be able to remove this
+// cfg completely.
 cfg_if! {
-    if #[cfg(libc_const_extern_fn)] {
+    if #[cfg(feature = "const-extern-fn")] {
         /// Define an `unsafe` function that is const as long as `const-extern-fn` is enabled.
         macro_rules! f {
             ($(

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -5522,18 +5522,9 @@ pub const VMADDR_CID_RESERVED: ::c_uint = 1;
 pub const VMADDR_CID_HOST: ::c_uint = 2;
 pub const VMADDR_PORT_ANY: ::c_uint = 0xFFFFFFFF;
 
-cfg_if! {
-    if #[cfg(libc_const_extern_fn)] {
-        const fn __DARWIN_ALIGN32(p: usize) -> usize {
-            const __DARWIN_ALIGNBYTES32: usize = ::mem::size_of::<u32>() - 1;
-            p + __DARWIN_ALIGNBYTES32 & !__DARWIN_ALIGNBYTES32
-        }
-    } else {
-        fn __DARWIN_ALIGN32(p: usize) -> usize {
-            const __DARWIN_ALIGNBYTES32: usize = ::mem::size_of::<u32>() - 1;
-            p + __DARWIN_ALIGNBYTES32 & !__DARWIN_ALIGNBYTES32
-        }
-    }
+const fn __DARWIN_ALIGN32(p: usize) -> usize {
+    const __DARWIN_ALIGNBYTES32: usize = ::mem::size_of::<u32>() - 1;
+    p + __DARWIN_ALIGNBYTES32 & !__DARWIN_ALIGNBYTES32
 }
 
 pub const THREAD_EXTENDED_POLICY_COUNT: mach_msg_type_number_t =

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -4902,16 +4902,8 @@ pub const TFD_TIMER_CANCEL_ON_SET: ::c_int = 0x02;
 
 pub const CLOSE_RANGE_CLOEXEC: ::c_uint = 1 << 2;
 
-cfg_if! {
-    if #[cfg(libc_const_extern_fn)] {
-        pub const fn MAP_ALIGNED(a: ::c_int) -> ::c_int {
-            a << 24
-        }
-    } else {
-        pub fn MAP_ALIGNED(a: ::c_int) -> ::c_int {
-            a << 24
-        }
-    }
+pub const fn MAP_ALIGNED(a: ::c_int) -> ::c_int {
+    a << 24
 }
 
 const_fn! {

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2398,17 +2398,8 @@ pub const RB_STRING: ::c_int = 0x000000400;
 pub const RB_POWERDOWN: ::c_int = RB_HALT | 0x000000800;
 pub const RB_USERCONF: ::c_int = 0x000001000;
 
-cfg_if! {
-
-    if #[cfg(libc_const_extern_fn)] {
-        pub const fn MAP_ALIGNED(alignment: ::c_int) -> ::c_int {
-            alignment << MAP_ALIGNMENT_SHIFT
-        }
-    } else {
-        pub fn MAP_ALIGNED(alignment: ::c_int) -> ::c_int {
-            alignment << MAP_ALIGNMENT_SHIFT
-        }
-    }
+pub const fn MAP_ALIGNED(alignment: ::c_int) -> ::c_int {
+    alignment << MAP_ALIGNMENT_SHIFT
 }
 
 // net/route.h

--- a/tests/const_fn.rs
+++ b/tests/const_fn.rs
@@ -1,5 +1,3 @@
-#![cfg(libc_const_extern_fn)] // If this does not hold, the file is empty
-
 #[cfg(target_os = "linux")]
 const _FOO: libc::c_uint = unsafe { libc::CMSG_SPACE(1) };
 //^ if CMSG_SPACE is not const, this will fail to compile


### PR DESCRIPTION
Additionally deprecate the `const-extern-fn` feature. This is possible since the MSRV was increased to 1.63.