### PR TITLE
[0.2] Eliminate uses of `struct_formatter`

### DIFF
--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -374,14 +374,14 @@ cfg_if! {
         }
         impl Eq for fileops_t {}
         impl ::fmt::Debug for fileops_t {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                let mut struct_formatter = f.debug_struct("fileops_t");
-                struct_formatter.field("fo_rw", &self.fo_rw);
-                struct_formatter.field("fo_ioctl", &self.fo_ioctl);
-                struct_formatter.field("fo_select", &self.fo_select);
-                struct_formatter.field("fo_close", &self.fo_close);
-                struct_formatter.field("fo_fstat", &self.fo_fstat);
-                struct_formatter.finish()
+            fn fmt(&self, f: &mut ::fmt::Formatter<'_>) -> ::fmt::Result {
+                f.debug_struct("fileops_t")
+                    .field("fo_rw", &self.fo_rw)
+                    .field("fo_ioctl", &self.fo_ioctl)
+                    .field("fo_select", &self.fo_select)
+                    .field("fo_close", &self.fo_close)
+                    .field("fo_fstat", &self.fo_fstat)
+                    .finish()
             }
         }
         impl ::hash::Hash for fileops_t {

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1720,17 +1720,14 @@ cfg_if! {
         }
         impl Eq for xucred {}
         impl ::fmt::Debug for xucred {
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                let mut struct_formatter = f.debug_struct("xucred");
-                struct_formatter.field("cr_version", &self.cr_version);
-                struct_formatter.field("cr_uid", &self.cr_uid);
-                struct_formatter.field("cr_ngroups", &self.cr_ngroups);
-                struct_formatter.field("cr_groups", &self.cr_groups);
-                struct_formatter.field(
-                    "cr_pid__c_anonymous_union",
-                    &self.cr_pid__c_anonymous_union
-                );
-                struct_formatter.finish()
+            fn fmt(&self, f: &mut ::fmt::Formatter<'_>) -> ::fmt::Result {
+                f.debug_struct("xucred")
+                    .field("cr_version", &self.cr_version)
+                    .field("cr_uid", &self.cr_uid)
+                    .field("cr_ngroups", &self.cr_ngroups)
+                    .field("cr_groups", &self.cr_groups)
+                    .field("cr_pid__c_anonymous_union", &self.cr_pid__c_anonymous_union)
+                    .finish()
             }
         }
         impl ::hash::Hash for xucred {


### PR DESCRIPTION
This pattern was previously used with `cfg` fields but is no longer needed.