### PR TITLE
[0.2] Synchronize branches, backport Sparc CI fix

### DIFF
--- a/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
@@ -12,14 +12,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev \
         gcc-sparc64-linux-gnu libc6-dev-sparc64-cross \
         qemu-system-sparc64 openbios-sparc seabios ipxe-qemu \
-        p7zip-full cpio linux-libc-dev-sparc64-cross
+        p7zip-full cpio linux-libc-dev-sparc64-cross qemu-user
 
 COPY linux-sparc64.sh /
 RUN /linux-sparc64.sh
 
-COPY test-runner-linux /
-
 ENV CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_LINKER=sparc64-linux-gnu-gcc \
-    CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_RUNNER="/test-runner-linux sparc64" \
+    CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_RUNNER="qemu-sparc64 -L /usr/sparc64-linux-gnu" \
     CC_sparc64_unknown_linux_gnu=sparc64-linux-gnu-gcc \
     PATH=$PATH:/rust/bin

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -3787,6 +3787,7 @@ extern "C" {
     pub fn close(fd: ::c_int) -> ::c_int;
     pub fn dup(fd: ::c_int) -> ::c_int;
     pub fn dup2(src: ::c_int, dst: ::c_int) -> ::c_int;
+
     pub fn execl(path: *const c_char, arg0: *const c_char, ...) -> ::c_int;
     pub fn execle(path: *const ::c_char, arg0: *const ::c_char, ...) -> ::c_int;
     pub fn execlp(file: *const ::c_char, arg0: *const ::c_char, ...) -> ::c_int;

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -6807,6 +6807,7 @@ cfg_if! {
 // These require a dependency on `libiconv`, and including this when built as
 // part of `std` means every Rust program gets it. Ideally we would have a link
 // modifier to only include these if they are used, but we do not.
+#[deprecated(note = "Will be removed in 1.0 to avoid the `iconv` dependency")]
 #[cfg_attr(not(feature = "rustc-dep-of-std"), link(name = "iconv"))]
 extern "C" {
     pub fn iconv_open(tocode: *const ::c_char, fromcode: *const ::c_char) -> iconv_t;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -821,6 +821,14 @@ s! {
         pub val: ::c_int,
     }
 
+    // linux/openat2.h
+    #[non_exhaustive]
+    pub struct open_how {
+        pub flags: ::__u64,
+        pub mode: ::__u64,
+        pub resolve: ::__u64,
+    }
+
     // linux/sctp.h
 
     pub struct sctp_initmsg {
@@ -998,14 +1006,6 @@ s! {
         pub mask: __u64,
         pub fd: ::c_int,
         pub pid: ::c_int,
-    }
-
-    // linux/openat2.h
-    #[non_exhaustive]
-    pub struct open_how {
-        pub flags: ::__u64,
-        pub mode: ::__u64,
-        pub resolve: ::__u64,
     }
 
     // linux/wireless.h

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -256,6 +256,8 @@ pub const SIG_GET: ::sighandler_t = 2;
 pub const SIG_SGE: ::sighandler_t = 3;
 pub const SIG_ACK: ::sighandler_t = 4;
 
+// DIFF(main): removed in 458c58f409
+// FIXME(msrv): done by `std` starting in 1.79.0
 // inline comment below appeases style checker
 #[cfg(all(target_env = "msvc", feature = "rustc-dep-of-std"))] // " if "
 #[link(name = "msvcrt", cfg(not(target_feature = "crt-static")))]


### PR DESCRIPTION
Make the branches a bit closer. Additionally, backport https://github.com/rust-lang/libc/pull/4133.