### PR TITLE
[0.2]  apple: Mark mach_task_self as deprecated

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -6657,6 +6657,7 @@ extern "C" {
         out_processor_infoCnt: *mut mach_msg_type_number_t,
     ) -> ::kern_return_t;
 
+    #[deprecated(since = "0.2.55", note = "Use the `mach2` crate instead")]
     pub static mut mach_task_self_: ::mach_port_t;
     pub fn task_for_pid(
         host: ::mach_port_t,
@@ -6774,6 +6775,8 @@ extern "C" {
     ) -> ::c_int;
 }
 
+#[allow(deprecated)]
+#[deprecated(since = "0.2.55", note = "Use the `mach2` crate instead")]
 pub unsafe fn mach_task_self() -> ::mach_port_t {
     mach_task_self_
 }


### PR DESCRIPTION
These were already removed on `main` in https://github.com/rust-lang/libc/commit/56d665c9b3f7687eb206c3a1d2f943852df65f54 ("macOs various updates").