### PR TITLE
openbsd: skip ATF_* constants in CI

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -550,6 +550,15 @@ fn test_openbsd(target: &str) {
         }
     });
 
+    cfg.skip_const(move |name| {
+        match name {
+            // Removed in OpenBSD 7.7 (unused since 1991)
+            "ATF_COM" | "ATF_PERM" | "ATF_PUBL" | "ATF_USETRAILERS" => true,
+
+            _ => false,
+        }
+    });
+
     cfg.skip_fn(move |name| {
         match name {
             // futex() has volatile arguments, but that doesn't exist in Rust.


### PR DESCRIPTION
# Description

CI is failing on OpenBSD (due to OpenBSD change).

Some constants (`ATF_*`) were removed in OpenBSD 7.7 by https://github.com/openbsd/src/commit/ff46e7d6ebc305e25e40b31e65a50463cfa5dc30

they were unused since 1991.

# Checklist

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
