### PR TITLE
[0.2] Require rust >= 1.37 and drop libc_underscore_const_names conditional

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,6 @@ const ALLOWED_CFGS: &'static [&'static str] = &[
     "libc_deny_warnings",
     "libc_long_array",
     "libc_thread_local",
-    "libc_underscore_const_names",
     "libc_ctest",
 ];
 
@@ -84,11 +83,6 @@ fn main() {
     // Rust >= 1.47 supports long array:
     if rustc_minor_ver >= 47 || rustc_dep_of_std {
         set_cfg("libc_long_array");
-    }
-
-    // Rust >= 1.37.0 allows underscores as anonymous constant names.
-    if rustc_minor_ver >= 37 || rustc_dep_of_std {
-        set_cfg("libc_underscore_const_names");
     }
 
     // #[thread_local] is currently unstable

--- a/src/fixed_width_ints.rs
+++ b/src/fixed_width_ints.rs
@@ -59,41 +59,39 @@ cfg_if! {
         /// C __uint128_t (alternate name for [__uint128][])
         pub type __uint128_t = u128;
 
-        cfg_if! {
-            if #[cfg(libc_underscore_const_names)] {
-                macro_rules! static_assert_eq {
-                    ($a:expr, $b:expr) => {
-                        const _: [(); $a] = [(); $b];
-                    };
-                }
+        // NOTE: if you add more platforms to here, you may need to cfg
+        // these consts. They should always match the platform's values
+        // for `sizeof(__int128)` and `_Alignof(__int128)`.
+        const _SIZE_128: usize = 16;
+        const _ALIGN_128: usize = 16;
 
-                // NOTE: if you add more platforms to here, you may need to cfg
-                // these consts. They should always match the platform's values
-                // for `sizeof(__int128)` and `_Alignof(__int128)`.
-                const _SIZE_128: usize = 16;
-                const _ALIGN_128: usize = 16;
+        // FIXME(ctest): ctest doesn't handle `_` as an identifier so these tests are temporarily
+        // disabled.
+        // macro_rules! static_assert_eq {
+        //     ($a:expr, $b:expr) => {
+        //         const _: [(); $a] = [(); $b];
+        //     };
+        // }
+        //
+        // // Since Rust doesn't officially guarantee that these types
+        // // have compatible ABIs, we const assert that these values have the
+        // // known size/align of the target platform's libc. If rustc ever
+        // // tries to regress things, it will cause a compilation error.
+        // //
+        // // This isn't a bullet-proof solution because e.g. it doesn't
+        // // catch the fact that llvm and gcc disagree on how x64 __int128
+        // // is actually *passed* on the stack (clang underaligns it for
+        // // the same reason that rustc *never* properly aligns it).
+        // static_assert_eq!(core::mem::size_of::<__int128>(), _SIZE_128);
+        // static_assert_eq!(core::mem::align_of::<__int128>(), _ALIGN_128);
 
-                // Since Rust doesn't officially guarantee that these types
-                // have compatible ABIs, we const assert that these values have the
-                // known size/align of the target platform's libc. If rustc ever
-                // tries to regress things, it will cause a compilation error.
-                //
-                // This isn't a bullet-proof solution because e.g. it doesn't
-                // catch the fact that llvm and gcc disagree on how x64 __int128
-                // is actually *passed* on the stack (clang underaligns it for
-                // the same reason that rustc *never* properly aligns it).
-                static_assert_eq!(core::mem::size_of::<__int128>(), _SIZE_128);
-                static_assert_eq!(core::mem::align_of::<__int128>(), _ALIGN_128);
+        // static_assert_eq!(core::mem::size_of::<__uint128>(), _SIZE_128);
+        // static_assert_eq!(core::mem::align_of::<__uint128>(), _ALIGN_128);
 
-                static_assert_eq!(core::mem::size_of::<__uint128>(), _SIZE_128);
-                static_assert_eq!(core::mem::align_of::<__uint128>(), _ALIGN_128);
+        // static_assert_eq!(core::mem::size_of::<__int128_t>(), _SIZE_128);
+        // static_assert_eq!(core::mem::align_of::<__int128_t>(), _ALIGN_128);
 
-                static_assert_eq!(core::mem::size_of::<__int128_t>(), _SIZE_128);
-                static_assert_eq!(core::mem::align_of::<__int128_t>(), _ALIGN_128);
-
-                static_assert_eq!(core::mem::size_of::<__uint128_t>(), _SIZE_128);
-                static_assert_eq!(core::mem::align_of::<__uint128_t>(), _ALIGN_128);
-            }
-        }
+        // static_assert_eq!(core::mem::size_of::<__uint128_t>(), _SIZE_128);
+        // static_assert_eq!(core::mem::align_of::<__uint128_t>(), _ALIGN_128);
     }
 }


### PR DESCRIPTION
Cherry picked from https://github.com/rust-lang/libc/pull/2845