### PR TITLE
hurd: Add domainname field to utsname

### DIFF
--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -876,6 +876,7 @@ s! {
         pub release: [::c_char; _UTSNAME_LENGTH],
         pub version: [::c_char; _UTSNAME_LENGTH],
         pub machine: [::c_char; _UTSNAME_LENGTH],
+        pub domainname: [::c_char; _UTSNAME_LENGTH],
     }
 
     pub struct rlimit64 {


### PR DESCRIPTION
158cd3063c11 ("hurd: fix definition of utsname struct") dropped it saying it is unused, but it is still there and read by the platform-info crate, whose build thus got broken. It is less troublesome to just declare the field.

# Description

This restores a field that was removed but is actually read.

# Sources

https://sourceware.org/git/?p=glibc.git;a=blob;f=posix/sys/utsname.h;h=c6884255e04595996dbbc337ac667d0defd035f3;hb=HEAD#l66

# Checklist

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
