### PR TITLE
[main] Drop the `libc_const_extern_fn` conditional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.63"
 description = "Raw FFI bindings to platform libraries like libc."
 
 [package.metadata.docs.rs]
-features = ["const-extern-fn", "extra_traits"]
+features = ["extra_traits"]
 default-target = "x86_64-unknown-linux-gnu"
 targets = [
     "aarch64-apple-darwin",
@@ -139,6 +139,9 @@ default = ["std"]
 std = []
 rustc-dep-of-std = ["rustc-std-workspace-core"]
 extra_traits = []
+
+# `const-extern-function` is deprecated and no longer does anything
+# FIXME(1.0): remove this completely
 const-extern-fn = []
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ libc = "0.2"
 * `extra_traits`: all `struct`s implemented in `libc` are `Copy` and `Clone`.
   This feature derives `Debug`, `Eq`, `Hash`, and `PartialEq`.
 
-* `const-extern-fn`: Changes some `extern fn`s into `const extern fn`s. If you
-  use Rust >= 1.62, this feature is implicitly enabled. Otherwise it requires a
-  nightly rustc.
-
 ## Rust version support
 
 The minimum supported Rust toolchain version is currently **Rust 1.63**.

--- a/build.rs
+++ b/build.rs
@@ -14,8 +14,6 @@ const ALLOWED_CFGS: &'static [&'static str] = &[
     "freebsd13",
     "freebsd14",
     "freebsd15",
-    "libc_const_extern_fn",
-    "libc_const_extern_fn_unstable",
     "libc_deny_warnings",
     "libc_ctest",
 ];
@@ -39,11 +37,10 @@ fn main() {
     // Avoid unnecessary re-building.
     println!("cargo:rerun-if-changed=build.rs");
 
-    let (rustc_minor_ver, is_nightly) = rustc_minor_nightly();
+    let (rustc_minor_ver, _is_nightly) = rustc_minor_nightly();
     let rustc_dep_of_std = env::var("CARGO_FEATURE_RUSTC_DEP_OF_STD").is_ok();
     let libc_ci = env::var("LIBC_CI").is_ok();
     let libc_check_cfg = env::var("LIBC_CHECK_CFG").is_ok() || rustc_minor_ver >= 80;
-    let const_extern_fn_cargo_feature = env::var("CARGO_FEATURE_CONST_EXTERN_FN").is_ok();
 
     // The ABI of libc used by std is backward compatible with FreeBSD 12.
     // The ABI of libc from crates.io is backward compatible with FreeBSD 11.
@@ -76,20 +73,6 @@ fn main() {
     // On CI: deny all warnings
     if libc_ci {
         set_cfg("libc_deny_warnings");
-    }
-
-    // Rust >= 1.62.0 allows to use `const_extern_fn` for "Rust" and "C".
-    if rustc_minor_ver >= 62 {
-        set_cfg("libc_const_extern_fn");
-    } else {
-        // Rust < 1.62.0 requires a crate feature and feature gate.
-        if const_extern_fn_cargo_feature {
-            if !is_nightly || rustc_minor_ver < 40 {
-                panic!("const-extern-fn requires a nightly compiler >= 1.40");
-            }
-            set_cfg("libc_const_extern_fn_unstable");
-            set_cfg("libc_const_extern_fn");
-        }
     }
 
     // check-cfg is a nightly cargo/rustc feature to warn when unknown cfgs are used across the


### PR DESCRIPTION
Additionally deprecate the `const-extern-fn` feature. This is possible since the MSRV was increased to 1.63.

(apply <https://github.com/rust-lang/libc/pull/4063> to `main`)
(cherry picked from commit 674cc1f47f605038ef1aa2cce8e8bc9dac128276)