### PR TITLE
[0.2] dragonfly: Add a note for items that differ between the branches

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly/errno.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/errno.rs
@@ -1,3 +1,5 @@
+/* DIFF(main): module removed in de76fee6 */
+
 // DragonFlyBSD's __error function is declared with "static inline", so it must
 // be implemented in the libc crate, as a pointer to a static thread_local.
 f! {

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1737,6 +1737,7 @@ extern "C" {
     ) -> vm_map_entry_t;
 }
 
+// DIFF(main): module removed in de76fee6
 cfg_if! {
     if #[cfg(libc_thread_local)] {
         mod errno;


### PR DESCRIPTION
Trying to sync these branches up is pretty tricky. Add comments as indicators when the diff between `main` and `libc-0.2` is expected to be different.
