### PR TITLE
ci: use some tricks to format macro bodies

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Format macro bodies
+a0c7f8017b964a2de8bc3aabebdabd4a8f2c0905

--- a/ci/style.rs
+++ b/ci/style.rs
@@ -97,7 +97,10 @@ enum State {
 
 fn check_style(file: &str, path: &Path, err: &mut Errors) {
     let mut state = State::Start;
-    let mut s_macros = 0;
+
+    // FIXME: see below
+    // let mut s_macros = 0;
+    
     let mut f_macros = 0;
     let mut in_impl = false;
 
@@ -140,7 +143,8 @@ fn check_style(file: &str, path: &Path, err: &mut Errors) {
         } else if line.starts_with("type ") && !in_impl {
             State::Typedefs
         } else if line.starts_with("s! {") {
-            s_macros += 1;
+            // FIXME: see below
+            // s_macros += 1;
             State::Structs
         } else if line.starts_with("s_no_extra_traits! {") {
             // multiple macros of this type are allowed
@@ -175,10 +179,13 @@ fn check_style(file: &str, path: &Path, err: &mut Errors) {
             f_macros += 1;
             err.error(path, i, "multiple f! macros in one module");
         }
-        if s_macros == 2 {
-            s_macros += 1;
-            err.error(path, i, "multiple s! macros in one module");
-        }
+
+        // FIXME(#4109): multiple should be allowed if at least one is `cfg(not) within `cfg_if`.
+        // For now just disable this and check by hand.
+        // if s_macros == 2 {
+        //     s_macros += 1;
+        //     err.error(path, i, "multiple s! macros in one module");
+        // }
 
         state = line_state;
     }

--- a/ci/style.sh
+++ b/ci/style.sh
@@ -13,7 +13,53 @@ rustc ci/style.rs && ./style src
 
 command -v rustfmt
 rustfmt -V
-cargo fmt --all -- ${check:+"$check"}
+
+# Save a list of all source files
+tmpfile="file-list~" # trailing tilde for gitignore
+find src -name '*.rs' > "$tmpfile"
+
+# Before formatting, replace all macro identifiers with a function signature.
+# This allows `rustfmt` to format it.
+while IFS= read -r file; do
+    if [ "$file" = "src/macros.rs" ]; then
+        # Too much special syntax in `macros.rs` that we don't want to format
+        continue
+    fi
+
+    # Turn all braced macro `foo! { /* ... */ }` invocations into
+    # `fn foo_fmt_tmp() { /* ... */ }`.
+    perl -pi -e 's/(?!macro_rules)\b(\w+)!\s*\{/fn $1_fmt_tmp() {/g' "$file"
+
+    # Replace `if #[cfg(...)]` within `cfg_if` with `if cfg_tmp!([...])` which
+    # `rustfmt` will format. We put brackets within the parens so it is easy to
+    # match (trying to match parentheses would catch the first closing `)` which
+    # wouldn't be correct for something like `all(any(...), ...)`).
+    perl -pi -0777 -e 's/if #\[cfg\((.*?)\)\]/if cfg_tmp!([$1])/gms' "$file"
+
+    # We have some instances of `{const}` that make macros happy but aren't
+    # valid syntax. Replace this with just the keyword, plus an indicator
+    # comment on the preceding line (which is where rustfmt puts it. Also
+    # rust-lang/rustfmt#5464).
+    perl -pi -e 's/^(\s*)(.*)\{const\}/$1\/\* FMT-CONST \*\/\n$1$2const/g' "$file"
+
+    # Format the file. We need to invoke `rustfmt` directly since `cargo fmt`
+    # can't figure out the module tree with the hacks in place.
+    failed=false
+    rustfmt --config-path rustfmt.toml "$file" ${check:+"$check"} || failed=true
+
+    # Restore all changes to the files.
+    perl -pi -e 's/fn (\w+)_fmt_tmp\(\)/$1!/g' "$file"
+    perl -pi -0777 -e 's/cfg_tmp!\(\[(.*?)\]\)/#[cfg($1)]/gms' "$file"
+    perl -pi -0777 -e 's/\/\* FMT-CONST \*\/(?:\n\s*)?(.*?)const/$1\{const\}/gms' "$file"
+
+    # Defer emitting the failure until after the files get reset
+    if [ "$failed" != "false" ]; then
+        echo "Formatting failed"
+        exit 1
+    fi
+done < "$tmpfile"
+
+rm "$tmpfile"
 
 if shellcheck --version ; then
     find . -name '*.sh' -print0 | xargs -0 shellcheck

--- a/ci/style.sh
+++ b/ci/style.sh
@@ -2,13 +2,18 @@
 
 set -eux
 
+if [ -n "${CI:-}" ]; then
+    rustup toolchain install nightly -c rustfmt --allow-downgrade
+    rustup override set nightly
+
+    check="--check"
+fi
+
 rustc ci/style.rs && ./style src
 
-rustup toolchain install nightly -c rustfmt --allow-downgrade
-rustup override set nightly
 command -v rustfmt
 rustfmt -V
-cargo fmt --all -- --check
+cargo fmt --all -- ${check:+"$check"}
 
 if shellcheck --version ; then
     find . -name '*.sh' -print0 | xargs -0 shellcheck

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 error_on_line_overflow = true
+edition = "2021"

--- a/src/fixed_width_ints.rs
+++ b/src/fixed_width_ints.rs
@@ -20,7 +20,16 @@ pub type uint32_t = u32;
 pub type uint64_t = u64;
 
 cfg_if! {
-    if #[cfg(all(target_arch = "aarch64", not(any(target_os = "windows", target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))))] {
+    if #[cfg(all(
+        target_arch = "aarch64",
+        not(any(
+            target_os = "windows",
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos"
+        ))
+    ))] {
         // This introduces partial support for FFI with __int128 and
         // equivalent types on platforms where Rust's definition is validated
         // to match the standard C ABI of that platform.
@@ -93,7 +102,15 @@ cfg_if! {
 
         // static_assert_eq!(core::mem::size_of::<__uint128_t>(), _SIZE_128);
         // static_assert_eq!(core::mem::align_of::<__uint128_t>(), _ALIGN_128);
-    } else if #[cfg(all(target_arch = "aarch64", any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos")))] {
+    } else if #[cfg(all(
+        target_arch = "aarch64",
+        any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos"
+        )
+    ))] {
         /// C `__int128_t`
         pub type __int128_t = i128;
         /// C `__uint128_t`

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -255,7 +255,7 @@ s! {
 
     pub struct sigval {
         // Actually a union of an int and a void*
-        pub sival_ptr: *mut ::c_void
+        pub sival_ptr: *mut ::c_void,
     }
 
     // <sys/time.h>
@@ -309,7 +309,7 @@ s! {
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: ::sigset_t,
         pub sa_flags: ::c_int,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
     }
 
     pub struct termios {
@@ -378,7 +378,7 @@ s! {
         pub sll_hatype: ::c_ushort,
         pub sll_pkttype: ::c_uchar,
         pub sll_halen: ::c_uchar,
-        pub sll_addr: [::c_uchar; 8]
+        pub sll_addr: [::c_uchar; 8],
     }
 
     pub struct fd_set {
@@ -471,7 +471,7 @@ s! {
         pub ifa_addr: *mut ::sockaddr,
         pub ifa_netmask: *mut ::sockaddr,
         pub ifa_ifu: *mut ::sockaddr, // FIXME This should be a union
-        pub ifa_data: *mut ::c_void
+        pub ifa_data: *mut ::c_void,
     }
 
     pub struct passwd {
@@ -563,11 +563,9 @@ s! {
     }
 
     pub struct cpu_set_t {
-        #[cfg(all(target_pointer_width = "32",
-                  not(target_arch = "x86_64")))]
+        #[cfg(all(target_pointer_width = "32", not(target_arch = "x86_64")))]
         bits: [u32; 32],
-        #[cfg(not(all(target_pointer_width = "32",
-                      not(target_arch = "x86_64"))))]
+        #[cfg(not(all(target_pointer_width = "32", not(target_arch = "x86_64"))))]
         bits: [u64; 16],
     }
 
@@ -785,11 +783,11 @@ s! {
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 
     pub struct pthread_attr_t {
-        __size: [u64; 7]
+        __size: [u64; 7],
     }
 
     pub struct sigset_t {
@@ -886,25 +884,19 @@ s! {
     }
 
     #[cfg_attr(
-        any(
-            target_pointer_width = "32",
-            target_arch = "x86_64"
-        ),
-        repr(align(4)))]
+        any(target_pointer_width = "32", target_arch = "x86_64"),
+        repr(align(4))
+    )]
     #[cfg_attr(
-        not(any(
-            target_pointer_width = "32",
-            target_arch = "x86_64"
-        )),
-        repr(align(8)))]
+        not(any(target_pointer_width = "32", target_arch = "x86_64")),
+        repr(align(8))
+    )]
     pub struct pthread_mutexattr_t {
         size: [u8; ::__SIZEOF_PTHREAD_MUTEXATTR_T],
     }
 
-    #[cfg_attr(target_pointer_width = "32",
-               repr(align(4)))]
-    #[cfg_attr(target_pointer_width = "64",
-               repr(align(8)))]
+    #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+    #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
     pub struct pthread_rwlockattr_t {
         size: [u8; ::__SIZEOF_PTHREAD_RWLOCKATTR_T],
     }
@@ -935,7 +927,7 @@ s_no_extra_traits! {
 
     pub struct sockaddr_un {
         pub sun_family: sa_family_t,
-        pub sun_path: [::c_char; 108]
+        pub sun_path: [::c_char; 108],
     }
 
     pub struct sockaddr_storage {
@@ -950,7 +942,7 @@ s_no_extra_traits! {
         pub release: [::c_char; 65],
         pub version: [::c_char; 65],
         pub machine: [::c_char; 65],
-        pub domainname: [::c_char; 65]
+        pub domainname: [::c_char; 65],
     }
 
     pub struct dirent {
@@ -999,7 +991,7 @@ s_no_extra_traits! {
         pub nl_family: ::sa_family_t,
         nl_pad: ::c_ushort,
         pub nl_pid: u32,
-        pub nl_groups: u32
+        pub nl_groups: u32,
     }
 
     pub struct sigevent {
@@ -1008,41 +1000,49 @@ s_no_extra_traits! {
         pub sigev_notify: ::c_int,
         pub sigev_notify_function: fn(::sigval),
         pub sigev_notify_attributes: *mut pthread_attr_t,
-        pub __pad: [::c_char; 56 - 3 * 8 /* 8 == sizeof(long) */],
+        pub __pad: [::c_char; 56 - 3 * 8],
     }
 
-    #[cfg_attr(all(target_pointer_width = "32",
-                   any(target_arch = "arm",
-                       target_arch = "x86_64")),
-               repr(align(4)))]
-    #[cfg_attr(any(target_pointer_width = "64",
-                   not(any(target_arch = "arm",
-                           target_arch = "x86_64"))),
-               repr(align(8)))]
+    #[cfg_attr(
+        all(
+            target_pointer_width = "32",
+            any(target_arch = "arm", target_arch = "x86_64")
+        ),
+        repr(align(4))
+    )]
+    #[cfg_attr(
+        any(
+            target_pointer_width = "64",
+            not(any(target_arch = "arm", target_arch = "x86_64"))
+        ),
+        repr(align(8))
+    )]
     pub struct pthread_mutex_t {
         size: [u8; ::__SIZEOF_PTHREAD_MUTEX_T],
     }
 
-    #[cfg_attr(all(target_pointer_width = "32",
-                   any(target_arch = "arm",
-                       target_arch = "x86_64")),
-               repr(align(4)))]
-    #[cfg_attr(any(target_pointer_width = "64",
-                   not(any(target_arch = "arm",
-                           target_arch = "x86_64"))),
-               repr(align(8)))]
+    #[cfg_attr(
+        all(
+            target_pointer_width = "32",
+            any(target_arch = "arm", target_arch = "x86_64")
+        ),
+        repr(align(4))
+    )]
+    #[cfg_attr(
+        any(
+            target_pointer_width = "64",
+            not(any(target_arch = "arm", target_arch = "x86_64"))
+        ),
+        repr(align(8))
+    )]
     pub struct pthread_rwlock_t {
         size: [u8; ::__SIZEOF_PTHREAD_RWLOCK_T],
     }
 
-    #[cfg_attr(target_pointer_width = "32",
-               repr(align(4)))]
-    #[cfg_attr(target_pointer_width = "64",
-               repr(align(8)))]
-    #[cfg_attr(target_arch = "x86",
-               repr(align(4)))]
-    #[cfg_attr(not(target_arch = "x86"),
-               repr(align(8)))]
+    #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+    #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+    #[cfg_attr(target_arch = "x86", repr(align(4)))]
+    #[cfg_attr(not(target_arch = "x86"), repr(align(8)))]
     pub struct pthread_cond_t {
         size: [u8; ::__SIZEOF_PTHREAD_COND_T],
     }
@@ -1069,7 +1069,7 @@ cfg_if! {
                         .__reserved
                         .iter()
                         .zip(other.__reserved.iter())
-                        .all(|(a,b)| a == b)
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for sysinfo {}
@@ -1116,10 +1116,10 @@ cfg_if! {
             fn eq(&self, other: &sockaddr_un) -> bool {
                 self.sun_family == other.sun_family
                     && self
-                    .sun_path
-                    .iter()
-                    .zip(other.sun_path.iter())
-                    .all(|(a,b)| a == b)
+                        .sun_path
+                        .iter()
+                        .zip(other.sun_path.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for sockaddr_un {}
@@ -1143,10 +1143,10 @@ cfg_if! {
                 self.ss_family == other.ss_family
                     && self.__ss_align == other.__ss_align
                     && self
-                    .__ss_pad2
-                    .iter()
-                    .zip(other.__ss_pad2.iter())
-                    .all(|(a, b)| a == b)
+                        .__ss_pad2
+                        .iter()
+                        .zip(other.__ss_pad2.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for sockaddr_storage {}
@@ -1172,27 +1172,27 @@ cfg_if! {
                 self.sysname
                     .iter()
                     .zip(other.sysname.iter())
-                    .all(|(a,b)| a == b)
+                    .all(|(a, b)| a == b)
                     && self
-                    .nodename
-                    .iter()
-                    .zip(other.nodename.iter())
-                    .all(|(a,b)| a == b)
+                        .nodename
+                        .iter()
+                        .zip(other.nodename.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .release
-                    .iter()
-                    .zip(other.release.iter())
-                    .all(|(a,b)| a == b)
+                        .release
+                        .iter()
+                        .zip(other.release.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .version
-                    .iter()
-                    .zip(other.version.iter())
-                    .all(|(a,b)| a == b)
+                        .version
+                        .iter()
+                        .zip(other.version.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .machine
-                    .iter()
-                    .zip(other.machine.iter())
-                    .all(|(a,b)| a == b)
+                        .machine
+                        .iter()
+                        .zip(other.machine.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for utsname {}
@@ -1224,10 +1224,10 @@ cfg_if! {
                     && self.d_reclen == other.d_reclen
                     && self.d_type == other.d_type
                     && self
-                    .d_name
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                        .d_name
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for dirent {}
@@ -1259,10 +1259,10 @@ cfg_if! {
                     && self.d_reclen == other.d_reclen
                     && self.d_type == other.d_type
                     && self
-                    .d_name
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                        .d_name
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for dirent64 {}
@@ -1289,10 +1289,10 @@ cfg_if! {
 
         impl PartialEq for mq_attr {
             fn eq(&self, other: &mq_attr) -> bool {
-                self.mq_flags == other.mq_flags &&
-                self.mq_maxmsg == other.mq_maxmsg &&
-                self.mq_msgsize == other.mq_msgsize &&
-                self.mq_curmsgs == other.mq_curmsgs
+                self.mq_flags == other.mq_flags
+                    && self.mq_maxmsg == other.mq_maxmsg
+                    && self.mq_msgsize == other.mq_msgsize
+                    && self.mq_curmsgs == other.mq_curmsgs
             }
         }
         impl Eq for mq_attr {}
@@ -1317,9 +1317,9 @@ cfg_if! {
 
         impl PartialEq for sockaddr_nl {
             fn eq(&self, other: &sockaddr_nl) -> bool {
-                self.nl_family == other.nl_family &&
-                self.nl_pid == other.nl_pid &&
-                self.nl_groups == other.nl_groups
+                self.nl_family == other.nl_family
+                    && self.nl_pid == other.nl_pid
+                    && self.nl_groups == other.nl_groups
             }
         }
         impl Eq for sockaddr_nl {}
@@ -1345,10 +1345,8 @@ cfg_if! {
                 self.sigev_value == other.sigev_value
                     && self.sigev_signo == other.sigev_signo
                     && self.sigev_notify == other.sigev_notify
-                    && self.sigev_notify_function
-                        == other.sigev_notify_function
-                    && self.sigev_notify_attributes
-                        == other.sigev_notify_attributes
+                    && self.sigev_notify_function == other.sigev_notify_function
+                    && self.sigev_notify_attributes == other.sigev_notify_attributes
             }
         }
         impl Eq for sigevent {}
@@ -1359,8 +1357,7 @@ cfg_if! {
                     .field("sigev_signo", &self.sigev_signo)
                     .field("sigev_notify", &self.sigev_notify)
                     .field("sigev_notify_function", &self.sigev_notify_function)
-                    .field("sigev_notify_attributes",
-                           &self.sigev_notify_attributes)
+                    .field("sigev_notify_attributes", &self.sigev_notify_attributes)
                     .finish()
             }
         }
@@ -1376,10 +1373,7 @@ cfg_if! {
 
         impl PartialEq for pthread_cond_t {
             fn eq(&self, other: &pthread_cond_t) -> bool {
-                self.size
-                    .iter()
-                    .zip(other.size.iter())
-                    .all(|(a,b)| a == b)
+                self.size.iter().zip(other.size.iter()).all(|(a, b)| a == b)
             }
         }
         impl Eq for pthread_cond_t {}
@@ -1398,10 +1392,7 @@ cfg_if! {
 
         impl PartialEq for pthread_mutex_t {
             fn eq(&self, other: &pthread_mutex_t) -> bool {
-                self.size
-                    .iter()
-                    .zip(other.size.iter())
-                    .all(|(a,b)| a == b)
+                self.size.iter().zip(other.size.iter()).all(|(a, b)| a == b)
             }
         }
         impl Eq for pthread_mutex_t {}
@@ -1420,10 +1411,7 @@ cfg_if! {
 
         impl PartialEq for pthread_rwlock_t {
             fn eq(&self, other: &pthread_rwlock_t) -> bool {
-                self.size
-                    .iter()
-                    .zip(other.size.iter())
-                    .all(|(a,b)| a == b)
+                self.size.iter().zip(other.size.iter()).all(|(a, b)| a == b)
             }
         }
         impl Eq for pthread_rwlock_t {}
@@ -3386,20 +3374,20 @@ f! {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
-        return
+        return;
     }
 
     pub fn FD_ISSET(fd: ::c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
-        return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0
+        return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: ::c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
-        return
+        return;
     }
 
     pub fn FD_ZERO(set: *mut fd_set) -> () {
@@ -3415,16 +3403,14 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits
-            = 8 * ::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * ::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] |= 1 << offset;
         ()
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits
-            = 8 * ::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * ::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] &= !(1 << offset);
         ()
@@ -3458,13 +3444,10 @@ f! {
         cmsg.offset(1) as *mut c_uchar
     }
 
-    pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr)
-        -> *mut cmsghdr
-    {
+    pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         if ((*cmsg).cmsg_len as ::size_t) < ::mem::size_of::<cmsghdr>() {
             0 as *mut cmsghdr
-        } else if __CMSG_NEXT(cmsg).add(::mem::size_of::<cmsghdr>())
-            >= __MHDR_END(mhdr) {
+        } else if __CMSG_NEXT(cmsg).add(::mem::size_of::<cmsghdr>()) >= __MHDR_END(mhdr) {
             0 as *mut cmsghdr
         } else {
             __CMSG_NEXT(cmsg).cast()
@@ -3480,13 +3463,11 @@ f! {
     }
 
     pub {const} fn CMSG_ALIGN(len: ::size_t) -> ::size_t {
-        (len + ::mem::size_of::<::size_t>() - 1)
-            & !(::mem::size_of::<::size_t>() - 1)
+        (len + ::mem::size_of::<::size_t>() - 1) & !(::mem::size_of::<::size_t>() - 1)
     }
 
     pub {const} fn CMSG_SPACE(len: ::c_uint) -> ::c_uint {
-        (CMSG_ALIGN(len as ::size_t) + CMSG_ALIGN(::mem::size_of::<cmsghdr>()))
-            as ::c_uint
+        (CMSG_ALIGN(len as ::size_t) + CMSG_ALIGN(::mem::size_of::<cmsghdr>())) as ::c_uint
     }
 
     pub {const} fn CMSG_LEN(len: ::c_uint) -> ::c_uint {

--- a/src/fuchsia/x86_64.rs
+++ b/src/fuchsia/x86_64.rs
@@ -60,7 +60,7 @@ s! {
         pub mode: ::mode_t,
         pub __seq: ::c_int,
         __unused1: ::c_long,
-        __unused2: ::c_long
+        __unused2: ::c_long,
     }
 }
 
@@ -85,10 +85,10 @@ cfg_if! {
                     && self.uc_mcontext == other.uc_mcontext
                     && self.uc_sigmask == other.uc_sigmask
                     && self
-                    .__private
-                    .iter()
-                    .zip(other.__private.iter())
-                    .all(|(a,b)| a == b)
+                        .__private
+                        .iter()
+                        .zip(other.__private.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for ucontext_t {}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -203,15 +203,13 @@ cfg_if! {
         macro_rules! f {
             ($(
                 $(#[$attr:meta])*
-                pub $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),*) -> $ret:ty {
-                    $($body:stmt);*
-                }
+                pub $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)?) -> $ret:ty
+                    $body:block
             )*) => ($(
                 #[inline]
                 $(#[$attr])*
-                pub $($constness)* unsafe extern fn $i($($arg: $argty),*) -> $ret {
-                    $($body);*
-                }
+                pub $($constness)* unsafe extern fn $i($($arg: $argty),*) -> $ret
+                    $body
             )*)
         }
 
@@ -219,15 +217,13 @@ cfg_if! {
         macro_rules! safe_f {
             ($(
                 $(#[$attr:meta])*
-                pub $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),*) -> $ret:ty {
-                    $($body:stmt);*
-                }
+                pub $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)?) -> $ret:ty
+                    $body:block
             )*) => ($(
                 #[inline]
                 $(#[$attr])*
-                pub $($constness)* extern fn $i($($arg: $argty),*) -> $ret {
-                    $($body);*
-                }
+                pub $($constness)* extern fn $i($($arg: $argty),*) -> $ret
+                    $body
             )*)
         }
 
@@ -235,15 +231,13 @@ cfg_if! {
         macro_rules! const_fn {
             ($(
                 $(#[$attr:meta])*
-                $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),*) -> $ret:ty {
-                    $($body:stmt);*
-                }
+                $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)?) -> $ret:ty
+                    $body:block
             )*) => ($(
                 #[inline]
                 $(#[$attr])*
-                $($constness)* fn $i($($arg: $argty),*) -> $ret {
-                    $($body);*
-                }
+                $($constness)* fn $i($($arg: $argty),*) -> $ret
+                    $body
             )*)
         }
     } else {
@@ -251,15 +245,13 @@ cfg_if! {
         macro_rules! f {
             ($(
                 $(#[$attr:meta])*
-                pub $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),*) -> $ret:ty {
-                    $($body:stmt);*
-                }
+                pub $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)?) -> $ret:ty
+                    $body:block
             )*) => ($(
                 #[inline]
                 $(#[$attr])*
-                pub unsafe extern fn $i($($arg: $argty),*) -> $ret {
-                    $($body);*
-                }
+                pub unsafe extern fn $i($($arg: $argty),*) -> $ret
+                    $body
             )*)
         }
 
@@ -267,15 +259,13 @@ cfg_if! {
         macro_rules! safe_f {
             ($(
                 $(#[$attr:meta])*
-                pub $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),*) -> $ret:ty {
-                    $($body:stmt);*
-                }
+                pub $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)?) -> $ret:ty
+                    $body:block
             )*) => ($(
                 #[inline]
                 $(#[$attr])*
-                pub extern fn $i($($arg: $argty),*) -> $ret {
-                    $($body);*
-                }
+                pub extern fn $i($($arg: $argty),*) -> $ret
+                    $body
             )*)
         }
 
@@ -283,15 +273,13 @@ cfg_if! {
         macro_rules! const_fn {
             ($(
                 $(#[$attr:meta])*
-                $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),*) -> $ret:ty {
-                    $($body:stmt);*
-                }
+                $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)?) -> $ret:ty
+                    $body:block
             )*) => ($(
                 #[inline]
                 $(#[$attr])*
-                fn $i($($arg: $argty),*) -> $ret {
-                    $($body);*
-                }
+                fn $i($($arg: $argty),*) -> $ret
+                    $body
             )*)
         }
     }

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -94,7 +94,7 @@ s! {
         pub d_ino: ::ino_t,
         pub d_reclen: ::c_ushort,
         pub d_namlen: ::c_ushort,
-        pub d_name: [::c_char; 256]
+        pub d_name: [::c_char; 256],
     }
 
     pub struct termios {
@@ -102,7 +102,7 @@ s! {
         pub c_oflag: ::tcflag_t,
         pub c_cflag: ::tcflag_t,
         pub c_lflag: ::tcflag_t,
-        pub c_cc: [::cc_t; ::NCCS]
+        pub c_cc: [::cc_t; ::NCCS],
     }
 
     pub struct flock64 {
@@ -139,7 +139,7 @@ s! {
         pub f_flag: ::c_ulong,
         pub f_namemax: ::c_ulong,
         pub f_fstr: [::c_char; 32],
-        pub f_filler: [::c_ulong; 16]
+        pub f_filler: [::c_ulong; 16],
     }
 
     pub struct lconv {
@@ -180,7 +180,7 @@ s! {
         pub tm_year: ::c_int,
         pub tm_wday: ::c_int,
         pub tm_yday: ::c_int,
-        pub tm_isdst: ::c_int
+        pub tm_isdst: ::c_int,
     }
 
     pub struct addrinfo {
@@ -196,7 +196,7 @@ s! {
     }
 
     pub struct in_addr {
-        pub s_addr: in_addr_t
+        pub s_addr: in_addr_t,
     }
 
     pub struct ip_mreq_source {
@@ -227,7 +227,7 @@ s! {
         pub sin_family: sa_family_t,
         pub sin_port: in_port_t,
         pub sin_addr: in_addr,
-        pub sin_zero: [::c_char; 8]
+        pub sin_zero: [::c_char; 8],
     }
 
     pub struct sockaddr_in6 {
@@ -236,7 +236,7 @@ s! {
         pub sin6_port: ::uint16_t,
         pub sin6_flowinfo: ::uint32_t,
         pub sin6_addr: ::in6_addr,
-        pub sin6_scope_id: ::uint32_t
+        pub sin6_scope_id: ::uint32_t,
     }
 
     pub struct sockaddr_storage {
@@ -250,7 +250,7 @@ s! {
     pub struct sockaddr_un {
         pub sun_len: ::c_uchar,
         pub sun_family: sa_family_t,
-        pub sun_path: [::c_char; 1023]
+        pub sun_path: [::c_char; 1023],
     }
 
     pub struct st_timespec {
@@ -286,7 +286,7 @@ s! {
         pub pw_gid: ::gid_t,
         pub pw_gecos: *mut ::c_char,
         pub pw_dir: *mut ::c_char,
-        pub pw_shell: *mut ::c_char
+        pub pw_shell: *mut ::c_char,
     }
 
     pub struct utsname {
@@ -313,7 +313,7 @@ s! {
         pub sigev_value: ::sigval,
         pub sigev_signo: ::c_int,
         pub sigev_notify: ::c_int,
-        pub sigev_notify_function: extern fn(val: ::sigval),
+        pub sigev_notify_function: extern "C" fn(val: ::sigval),
         pub sigev_notify_attributes: *mut pthread_attr_t,
     }
 
@@ -536,8 +536,8 @@ s! {
 
 s_no_extra_traits! {
     pub union __sigaction_sa_union {
-        pub __su_handler: extern fn(c: ::c_int),
-        pub __su_sigaction: extern fn(c: ::c_int, info: *mut siginfo_t, ptr: *mut ::c_void),
+        pub __su_handler: extern "C" fn(c: ::c_int),
+        pub __su_sigaction: extern "C" fn(c: ::c_int, info: *mut siginfo_t, ptr: *mut ::c_void),
     }
 
     pub struct sigaction {
@@ -2513,8 +2513,9 @@ f! {
         if cmsg.is_null() {
             CMSG_FIRSTHDR(mhdr)
         } else {
-            if (cmsg as usize + (*cmsg).cmsg_len as usize + ::mem::size_of::<::cmsghdr>()) >
-                ((*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize) {
+            if (cmsg as usize + (*cmsg).cmsg_len as usize + ::mem::size_of::<::cmsghdr>())
+                > ((*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize)
+            {
                 0 as *mut ::cmsghdr
             } else {
                 // AIX does not have any alignment/padding for ancillary data, so we don't need _CMSG_ALIGN here.
@@ -2545,20 +2546,20 @@ f! {
         let bits = ::mem::size_of::<::c_long>() * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] |= 1 << (fd % bits);
-        return
+        return;
     }
 
     pub fn FD_CLR(fd: ::c_int, set: *mut fd_set) -> () {
         let bits = ::mem::size_of::<::c_long>() * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] &= !(1 << (fd % bits));
-        return
+        return;
     }
 
     pub fn FD_ISSET(fd: ::c_int, set: *const fd_set) -> bool {
         let bits = ::mem::size_of::<::c_long>() * 8;
         let fd = fd as usize;
-        return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0
+        return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0;
     }
 
     pub fn major(dev: ::dev_t) -> ::c_uint {

--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -34,7 +34,7 @@ s! {
         pub f_flag: ::c_ulong,
         pub f_namemax: ::c_ulong,
         pub f_fstr: [::c_char; 32],
-        pub f_filler: [::c_ulong; 16]
+        pub f_filler: [::c_ulong; 16],
     }
 
     pub struct pthread_rwlock_t {
@@ -206,14 +206,28 @@ s_no_extra_traits! {
     }
 
     pub struct fileops_t {
-        pub fo_rw: extern fn(file: *mut file, rw: ::uio_rw, io: *mut ::c_void, ext: ::c_long,
-                             secattr: *mut ::c_void) -> ::c_int,
-        pub fo_ioctl: extern fn(file: *mut file, a: ::c_long, b: ::caddr_t, c: ::c_long,
-                                d: ::c_long) -> ::c_int,
-        pub fo_select: extern fn(file: *mut file, a: ::c_int, b: *mut ::c_ushort,
-                                 c: extern fn()) -> ::c_int,
-        pub fo_close: extern fn(file: *mut file) -> ::c_int,
-        pub fo_fstat: extern fn(file: *mut file, sstat: *mut ::stat) -> ::c_int,
+        pub fo_rw: extern "C" fn(
+            file: *mut file,
+            rw: ::uio_rw,
+            io: *mut ::c_void,
+            ext: ::c_long,
+            secattr: *mut ::c_void,
+        ) -> ::c_int,
+        pub fo_ioctl: extern "C" fn(
+            file: *mut file,
+            a: ::c_long,
+            b: ::caddr_t,
+            c: ::c_long,
+            d: ::c_long,
+        ) -> ::c_int,
+        pub fo_select: extern "C" fn(
+            file: *mut file,
+            a: ::c_int,
+            b: *mut ::c_ushort,
+            c: extern "C" fn(),
+        ) -> ::c_int,
+        pub fo_close: extern "C" fn(file: *mut file) -> ::c_int,
+        pub fo_fstat: extern "C" fn(file: *mut file, sstat: *mut ::stat) -> ::c_int,
     }
 
     pub struct file {
@@ -339,10 +353,7 @@ cfg_if! {
 
         impl PartialEq for _kernel_simple_lock {
             fn eq(&self, other: &_kernel_simple_lock) -> bool {
-                unsafe {
-                    self._slock == other._slock
-                        && self._slockp == other._slockp
-                }
+                unsafe { self._slock == other._slock && self._slockp == other._slockp }
             }
         }
         impl Eq for _kernel_simple_lock {}

--- a/src/unix/bsd/apple/b32/mod.rs
+++ b/src/unix/bsd/apple/b32/mod.rs
@@ -52,7 +52,7 @@ s! {
 s_no_extra_traits! {
     pub struct pthread_attr_t {
         __sig: c_long,
-        __opaque: [::c_char; 36]
+        __opaque: [::c_char; 36],
     }
 
     pub struct pthread_once_t {
@@ -63,7 +63,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
-        priv_: [f64; 2]
+        priv_: [f64; 2],
     }
 }
 
@@ -72,10 +72,11 @@ cfg_if! {
         impl PartialEq for pthread_attr_t {
             fn eq(&self, other: &pthread_attr_t) -> bool {
                 self.__sig == other.__sig
-                    && self.__opaque
-                    .iter()
-                    .zip(other.__opaque.iter())
-                    .all(|(a,b)| a == b)
+                    && self
+                        .__opaque
+                        .iter()
+                        .zip(other.__opaque.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for pthread_attr_t {}
@@ -83,7 +84,7 @@ cfg_if! {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("pthread_attr_t")
                     .field("__sig", &self.__sig)
-                // FIXME: .field("__opaque", &self.__opaque)
+                    // FIXME: .field("__opaque", &self.__opaque)
                     .finish()
             }
         }
@@ -96,10 +97,11 @@ cfg_if! {
         impl PartialEq for pthread_once_t {
             fn eq(&self, other: &pthread_once_t) -> bool {
                 self.__sig == other.__sig
-                    && self.__opaque
-                    .iter()
-                    .zip(other.__opaque.iter())
-                    .all(|(a,b)| a == b)
+                    && self
+                        .__opaque
+                        .iter()
+                        .zip(other.__opaque.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for pthread_once_t {}

--- a/src/unix/bsd/apple/b64/aarch64/mod.rs
+++ b/src/unix/bsd/apple/b64/aarch64/mod.rs
@@ -47,6 +47,6 @@ s! {
 s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     pub struct max_align_t {
-        priv_: f64
+        priv_: f64,
     }
 }

--- a/src/unix/bsd/apple/b64/mod.rs
+++ b/src/unix/bsd/apple/b64/mod.rs
@@ -52,7 +52,7 @@ s! {
 s_no_extra_traits! {
     pub struct pthread_attr_t {
         __sig: c_long,
-        __opaque: [::c_char; 56]
+        __opaque: [::c_char; 56],
     }
 
     pub struct pthread_once_t {
@@ -66,10 +66,11 @@ cfg_if! {
         impl PartialEq for pthread_attr_t {
             fn eq(&self, other: &pthread_attr_t) -> bool {
                 self.__sig == other.__sig
-                    && self.__opaque
-                    .iter()
-                    .zip(other.__opaque.iter())
-                    .all(|(a,b)| a == b)
+                    && self
+                        .__opaque
+                        .iter()
+                        .zip(other.__opaque.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for pthread_attr_t {}
@@ -77,7 +78,7 @@ cfg_if! {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("pthread_attr_t")
                     .field("__sig", &self.__sig)
-                // FIXME: .field("__opaque", &self.__opaque)
+                    // FIXME: .field("__opaque", &self.__opaque)
                     .finish()
             }
         }
@@ -90,10 +91,11 @@ cfg_if! {
         impl PartialEq for pthread_once_t {
             fn eq(&self, other: &pthread_once_t) -> bool {
                 self.__sig == other.__sig
-                    && self.__opaque
-                    .iter()
-                    .zip(other.__opaque.iter())
-                    .all(|(a,b)| a == b)
+                    && self
+                        .__opaque
+                        .iter()
+                        .zip(other.__opaque.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for pthread_once_t {}

--- a/src/unix/bsd/apple/b64/x86_64/mod.rs
+++ b/src/unix/bsd/apple/b64/x86_64/mod.rs
@@ -110,65 +110,64 @@ s! {
     pub struct malloc_zone_t {
         _reserved1: *mut ::c_void,
         _reserved2: *mut ::c_void,
-        pub size: ::Option<unsafe extern "C" fn(
-            zone: *mut malloc_zone_t,
-            ptr: *const ::c_void,
-        ) -> ::size_t>,
-        pub malloc: ::Option<unsafe extern "C" fn(
-            zone: *mut malloc_zone_t,
-            size: ::size_t,
-        ) -> *mut ::c_void>,
-        pub calloc: ::Option<unsafe extern "C" fn(
-            zone: *mut malloc_zone_t,
-            num_items: ::size_t,
-            size: ::size_t,
-        ) -> *mut ::c_void>,
-        pub valloc: ::Option<unsafe extern "C" fn(
-            zone: *mut malloc_zone_t,
-            size: ::size_t
-        ) -> *mut ::c_void>,
-        pub free: ::Option<unsafe extern "C" fn(
-            zone: *mut malloc_zone_t,
-            ptr: *mut ::c_void
-        )>,
-        pub realloc: ::Option<unsafe extern "C" fn(
-            zone: *mut malloc_zone_t,
-            ptr: *mut ::c_void,
-            size: ::size_t,
-        ) -> *mut ::c_void>,
+        pub size: ::Option<
+            unsafe extern "C" fn(zone: *mut malloc_zone_t, ptr: *const ::c_void) -> ::size_t,
+        >,
+        pub malloc: ::Option<
+            unsafe extern "C" fn(zone: *mut malloc_zone_t, size: ::size_t) -> *mut ::c_void,
+        >,
+        pub calloc: ::Option<
+            unsafe extern "C" fn(
+                zone: *mut malloc_zone_t,
+                num_items: ::size_t,
+                size: ::size_t,
+            ) -> *mut ::c_void,
+        >,
+        pub valloc: ::Option<
+            unsafe extern "C" fn(zone: *mut malloc_zone_t, size: ::size_t) -> *mut ::c_void,
+        >,
+        pub free: ::Option<unsafe extern "C" fn(zone: *mut malloc_zone_t, ptr: *mut ::c_void)>,
+        pub realloc: ::Option<
+            unsafe extern "C" fn(
+                zone: *mut malloc_zone_t,
+                ptr: *mut ::c_void,
+                size: ::size_t,
+            ) -> *mut ::c_void,
+        >,
         pub destroy: ::Option<unsafe extern "C" fn(zone: *mut malloc_zone_t)>,
         pub zone_name: *const ::c_char,
-        pub batch_malloc: ::Option<unsafe extern "C" fn(
-            zone: *mut malloc_zone_t,
-            size: ::size_t,
-            results: *mut *mut ::c_void,
-            num_requested: ::c_uint,
-        ) -> ::c_uint>,
-        pub batch_free: ::Option<unsafe extern "C" fn(
-            zone: *mut malloc_zone_t,
-            to_be_freed: *mut *mut ::c_void,
-            num_to_be_freed: ::c_uint,
-        )>,
+        pub batch_malloc: ::Option<
+            unsafe extern "C" fn(
+                zone: *mut malloc_zone_t,
+                size: ::size_t,
+                results: *mut *mut ::c_void,
+                num_requested: ::c_uint,
+            ) -> ::c_uint,
+        >,
+        pub batch_free: ::Option<
+            unsafe extern "C" fn(
+                zone: *mut malloc_zone_t,
+                to_be_freed: *mut *mut ::c_void,
+                num_to_be_freed: ::c_uint,
+            ),
+        >,
         pub introspect: *mut malloc_introspection_t,
         pub version: ::c_uint,
-        pub memalign: ::Option<unsafe extern "C" fn(
-            zone: *mut malloc_zone_t,
-            alignment: ::size_t,
-            size: ::size_t,
-        ) -> *mut ::c_void>,
-        pub free_definite_size: ::Option<unsafe extern "C" fn(
-            zone: *mut malloc_zone_t,
-            ptr: *mut ::c_void,
-            size: ::size_t
-        )>,
-        pub pressure_relief: ::Option<unsafe extern "C" fn(
-            zone: *mut malloc_zone_t,
-            goal: ::size_t,
-        ) -> ::size_t>,
-        pub claimed_address: ::Option<unsafe extern "C" fn(
-            zone: *mut malloc_zone_t,
-            ptr: *mut ::c_void,
-        ) -> ::boolean_t>,
+        pub memalign: ::Option<
+            unsafe extern "C" fn(
+                zone: *mut malloc_zone_t,
+                alignment: ::size_t,
+                size: ::size_t,
+            ) -> *mut ::c_void,
+        >,
+        pub free_definite_size: ::Option<
+            unsafe extern "C" fn(zone: *mut malloc_zone_t, ptr: *mut ::c_void, size: ::size_t),
+        >,
+        pub pressure_relief:
+            ::Option<unsafe extern "C" fn(zone: *mut malloc_zone_t, goal: ::size_t) -> ::size_t>,
+        pub claimed_address: ::Option<
+            unsafe extern "C" fn(zone: *mut malloc_zone_t, ptr: *mut ::c_void) -> ::boolean_t,
+        >,
     }
 }
 
@@ -176,6 +175,6 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
-        priv_: [f64; 2]
+        priv_: [f64; 2],
     }
 }

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -274,15 +274,15 @@ s! {
         pub aio_nbytes: ::size_t,
         pub aio_reqprio: ::c_int,
         pub aio_sigevent: sigevent,
-        pub aio_lio_opcode: ::c_int
+        pub aio_lio_opcode: ::c_int,
     }
 
     pub struct glob_t {
-        pub gl_pathc:  ::size_t,
+        pub gl_pathc: ::size_t,
         __unused1: ::c_int,
-        pub gl_offs:   ::size_t,
+        pub gl_offs: ::size_t,
         __unused2: ::c_int,
-        pub gl_pathv:  *mut *mut ::c_char,
+        pub gl_pathv: *mut *mut ::c_char,
 
         __unused3: *mut ::c_void,
 
@@ -652,7 +652,7 @@ s! {
         pub cr_version: ::c_uint,
         pub cr_uid: ::uid_t,
         pub cr_ngroups: ::c_short,
-        pub cr_groups: [::gid_t;16]
+        pub cr_groups: [::gid_t; 16],
     }
 
     pub struct segment_command {
@@ -773,11 +773,11 @@ s! {
     // sys/socket.h
 
     pub struct sa_endpoints_t {
-        pub sae_srcif: ::c_uint, // optional source interface
+        pub sae_srcif: ::c_uint,            // optional source interface
         pub sae_srcaddr: *const ::sockaddr, // optional source address
-        pub sae_srcaddrlen: ::socklen_t, // size of source address
+        pub sae_srcaddrlen: ::socklen_t,    // size of source address
         pub sae_dstaddr: *const ::sockaddr, // destination address
-        pub sae_dstaddrlen: ::socklen_t, // size of destination address
+        pub sae_dstaddrlen: ::socklen_t,    // size of destination address
     }
 
     pub struct timex {
@@ -1307,9 +1307,9 @@ s_no_extra_traits! {
         pub shm_lpid: ::pid_t,
         pub shm_cpid: ::pid_t,
         pub shm_nattch: ::shmatt_t,
-        pub shm_atime: ::time_t,  // FIXME: 64-bit wrong align => wrong offset
-        pub shm_dtime: ::time_t,  // FIXME: 64-bit wrong align => wrong offset
-        pub shm_ctime: ::time_t,  // FIXME: 64-bit wrong align => wrong offset
+        pub shm_atime: ::time_t, // FIXME: 64-bit wrong align => wrong offset
+        pub shm_dtime: ::time_t, // FIXME: 64-bit wrong align => wrong offset
+        pub shm_ctime: ::time_t, // FIXME: 64-bit wrong align => wrong offset
         // FIXME: 64-bit wrong align => wrong offset:
         pub shm_internal: *mut ::c_void,
     }
@@ -1395,8 +1395,8 @@ s_no_extra_traits! {
         pub sigev_notify: ::c_int,
         pub sigev_signo: ::c_int,
         pub sigev_value: ::sigval,
-        __unused1: *mut ::c_void,       //actually a function pointer
-        pub sigev_notify_attributes: *mut ::pthread_attr_t
+        __unused1: *mut ::c_void, //actually a function pointer
+        pub sigev_notify_attributes: *mut ::pthread_attr_t,
     }
 
     pub struct processor_cpu_load_info {
@@ -1880,10 +1880,11 @@ cfg_if! {
                     && self.pth_curpri == other.pth_curpri
                     && self.pth_priority == other.pth_priority
                     && self.pth_maxpriority == other.pth_maxpriority
-                    && self.pth_name
-                           .iter()
-                           .zip(other.pth_name.iter())
-                           .all(|(a,b)| a == b)
+                    && self
+                        .pth_name
+                        .iter()
+                        .zip(other.pth_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for proc_threadinfo {}
@@ -1900,7 +1901,7 @@ cfg_if! {
                     .field("pth_curpri", &self.pth_curpri)
                     .field("pth_priority", &self.pth_priority)
                     .field("pth_maxpriority", &self.pth_maxpriority)
-                      // FIXME: .field("pth_name", &self.pth_name)
+                    // FIXME: .field("pth_name", &self.pth_name)
                     .finish()
             }
         }
@@ -1936,15 +1937,15 @@ cfg_if! {
                     && self.f_fstypename == other.f_fstypename
                     && self.f_type == other.f_type
                     && self
-                    .f_mntonname
-                    .iter()
-                    .zip(other.f_mntonname.iter())
-                    .all(|(a,b)| a == b)
+                        .f_mntonname
+                        .iter()
+                        .zip(other.f_mntonname.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .f_mntfromname
-                    .iter()
-                    .zip(other.f_mntfromname.iter())
-                    .all(|(a,b)| a == b)
+                        .f_mntfromname
+                        .iter()
+                        .zip(other.f_mntfromname.iter())
+                        .all(|(a, b)| a == b)
                     && self.f_reserved == other.f_reserved
             }
         }
@@ -1966,8 +1967,8 @@ cfg_if! {
                     .field("f_fssubtype", &self.f_fssubtype)
                     .field("f_fstypename", &self.f_fstypename)
                     .field("f_type", &self.f_type)
-                // FIXME: .field("f_mntonname", &self.f_mntonname)
-                // FIXME: .field("f_mntfromname", &self.f_mntfromname)
+                    // FIXME: .field("f_mntonname", &self.f_mntonname)
+                    // FIXME: .field("f_mntfromname", &self.f_mntfromname)
                     .field("f_reserved", &self.f_reserved)
                     .finish()
             }
@@ -2002,10 +2003,10 @@ cfg_if! {
                     && self.d_namlen == other.d_namlen
                     && self.d_type == other.d_type
                     && self
-                    .d_name
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                        .d_name
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for dirent {}
@@ -2034,11 +2035,11 @@ cfg_if! {
         impl PartialEq for pthread_rwlock_t {
             fn eq(&self, other: &pthread_rwlock_t) -> bool {
                 self.__sig == other.__sig
-                    && self.
-                    __opaque
-                    .iter()
-                    .zip(other.__opaque.iter())
-                    .all(|(a,b)| a == b)
+                    && self
+                        .__opaque
+                        .iter()
+                        .zip(other.__opaque.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for pthread_rwlock_t {}
@@ -2060,11 +2061,11 @@ cfg_if! {
         impl PartialEq for pthread_mutex_t {
             fn eq(&self, other: &pthread_mutex_t) -> bool {
                 self.__sig == other.__sig
-                    && self.
-                    __opaque
-                    .iter()
-                    .zip(other.__opaque.iter())
-                    .all(|(a,b)| a == b)
+                    && self
+                        .__opaque
+                        .iter()
+                        .zip(other.__opaque.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -2089,11 +2090,11 @@ cfg_if! {
         impl PartialEq for pthread_cond_t {
             fn eq(&self, other: &pthread_cond_t) -> bool {
                 self.__sig == other.__sig
-                    && self.
-                    __opaque
-                    .iter()
-                    .zip(other.__opaque.iter())
-                    .all(|(a,b)| a == b)
+                    && self
+                        .__opaque
+                        .iter()
+                        .zip(other.__opaque.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -2120,16 +2121,16 @@ cfg_if! {
                 self.ss_len == other.ss_len
                     && self.ss_family == other.ss_family
                     && self
-                    .__ss_pad1
-                    .iter()
-                    .zip(other.__ss_pad1.iter())
-                    .all(|(a, b)| a == b)
+                        .__ss_pad1
+                        .iter()
+                        .zip(other.__ss_pad1.iter())
+                        .all(|(a, b)| a == b)
                     && self.__ss_align == other.__ss_align
                     && self
-                    .__ss_pad2
-                    .iter()
-                    .zip(other.__ss_pad2.iter())
-                    .all(|(a, b)| a == b)
+                        .__ss_pad2
+                        .iter()
+                        .zip(other.__ss_pad2.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -2162,17 +2163,17 @@ cfg_if! {
                 self.ut_user
                     .iter()
                     .zip(other.ut_user.iter())
-                    .all(|(a,b)| a == b)
+                    .all(|(a, b)| a == b)
                     && self.ut_id == other.ut_id
                     && self.ut_line == other.ut_line
                     && self.ut_pid == other.ut_pid
                     && self.ut_type == other.ut_type
                     && self.ut_tv == other.ut_tv
                     && self
-                    .ut_host
-                    .iter()
-                    .zip(other.ut_host.iter())
-                    .all(|(a,b)| a == b)
+                        .ut_host
+                        .iter()
+                        .zip(other.ut_host.iter())
+                        .all(|(a, b)| a == b)
                     && self.ut_pad == other.ut_pad
             }
         }
@@ -2212,8 +2213,7 @@ cfg_if! {
                 self.sigev_notify == other.sigev_notify
                     && self.sigev_signo == other.sigev_signo
                     && self.sigev_value == other.sigev_value
-                    && self.sigev_notify_attributes
-                        == other.sigev_notify_attributes
+                    && self.sigev_notify_attributes == other.sigev_notify_attributes
             }
         }
 
@@ -2225,8 +2225,7 @@ cfg_if! {
                     .field("sigev_notify", &self.sigev_notify)
                     .field("sigev_signo", &self.sigev_signo)
                     .field("sigev_value", &self.sigev_value)
-                    .field("sigev_notify_attributes",
-                           &self.sigev_notify_attributes)
+                    .field("sigev_notify_attributes", &self.sigev_notify_attributes)
                     .finish()
             }
         }
@@ -2342,8 +2341,7 @@ cfg_if! {
 
         impl PartialEq for time_value_t {
             fn eq(&self, other: &time_value_t) -> bool {
-                self.seconds == other.seconds
-                    && self.microseconds == other.microseconds
+                self.seconds == other.seconds && self.microseconds == other.microseconds
             }
         }
         impl Eq for time_value_t {}
@@ -2412,10 +2410,11 @@ cfg_if! {
                     && self.pth_curpri == other.pth_curpri
                     && self.pth_priority == other.pth_priority
                     && self.pth_maxpriority == other.pth_maxpriority
-                    && self.pth_name
-                           .iter()
-                           .zip(other.pth_name.iter())
-                           .all(|(a,b)| a == b)
+                    && self
+                        .pth_name
+                        .iter()
+                        .zip(other.pth_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for thread_extended_info {}
@@ -2432,7 +2431,7 @@ cfg_if! {
                     .field("pth_curpri", &self.pth_curpri)
                     .field("pth_priority", &self.pth_priority)
                     .field("pth_maxpriority", &self.pth_maxpriority)
-                      // FIXME: .field("pth_name", &self.pth_name)
+                    // FIXME: .field("pth_name", &self.pth_name)
                     .finish()
             }
         }
@@ -2477,31 +2476,31 @@ cfg_if! {
         }
         impl PartialEq for if_data64 {
             fn eq(&self, other: &if_data64) -> bool {
-                self.ifi_type == other.ifi_type &&
-                self.ifi_typelen == other.ifi_typelen &&
-                self.ifi_physical == other.ifi_physical &&
-                self.ifi_addrlen == other.ifi_addrlen &&
-                self.ifi_hdrlen == other.ifi_hdrlen &&
-                self.ifi_recvquota == other.ifi_recvquota &&
-                self.ifi_xmitquota == other.ifi_xmitquota &&
-                self.ifi_unused1 == other.ifi_unused1 &&
-                self.ifi_mtu == other.ifi_mtu &&
-                self.ifi_metric == other.ifi_metric &&
-                self.ifi_baudrate == other.ifi_baudrate &&
-                self.ifi_ipackets == other.ifi_ipackets &&
-                self.ifi_ierrors == other.ifi_ierrors &&
-                self.ifi_opackets == other.ifi_opackets &&
-                self.ifi_oerrors == other.ifi_oerrors &&
-                self.ifi_collisions == other.ifi_collisions &&
-                self.ifi_ibytes == other.ifi_ibytes &&
-                self.ifi_obytes == other.ifi_obytes &&
-                self.ifi_imcasts == other.ifi_imcasts &&
-                self.ifi_omcasts == other.ifi_omcasts &&
-                self.ifi_iqdrops == other.ifi_iqdrops &&
-                self.ifi_noproto == other.ifi_noproto &&
-                self.ifi_recvtiming == other.ifi_recvtiming &&
-                self.ifi_xmittiming == other.ifi_xmittiming &&
-                self.ifi_lastchange == other.ifi_lastchange
+                self.ifi_type == other.ifi_type
+                    && self.ifi_typelen == other.ifi_typelen
+                    && self.ifi_physical == other.ifi_physical
+                    && self.ifi_addrlen == other.ifi_addrlen
+                    && self.ifi_hdrlen == other.ifi_hdrlen
+                    && self.ifi_recvquota == other.ifi_recvquota
+                    && self.ifi_xmitquota == other.ifi_xmitquota
+                    && self.ifi_unused1 == other.ifi_unused1
+                    && self.ifi_mtu == other.ifi_mtu
+                    && self.ifi_metric == other.ifi_metric
+                    && self.ifi_baudrate == other.ifi_baudrate
+                    && self.ifi_ipackets == other.ifi_ipackets
+                    && self.ifi_ierrors == other.ifi_ierrors
+                    && self.ifi_opackets == other.ifi_opackets
+                    && self.ifi_oerrors == other.ifi_oerrors
+                    && self.ifi_collisions == other.ifi_collisions
+                    && self.ifi_ibytes == other.ifi_ibytes
+                    && self.ifi_obytes == other.ifi_obytes
+                    && self.ifi_imcasts == other.ifi_imcasts
+                    && self.ifi_omcasts == other.ifi_omcasts
+                    && self.ifi_iqdrops == other.ifi_iqdrops
+                    && self.ifi_noproto == other.ifi_noproto
+                    && self.ifi_recvtiming == other.ifi_recvtiming
+                    && self.ifi_xmittiming == other.ifi_xmittiming
+                    && self.ifi_lastchange == other.ifi_lastchange
             }
         }
         impl Eq for if_data64 {}
@@ -2617,17 +2616,17 @@ cfg_if! {
         }
         impl PartialEq for if_msghdr2 {
             fn eq(&self, other: &if_msghdr2) -> bool {
-                self.ifm_msglen == other.ifm_msglen &&
-                self.ifm_version == other.ifm_version &&
-                self.ifm_type == other.ifm_type &&
-                self.ifm_addrs == other.ifm_addrs &&
-                self.ifm_flags == other.ifm_flags &&
-                self.ifm_index == other.ifm_index &&
-                self.ifm_snd_len == other.ifm_snd_len &&
-                self.ifm_snd_maxlen == other.ifm_snd_maxlen &&
-                self.ifm_snd_drops == other.ifm_snd_drops &&
-                self.ifm_timer == other.ifm_timer &&
-                self.ifm_data == other.ifm_data
+                self.ifm_msglen == other.ifm_msglen
+                    && self.ifm_version == other.ifm_version
+                    && self.ifm_type == other.ifm_type
+                    && self.ifm_addrs == other.ifm_addrs
+                    && self.ifm_flags == other.ifm_flags
+                    && self.ifm_index == other.ifm_index
+                    && self.ifm_snd_len == other.ifm_snd_len
+                    && self.ifm_snd_maxlen == other.ifm_snd_maxlen
+                    && self.ifm_snd_drops == other.ifm_snd_drops
+                    && self.ifm_timer == other.ifm_timer
+                    && self.ifm_data == other.ifm_data
             }
         }
         impl Eq for if_msghdr2 {}
@@ -2689,30 +2688,30 @@ cfg_if! {
             fn eq(&self, other: &vm_statistics64) -> bool {
                 // Otherwise rustfmt crashes...
                 let total_uncompressed = self.total_uncompressed_pages_in_compressor;
-                self.free_count == other.free_count &&
-                self.active_count == other.active_count &&
-                self.inactive_count == other.inactive_count &&
-                self.wire_count == other.wire_count &&
-                self.zero_fill_count == other.zero_fill_count &&
-                self.reactivations == other.reactivations &&
-                self.pageins == other.pageins &&
-                self.pageouts == other.pageouts &&
-                self.faults == other.faults &&
-                self.cow_faults == other.cow_faults &&
-                self.lookups == other.lookups &&
-                self.hits == other.hits &&
-                self.purges == other.purges &&
-                self.purgeable_count == other.purgeable_count &&
-                self.speculative_count == other.speculative_count &&
-                self.decompressions == other.decompressions &&
-                self.compressions == other.compressions &&
-                self.swapins == other.swapins &&
-                self.swapouts == other.swapouts &&
-                self.compressor_page_count == other.compressor_page_count &&
-                self.throttled_count == other.throttled_count &&
-                self.external_page_count == other.external_page_count &&
-                self.internal_page_count == other.internal_page_count &&
-                total_uncompressed == other.total_uncompressed_pages_in_compressor
+                self.free_count == other.free_count
+                    && self.active_count == other.active_count
+                    && self.inactive_count == other.inactive_count
+                    && self.wire_count == other.wire_count
+                    && self.zero_fill_count == other.zero_fill_count
+                    && self.reactivations == other.reactivations
+                    && self.pageins == other.pageins
+                    && self.pageouts == other.pageouts
+                    && self.faults == other.faults
+                    && self.cow_faults == other.cow_faults
+                    && self.lookups == other.lookups
+                    && self.hits == other.hits
+                    && self.purges == other.purges
+                    && self.purgeable_count == other.purgeable_count
+                    && self.speculative_count == other.speculative_count
+                    && self.decompressions == other.decompressions
+                    && self.compressions == other.compressions
+                    && self.swapins == other.swapins
+                    && self.swapouts == other.swapouts
+                    && self.compressor_page_count == other.compressor_page_count
+                    && self.throttled_count == other.throttled_count
+                    && self.external_page_count == other.external_page_count
+                    && self.internal_page_count == other.internal_page_count
+                    && total_uncompressed == other.total_uncompressed_pages_in_compressor
             }
         }
         impl Eq for vm_statistics64 {}
@@ -2767,7 +2766,10 @@ cfg_if! {
                     .field("throttled_count", &throttled_count)
                     .field("external_page_count", &external_page_count)
                     .field("internal_page_count", &internal_page_count)
-                    .field("total_uncompressed_pages_in_compressor", &total_uncompressed)
+                    .field(
+                        "total_uncompressed_pages_in_compressor",
+                        &total_uncompressed,
+                    )
                     .finish()
             }
         }
@@ -2949,11 +2951,11 @@ cfg_if! {
                 let svm_cid = self.svm_cid;
 
                 f.debug_struct("sockaddr_vm")
-                    .field("svm_len",&svm_len)
-                    .field("svm_family",&svm_family)
-                    .field("svm_reserved1",&svm_reserved1)
-                    .field("svm_port",&svm_port)
-                    .field("svm_cid",&svm_cid)
+                    .field("svm_len", &svm_len)
+                    .field("svm_family", &svm_family)
+                    .field("svm_reserved1", &svm_reserved1)
+                    .field("svm_port", &svm_port)
+                    .field("svm_cid", &svm_cid)
                     .finish()
             }
         }
@@ -3004,10 +3006,7 @@ cfg_if! {
 
         impl PartialEq for __c_anonymous_ifk_data {
             fn eq(&self, other: &__c_anonymous_ifk_data) -> bool {
-                unsafe {
-                    self.ifk_ptr == other.ifk_ptr
-                        && self.ifk_value == other.ifk_value
-                }
+                unsafe { self.ifk_ptr == other.ifk_ptr && self.ifk_value == other.ifk_value }
             }
         }
 
@@ -3032,8 +3031,7 @@ cfg_if! {
 
         impl PartialEq for ifkpi {
             fn eq(&self, other: &ifkpi) -> bool {
-                self.ifk_module_id == other.ifk_module_id
-                    && self.ifk_type == other.ifk_type
+                self.ifk_module_id == other.ifk_module_id && self.ifk_type == other.ifk_type
             }
         }
 
@@ -3072,7 +3070,11 @@ cfg_if! {
                         && self.ifru_kpi == other.ifru_kpi
                         && self.ifru_wake_flags == other.ifru_wake_flags
                         && self.ifru_route_refcnt == other.ifru_route_refcnt
-                        && self.ifru_cap.iter().zip(other.ifru_cap.iter()).all(|(a,b)| a == b)
+                        && self
+                            .ifru_cap
+                            .iter()
+                            .zip(other.ifru_cap.iter())
+                            .all(|(a, b)| a == b)
                         && self.ifru_functional_type == other.ifru_functional_type
                 }
             }
@@ -3098,7 +3100,9 @@ cfg_if! {
                     .field("ifru_wake_flags", unsafe { &self.ifru_wake_flags })
                     .field("ifru_route_refcnt", unsafe { &self.ifru_route_refcnt })
                     .field("ifru_cap", unsafe { &self.ifru_cap })
-                    .field("ifru_functional_type", unsafe { &self.ifru_functional_type })
+                    .field("ifru_functional_type", unsafe {
+                        &self.ifru_functional_type
+                    })
                     .finish()
             }
         }
@@ -3128,8 +3132,7 @@ cfg_if! {
 
         impl PartialEq for ifreq {
             fn eq(&self, other: &ifreq) -> bool {
-                self.ifr_name == other.ifr_name
-                    && self.ifr_ifru == other.ifr_ifru
+                self.ifr_name == other.ifr_name && self.ifr_ifru == other.ifr_ifru
             }
         }
 
@@ -3173,10 +3176,11 @@ cfg_if! {
                         && self.ifru_metrics == other.ifru_metrics
                         && self.ifru_intval == other.ifru_intval
                         && self.ifru_data == other.ifru_data
-                        && self.ifru_scope_id
+                        && self
+                            .ifru_scope_id
                             .iter()
                             .zip(other.ifru_scope_id.iter())
-                            .all(|(a,b)| a == b)
+                            .all(|(a, b)| a == b)
                 }
             }
         }
@@ -3215,8 +3219,7 @@ cfg_if! {
 
         impl PartialEq for in6_ifreq {
             fn eq(&self, other: &in6_ifreq) -> bool {
-                self.ifr_name == other.ifr_name
-                    && self.ifr_ifru == other.ifr_ifru
+                self.ifr_name == other.ifr_name && self.ifr_ifru == other.ifr_ifru
             }
         }
 
@@ -5575,15 +5578,13 @@ pub const DOT3COMPLIANCE_COLLS: ::c_int = 2;
 pub const MAX_KCTL_NAME: usize = 96;
 
 f! {
-    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr,
-                       cmsg: *const ::cmsghdr) -> *mut ::cmsghdr {
+    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr, cmsg: *const ::cmsghdr) -> *mut ::cmsghdr {
         if cmsg.is_null() {
             return ::CMSG_FIRSTHDR(mhdr);
         };
         let cmsg_len = (*cmsg).cmsg_len as usize;
         let next = cmsg as usize + __DARWIN_ALIGN32(cmsg_len);
-        let max = (*mhdr).msg_control as usize
-                    + (*mhdr).msg_controllen as usize;
+        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next + __DARWIN_ALIGN32(::mem::size_of::<::cmsghdr>()) > max {
             core::ptr::null_mut()
         } else {
@@ -5592,19 +5593,16 @@ f! {
     }
 
     pub fn CMSG_DATA(cmsg: *const ::cmsghdr) -> *mut ::c_uchar {
-        (cmsg as *mut ::c_uchar)
-            .add(__DARWIN_ALIGN32(::mem::size_of::<::cmsghdr>()))
+        (cmsg as *mut ::c_uchar).add(__DARWIN_ALIGN32(::mem::size_of::<::cmsghdr>()))
     }
 
     pub {const} fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
-        (__DARWIN_ALIGN32(::mem::size_of::<::cmsghdr>())
-            + __DARWIN_ALIGN32(length as usize))
+        (__DARWIN_ALIGN32(::mem::size_of::<::cmsghdr>()) + __DARWIN_ALIGN32(length as usize))
             as ::c_uint
     }
 
     pub {const} fn CMSG_LEN(length: ::c_uint) -> ::c_uint {
-        (__DARWIN_ALIGN32(::mem::size_of::<::cmsghdr>()) + length as usize)
-            as ::c_uint
+        (__DARWIN_ALIGN32(::mem::size_of::<::cmsghdr>()) + length as usize) as ::c_uint
     }
 
     pub {const} fn VM_MAKE_TAG(id: u8) -> u32 {
@@ -6565,7 +6563,12 @@ cfg_if! {
     }
 }
 cfg_if! {
-    if #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "visionos"))] {
+    if #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "visionos"
+    ))] {
         extern "C" {
             pub fn memmem(
                 haystack: *const ::c_void,
@@ -6573,10 +6576,11 @@ cfg_if! {
                 needle: *const ::c_void,
                 needlelen: ::size_t,
             ) -> *mut ::c_void;
-            pub fn task_set_info(target_task: ::task_t,
-                                 flavor: ::task_flavor_t,
-                                 task_info_in: ::task_info_t,
-                                 task_info_inCnt: ::mach_msg_type_number_t
+            pub fn task_set_info(
+                target_task: ::task_t,
+                flavor: ::task_flavor_t,
+                task_info_in: ::task_info_t,
+                task_info_inCnt: ::mach_msg_type_number_t,
             ) -> ::kern_return_t;
         }
     }

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -84,7 +84,7 @@ s! {
 
     pub struct exit_status {
         pub e_termination: u16,
-        pub e_exit: u16
+        pub e_exit: u16,
     }
 
     pub struct aiocb {
@@ -96,7 +96,7 @@ s! {
         pub aio_lio_opcode: ::c_int,
         pub aio_reqprio: ::c_int,
         _aio_val: ::c_int,
-        _aio_err: ::c_int
+        _aio_err: ::c_int,
     }
 
     pub struct uuid {
@@ -294,7 +294,7 @@ s! {
         pub kl_sigmask: ::sigset_t,
         pub kl_wchan: ::uintptr_t,
         pub kl_wmesg: [::c_char; 9],
-        pub kl_comm: [::c_char; MAXCOMLEN+1],
+        pub kl_comm: [::c_char; MAXCOMLEN + 1],
     }
 
     pub struct kinfo_proc {
@@ -310,7 +310,7 @@ s! {
         pub kp_sigcatch: ::sigset_t,
         pub kp_sigflag: ::c_int,
         pub kp_start: ::timeval,
-        pub kp_comm: [::c_char; MAXCOMLEN+1],
+        pub kp_comm: [::c_char; MAXCOMLEN + 1],
         pub kp_uid: ::uid_t,
         pub kp_ngroups: ::c_short,
         pub kp_groups: [::gid_t; NGROUPS],
@@ -477,12 +477,12 @@ s_no_extra_traits! {
         // The union is 8-byte in size, so it is aligned at a 8-byte offset.
         #[cfg(target_pointer_width = "64")]
         __unused1: ::c_int,
-        pub sigev_signo: ::c_int,       //actually a union
+        pub sigev_signo: ::c_int, //actually a union
         // pad the union
         #[cfg(target_pointer_width = "64")]
         __unused2: ::c_int,
         pub sigev_value: ::sigval,
-        __unused3: *mut ::c_void        //actually a function pointer
+        __unused3: *mut ::c_void, //actually a function pointer
     }
 
     pub struct mcontext_t {
@@ -539,10 +539,10 @@ cfg_if! {
                     && self.ut_id == other.ut_id
                     && self.ut_line == other.ut_line
                     && self
-                    .ut_host
-                    .iter()
-                    .zip(other.ut_host.iter())
-                    .all(|(a,b)| a == b)
+                        .ut_host
+                        .iter()
+                        .zip(other.ut_host.iter())
+                        .all(|(a, b)| a == b)
                     && self.ut_unused == other.ut_unused
                     && self.ut_session == other.ut_session
                     && self.ut_type == other.ut_type
@@ -648,8 +648,8 @@ cfg_if! {
                 self.d_fileno.hash(state);
                 self.d_namlen.hash(state);
                 self.d_type.hash(state);
-                    // Ignore __unused1
-                    // Ignore __unused2
+                // Ignore __unused1
+                // Ignore __unused2
                 self.d_name.hash(state);
             }
         }
@@ -671,17 +671,17 @@ cfg_if! {
                     && self.f_asyncwrites == other.f_asyncwrites
                     && self.f_fstypename == other.f_fstypename
                     && self
-                    .f_mntonname
-                    .iter()
-                    .zip(other.f_mntonname.iter())
-                    .all(|(a,b)| a == b)
+                        .f_mntonname
+                        .iter()
+                        .zip(other.f_mntonname.iter())
+                        .all(|(a, b)| a == b)
                     && self.f_syncreads == other.f_syncreads
                     && self.f_asyncreads == other.f_asyncreads
                     && self
-                    .f_mntfromname
-                    .iter()
-                    .zip(other.f_mntfromname.iter())
-                    .all(|(a,b)| a == b)
+                        .f_mntfromname
+                        .iter()
+                        .zip(other.f_mntfromname.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for statfs {}
@@ -757,36 +757,36 @@ cfg_if! {
         }
         impl PartialEq for mcontext_t {
             fn eq(&self, other: &mcontext_t) -> bool {
-                self.mc_onstack == other.mc_onstack &&
-                self.mc_rdi == other.mc_rdi &&
-                self.mc_rsi == other.mc_rsi &&
-                self.mc_rdx == other.mc_rdx &&
-                self.mc_rcx == other.mc_rcx &&
-                self.mc_r8 == other.mc_r8 &&
-                self.mc_r9 == other.mc_r9 &&
-                self.mc_rax == other.mc_rax &&
-                self.mc_rbx == other.mc_rbx &&
-                self.mc_rbp == other.mc_rbp &&
-                self.mc_r10 == other.mc_r10 &&
-                self.mc_r11 == other.mc_r11 &&
-                self.mc_r12 == other.mc_r12 &&
-                self.mc_r13 == other.mc_r13 &&
-                self.mc_r14 == other.mc_r14 &&
-                self.mc_r15 == other.mc_r15 &&
-                self.mc_xflags == other.mc_xflags &&
-                self.mc_trapno == other.mc_trapno &&
-                self.mc_addr == other.mc_addr &&
-                self.mc_flags == other.mc_flags &&
-                self.mc_err == other.mc_err &&
-                self.mc_rip == other.mc_rip &&
-                self.mc_cs == other.mc_cs &&
-                self.mc_rflags == other.mc_rflags &&
-                self.mc_rsp == other.mc_rsp &&
-                self.mc_ss == other.mc_ss &&
-                self.mc_len == other.mc_len &&
-                self.mc_fpformat == other.mc_fpformat &&
-                self.mc_ownedfp == other.mc_ownedfp &&
-                self.mc_fpregs == other.mc_fpregs
+                self.mc_onstack == other.mc_onstack
+                    && self.mc_rdi == other.mc_rdi
+                    && self.mc_rsi == other.mc_rsi
+                    && self.mc_rdx == other.mc_rdx
+                    && self.mc_rcx == other.mc_rcx
+                    && self.mc_r8 == other.mc_r8
+                    && self.mc_r9 == other.mc_r9
+                    && self.mc_rax == other.mc_rax
+                    && self.mc_rbx == other.mc_rbx
+                    && self.mc_rbp == other.mc_rbp
+                    && self.mc_r10 == other.mc_r10
+                    && self.mc_r11 == other.mc_r11
+                    && self.mc_r12 == other.mc_r12
+                    && self.mc_r13 == other.mc_r13
+                    && self.mc_r14 == other.mc_r14
+                    && self.mc_r15 == other.mc_r15
+                    && self.mc_xflags == other.mc_xflags
+                    && self.mc_trapno == other.mc_trapno
+                    && self.mc_addr == other.mc_addr
+                    && self.mc_flags == other.mc_flags
+                    && self.mc_err == other.mc_err
+                    && self.mc_rip == other.mc_rip
+                    && self.mc_cs == other.mc_cs
+                    && self.mc_rflags == other.mc_rflags
+                    && self.mc_rsp == other.mc_rsp
+                    && self.mc_ss == other.mc_ss
+                    && self.mc_len == other.mc_len
+                    && self.mc_fpformat == other.mc_fpformat
+                    && self.mc_ownedfp == other.mc_ownedfp
+                    && self.mc_fpregs == other.mc_fpregs
             }
         }
         impl Eq for mcontext_t {}
@@ -1543,33 +1543,27 @@ const_fn! {
 
 f! {
     pub fn CMSG_DATA(cmsg: *const ::cmsghdr) -> *mut ::c_uchar {
-        (cmsg as *mut ::c_uchar)
-            .offset(_CMSG_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
+        (cmsg as *mut ::c_uchar).offset(_CMSG_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_LEN(length: ::c_uint) -> ::c_uint {
-        (_CMSG_ALIGN(::mem::size_of::<::cmsghdr>()) + length as usize)
-            as ::c_uint
+        (_CMSG_ALIGN(::mem::size_of::<::cmsghdr>()) + length as usize) as ::c_uint
     }
 
-    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr, cmsg: *const ::cmsghdr)
-        -> *mut ::cmsghdr
-    {
-        let next = cmsg as usize + _CMSG_ALIGN((*cmsg).cmsg_len as usize)
+    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr, cmsg: *const ::cmsghdr) -> *mut ::cmsghdr {
+        let next = cmsg as usize
+            + _CMSG_ALIGN((*cmsg).cmsg_len as usize)
             + _CMSG_ALIGN(::mem::size_of::<::cmsghdr>());
-        let max = (*mhdr).msg_control as usize
-            + (*mhdr).msg_controllen as usize;
+        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next <= max {
-            (cmsg as usize + _CMSG_ALIGN((*cmsg).cmsg_len as usize))
-                as *mut ::cmsghdr
+            (cmsg as usize + _CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut ::cmsghdr
         } else {
             0 as *mut ::cmsghdr
         }
     }
 
     pub {const} fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
-        (_CMSG_ALIGN(::mem::size_of::<::cmsghdr>()) +
-            _CMSG_ALIGN(length as usize)) as ::c_uint
+        (_CMSG_ALIGN(::mem::size_of::<::cmsghdr>()) + _CMSG_ALIGN(length as usize)) as ::c_uint
     }
 
     pub fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {
@@ -1596,7 +1590,7 @@ f! {
     }
 
     pub fn major(dev: ::dev_t) -> ::c_int {
-         ((dev >> 8) & 0xff) as ::c_int
+        ((dev >> 8) & 0xff) as ::c_int
     }
 
     pub fn minor(dev: ::dev_t) -> ::c_int {

--- a/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
@@ -40,12 +40,12 @@ cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         impl PartialEq for gpregs {
             fn eq(&self, other: &gpregs) -> bool {
-                self.gp_x.iter().zip(other.gp_x.iter()).all(|(a, b)| a == b) &&
-                self.gp_lr == other.gp_lr &&
-                self.gp_sp == other.gp_sp &&
-                self.gp_elr == other.gp_elr &&
-                self.gp_spsr == other.gp_spsr &&
-                self.gp_pad == other.gp_pad
+                self.gp_x.iter().zip(other.gp_x.iter()).all(|(a, b)| a == b)
+                    && self.gp_lr == other.gp_lr
+                    && self.gp_sp == other.gp_sp
+                    && self.gp_elr == other.gp_elr
+                    && self.gp_spsr == other.gp_spsr
+                    && self.gp_pad == other.gp_pad
             }
         }
         impl Eq for gpregs {}
@@ -73,11 +73,11 @@ cfg_if! {
         }
         impl PartialEq for fpregs {
             fn eq(&self, other: &fpregs) -> bool {
-                self.fp_q == other.fp_q &&
-                self.fp_sr == other.fp_sr &&
-                self.fp_cr == other.fp_cr &&
-                self.fp_flags == other.fp_flags &&
-                self.fp_pad == other.fp_pad
+                self.fp_q == other.fp_q
+                    && self.fp_sr == other.fp_sr
+                    && self.fp_cr == other.fp_cr
+                    && self.fp_flags == other.fp_flags
+                    && self.fp_pad == other.fp_pad
             }
         }
         impl Eq for fpregs {}
@@ -103,11 +103,15 @@ cfg_if! {
         }
         impl PartialEq for mcontext_t {
             fn eq(&self, other: &mcontext_t) -> bool {
-                self.mc_gpregs == other.mc_gpregs &&
-                self.mc_fpregs == other.mc_fpregs &&
-                self.mc_flags == other.mc_flags &&
-                self.mc_pad == other.mc_pad &&
-                self.mc_spare.iter().zip(other.mc_spare.iter()).all(|(a, b)| a == b)
+                self.mc_gpregs == other.mc_gpregs
+                    && self.mc_fpregs == other.mc_fpregs
+                    && self.mc_flags == other.mc_flags
+                    && self.mc_pad == other.mc_pad
+                    && self
+                        .mc_spare
+                        .iter()
+                        .zip(other.mc_spare.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for mcontext_t {}

--- a/src/unix/bsd/freebsdlike/freebsd/arm.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/arm.rs
@@ -22,10 +22,14 @@ cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         impl PartialEq for mcontext_t {
             fn eq(&self, other: &mcontext_t) -> bool {
-                self.__gregs == other.__gregs &&
-                self.mc_vfp_size == other.mc_vfp_size &&
-                self.mc_vfp_ptr == other.mc_vfp_ptr &&
-                self.mc_spare.iter().zip(other.mc_spare.iter()).all(|(a, b)| a == b)
+                self.__gregs == other.__gregs
+                    && self.mc_vfp_size == other.mc_vfp_size
+                    && self.mc_vfp_ptr == other.mc_vfp_ptr
+                    && self
+                        .mc_spare
+                        .iter()
+                        .zip(other.mc_spare.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for mcontext_t {}

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
@@ -283,15 +283,15 @@ cfg_if! {
                     && self.f_fsid == other.f_fsid
                     && self.f_fstypename == other.f_fstypename
                     && self
-                    .f_mntfromname
-                    .iter()
-                    .zip(other.f_mntfromname.iter())
-                    .all(|(a,b)| a == b)
+                        .f_mntfromname
+                        .iter()
+                        .zip(other.f_mntfromname.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .f_mntonname
-                    .iter()
-                    .zip(other.f_mntonname.iter())
-                    .all(|(a,b)| a == b)
+                        .f_mntonname
+                        .iter()
+                        .zip(other.f_mntonname.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for statfs {}
@@ -349,11 +349,10 @@ cfg_if! {
                     && self.d_reclen == other.d_reclen
                     && self.d_type == other.d_type
                     && self.d_namlen == other.d_namlen
-                    && self
-                    .d_name[..self.d_namlen as _]
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                    && self.d_name[..self.d_namlen as _]
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for dirent {}
@@ -383,14 +382,14 @@ cfg_if! {
                 let self_vn_devname: &[::c_char] = &self.vn_devname;
                 let other_vn_devname: &[::c_char] = &other.vn_devname;
 
-                self.vn_fileid == other.vn_fileid &&
-                self.vn_size == other.vn_size &&
-                self.vn_mntdir == other.vn_mntdir &&
-                self.vn_dev == other.vn_dev &&
-                self.vn_fsid == other.vn_fsid &&
-                self.vn_type == other.vn_type &&
-                self.vn_mode == other.vn_mode &&
-                self_vn_devname == other_vn_devname
+                self.vn_fileid == other.vn_fileid
+                    && self.vn_size == other.vn_size
+                    && self.vn_mntdir == other.vn_mntdir
+                    && self.vn_dev == other.vn_dev
+                    && self.vn_fsid == other.vn_fsid
+                    && self.vn_type == other.vn_type
+                    && self.vn_mode == other.vn_mode
+                    && self_vn_devname == other_vn_devname
             }
         }
         impl Eq for vnstat {}
@@ -444,7 +443,7 @@ safe_f! {
 
 f! {
     pub fn major(dev: ::dev_t) -> ::c_int {
-         ((dev >> 8) & 0xff) as ::c_int
+        ((dev >> 8) & 0xff) as ::c_int
     }
 
     pub fn minor(dev: ::dev_t) -> ::c_int {

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -326,15 +326,15 @@ cfg_if! {
                     && self.f_fsid == other.f_fsid
                     && self.f_fstypename == other.f_fstypename
                     && self
-                    .f_mntfromname
-                    .iter()
-                    .zip(other.f_mntfromname.iter())
-                    .all(|(a,b)| a == b)
+                        .f_mntfromname
+                        .iter()
+                        .zip(other.f_mntfromname.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .f_mntonname
-                    .iter()
-                    .zip(other.f_mntonname.iter())
-                    .all(|(a,b)| a == b)
+                        .f_mntonname
+                        .iter()
+                        .zip(other.f_mntonname.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for statfs {}
@@ -394,11 +394,10 @@ cfg_if! {
                     && self.d_reclen == other.d_reclen
                     && self.d_type == other.d_type
                     && self.d_namlen == other.d_namlen
-                    && self
-                    .d_name[..self.d_namlen as _]
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                    && self.d_name[..self.d_namlen as _]
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for dirent {}
@@ -430,14 +429,14 @@ cfg_if! {
                 let self_vn_devname: &[::c_char] = &self.vn_devname;
                 let other_vn_devname: &[::c_char] = &other.vn_devname;
 
-                self.vn_fileid == other.vn_fileid &&
-                self.vn_size == other.vn_size &&
-                self.vn_dev == other.vn_dev &&
-                self.vn_fsid == other.vn_fsid &&
-                self.vn_mntdir == other.vn_mntdir &&
-                self.vn_type == other.vn_type &&
-                self.vn_mode == other.vn_mode &&
-                self_vn_devname == other_vn_devname
+                self.vn_fileid == other.vn_fileid
+                    && self.vn_size == other.vn_size
+                    && self.vn_dev == other.vn_dev
+                    && self.vn_fsid == other.vn_fsid
+                    && self.vn_mntdir == other.vn_mntdir
+                    && self.vn_type == other.vn_type
+                    && self.vn_mode == other.vn_mode
+                    && self_vn_devname == other_vn_devname
             }
         }
         impl Eq for vnstat {}

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -339,15 +339,15 @@ cfg_if! {
                     && self.f_fsid == other.f_fsid
                     && self.f_fstypename == other.f_fstypename
                     && self
-                    .f_mntfromname
-                    .iter()
-                    .zip(other.f_mntfromname.iter())
-                    .all(|(a,b)| a == b)
+                        .f_mntfromname
+                        .iter()
+                        .zip(other.f_mntfromname.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .f_mntonname
-                    .iter()
-                    .zip(other.f_mntonname.iter())
-                    .all(|(a,b)| a == b)
+                        .f_mntonname
+                        .iter()
+                        .zip(other.f_mntonname.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for statfs {}
@@ -407,11 +407,10 @@ cfg_if! {
                     && self.d_reclen == other.d_reclen
                     && self.d_type == other.d_type
                     && self.d_namlen == other.d_namlen
-                    && self
-                    .d_name[..self.d_namlen as _]
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                    && self.d_name[..self.d_namlen as _]
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for dirent {}
@@ -443,14 +442,14 @@ cfg_if! {
                 let self_vn_devname: &[::c_char] = &self.vn_devname;
                 let other_vn_devname: &[::c_char] = &other.vn_devname;
 
-                self.vn_fileid == other.vn_fileid &&
-                self.vn_size == other.vn_size &&
-                self.vn_dev == other.vn_dev &&
-                self.vn_fsid == other.vn_fsid &&
-                self.vn_mntdir == other.vn_mntdir &&
-                self.vn_type == other.vn_type &&
-                self.vn_mode == other.vn_mode &&
-                self_vn_devname == other_vn_devname
+                self.vn_fileid == other.vn_fileid
+                    && self.vn_size == other.vn_size
+                    && self.vn_dev == other.vn_dev
+                    && self.vn_fsid == other.vn_fsid
+                    && self.vn_mntdir == other.vn_mntdir
+                    && self.vn_type == other.vn_type
+                    && self.vn_mode == other.vn_mode
+                    && self_vn_devname == other_vn_devname
             }
         }
         impl Eq for vnstat {}

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -339,15 +339,15 @@ cfg_if! {
                     && self.f_fsid == other.f_fsid
                     && self.f_fstypename == other.f_fstypename
                     && self
-                    .f_mntfromname
-                    .iter()
-                    .zip(other.f_mntfromname.iter())
-                    .all(|(a,b)| a == b)
+                        .f_mntfromname
+                        .iter()
+                        .zip(other.f_mntfromname.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .f_mntonname
-                    .iter()
-                    .zip(other.f_mntonname.iter())
-                    .all(|(a,b)| a == b)
+                        .f_mntonname
+                        .iter()
+                        .zip(other.f_mntonname.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for statfs {}
@@ -407,11 +407,10 @@ cfg_if! {
                     && self.d_reclen == other.d_reclen
                     && self.d_type == other.d_type
                     && self.d_namlen == other.d_namlen
-                    && self
-                    .d_name[..self.d_namlen as _]
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                    && self.d_name[..self.d_namlen as _]
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for dirent {}
@@ -443,14 +442,14 @@ cfg_if! {
                 let self_vn_devname: &[::c_char] = &self.vn_devname;
                 let other_vn_devname: &[::c_char] = &other.vn_devname;
 
-                self.vn_fileid == other.vn_fileid &&
-                self.vn_size == other.vn_size &&
-                self.vn_dev == other.vn_dev &&
-                self.vn_fsid == other.vn_fsid &&
-                self.vn_mntdir == other.vn_mntdir &&
-                self.vn_type == other.vn_type &&
-                self.vn_mode == other.vn_mode &&
-                self_vn_devname == other_vn_devname
+                self.vn_fileid == other.vn_fileid
+                    && self.vn_size == other.vn_size
+                    && self.vn_dev == other.vn_dev
+                    && self.vn_fsid == other.vn_fsid
+                    && self.vn_mntdir == other.vn_mntdir
+                    && self.vn_type == other.vn_type
+                    && self.vn_mode == other.vn_mode
+                    && self_vn_devname == other_vn_devname
             }
         }
         impl Eq for vnstat {}

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
@@ -339,15 +339,15 @@ cfg_if! {
                     && self.f_fsid == other.f_fsid
                     && self.f_fstypename == other.f_fstypename
                     && self
-                    .f_mntfromname
-                    .iter()
-                    .zip(other.f_mntfromname.iter())
-                    .all(|(a,b)| a == b)
+                        .f_mntfromname
+                        .iter()
+                        .zip(other.f_mntfromname.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .f_mntonname
-                    .iter()
-                    .zip(other.f_mntonname.iter())
-                    .all(|(a,b)| a == b)
+                        .f_mntonname
+                        .iter()
+                        .zip(other.f_mntonname.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for statfs {}
@@ -407,11 +407,10 @@ cfg_if! {
                     && self.d_reclen == other.d_reclen
                     && self.d_type == other.d_type
                     && self.d_namlen == other.d_namlen
-                    && self
-                    .d_name[..self.d_namlen as _]
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                    && self.d_name[..self.d_namlen as _]
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for dirent {}
@@ -443,14 +442,14 @@ cfg_if! {
                 let self_vn_devname: &[::c_char] = &self.vn_devname;
                 let other_vn_devname: &[::c_char] = &other.vn_devname;
 
-                self.vn_fileid == other.vn_fileid &&
-                self.vn_size == other.vn_size &&
-                self.vn_dev == other.vn_dev &&
-                self.vn_fsid == other.vn_fsid &&
-                self.vn_mntdir == other.vn_mntdir &&
-                self.vn_type == other.vn_type &&
-                self.vn_mode == other.vn_mode &&
-                self_vn_devname == other_vn_devname
+                self.vn_fileid == other.vn_fileid
+                    && self.vn_size == other.vn_size
+                    && self.vn_dev == other.vn_dev
+                    && self.vn_fsid == other.vn_fsid
+                    && self.vn_mntdir == other.vn_mntdir
+                    && self.vn_type == other.vn_type
+                    && self.vn_mode == other.vn_mode
+                    && self_vn_devname == other_vn_devname
             }
         }
         impl Eq for vnstat {}

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -249,7 +249,7 @@ s! {
         __unused3: ::c_long,
         __unused4: ::c_long,
         __unused5: *mut ::c_void,
-        pub aio_sigevent: sigevent
+        pub aio_sigevent: sigevent,
     }
 
     pub struct jail {
@@ -388,7 +388,6 @@ s! {
         #[cfg(target_pointer_width = "32")]
         m_pad: u32,
         m_spare: [u32; 2],
-
     }
 
     pub struct ucond {
@@ -609,7 +608,7 @@ s! {
 
     pub struct spacectl_range {
         pub r_offset: ::off_t,
-        pub r_len: ::off_t
+        pub r_len: ::off_t,
     }
 
     pub struct rusage_ext {
@@ -1392,7 +1391,7 @@ s_no_extra_traits! {
         pub mq_maxmsg: ::c_long,
         pub mq_msgsize: ::c_long,
         pub mq_curmsgs: ::c_long,
-        __reserved: [::c_long; 4]
+        __reserved: [::c_long; 4],
     }
 
     pub struct sigevent {
@@ -1404,7 +1403,7 @@ s_no_extra_traits! {
         pub sigev_notify_thread_id: ::lwpid_t,
         #[cfg(target_pointer_width = "64")]
         __unused1: ::c_int,
-        __unused2: [::c_long; 7]
+        __unused2: [::c_long; 7],
     }
 
     pub struct ptsstat {
@@ -1629,7 +1628,7 @@ s_no_extra_traits! {
         pub kf_flags: ::c_int,
         _kf_pad0: ::c_int,
         pub kf_offset: i64,
-        _priv: [u8; 304],   // FIXME: this is really a giant union
+        _priv: [u8; 304], // FIXME: this is really a giant union
         pub kf_status: u16,
         _kf_pad1: u16,
         _kf_ispare0: ::c_int,
@@ -1659,15 +1658,15 @@ cfg_if! {
                     && self.ut_user == other.ut_user
                     && self.ut_line == other.ut_line
                     && self
-                    .ut_host
-                    .iter()
-                    .zip(other.ut_host.iter())
-                    .all(|(a,b)| a == b)
+                        .ut_host
+                        .iter()
+                        .zip(other.ut_host.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .__ut_spare
-                    .iter()
-                    .zip(other.__ut_spare.iter())
-                    .all(|(a,b)| a == b)
+                        .__ut_spare
+                        .iter()
+                        .zip(other.__ut_spare.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for utmpx {}
@@ -1700,7 +1699,7 @@ cfg_if! {
 
         impl PartialEq for __c_anonymous_cr_pid {
             fn eq(&self, other: &__c_anonymous_cr_pid) -> bool {
-                unsafe { self.cr_pid == other.cr_pid}
+                unsafe { self.cr_pid == other.cr_pid }
             }
         }
         impl Eq for __c_anonymous_cr_pid {}
@@ -1758,10 +1757,10 @@ cfg_if! {
                     && self.sdl_alen == other.sdl_alen
                     && self.sdl_slen == other.sdl_slen
                     && self
-                    .sdl_data
-                    .iter()
-                    .zip(other.sdl_data.iter())
-                    .all(|(a,b)| a == b)
+                        .sdl_data
+                        .iter()
+                        .zip(other.sdl_data.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for sockaddr_dl {}
@@ -1794,10 +1793,10 @@ cfg_if! {
 
         impl PartialEq for mq_attr {
             fn eq(&self, other: &mq_attr) -> bool {
-                self.mq_flags == other.mq_flags &&
-                self.mq_maxmsg == other.mq_maxmsg &&
-                self.mq_msgsize == other.mq_msgsize &&
-                self.mq_curmsgs == other.mq_curmsgs
+                self.mq_flags == other.mq_flags
+                    && self.mq_maxmsg == other.mq_maxmsg
+                    && self.mq_msgsize == other.mq_msgsize
+                    && self.mq_curmsgs == other.mq_curmsgs
             }
         }
         impl Eq for mq_attr {}
@@ -1825,8 +1824,7 @@ cfg_if! {
                 self.sigev_notify == other.sigev_notify
                     && self.sigev_signo == other.sigev_signo
                     && self.sigev_value == other.sigev_value
-                    && self.sigev_notify_thread_id
-                        == other.sigev_notify_thread_id
+                    && self.sigev_notify_thread_id == other.sigev_notify_thread_id
             }
         }
         impl Eq for sigevent {}
@@ -1836,8 +1834,7 @@ cfg_if! {
                     .field("sigev_notify", &self.sigev_notify)
                     .field("sigev_signo", &self.sigev_signo)
                     .field("sigev_value", &self.sigev_value)
-                    .field("sigev_notify_thread_id",
-                           &self.sigev_notify_thread_id)
+                    .field("sigev_notify_thread_id", &self.sigev_notify_thread_id)
                     .finish()
             }
         }
@@ -1880,7 +1877,7 @@ cfg_if! {
 
         impl PartialEq for __c_anonymous_elf32_auxv_union {
             fn eq(&self, other: &__c_anonymous_elf32_auxv_union) -> bool {
-                unsafe { self.a_val == other.a_val}
+                unsafe { self.a_val == other.a_val }
             }
         }
         impl Eq for __c_anonymous_elf32_auxv_union {}
@@ -1893,8 +1890,7 @@ cfg_if! {
         }
         impl PartialEq for Elf32_Auxinfo {
             fn eq(&self, other: &Elf32_Auxinfo) -> bool {
-                self.a_type == other.a_type
-                    && self.a_un == other.a_un
+                self.a_type == other.a_type && self.a_un == other.a_un
             }
         }
         impl Eq for Elf32_Auxinfo {}
@@ -1910,21 +1906,21 @@ cfg_if! {
         impl PartialEq for __c_anonymous_ifr_ifru {
             fn eq(&self, other: &__c_anonymous_ifr_ifru) -> bool {
                 unsafe {
-                    self.ifru_addr == other.ifru_addr &&
-                    self.ifru_dstaddr == other.ifru_dstaddr &&
-                    self.ifru_broadaddr == other.ifru_broadaddr &&
-                    self.ifru_buffer == other.ifru_buffer &&
-                    self.ifru_flags == other.ifru_flags &&
-                    self.ifru_index == other.ifru_index &&
-                    self.ifru_jid == other.ifru_jid &&
-                    self.ifru_metric == other.ifru_metric &&
-                    self.ifru_mtu == other.ifru_mtu &&
-                    self.ifru_phys == other.ifru_phys &&
-                    self.ifru_media == other.ifru_media &&
-                    self.ifru_data == other.ifru_data &&
-                    self.ifru_cap == other.ifru_cap &&
-                    self.ifru_fib == other.ifru_fib &&
-                    self.ifru_vlan_pcp == other.ifru_vlan_pcp
+                    self.ifru_addr == other.ifru_addr
+                        && self.ifru_dstaddr == other.ifru_dstaddr
+                        && self.ifru_broadaddr == other.ifru_broadaddr
+                        && self.ifru_buffer == other.ifru_buffer
+                        && self.ifru_flags == other.ifru_flags
+                        && self.ifru_index == other.ifru_index
+                        && self.ifru_jid == other.ifru_jid
+                        && self.ifru_metric == other.ifru_metric
+                        && self.ifru_mtu == other.ifru_mtu
+                        && self.ifru_phys == other.ifru_phys
+                        && self.ifru_media == other.ifru_media
+                        && self.ifru_data == other.ifru_data
+                        && self.ifru_cap == other.ifru_cap
+                        && self.ifru_fib == other.ifru_fib
+                        && self.ifru_vlan_pcp == other.ifru_vlan_pcp
                 }
             }
         }
@@ -1995,10 +1991,7 @@ cfg_if! {
 
         impl PartialEq for __c_anonymous_ifc_ifcu {
             fn eq(&self, other: &__c_anonymous_ifc_ifcu) -> bool {
-                unsafe {
-                    self.ifcu_buf == other.ifcu_buf &&
-                    self.ifcu_req == other.ifcu_req
-                }
+                unsafe { self.ifcu_buf == other.ifcu_buf && self.ifcu_req == other.ifcu_req }
             }
         }
 
@@ -2049,11 +2042,11 @@ cfg_if! {
                 let self_ifrk_key: &[u8] = &self.ifrk_key;
                 let other_ifrk_key: &[u8] = &other.ifrk_key;
 
-                self.ifrk_name == other.ifrk_name &&
-                self.ifrk_func == other.ifrk_func &&
-                self.ifrk_spare0 == other.ifrk_spare0 &&
-                self.ifrk_keylen == other.ifrk_keylen &&
-                self_ifrk_key == other_ifrk_key
+                self.ifrk_name == other.ifrk_name
+                    && self.ifrk_func == other.ifrk_func
+                    && self.ifrk_spare0 == other.ifrk_spare0
+                    && self.ifrk_keylen == other.ifrk_keylen
+                    && self_ifrk_key == other_ifrk_key
             }
         }
         impl Eq for ifrsskey {}
@@ -2085,10 +2078,10 @@ cfg_if! {
                 let self_ifdr_msg: &[::c_char] = &self.ifdr_msg;
                 let other_ifdr_msg: &[::c_char] = &other.ifdr_msg;
 
-                self.ifdr_name == other.ifdr_name &&
-                self.ifdr_reason == other.ifdr_reason &&
-                self.ifdr_vendor == other.ifdr_vendor &&
-                self_ifdr_msg == other_ifdr_msg
+                self.ifdr_name == other.ifdr_name
+                    && self.ifdr_reason == other.ifdr_reason
+                    && self.ifdr_vendor == other.ifdr_vendor
+                    && self_ifdr_msg == other_ifdr_msg
             }
         }
         impl Eq for ifdownreason {}
@@ -2115,10 +2108,7 @@ cfg_if! {
 
         impl PartialEq for __c_anonymous_ifi_epoch {
             fn eq(&self, other: &__c_anonymous_ifi_epoch) -> bool {
-                unsafe {
-                    self.tt == other.tt &&
-                    self.ph == other.ph
-                }
+                unsafe { self.tt == other.tt && self.ph == other.ph }
             }
         }
         impl Eq for __c_anonymous_ifi_epoch {}
@@ -2141,10 +2131,7 @@ cfg_if! {
 
         impl PartialEq for __c_anonymous_ifi_lastchange {
             fn eq(&self, other: &__c_anonymous_ifi_lastchange) -> bool {
-                unsafe {
-                    self.tv == other.tv &&
-                    self.ph == other.ph
-                }
+                unsafe { self.tv == other.tv && self.ph == other.ph }
             }
         }
         impl Eq for __c_anonymous_ifi_lastchange {}
@@ -2167,31 +2154,31 @@ cfg_if! {
 
         impl PartialEq for if_data {
             fn eq(&self, other: &if_data) -> bool {
-                self.ifi_type == other.ifi_type &&
-                self.ifi_physical == other.ifi_physical &&
-                self.ifi_addrlen == other.ifi_addrlen &&
-                self.ifi_hdrlen == other.ifi_hdrlen &&
-                self.ifi_link_state == other.ifi_link_state &&
-                self.ifi_vhid == other.ifi_vhid &&
-                self.ifi_datalen == other.ifi_datalen &&
-                self.ifi_mtu == other.ifi_mtu &&
-                self.ifi_metric == other.ifi_metric &&
-                self.ifi_baudrate == other.ifi_baudrate &&
-                self.ifi_ipackets == other.ifi_ipackets &&
-                self.ifi_ierrors == other.ifi_ierrors &&
-                self.ifi_opackets == other.ifi_opackets &&
-                self.ifi_oerrors == other.ifi_oerrors &&
-                self.ifi_collisions == other.ifi_collisions &&
-                self.ifi_ibytes == other.ifi_ibytes &&
-                self.ifi_obytes == other.ifi_obytes &&
-                self.ifi_imcasts == other.ifi_imcasts &&
-                self.ifi_omcasts == other.ifi_omcasts &&
-                self.ifi_iqdrops == other.ifi_iqdrops &&
-                self.ifi_oqdrops == other.ifi_oqdrops &&
-                self.ifi_noproto == other.ifi_noproto &&
-                self.ifi_hwassist == other.ifi_hwassist &&
-                self.__ifi_epoch == other.__ifi_epoch &&
-                self.__ifi_lastchange == other.__ifi_lastchange
+                self.ifi_type == other.ifi_type
+                    && self.ifi_physical == other.ifi_physical
+                    && self.ifi_addrlen == other.ifi_addrlen
+                    && self.ifi_hdrlen == other.ifi_hdrlen
+                    && self.ifi_link_state == other.ifi_link_state
+                    && self.ifi_vhid == other.ifi_vhid
+                    && self.ifi_datalen == other.ifi_datalen
+                    && self.ifi_mtu == other.ifi_mtu
+                    && self.ifi_metric == other.ifi_metric
+                    && self.ifi_baudrate == other.ifi_baudrate
+                    && self.ifi_ipackets == other.ifi_ipackets
+                    && self.ifi_ierrors == other.ifi_ierrors
+                    && self.ifi_opackets == other.ifi_opackets
+                    && self.ifi_oerrors == other.ifi_oerrors
+                    && self.ifi_collisions == other.ifi_collisions
+                    && self.ifi_ibytes == other.ifi_ibytes
+                    && self.ifi_obytes == other.ifi_obytes
+                    && self.ifi_imcasts == other.ifi_imcasts
+                    && self.ifi_omcasts == other.ifi_omcasts
+                    && self.ifi_iqdrops == other.ifi_iqdrops
+                    && self.ifi_oqdrops == other.ifi_oqdrops
+                    && self.ifi_noproto == other.ifi_noproto
+                    && self.ifi_hwassist == other.ifi_hwassist
+                    && self.__ifi_epoch == other.__ifi_epoch
+                    && self.__ifi_lastchange == other.__ifi_lastchange
             }
         }
         impl Eq for if_data {}
@@ -2258,313 +2245,319 @@ cfg_if! {
 
         impl PartialEq for sctphdr {
             fn eq(&self, other: &sctphdr) -> bool {
-                return {self.src_port} == {other.src_port} &&
-                {self.dest_port} == {other.dest_port} &&
-                {self.v_tag} == {other.v_tag} &&
-                {self.checksum} == {other.checksum}
+                return { self.src_port } == { other.src_port }
+                    && { self.dest_port } == { other.dest_port }
+                    && { self.v_tag } == { other.v_tag }
+                    && { self.checksum } == { other.checksum };
             }
         }
         impl Eq for sctphdr {}
         impl ::fmt::Debug for sctphdr {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("sctphdr")
-                    .field("src_port", &{self.src_port})
-                    .field("dest_port", &{self.dest_port})
-                    .field("v_tag", &{self.v_tag})
-                    .field("checksum", &{self.checksum})
+                    .field("src_port", &{ self.src_port })
+                    .field("dest_port", &{ self.dest_port })
+                    .field("v_tag", &{ self.v_tag })
+                    .field("checksum", &{ self.checksum })
                     .finish()
             }
         }
         impl ::hash::Hash for sctphdr {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                {self.src_port}.hash(state);
-                {self.dest_port}.hash(state);
-                {self.v_tag}.hash(state);
-                {self.checksum}.hash(state);
+                { self.src_port }.hash(state);
+                { self.dest_port }.hash(state);
+                { self.v_tag }.hash(state);
+                { self.checksum }.hash(state);
             }
         }
 
         impl PartialEq for sctp_chunkhdr {
             fn eq(&self, other: &sctp_chunkhdr) -> bool {
-                return {self.chunk_type} == {other.chunk_type} &&
-                {self.chunk_flags} == {other.chunk_flags} &&
-                {self.chunk_length} == {other.chunk_length}
+                return { self.chunk_type } == { other.chunk_type }
+                    && { self.chunk_flags } == { other.chunk_flags }
+                    && { self.chunk_length } == { other.chunk_length };
             }
         }
         impl Eq for sctp_chunkhdr {}
         impl ::fmt::Debug for sctp_chunkhdr {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("sctp_chunkhdr")
-                    .field("chunk_type", &{self.chunk_type})
-                    .field("chunk_flags", &{self.chunk_flags})
-                    .field("chunk_length", &{self.chunk_length})
+                    .field("chunk_type", &{ self.chunk_type })
+                    .field("chunk_flags", &{ self.chunk_flags })
+                    .field("chunk_length", &{ self.chunk_length })
                     .finish()
             }
         }
         impl ::hash::Hash for sctp_chunkhdr {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                {self.chunk_type}.hash(state);
-                {self.chunk_flags}.hash(state);
-                {self.chunk_length}.hash(state);
+                { self.chunk_type }.hash(state);
+                { self.chunk_flags }.hash(state);
+                { self.chunk_length }.hash(state);
             }
         }
 
         impl PartialEq for sctp_paramhdr {
             fn eq(&self, other: &sctp_paramhdr) -> bool {
-                return {self.param_type} == {other.param_type} &&
-                {self.param_length} == {other.param_length}
+                return { self.param_type } == { other.param_type } && { self.param_length } == {
+                    other.param_length
+                };
             }
         }
         impl Eq for sctp_paramhdr {}
         impl ::fmt::Debug for sctp_paramhdr {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("sctp_paramhdr")
-                    .field("param_type", &{self.param_type})
-                    .field("param_length", &{self.param_length})
+                    .field("param_type", &{ self.param_type })
+                    .field("param_length", &{ self.param_length })
                     .finish()
             }
         }
         impl ::hash::Hash for sctp_paramhdr {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                {self.param_type}.hash(state);
-                {self.param_length}.hash(state);
+                { self.param_type }.hash(state);
+                { self.param_length }.hash(state);
             }
         }
 
         impl PartialEq for sctp_gen_error_cause {
             fn eq(&self, other: &sctp_gen_error_cause) -> bool {
-                return {self.code} == {other.code} &&
-                {self.length} == {other.length} &&
-                {self.info}.iter().zip({other.info}.iter()).all(|(a,b)| a == b)
+                return { self.code } == { other.code } && { self.length } == { other.length } && {
+                    self.info
+                }
+                .iter()
+                .zip({ other.info }.iter())
+                .all(|(a, b)| a == b);
             }
         }
         impl Eq for sctp_gen_error_cause {}
         impl ::fmt::Debug for sctp_gen_error_cause {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("sctp_gen_error_cause")
-                    .field("code", &{self.code})
-                    .field("length", &{self.length})
+                    .field("code", &{ self.code })
+                    .field("length", &{ self.length })
                     // FIXME: .field("info", &{self.info})
                     .finish()
             }
         }
         impl ::hash::Hash for sctp_gen_error_cause {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                {self.code}.hash(state);
-                {self.length}.hash(state);
-                {self.info}.hash(state);
+                { self.code }.hash(state);
+                { self.length }.hash(state);
+                { self.info }.hash(state);
             }
         }
 
         impl PartialEq for sctp_error_cause {
             fn eq(&self, other: &sctp_error_cause) -> bool {
-                return {self.code} == {other.code} &&
-                {self.length} == {other.length}
+                return { self.code } == { other.code } && { self.length } == { other.length };
             }
         }
         impl Eq for sctp_error_cause {}
         impl ::fmt::Debug for sctp_error_cause {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("sctp_error_cause")
-                    .field("code", &{self.code})
-                    .field("length", &{self.length})
+                    .field("code", &{ self.code })
+                    .field("length", &{ self.length })
                     .finish()
             }
         }
         impl ::hash::Hash for sctp_error_cause {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                {self.code}.hash(state);
-                {self.length}.hash(state);
+                { self.code }.hash(state);
+                { self.length }.hash(state);
             }
         }
 
         impl PartialEq for sctp_error_invalid_stream {
             fn eq(&self, other: &sctp_error_invalid_stream) -> bool {
-                return {self.cause} == {other.cause} &&
-                {self.stream_id} == {other.stream_id}
+                return { self.cause } == { other.cause } && { self.stream_id } == {
+                    other.stream_id
+                };
             }
         }
         impl Eq for sctp_error_invalid_stream {}
         impl ::fmt::Debug for sctp_error_invalid_stream {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("sctp_error_invalid_stream")
-                    .field("cause", &{self.cause})
-                    .field("stream_id", &{self.stream_id})
+                    .field("cause", &{ self.cause })
+                    .field("stream_id", &{ self.stream_id })
                     .finish()
             }
         }
         impl ::hash::Hash for sctp_error_invalid_stream {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                {self.cause}.hash(state);
-                {self.stream_id}.hash(state);
+                { self.cause }.hash(state);
+                { self.stream_id }.hash(state);
             }
         }
 
         impl PartialEq for sctp_error_missing_param {
             fn eq(&self, other: &sctp_error_missing_param) -> bool {
-                return {self.cause} == {other.cause} &&
-                {self.num_missing_params} == {other.num_missing_params} &&
-                {self.tpe}.iter().zip({other.tpe}.iter()).all(|(a,b)| a == b)
+                return { self.cause } == { other.cause }
+                    && { self.num_missing_params } == { other.num_missing_params }
+                    && { self.tpe }
+                        .iter()
+                        .zip({ other.tpe }.iter())
+                        .all(|(a, b)| a == b);
             }
         }
         impl Eq for sctp_error_missing_param {}
         impl ::fmt::Debug for sctp_error_missing_param {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("sctp_error_missing_param")
-                    .field("cause", &{self.cause})
-                    .field("num_missing_params", &{self.num_missing_params})
+                    .field("cause", &{ self.cause })
+                    .field("num_missing_params", &{ self.num_missing_params })
                     // FIXME: .field("tpe", &{self.tpe})
                     .finish()
             }
         }
         impl ::hash::Hash for sctp_error_missing_param {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                {self.cause}.hash(state);
-                {self.num_missing_params}.hash(state);
-                {self.tpe}.hash(state);
+                { self.cause }.hash(state);
+                { self.num_missing_params }.hash(state);
+                { self.tpe }.hash(state);
             }
         }
 
         impl PartialEq for sctp_error_stale_cookie {
             fn eq(&self, other: &sctp_error_stale_cookie) -> bool {
-                return {self.cause} == {other.cause} &&
-                {self.stale_time} == {other.stale_time}
+                return { self.cause } == { other.cause } && { self.stale_time } == {
+                    other.stale_time
+                };
             }
         }
         impl Eq for sctp_error_stale_cookie {}
         impl ::fmt::Debug for sctp_error_stale_cookie {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("sctp_error_stale_cookie")
-                    .field("cause", &{self.cause})
-                    .field("stale_time", &{self.stale_time})
+                    .field("cause", &{ self.cause })
+                    .field("stale_time", &{ self.stale_time })
                     .finish()
             }
         }
         impl ::hash::Hash for sctp_error_stale_cookie {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                {self.cause}.hash(state);
-                {self.stale_time}.hash(state);
+                { self.cause }.hash(state);
+                { self.stale_time }.hash(state);
             }
         }
 
         impl PartialEq for sctp_error_out_of_resource {
             fn eq(&self, other: &sctp_error_out_of_resource) -> bool {
-                return {self.cause} == {other.cause}
+                return { self.cause } == { other.cause };
             }
         }
         impl Eq for sctp_error_out_of_resource {}
         impl ::fmt::Debug for sctp_error_out_of_resource {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("sctp_error_out_of_resource")
-                    .field("cause", &{self.cause})
+                    .field("cause", &{ self.cause })
                     .finish()
             }
         }
         impl ::hash::Hash for sctp_error_out_of_resource {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                {self.cause}.hash(state);
+                { self.cause }.hash(state);
             }
         }
 
         impl PartialEq for sctp_error_unresolv_addr {
             fn eq(&self, other: &sctp_error_unresolv_addr) -> bool {
-                return {self.cause} == {other.cause}
+                return { self.cause } == { other.cause };
             }
         }
         impl Eq for sctp_error_unresolv_addr {}
         impl ::fmt::Debug for sctp_error_unresolv_addr {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("sctp_error_unresolv_addr")
-                    .field("cause", &{self.cause})
+                    .field("cause", &{ self.cause })
                     .finish()
             }
         }
         impl ::hash::Hash for sctp_error_unresolv_addr {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                {self.cause}.hash(state);
+                { self.cause }.hash(state);
             }
         }
 
         impl PartialEq for sctp_error_unrecognized_chunk {
             fn eq(&self, other: &sctp_error_unrecognized_chunk) -> bool {
-                return {self.cause} == {other.cause} &&
-                {self.ch} == {other.ch}
+                return { self.cause } == { other.cause } && { self.ch } == { other.ch };
             }
         }
         impl Eq for sctp_error_unrecognized_chunk {}
         impl ::fmt::Debug for sctp_error_unrecognized_chunk {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("sctp_error_unrecognized_chunk")
-                    .field("cause", &{self.cause})
-                    .field("ch", &{self.ch})
+                    .field("cause", &{ self.cause })
+                    .field("ch", &{ self.ch })
                     .finish()
             }
         }
         impl ::hash::Hash for sctp_error_unrecognized_chunk {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                {self.cause}.hash(state);
-                {self.ch}.hash(state);
+                { self.cause }.hash(state);
+                { self.ch }.hash(state);
             }
         }
 
         impl PartialEq for sctp_error_no_user_data {
             fn eq(&self, other: &sctp_error_no_user_data) -> bool {
-                return {self.cause} == {other.cause} &&
-                {self.tsn} == {other.tsn}
+                return { self.cause } == { other.cause } && { self.tsn } == { other.tsn };
             }
         }
         impl Eq for sctp_error_no_user_data {}
         impl ::fmt::Debug for sctp_error_no_user_data {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("sctp_error_no_user_data")
-                    .field("cause", &{self.cause})
-                    .field("tsn", &{self.tsn})
+                    .field("cause", &{ self.cause })
+                    .field("tsn", &{ self.tsn })
                     .finish()
             }
         }
         impl ::hash::Hash for sctp_error_no_user_data {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                {self.cause}.hash(state);
-                {self.tsn}.hash(state);
+                { self.cause }.hash(state);
+                { self.tsn }.hash(state);
             }
         }
 
         impl PartialEq for sctp_error_auth_invalid_hmac {
             fn eq(&self, other: &sctp_error_auth_invalid_hmac) -> bool {
-                return {self.cause} == {other.cause} &&
-                {self.hmac_id} == {other.hmac_id}
+                return { self.cause } == { other.cause } && { self.hmac_id } == { other.hmac_id };
             }
         }
         impl Eq for sctp_error_auth_invalid_hmac {}
         impl ::fmt::Debug for sctp_error_auth_invalid_hmac {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("sctp_error_invalid_hmac")
-                    .field("cause", &{self.cause})
-                    .field("hmac_id", &{self.hmac_id})
+                    .field("cause", &{ self.cause })
+                    .field("hmac_id", &{ self.hmac_id })
                     .finish()
             }
         }
         impl ::hash::Hash for sctp_error_auth_invalid_hmac {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                {self.cause}.hash(state);
-                {self.hmac_id}.hash(state);
+                { self.cause }.hash(state);
+                { self.hmac_id }.hash(state);
             }
         }
 
         impl PartialEq for kinfo_file {
             fn eq(&self, other: &kinfo_file) -> bool {
-                self.kf_structsize == other.kf_structsize &&
-                    self.kf_type == other.kf_type &&
-                    self.kf_fd == other.kf_fd &&
-                    self.kf_ref_count == other.kf_ref_count &&
-                    self.kf_flags == other.kf_flags &&
-                    self.kf_offset == other.kf_offset &&
-                    self.kf_status == other.kf_status &&
-                    self.kf_cap_rights == other.kf_cap_rights &&
-                    self.kf_path
+                self.kf_structsize == other.kf_structsize
+                    && self.kf_type == other.kf_type
+                    && self.kf_fd == other.kf_fd
+                    && self.kf_ref_count == other.kf_ref_count
+                    && self.kf_flags == other.kf_flags
+                    && self.kf_offset == other.kf_offset
+                    && self.kf_status == other.kf_status
+                    && self.kf_cap_rights == other.kf_cap_rights
+                    && self
+                        .kf_path
                         .iter()
                         .zip(other.kf_path.iter())
-                        .all(|(a,b)| a == b)
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for kinfo_file {}
@@ -4925,35 +4918,30 @@ const_fn! {
 
 f! {
     pub fn CMSG_DATA(cmsg: *const ::cmsghdr) -> *mut ::c_uchar {
-        (cmsg as *mut ::c_uchar)
-            .offset(_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
+        (cmsg as *mut ::c_uchar).offset(_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_LEN(length: ::c_uint) -> ::c_uint {
         _ALIGN(::mem::size_of::<::cmsghdr>()) as ::c_uint + length
     }
 
-    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr, cmsg: *const ::cmsghdr)
-        -> *mut ::cmsghdr
-    {
+    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr, cmsg: *const ::cmsghdr) -> *mut ::cmsghdr {
         if cmsg.is_null() {
             return ::CMSG_FIRSTHDR(mhdr);
         };
-        let next = cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize)
+        let next = cmsg as usize
+            + _ALIGN((*cmsg).cmsg_len as usize)
             + _ALIGN(::mem::size_of::<::cmsghdr>());
-        let max = (*mhdr).msg_control as usize
-            + (*mhdr).msg_controllen as usize;
+        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next > max {
             0 as *mut ::cmsghdr
         } else {
-            (cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize))
-                as *mut ::cmsghdr
+            (cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize)) as *mut ::cmsghdr
         }
     }
 
     pub {const} fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
-        (_ALIGN(::mem::size_of::<::cmsghdr>()) + _ALIGN(length as usize))
-            as ::c_uint
+        (_ALIGN(::mem::size_of::<::cmsghdr>()) + _ALIGN(length as usize)) as ::c_uint
     }
 
     pub fn MALLOCX_ALIGN(lg: ::c_uint) -> ::c_int {
@@ -4969,11 +4957,7 @@ f! {
     }
 
     pub fn SOCKCREDSIZE(ngrps: usize) -> usize {
-        let ngrps = if ngrps > 0 {
-            ngrps - 1
-        } else {
-            0
-        };
+        let ngrps = if ngrps > 0 { ngrps - 1 } else { 0 };
         ::mem::size_of::<sockcred>() + ::mem::size_of::<::gid_t>() * ngrps
     }
 
@@ -5020,16 +5004,12 @@ f! {
 
         for i in cpuset.__bits[..(cpuset_size / bitset_size)].iter() {
             s += i.count_ones();
-        };
+        }
         s as ::c_int
     }
 
     pub fn SOCKCRED2SIZE(ngrps: usize) -> usize {
-        let ngrps = if ngrps > 0 {
-            ngrps - 1
-        } else {
-            0
-        };
+        let ngrps = if ngrps > 0 { ngrps - 1 } else { 0 };
         ::mem::size_of::<sockcred2>() + ::mem::size_of::<::gid_t>() * ngrps
     }
 
@@ -5048,8 +5028,15 @@ safe_f! {
     }
 
     pub {const} fn INVALID_SINFO_FLAG(x: ::c_int) -> bool {
-        (x) & 0xfffffff0 & !(SCTP_EOF | SCTP_ABORT | SCTP_UNORDERED |
-        SCTP_ADDR_OVER | SCTP_SENDALL | SCTP_EOR | SCTP_SACK_IMMEDIATELY) != 0
+        (x) & 0xfffffff0
+            & !(SCTP_EOF
+                | SCTP_ABORT
+                | SCTP_UNORDERED
+                | SCTP_ADDR_OVER
+                | SCTP_SENDALL
+                | SCTP_EOR
+                | SCTP_SACK_IMMEDIATELY)
+            != 0
     }
 
     pub {const} fn PR_SCTP_POLICY(x: ::c_int) -> ::c_int {

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
@@ -26,15 +26,15 @@ cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         impl PartialEq for mcontext_t {
             fn eq(&self, other: &mcontext_t) -> bool {
-                self.mc_vers == other.mc_vers &&
-                self.mc_flags == other.mc_flags &&
-                self.mc_onstack == other.mc_onstack &&
-                self.mc_len == other.mc_len &&
-                self.mc_avec == other.mc_avec &&
-                self.mc_av == other.mc_av &&
-                self.mc_frame == other.mc_frame &&
-                self.mc_fpreg == other.mc_fpreg &&
-                self.mc_vsxfpreg == other.mc_vsxfpreg
+                self.mc_vers == other.mc_vers
+                    && self.mc_flags == other.mc_flags
+                    && self.mc_onstack == other.mc_onstack
+                    && self.mc_len == other.mc_len
+                    && self.mc_avec == other.mc_avec
+                    && self.mc_av == other.mc_av
+                    && self.mc_frame == other.mc_frame
+                    && self.mc_fpreg == other.mc_fpreg
+                    && self.mc_vsxfpreg == other.mc_vsxfpreg
             }
         }
         impl Eq for mcontext_t {}

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
@@ -26,15 +26,15 @@ cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         impl PartialEq for mcontext_t {
             fn eq(&self, other: &mcontext_t) -> bool {
-                self.mc_vers == other.mc_vers &&
-                self.mc_flags == other.mc_flags &&
-                self.mc_onstack == other.mc_onstack &&
-                self.mc_len == other.mc_len &&
-                self.mc_avec == other.mc_avec &&
-                self.mc_av == other.mc_av &&
-                self.mc_frame == other.mc_frame &&
-                self.mc_fpreg == other.mc_fpreg &&
-                self.mc_vsxfpreg == other.mc_vsxfpreg
+                self.mc_vers == other.mc_vers
+                    && self.mc_flags == other.mc_flags
+                    && self.mc_onstack == other.mc_onstack
+                    && self.mc_len == other.mc_len
+                    && self.mc_avec == other.mc_avec
+                    && self.mc_av == other.mc_av
+                    && self.mc_frame == other.mc_frame
+                    && self.mc_fpreg == other.mc_fpreg
+                    && self.mc_vsxfpreg == other.mc_vsxfpreg
             }
         }
         impl Eq for mcontext_t {}

--- a/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
@@ -40,15 +40,15 @@ cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         impl PartialEq for gpregs {
             fn eq(&self, other: &gpregs) -> bool {
-                self.gp_ra == other.gp_ra &&
-                self.gp_sp == other.gp_sp &&
-                self.gp_gp == other.gp_gp &&
-                self.gp_tp == other.gp_tp &&
-                self.gp_t.iter().zip(other.gp_t.iter()).all(|(a, b)| a == b) &&
-                self.gp_s.iter().zip(other.gp_s.iter()).all(|(a, b)| a == b) &&
-                self.gp_a.iter().zip(other.gp_a.iter()).all(|(a, b)| a == b) &&
-                self.gp_sepc == other.gp_sepc &&
-                self.gp_sstatus == other.gp_sstatus
+                self.gp_ra == other.gp_ra
+                    && self.gp_sp == other.gp_sp
+                    && self.gp_gp == other.gp_gp
+                    && self.gp_tp == other.gp_tp
+                    && self.gp_t.iter().zip(other.gp_t.iter()).all(|(a, b)| a == b)
+                    && self.gp_s.iter().zip(other.gp_s.iter()).all(|(a, b)| a == b)
+                    && self.gp_a.iter().zip(other.gp_a.iter()).all(|(a, b)| a == b)
+                    && self.gp_sepc == other.gp_sepc
+                    && self.gp_sstatus == other.gp_sstatus
             }
         }
         impl Eq for gpregs {}
@@ -82,10 +82,10 @@ cfg_if! {
         }
         impl PartialEq for fpregs {
             fn eq(&self, other: &fpregs) -> bool {
-                self.fp_x == other.fp_x &&
-                self.fp_fcsr == other.fp_fcsr &&
-                self.fp_flags == other.fp_flags &&
-                self.fp_pad == other.fp_pad
+                self.fp_x == other.fp_x
+                    && self.fp_fcsr == other.fp_fcsr
+                    && self.fp_flags == other.fp_flags
+                    && self.fp_pad == other.fp_pad
             }
         }
         impl Eq for fpregs {}
@@ -109,11 +109,15 @@ cfg_if! {
         }
         impl PartialEq for mcontext_t {
             fn eq(&self, other: &mcontext_t) -> bool {
-                self.mc_gpregs == other.mc_gpregs &&
-                self.mc_fpregs == other.mc_fpregs &&
-                self.mc_flags == other.mc_flags &&
-                self.mc_pad == other.mc_pad &&
-                self.mc_spare.iter().zip(other.mc_spare.iter()).all(|(a, b)| a == b)
+                self.mc_gpregs == other.mc_gpregs
+                    && self.mc_fpregs == other.mc_fpregs
+                    && self.mc_flags == other.mc_flags
+                    && self.mc_pad == other.mc_pad
+                    && self
+                        .mc_spare
+                        .iter()
+                        .zip(other.mc_spare.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for mcontext_t {}

--- a/src/unix/bsd/freebsdlike/freebsd/x86.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86.rs
@@ -49,36 +49,44 @@ cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         impl PartialEq for mcontext_t {
             fn eq(&self, other: &mcontext_t) -> bool {
-                self.mc_onstack == other.mc_onstack &&
-                self.mc_gs == other.mc_gs &&
-                self.mc_fs == other.mc_fs &&
-                self.mc_es == other.mc_es &&
-                self.mc_ds == other.mc_ds &&
-                self.mc_edi == other.mc_edi &&
-                self.mc_esi == other.mc_esi &&
-                self.mc_ebp == other.mc_ebp &&
-                self.mc_isp == other.mc_isp &&
-                self.mc_ebx == other.mc_ebx &&
-                self.mc_edx == other.mc_edx &&
-                self.mc_ecx == other.mc_ecx &&
-                self.mc_eax == other.mc_eax &&
-                self.mc_trapno == other.mc_trapno &&
-                self.mc_err == other.mc_err &&
-                self.mc_eip == other.mc_eip &&
-                self.mc_cs == other.mc_cs &&
-                self.mc_eflags == other.mc_eflags &&
-                self.mc_esp == other.mc_esp &&
-                self.mc_ss == other.mc_ss &&
-                self.mc_len == other.mc_len &&
-                self.mc_fpformat == other.mc_fpformat &&
-                self.mc_ownedfp == other.mc_ownedfp &&
-                self.mc_flags == other.mc_flags &&
-                self.mc_fpstate.iter().zip(other.mc_fpstate.iter()).all(|(a, b)| a == b) &&
-                self.mc_fsbase == other.mc_fsbase &&
-                self.mc_gsbase == other.mc_gsbase &&
-                self.mc_xfpustate == other.mc_xfpustate &&
-                self.mc_xfpustate_len == other.mc_xfpustate_len &&
-                self.mc_spare2.iter().zip(other.mc_spare2.iter()).all(|(a, b)| a == b)
+                self.mc_onstack == other.mc_onstack
+                    && self.mc_gs == other.mc_gs
+                    && self.mc_fs == other.mc_fs
+                    && self.mc_es == other.mc_es
+                    && self.mc_ds == other.mc_ds
+                    && self.mc_edi == other.mc_edi
+                    && self.mc_esi == other.mc_esi
+                    && self.mc_ebp == other.mc_ebp
+                    && self.mc_isp == other.mc_isp
+                    && self.mc_ebx == other.mc_ebx
+                    && self.mc_edx == other.mc_edx
+                    && self.mc_ecx == other.mc_ecx
+                    && self.mc_eax == other.mc_eax
+                    && self.mc_trapno == other.mc_trapno
+                    && self.mc_err == other.mc_err
+                    && self.mc_eip == other.mc_eip
+                    && self.mc_cs == other.mc_cs
+                    && self.mc_eflags == other.mc_eflags
+                    && self.mc_esp == other.mc_esp
+                    && self.mc_ss == other.mc_ss
+                    && self.mc_len == other.mc_len
+                    && self.mc_fpformat == other.mc_fpformat
+                    && self.mc_ownedfp == other.mc_ownedfp
+                    && self.mc_flags == other.mc_flags
+                    && self
+                        .mc_fpstate
+                        .iter()
+                        .zip(other.mc_fpstate.iter())
+                        .all(|(a, b)| a == b)
+                    && self.mc_fsbase == other.mc_fsbase
+                    && self.mc_gsbase == other.mc_gsbase
+                    && self.mc_xfpustate == other.mc_xfpustate
+                    && self.mc_xfpustate_len == other.mc_xfpustate_len
+                    && self
+                        .mc_spare2
+                        .iter()
+                        .zip(other.mc_spare2.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for mcontext_t {}

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -96,7 +96,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
-        priv_: [f64; 4]
+        priv_: [f64; 4],
     }
 
     #[repr(align(16))]
@@ -146,13 +146,14 @@ cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         impl PartialEq for fpreg32 {
             fn eq(&self, other: &fpreg32) -> bool {
-                self.fpr_env == other.fpr_env &&
-                    self.fpr_acc == other.fpr_acc &&
-                    self.fpr_ex_sw == other.fpr_ex_sw &&
-                    self.fpr_pad
+                self.fpr_env == other.fpr_env
+                    && self.fpr_acc == other.fpr_acc
+                    && self.fpr_ex_sw == other.fpr_ex_sw
+                    && self
+                        .fpr_pad
                         .iter()
                         .zip(other.fpr_pad.iter())
-                        .all(|(a,b)| a == b)
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for fpreg32 {}
@@ -177,10 +178,10 @@ cfg_if! {
 
         impl PartialEq for fpreg {
             fn eq(&self, other: &fpreg) -> bool {
-                self.fpr_env == other.fpr_env &&
-                    self.fpr_acc == other.fpr_acc &&
-                    self.fpr_xacc == other.fpr_xacc &&
-                    self.fpr_spare == other.fpr_spare
+                self.fpr_env == other.fpr_env
+                    && self.fpr_acc == other.fpr_acc
+                    && self.fpr_xacc == other.fpr_xacc
+                    && self.fpr_spare == other.fpr_spare
             }
         }
         impl Eq for fpreg {}
@@ -205,13 +206,14 @@ cfg_if! {
 
         impl PartialEq for xmmreg {
             fn eq(&self, other: &xmmreg) -> bool {
-                self.xmm_env == other.xmm_env &&
-                    self.xmm_acc == other.xmm_acc &&
-                    self.xmm_reg == other.xmm_reg &&
-                    self.xmm_pad
+                self.xmm_env == other.xmm_env
+                    && self.xmm_acc == other.xmm_acc
+                    && self.xmm_reg == other.xmm_reg
+                    && self
+                        .xmm_pad
                         .iter()
                         .zip(other.xmm_pad.iter())
-                        .all(|(a,b)| a == b)
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for xmmreg {}
@@ -236,9 +238,11 @@ cfg_if! {
 
         impl PartialEq for __c_anonymous_elf64_auxv_union {
             fn eq(&self, other: &__c_anonymous_elf64_auxv_union) -> bool {
-                unsafe { self.a_val == other.a_val
+                unsafe {
+                    self.a_val == other.a_val
                         || self.a_ptr == other.a_ptr
-                        || self.a_fcn == other.a_fcn }
+                        || self.a_fcn == other.a_fcn
+                }
             }
         }
         impl Eq for __c_anonymous_elf64_auxv_union {}
@@ -251,8 +255,7 @@ cfg_if! {
         }
         impl PartialEq for Elf64_Auxinfo {
             fn eq(&self, other: &Elf64_Auxinfo) -> bool {
-                self.a_type == other.a_type
-                    && self.a_un == other.a_un
+                self.a_type == other.a_type && self.a_un == other.a_un
             }
         }
         impl Eq for Elf64_Auxinfo {}
@@ -265,48 +268,50 @@ cfg_if! {
             }
         }
 
-
         impl PartialEq for mcontext_t {
             fn eq(&self, other: &mcontext_t) -> bool {
-                self.mc_onstack == other.mc_onstack &&
-                self.mc_rdi == other.mc_rdi &&
-                self.mc_rsi == other.mc_rsi &&
-                self.mc_rdx == other.mc_rdx &&
-                self.mc_rcx == other.mc_rcx &&
-                self.mc_r8 == other.mc_r8 &&
-                self.mc_r9 == other.mc_r9 &&
-                self.mc_rax == other.mc_rax &&
-                self.mc_rbx == other.mc_rbx &&
-                self.mc_rbp == other.mc_rbp &&
-                self.mc_r10 == other.mc_r10 &&
-                self.mc_r11 == other.mc_r11 &&
-                self.mc_r12 == other.mc_r12 &&
-                self.mc_r13 == other.mc_r13 &&
-                self.mc_r14 == other.mc_r14 &&
-                self.mc_r15 == other.mc_r15 &&
-                self.mc_trapno == other.mc_trapno &&
-                self.mc_fs == other.mc_fs &&
-                self.mc_gs == other.mc_gs &&
-                self.mc_addr == other.mc_addr &&
-                self.mc_flags == other.mc_flags &&
-                self.mc_es == other.mc_es &&
-                self.mc_ds == other.mc_ds &&
-                self.mc_err == other.mc_err &&
-                self.mc_rip == other.mc_rip &&
-                self.mc_cs == other.mc_cs &&
-                self.mc_rflags == other.mc_rflags &&
-                self.mc_rsp == other.mc_rsp &&
-                self.mc_ss == other.mc_ss &&
-                self.mc_len == other.mc_len &&
-                self.mc_fpformat == other.mc_fpformat &&
-                self.mc_ownedfp == other.mc_ownedfp &&
-                self.mc_fpstate.iter().zip(other.mc_fpstate.iter())
-                .all(|(a, b)| a == b) &&
-                self.mc_fsbase == other.mc_fsbase &&
-                self.mc_gsbase == other.mc_gsbase &&
-                self.mc_xfpustate == other.mc_xfpustate &&
-                self.mc_xfpustate_len == other.mc_xfpustate_len &&
-                self.mc_spare == other.mc_spare
+                self.mc_onstack == other.mc_onstack
+                    && self.mc_rdi == other.mc_rdi
+                    && self.mc_rsi == other.mc_rsi
+                    && self.mc_rdx == other.mc_rdx
+                    && self.mc_rcx == other.mc_rcx
+                    && self.mc_r8 == other.mc_r8
+                    && self.mc_r9 == other.mc_r9
+                    && self.mc_rax == other.mc_rax
+                    && self.mc_rbx == other.mc_rbx
+                    && self.mc_rbp == other.mc_rbp
+                    && self.mc_r10 == other.mc_r10
+                    && self.mc_r11 == other.mc_r11
+                    && self.mc_r12 == other.mc_r12
+                    && self.mc_r13 == other.mc_r13
+                    && self.mc_r14 == other.mc_r14
+                    && self.mc_r15 == other.mc_r15
+                    && self.mc_trapno == other.mc_trapno
+                    && self.mc_fs == other.mc_fs
+                    && self.mc_gs == other.mc_gs
+                    && self.mc_addr == other.mc_addr
+                    && self.mc_flags == other.mc_flags
+                    && self.mc_es == other.mc_es
+                    && self.mc_ds == other.mc_ds
+                    && self.mc_err == other.mc_err
+                    && self.mc_rip == other.mc_rip
+                    && self.mc_cs == other.mc_cs
+                    && self.mc_rflags == other.mc_rflags
+                    && self.mc_rsp == other.mc_rsp
+                    && self.mc_ss == other.mc_ss
+                    && self.mc_len == other.mc_len
+                    && self.mc_fpformat == other.mc_fpformat
+                    && self.mc_ownedfp == other.mc_ownedfp
+                    && self
+                        .mc_fpstate
+                        .iter()
+                        .zip(other.mc_fpstate.iter())
+                        .all(|(a, b)| a == b)
+                    && self.mc_fsbase == other.mc_fsbase
+                    && self.mc_gsbase == other.mc_gsbase
+                    && self.mc_xfpustate == other.mc_xfpustate
+                    && self.mc_xfpustate_len == other.mc_xfpustate_len
+                    && self.mc_spare == other.mc_spare
             }
         }
         impl Eq for mcontext_t {}

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -107,11 +107,11 @@ s! {
     }
 
     pub struct glob_t {
-        pub gl_pathc:  ::size_t,
+        pub gl_pathc: ::size_t,
         pub gl_matchc: ::size_t,
-        pub gl_offs:   ::size_t,
-        pub gl_flags:  ::c_int,
-        pub gl_pathv:  *mut *mut ::c_char,
+        pub gl_offs: ::size_t,
+        pub gl_flags: ::c_int,
+        pub gl_pathv: *mut *mut ::c_char,
         __unused3: *mut ::c_void,
         __unused4: *mut ::c_void,
         __unused5: *mut ::c_void,
@@ -401,10 +401,10 @@ cfg_if! {
                     && self.__ss_pad1 == other.__ss_pad1
                     && self.__ss_align == other.__ss_align
                     && self
-                    .__ss_pad2
-                    .iter()
-                    .zip(other.__ss_pad2.iter())
-                    .all(|(a, b)| a == b)
+                        .__ss_pad2
+                        .iter()
+                        .zip(other.__ss_pad2.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for sockaddr_storage {}

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -35,13 +35,15 @@ s! {
         pub pw_shell: *mut ::c_char,
         pub pw_expire: ::time_t,
 
-        #[cfg(not(any(target_os = "macos",
-                      target_os = "ios",
-                      target_os = "tvos",
-                      target_os = "watchos",
-                      target_os = "visionos",
-                      target_os = "netbsd",
-                      target_os = "openbsd")))]
+        #[cfg(not(any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "visionos",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        )))]
         pub pw_fields: ::c_int,
     }
 
@@ -54,15 +56,19 @@ s! {
         pub ifa_dstaddr: *mut ::sockaddr,
         pub ifa_data: *mut ::c_void,
         #[cfg(target_os = "netbsd")]
-        pub ifa_addrflags: ::c_uint
+        pub ifa_addrflags: ::c_uint,
     }
 
     pub struct fd_set {
-        #[cfg(all(target_pointer_width = "64",
-                  any(target_os = "freebsd", target_os = "dragonfly")))]
+        #[cfg(all(
+            target_pointer_width = "64",
+            any(target_os = "freebsd", target_os = "dragonfly")
+        ))]
         fds_bits: [i64; FD_SETSIZE as usize / 64],
-        #[cfg(not(all(target_pointer_width = "64",
-                      any(target_os = "freebsd", target_os = "dragonfly"))))]
+        #[cfg(not(all(
+            target_pointer_width = "64",
+            any(target_os = "freebsd", target_os = "dragonfly")
+        )))]
         fds_bits: [i32; FD_SETSIZE as usize / 32],
     }
 
@@ -129,7 +135,7 @@ s_no_extra_traits! {
     pub struct sockaddr_un {
         pub sun_len: u8,
         pub sun_family: sa_family_t,
-        pub sun_path: [::c_char; 104]
+        pub sun_path: [::c_char; 104],
     }
 
     pub struct utsname {
@@ -154,7 +160,6 @@ s_no_extra_traits! {
         #[cfg(target_os = "dragonfly")]
         pub machine: [::c_char; 32],
     }
-
 }
 
 cfg_if! {
@@ -164,10 +169,10 @@ cfg_if! {
                 self.sun_len == other.sun_len
                     && self.sun_family == other.sun_family
                     && self
-                    .sun_path
-                    .iter()
-                    .zip(other.sun_path.iter())
-                    .all(|(a,b)| a == b)
+                        .sun_path
+                        .iter()
+                        .zip(other.sun_path.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -178,7 +183,7 @@ cfg_if! {
                 f.debug_struct("sockaddr_un")
                     .field("sun_len", &self.sun_len)
                     .field("sun_family", &self.sun_family)
-                // FIXME: .field("sun_path", &self.sun_path)
+                    // FIXME: .field("sun_path", &self.sun_path)
                     .finish()
             }
         }
@@ -196,27 +201,27 @@ cfg_if! {
                 self.sysname
                     .iter()
                     .zip(other.sysname.iter())
-                    .all(|(a,b)| a == b)
+                    .all(|(a, b)| a == b)
                     && self
-                    .nodename
-                    .iter()
-                    .zip(other.nodename.iter())
-                    .all(|(a,b)| a == b)
+                        .nodename
+                        .iter()
+                        .zip(other.nodename.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .release
-                    .iter()
-                    .zip(other.release.iter())
-                    .all(|(a,b)| a == b)
+                        .release
+                        .iter()
+                        .zip(other.release.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .version
-                    .iter()
-                    .zip(other.version.iter())
-                    .all(|(a,b)| a == b)
+                        .version
+                        .iter()
+                        .zip(other.version.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .machine
-                    .iter()
-                    .zip(other.machine.iter())
-                    .all(|(a,b)| a == b)
+                        .machine
+                        .iter()
+                        .zip(other.machine.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -225,11 +230,11 @@ cfg_if! {
         impl ::fmt::Debug for utsname {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("utsname")
-                // FIXME: .field("sysname", &self.sysname)
-                // FIXME: .field("nodename", &self.nodename)
-                // FIXME: .field("release", &self.release)
-                // FIXME: .field("version", &self.version)
-                // FIXME: .field("machine", &self.machine)
+                    // FIXME: .field("sysname", &self.sysname)
+                    // FIXME: .field("nodename", &self.nodename)
+                    // FIXME: .field("release", &self.release)
+                    // FIXME: .field("version", &self.version)
+                    // FIXME: .field("machine", &self.machine)
                     .finish()
             }
         }
@@ -599,20 +604,20 @@ f! {
         let bits = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] &= !(1 << (fd % bits));
-        return
+        return;
     }
 
     pub fn FD_ISSET(fd: ::c_int, set: *const fd_set) -> bool {
         let bits = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
-        return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0
+        return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0;
     }
 
     pub fn FD_SET(fd: ::c_int, set: *mut fd_set) -> () {
         let bits = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] |= 1 << (fd % bits);
-        return
+        return;
     }
 
     pub fn FD_ZERO(set: *mut fd_set) -> () {
@@ -969,7 +974,13 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))] {
+    if #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos"
+    ))] {
         mod apple;
         pub use self::apple::*;
     } else if #[cfg(any(target_os = "openbsd", target_os = "netbsd"))] {

--- a/src/unix/bsd/netbsdlike/netbsd/aarch64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/aarch64.rs
@@ -44,11 +44,11 @@ cfg_if! {
         impl PartialEq for __c_anonymous__freg {
             fn eq(&self, other: &__c_anonymous__freg) -> bool {
                 unsafe {
-                self.__b8 == other.__b8
-                    || self.__h16 == other.__h16
-                    || self.__s32 == other.__s32
-                    || self.__d64 == other.__d64
-                    || self.__q128 == other.__q128
+                    self.__b8 == other.__b8
+                        || self.__h16 == other.__h16
+                        || self.__s32 == other.__s32
+                        || self.__d64 == other.__d64
+                        || self.__q128 == other.__q128
                 }
             }
         }
@@ -56,24 +56,24 @@ cfg_if! {
         impl ::fmt::Debug for __c_anonymous__freg {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
-                f.debug_struct("__c_anonymous__freg")
-                    .field("__b8", &self.__b8)
-                    .field("__h16", &self.__h16)
-                    .field("__s32", &self.__s32)
-                    .field("__d64", &self.__d64)
-                    .field("__q128", &self.__q128)
-                    .finish()
+                    f.debug_struct("__c_anonymous__freg")
+                        .field("__b8", &self.__b8)
+                        .field("__h16", &self.__h16)
+                        .field("__s32", &self.__s32)
+                        .field("__d64", &self.__d64)
+                        .field("__q128", &self.__q128)
+                        .finish()
                 }
             }
         }
         impl ::hash::Hash for __c_anonymous__freg {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
-                self.__b8.hash(state);
-                self.__h16.hash(state);
-                self.__s32.hash(state);
-                self.__d64.hash(state);
-                self.__q128.hash(state);
+                    self.__b8.hash(state);
+                    self.__h16.hash(state);
+                    self.__s32.hash(state);
+                    self.__d64.hash(state);
+                    self.__q128.hash(state);
                 }
             }
         }

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -136,15 +136,15 @@ s! {
         pub aio_sigevent: ::sigevent,
         _state: ::c_int,
         _errno: ::c_int,
-        _retval: ::ssize_t
+        _retval: ::ssize_t,
     }
 
     pub struct glob_t {
-        pub gl_pathc:   ::size_t,
-        pub gl_matchc:  ::size_t,
-        pub gl_offs:    ::size_t,
-        pub gl_flags:   ::c_int,
-        pub gl_pathv:   *mut *mut ::c_char,
+        pub gl_pathc: ::size_t,
+        pub gl_matchc: ::size_t,
+        pub gl_offs: ::size_t,
+        pub gl_flags: ::c_int,
+        pub gl_pathv: *mut *mut ::c_char,
 
         __unused3: *mut ::c_void,
 
@@ -224,13 +224,21 @@ s! {
     pub struct pthread_mutex_t {
         ptm_magic: ::c_uint,
         ptm_errorcheck: __pthread_spin_t,
-        #[cfg(any(target_arch = "sparc", target_arch = "sparc64",
-                  target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(any(
+            target_arch = "sparc",
+            target_arch = "sparc64",
+            target_arch = "x86",
+            target_arch = "x86_64"
+        ))]
         ptm_pad1: [u8; 3],
         // actually a union with a non-unused, 0-initialized field
         ptm_unused: __pthread_spin_t,
-        #[cfg(any(target_arch = "sparc", target_arch = "sparc64",
-                  target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(any(
+            target_arch = "sparc",
+            target_arch = "sparc64",
+            target_arch = "x86",
+            target_arch = "x86_64"
+        ))]
         ptm_pad2: [u8; 3],
         ptm_owner: ::pthread_t,
         ptm_waiters: *mut u8,
@@ -422,13 +430,13 @@ s! {
         pub ut_line: [::c_char; UT_LINESIZE],
         pub ut_name: [::c_char; UT_NAMESIZE],
         pub ut_host: [::c_char; UT_HOSTSIZE],
-        pub ut_time: ::time_t
+        pub ut_time: ::time_t,
     }
 
     pub struct lastlog {
         pub ll_line: [::c_char; UT_LINESIZE],
         pub ll_host: [::c_char; UT_HOSTSIZE],
-        pub ll_time: ::time_t
+        pub ll_time: ::time_t,
     }
 
     pub struct timex {
@@ -507,7 +515,7 @@ s! {
     }
 
     pub struct _cpuset {
-        bits: [u32; 0]
+        bits: [u32; 0],
     }
 
     pub struct accept_filter_arg {
@@ -780,7 +788,6 @@ s! {
 }
 
 s_no_extra_traits! {
-
     pub struct utmpx {
         pub ut_name: [::c_char; _UTX_USERSIZE],
         pub ut_id: [::c_char; _UTX_IDSIZE],
@@ -886,8 +893,8 @@ s_no_extra_traits! {
         pub sigev_notify: ::c_int,
         pub sigev_signo: ::c_int,
         pub sigev_value: ::sigval,
-        __unused1: *mut ::c_void,       //actually a function pointer
-        pub sigev_notify_attributes: *mut ::c_void
+        __unused1: *mut ::c_void, //actually a function pointer
+        pub sigev_notify_attributes: *mut ::c_void,
     }
 
     pub union __c_anonymous_posix_spawn_fae {
@@ -915,15 +922,15 @@ cfg_if! {
                     && self.ut_tv == other.ut_tv
                     && self.ut_ss == other.ut_ss
                     && self
-                    .ut_pad
-                    .iter()
-                    .zip(other.ut_pad.iter())
-                    .all(|(a,b)| a == b)
+                        .ut_pad
+                        .iter()
+                        .zip(other.ut_pad.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .ut_host
-                    .iter()
-                    .zip(other.ut_host.iter())
-                    .all(|(a,b)| a == b)
+                        .ut_host
+                        .iter()
+                        .zip(other.ut_host.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -935,14 +942,14 @@ cfg_if! {
                     .field("ut_name", &self.ut_name)
                     .field("ut_id", &self.ut_id)
                     .field("ut_line", &self.ut_line)
-                // FIXME .field("ut_host", &self.ut_host)
+                    // FIXME .field("ut_host", &self.ut_host)
                     .field("ut_session", &self.ut_session)
                     .field("ut_type", &self.ut_type)
                     .field("ut_pid", &self.ut_pid)
                     .field("ut_exit", &self.ut_exit)
                     .field("ut_ss", &self.ut_ss)
                     .field("ut_tv", &self.ut_tv)
-                // FIXME .field("ut_pad", &self.ut_pad)
+                    // FIXME .field("ut_pad", &self.ut_pad)
                     .finish()
             }
         }
@@ -969,10 +976,10 @@ cfg_if! {
                     && self.ll_line == other.ll_line
                     && self.ll_ss == other.ll_ss
                     && self
-                    .ll_host
-                    .iter()
-                    .zip(other.ll_host.iter())
-                    .all(|(a,b)| a == b)
+                        .ll_host
+                        .iter()
+                        .zip(other.ll_host.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -983,7 +990,7 @@ cfg_if! {
                 f.debug_struct("lastlogx")
                     .field("ll_tv", &self.ll_tv)
                     .field("ll_line", &self.ll_line)
-                // FIXME.field("ll_host", &self.ll_host)
+                    // FIXME.field("ll_host", &self.ll_host)
                     .field("ll_ss", &self.ll_ss)
                     .finish()
             }
@@ -1000,8 +1007,7 @@ cfg_if! {
 
         impl PartialEq for in_pktinfo {
             fn eq(&self, other: &in_pktinfo) -> bool {
-                self.ipi_addr == other.ipi_addr
-                    && self.ipi_ifindex == other.ipi_ifindex
+                self.ipi_addr == other.ipi_addr && self.ipi_ifindex == other.ipi_ifindex
             }
         }
         impl Eq for in_pktinfo {}
@@ -1066,9 +1072,7 @@ cfg_if! {
         impl ::fmt::Debug for in_addr {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 let s_addr = self.s_addr;
-                f.debug_struct("in_addr")
-                    .field("s_addr", &s_addr)
-                    .finish()
+                f.debug_struct("in_addr").field("s_addr", &s_addr).finish()
             }
         }
         impl ::hash::Hash for in_addr {
@@ -1138,10 +1142,10 @@ cfg_if! {
                     && self.d_namlen == other.d_namlen
                     && self.d_type == other.d_type
                     && self
-                    .d_name
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                        .d_name
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for dirent {}
@@ -1191,15 +1195,15 @@ cfg_if! {
                     && self.f_spare == other.f_spare
                     && self.f_fstypename == other.f_fstypename
                     && self
-                    .f_mntonname
-                    .iter()
-                    .zip(other.f_mntonname.iter())
-                    .all(|(a,b)| a == b)
+                        .f_mntonname
+                        .iter()
+                        .zip(other.f_mntonname.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .f_mntfromname
-                    .iter()
-                    .zip(other.f_mntfromname.iter())
-                    .all(|(a,b)| a == b)
+                        .f_mntfromname
+                        .iter()
+                        .zip(other.f_mntfromname.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for statvfs {}
@@ -1269,10 +1273,10 @@ cfg_if! {
                     && self.__ss_pad1 == other.__ss_pad1
                     && self.__ss_pad2 == other.__ss_pad2
                     && self
-                    .__ss_pad3
-                    .iter()
-                    .zip(other.__ss_pad3.iter())
-                    .all(|(a,b)| a == b)
+                        .__ss_pad3
+                        .iter()
+                        .zip(other.__ss_pad3.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for sockaddr_storage {}
@@ -1302,8 +1306,7 @@ cfg_if! {
                 self.sigev_notify == other.sigev_notify
                     && self.sigev_signo == other.sigev_signo
                     && self.sigev_value == other.sigev_value
-                    && self.sigev_notify_attributes
-                        == other.sigev_notify_attributes
+                    && self.sigev_notify_attributes == other.sigev_notify_attributes
             }
         }
         impl Eq for sigevent {}
@@ -1313,8 +1316,7 @@ cfg_if! {
                     .field("sigev_notify", &self.sigev_notify)
                     .field("sigev_signo", &self.sigev_signo)
                     .field("sigev_value", &self.sigev_value)
-                    .field("sigev_notify_attributes",
-                           &self.sigev_notify_attributes)
+                    .field("sigev_notify_attributes", &self.sigev_notify_attributes)
                     .finish()
             }
         }
@@ -1331,10 +1333,7 @@ cfg_if! {
 
         impl PartialEq for __c_anonymous_posix_spawn_fae {
             fn eq(&self, other: &__c_anonymous_posix_spawn_fae) -> bool {
-                unsafe {
-                    self.open == other.open
-                        || self.dup2 == other.dup2
-                }
+                unsafe { self.open == other.open || self.dup2 == other.dup2 }
             }
         }
 
@@ -1362,10 +1361,7 @@ cfg_if! {
 
         impl PartialEq for __c_anonymous_ifc_ifcu {
             fn eq(&self, other: &__c_anonymous_ifc_ifcu) -> bool {
-                unsafe {
-                    self.ifcu_buf == other.ifcu_buf
-                        || self.ifcu_req == other.ifcu_req
-                }
+                unsafe { self.ifcu_buf == other.ifcu_buf || self.ifcu_req == other.ifcu_req }
             }
         }
 
@@ -1934,10 +1930,13 @@ pub const PL_EVENT_SIGNAL: ::c_int = 1;
 pub const PL_EVENT_SUSPENDED: ::c_int = 2;
 
 cfg_if! {
-    if #[cfg(any(target_arch = "sparc", target_arch = "sparc64",
-                 target_arch = "x86", target_arch = "x86_64"))] {
-        pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t
-          = pthread_mutex_t {
+    if #[cfg(any(
+        target_arch = "sparc",
+        target_arch = "sparc64",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))] {
+        pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
             ptm_magic: 0x33330003,
             ptm_errorcheck: 0,
             ptm_pad1: [0; 3],
@@ -1949,8 +1948,7 @@ cfg_if! {
             ptm_spare2: 0 as *mut _,
         };
     } else {
-        pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t
-          = pthread_mutex_t {
+        pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
             ptm_magic: 0x33330003,
             ptm_errorcheck: 0,
             ptm_unused: 0,
@@ -2437,35 +2435,30 @@ const_fn! {
 
 f! {
     pub fn CMSG_DATA(cmsg: *const ::cmsghdr) -> *mut ::c_uchar {
-        (cmsg as *mut ::c_uchar)
-            .offset(_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
+        (cmsg as *mut ::c_uchar).offset(_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_LEN(length: ::c_uint) -> ::c_uint {
         _ALIGN(::mem::size_of::<::cmsghdr>()) as ::c_uint + length
     }
 
-    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr, cmsg: *const ::cmsghdr)
-        -> *mut ::cmsghdr
-    {
+    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr, cmsg: *const ::cmsghdr) -> *mut ::cmsghdr {
         if cmsg.is_null() {
             return ::CMSG_FIRSTHDR(mhdr);
         };
-        let next = cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize)
+        let next = cmsg as usize
+            + _ALIGN((*cmsg).cmsg_len as usize)
             + _ALIGN(::mem::size_of::<::cmsghdr>());
-        let max = (*mhdr).msg_control as usize
-            + (*mhdr).msg_controllen as usize;
+        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next > max {
             0 as *mut ::cmsghdr
         } else {
-            (cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize))
-                as *mut ::cmsghdr
+            (cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize)) as *mut ::cmsghdr
         }
     }
 
     pub {const} fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
-        (_ALIGN(::mem::size_of::<::cmsghdr>()) + _ALIGN(length as usize))
-            as ::c_uint
+        (_ALIGN(::mem::size_of::<::cmsghdr>()) + _ALIGN(length as usize)) as ::c_uint
     }
 
     // dirfd() is a macro on netbsd to access
@@ -2476,11 +2469,7 @@ f! {
     }
 
     pub fn SOCKCREDSIZE(ngrps: usize) -> usize {
-        let ngrps = if ngrps > 0 {
-            ngrps - 1
-        } else {
-            0
-        };
+        let ngrps = if ngrps > 0 { ngrps - 1 } else { 0 };
         ::mem::size_of::<sockcred>() + ::mem::size_of::<::gid_t>() * ngrps
     }
 
@@ -2493,7 +2482,7 @@ f! {
     }
 
     pub fn major(dev: ::dev_t) -> ::c_int {
-        (((dev as u32) & 0x000fff00) >>  8) as ::c_int
+        (((dev as u32) & 0x000fff00) >> 8) as ::c_int
     }
 
     pub fn minor(dev: ::dev_t) -> ::c_int {

--- a/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
@@ -10,7 +10,7 @@ s! {
     pub struct mcontext_t {
         pub __gregs: [c___greg_t; 26],
         pub _mc_tlsbase: c___greg_t,
-        pub __fpregs: [[::c_char;32]; 16],
+        pub __fpregs: [[::c_char; 32]; 16],
     }
 
     pub struct ucontext_t {

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -65,11 +65,11 @@ s! {
     }
 
     pub struct glob_t {
-        pub gl_pathc:   ::size_t,
-        pub gl_matchc:  ::size_t,
-        pub gl_offs:    ::size_t,
-        pub gl_flags:   ::c_int,
-        pub gl_pathv:   *mut *mut ::c_char,
+        pub gl_pathc: ::size_t,
+        pub gl_matchc: ::size_t,
+        pub gl_offs: ::size_t,
+        pub gl_flags: ::c_int,
+        pub gl_pathv: *mut *mut ::c_char,
         __unused1: *mut ::c_void,
         __unused2: *mut ::c_void,
         __unused3: *mut ::c_void,
@@ -761,10 +761,10 @@ cfg_if! {
                     && self.d_type == other.d_type
                     && self.d_namlen == other.d_namlen
                     && self
-                    .d_name
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                        .d_name
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -778,7 +778,7 @@ cfg_if! {
                     .field("d_reclen", &self.d_reclen)
                     .field("d_type", &self.d_type)
                     .field("d_namlen", &self.d_namlen)
-                // FIXME: .field("d_name", &self.d_name)
+                    // FIXME: .field("d_name", &self.d_name)
                     .finish()
             }
         }
@@ -796,8 +796,7 @@ cfg_if! {
 
         impl PartialEq for sockaddr_storage {
             fn eq(&self, other: &sockaddr_storage) -> bool {
-                self.ss_len == other.ss_len
-                    && self.ss_family == other.ss_family
+                self.ss_len == other.ss_len && self.ss_family == other.ss_family
             }
         }
 
@@ -854,15 +853,15 @@ cfg_if! {
             fn eq(&self, other: &lastlog) -> bool {
                 self.ll_time == other.ll_time
                     && self
-                    .ll_line
-                    .iter()
-                    .zip(other.ll_line.iter())
-                    .all(|(a,b)| a == b)
+                        .ll_line
+                        .iter()
+                        .zip(other.ll_line.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .ll_host
-                    .iter()
-                    .zip(other.ll_host.iter())
-                    .all(|(a,b)| a == b)
+                        .ll_host
+                        .iter()
+                        .zip(other.ll_host.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -872,8 +871,8 @@ cfg_if! {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("lastlog")
                     .field("ll_time", &self.ll_time)
-                // FIXME: .field("ll_line", &self.ll_line)
-                // FIXME: .field("ll_host", &self.ll_host)
+                    // FIXME: .field("ll_line", &self.ll_line)
+                    // FIXME: .field("ll_host", &self.ll_host)
                     .finish()
             }
         }
@@ -890,20 +889,20 @@ cfg_if! {
             fn eq(&self, other: &utmp) -> bool {
                 self.ut_time == other.ut_time
                     && self
-                    .ut_line
-                    .iter()
-                    .zip(other.ut_line.iter())
-                    .all(|(a,b)| a == b)
+                        .ut_line
+                        .iter()
+                        .zip(other.ut_line.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .ut_name
-                    .iter()
-                    .zip(other.ut_name.iter())
-                    .all(|(a,b)| a == b)
+                        .ut_name
+                        .iter()
+                        .zip(other.ut_name.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .ut_host
-                    .iter()
-                    .zip(other.ut_host.iter())
-                    .all(|(a,b)| a == b)
+                        .ut_host
+                        .iter()
+                        .zip(other.ut_host.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -912,9 +911,9 @@ cfg_if! {
         impl ::fmt::Debug for utmp {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("utmp")
-                // FIXME: .field("ut_line", &self.ut_line)
-                // FIXME: .field("ut_name", &self.ut_name)
-                // FIXME: .field("ut_host", &self.ut_host)
+                    // FIXME: .field("ut_line", &self.ut_line)
+                    // FIXME: .field("ut_name", &self.ut_name)
+                    // FIXME: .field("ut_host", &self.ut_host)
                     .field("ut_time", &self.ut_time)
                     .finish()
             }
@@ -935,17 +934,17 @@ cfg_if! {
                     self.align
                         .iter()
                         .zip(other.align.iter())
-                        .all(|(a,b)| a == b)
+                        .all(|(a, b)| a == b)
                 }
             }
         }
 
-        impl Eq for mount_info { }
+        impl Eq for mount_info {}
 
         impl ::fmt::Debug for mount_info {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("mount_info")
-                // FIXME: .field("align", &self.align)
+                    // FIXME: .field("align", &self.align)
                     .finish()
             }
         }
@@ -1025,22 +1024,26 @@ cfg_if! {
                     && self.f_namemax == other.f_namemax
                     && self.f_owner == other.f_owner
                     && self.f_ctime == other.f_ctime
-                    && self.f_fstypename
-                    .iter()
-                    .zip(other.f_fstypename.iter())
-                    .all(|(a,b)| a == b)
-                    && self.f_mntonname
-                    .iter()
-                    .zip(other.f_mntonname.iter())
-                    .all(|(a,b)| a == b)
-                    && self.f_mntfromname
-                    .iter()
-                    .zip(other.f_mntfromname.iter())
-                    .all(|(a,b)| a == b)
-                    && self.f_mntfromspec
-                    .iter()
-                    .zip(other.f_mntfromspec.iter())
-                    .all(|(a,b)| a == b)
+                    && self
+                        .f_fstypename
+                        .iter()
+                        .zip(other.f_fstypename.iter())
+                        .all(|(a, b)| a == b)
+                    && self
+                        .f_mntonname
+                        .iter()
+                        .zip(other.f_mntonname.iter())
+                        .all(|(a, b)| a == b)
+                    && self
+                        .f_mntfromname
+                        .iter()
+                        .zip(other.f_mntfromname.iter())
+                        .all(|(a, b)| a == b)
+                    && self
+                        .f_mntfromspec
+                        .iter()
+                        .zip(other.f_mntfromspec.iter())
+                        .all(|(a, b)| a == b)
                     && self.mount_info == other.mount_info
             }
         }
@@ -1067,10 +1070,10 @@ cfg_if! {
                     .field("f_namemax", &self.f_namemax)
                     .field("f_owner", &self.f_owner)
                     .field("f_ctime", &self.f_ctime)
-                // FIXME: .field("f_fstypename", &self.f_fstypename)
-                // FIXME: .field("f_mntonname", &self.f_mntonname)
-                // FIXME: .field("f_mntfromname", &self.f_mntfromname)
-                // FIXME: .field("f_mntfromspec", &self.f_mntfromspec)
+                    // FIXME: .field("f_fstypename", &self.f_fstypename)
+                    // FIXME: .field("f_mntonname", &self.f_mntonname)
+                    // FIXME: .field("f_mntfromname", &self.f_mntfromname)
+                    // FIXME: .field("f_mntfromspec", &self.f_mntfromspec)
                     .field("mount_info", &self.mount_info)
                     .finish()
             }
@@ -1944,38 +1947,33 @@ const_fn! {
 
 f! {
     pub fn CMSG_DATA(cmsg: *const ::cmsghdr) -> *mut ::c_uchar {
-        (cmsg as *mut ::c_uchar)
-            .offset(_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
+        (cmsg as *mut ::c_uchar).offset(_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_LEN(length: ::c_uint) -> ::c_uint {
         _ALIGN(::mem::size_of::<::cmsghdr>()) as ::c_uint + length
     }
 
-    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr, cmsg: *const ::cmsghdr)
-        -> *mut ::cmsghdr
-    {
+    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr, cmsg: *const ::cmsghdr) -> *mut ::cmsghdr {
         if cmsg.is_null() {
             return ::CMSG_FIRSTHDR(mhdr);
         };
-        let next = cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize)
+        let next = cmsg as usize
+            + _ALIGN((*cmsg).cmsg_len as usize)
             + _ALIGN(::mem::size_of::<::cmsghdr>());
-        let max = (*mhdr).msg_control as usize
-            + (*mhdr).msg_controllen as usize;
+        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next > max {
             0 as *mut ::cmsghdr
         } else {
-            (cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize))
-                as *mut ::cmsghdr
+            (cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize)) as *mut ::cmsghdr
         }
     }
 
     pub {const} fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
-        (_ALIGN(::mem::size_of::<::cmsghdr>()) + _ALIGN(length as usize))
-            as ::c_uint
+        (_ALIGN(::mem::size_of::<::cmsghdr>()) + _ALIGN(length as usize)) as ::c_uint
     }
 
-    pub fn major(dev: ::dev_t) -> ::c_uint{
+    pub fn major(dev: ::dev_t) -> ::c_uint {
         ((dev as ::c_uint) >> 8) & 0xff
     }
 

--- a/src/unix/bsd/netbsdlike/openbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/x86_64.rs
@@ -64,30 +64,36 @@ cfg_if! {
         // use {x} to create temporary storage, copy field to it, and do aligned access.
         impl PartialEq for fxsave64 {
             fn eq(&self, other: &fxsave64) -> bool {
-                return {self.fx_fcw} == {other.fx_fcw} &&
-                    {self.fx_fsw} == {other.fx_fsw} &&
-                    {self.fx_ftw} == {other.fx_ftw} &&
-                    {self.fx_fop} == {other.fx_fop} &&
-                    {self.fx_rip} == {other.fx_rip} &&
-                    {self.fx_rdp} == {other.fx_rdp} &&
-                    {self.fx_mxcsr} == {other.fx_mxcsr} &&
-                    {self.fx_mxcsr_mask} == {other.fx_mxcsr_mask} &&
-                    {self.fx_st}.iter().zip({other.fx_st}.iter()).all(|(a,b)| a == b) &&
-                    {self.fx_xmm}.iter().zip({other.fx_xmm}.iter()).all(|(a,b)| a == b)
+                return { self.fx_fcw } == { other.fx_fcw }
+                    && { self.fx_fsw } == { other.fx_fsw }
+                    && { self.fx_ftw } == { other.fx_ftw }
+                    && { self.fx_fop } == { other.fx_fop }
+                    && { self.fx_rip } == { other.fx_rip }
+                    && { self.fx_rdp } == { other.fx_rdp }
+                    && { self.fx_mxcsr } == { other.fx_mxcsr }
+                    && { self.fx_mxcsr_mask } == { other.fx_mxcsr_mask }
+                    && { self.fx_st }
+                        .iter()
+                        .zip({ other.fx_st }.iter())
+                        .all(|(a, b)| a == b)
+                    && { self.fx_xmm }
+                        .iter()
+                        .zip({ other.fx_xmm }.iter())
+                        .all(|(a, b)| a == b);
             }
         }
         impl Eq for fxsave64 {}
         impl ::fmt::Debug for fxsave64 {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("fxsave64")
-                    .field("fx_fcw", &{self.fx_fcw})
-                    .field("fx_fsw", &{self.fx_fsw})
-                    .field("fx_ftw", &{self.fx_ftw})
-                    .field("fx_fop", &{self.fx_fop})
-                    .field("fx_rip", &{self.fx_rip})
-                    .field("fx_rdp", &{self.fx_rdp})
-                    .field("fx_mxcsr", &{self.fx_mxcsr})
-                    .field("fx_mxcsr_mask", &{self.fx_mxcsr_mask})
+                    .field("fx_fcw", &{ self.fx_fcw })
+                    .field("fx_fsw", &{ self.fx_fsw })
+                    .field("fx_ftw", &{ self.fx_ftw })
+                    .field("fx_fop", &{ self.fx_fop })
+                    .field("fx_rip", &{ self.fx_rip })
+                    .field("fx_rdp", &{ self.fx_rdp })
+                    .field("fx_mxcsr", &{ self.fx_mxcsr })
+                    .field("fx_mxcsr_mask", &{ self.fx_mxcsr_mask })
                     // FIXME: .field("fx_st", &{self.fx_st})
                     // FIXME: .field("fx_xmm", &{self.fx_xmm})
                     .finish()
@@ -95,16 +101,16 @@ cfg_if! {
         }
         impl ::hash::Hash for fxsave64 {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                {self.fx_fcw}.hash(state);
-                {self.fx_fsw}.hash(state);
-                {self.fx_ftw}.hash(state);
-                {self.fx_fop}.hash(state);
-                {self.fx_rip}.hash(state);
-                {self.fx_rdp}.hash(state);
-                {self.fx_mxcsr}.hash(state);
-                {self.fx_mxcsr_mask}.hash(state);
-                {self.fx_st}.hash(state);
-                {self.fx_xmm}.hash(state);
+                { self.fx_fcw }.hash(state);
+                { self.fx_fsw }.hash(state);
+                { self.fx_ftw }.hash(state);
+                { self.fx_fop }.hash(state);
+                { self.fx_rip }.hash(state);
+                { self.fx_rdp }.hash(state);
+                { self.fx_mxcsr }.hash(state);
+                { self.fx_mxcsr_mask }.hash(state);
+                { self.fx_st }.hash(state);
+                { self.fx_xmm }.hash(state);
             }
         }
     }

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -220,7 +220,7 @@ s! {
         pub c_oflag: ::tcflag_t,
         pub c_cflag: ::tcflag_t,
         pub c_lflag: ::tcflag_t,
-        pub c_line:  ::c_char,
+        pub c_line: ::c_char,
         pub c_ispeed: ::speed_t,
         pub c_ospeed: ::speed_t,
         pub c_cc: [::cc_t; ::NCCS],
@@ -290,7 +290,7 @@ s! {
     pub struct pthread_rwlock_t {
         flags: u32,
         owner: i32,
-        lock_sem: i32,      // this is actually a union
+        lock_sem: i32, // this is actually a union
         lock_count: i32,
         reader_count: i32,
         writer_count: i32,
@@ -458,7 +458,7 @@ s_no_extra_traits! {
     pub struct sockaddr_un {
         pub sun_len: u8,
         pub sun_family: sa_family_t,
-        pub sun_path: [::c_char; 126]
+        pub sun_path: [::c_char; 126],
     }
     pub struct sockaddr_storage {
         pub ss_len: u8,
@@ -506,7 +506,11 @@ cfg_if! {
                     && self.ut_pid == other.ut_pid
                     && self.ut_user == other.ut_user
                     && self.ut_line == other.ut_line
-                    && self.ut_host.iter().zip(other.ut_host.iter()).all(|(a,b)| a == b)
+                    && self
+                        .ut_host
+                        .iter()
+                        .zip(other.ut_host.iter())
+                        .all(|(a, b)| a == b)
                     && self.__ut_reserved == other.__ut_reserved
             }
         }
@@ -545,10 +549,10 @@ cfg_if! {
                 self.sun_len == other.sun_len
                     && self.sun_family == other.sun_family
                     && self
-                    .sun_path
-                    .iter()
-                    .zip(other.sun_path.iter())
-                    .all(|(a,b)| a == b)
+                        .sun_path
+                        .iter()
+                        .zip(other.sun_path.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for sockaddr_un {}
@@ -574,16 +578,16 @@ cfg_if! {
                 self.ss_len == other.ss_len
                     && self.ss_family == other.ss_family
                     && self
-                    .__ss_pad1
-                    .iter()
-                    .zip(other.__ss_pad1.iter())
-                    .all(|(a, b)| a == b)
+                        .__ss_pad1
+                        .iter()
+                        .zip(other.__ss_pad1.iter())
+                        .all(|(a, b)| a == b)
                     && self.__ss_pad2 == other.__ss_pad2
                     && self
-                    .__ss_pad3
-                    .iter()
-                    .zip(other.__ss_pad3.iter())
-                    .all(|(a, b)| a == b)
+                        .__ss_pad3
+                        .iter()
+                        .zip(other.__ss_pad3.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for sockaddr_storage {}
@@ -616,10 +620,10 @@ cfg_if! {
                     && self.d_pino == other.d_pino
                     && self.d_reclen == other.d_reclen
                     && self
-                    .d_name
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                        .d_name
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for dirent {}
@@ -651,8 +655,7 @@ cfg_if! {
                 self.sigev_notify == other.sigev_notify
                     && self.sigev_signo == other.sigev_signo
                     && self.sigev_value == other.sigev_value
-                    && self.sigev_notify_attributes
-                        == other.sigev_notify_attributes
+                    && self.sigev_notify_attributes == other.sigev_notify_attributes
             }
         }
         impl Eq for sigevent {}
@@ -662,8 +665,7 @@ cfg_if! {
                     .field("sigev_notify", &self.sigev_notify)
                     .field("sigev_signo", &self.sigev_signo)
                     .field("sigev_value", &self.sigev_value)
-                    .field("sigev_notify_attributes",
-                           &self.sigev_notify_attributes)
+                    .field("sigev_notify_attributes", &self.sigev_notify_attributes)
                     .finish()
             }
         }
@@ -1572,33 +1574,29 @@ f! {
     }
 
     pub fn CMSG_DATA(cmsg: *const ::cmsghdr) -> *mut ::c_uchar {
-        (cmsg as *mut ::c_uchar)
-            .offset(CMSG_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
+        (cmsg as *mut ::c_uchar).offset(CMSG_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(::mem::size_of::<cmsghdr>()))
-            as ::c_uint
+        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(::mem::size_of::<cmsghdr>())) as ::c_uint
     }
 
     pub {const} fn CMSG_LEN(length: ::c_uint) -> ::c_uint {
         CMSG_ALIGN(::mem::size_of::<cmsghdr>()) as ::c_uint + length
     }
 
-    pub fn CMSG_NXTHDR(mhdr: *const msghdr,
-                       cmsg: *const cmsghdr) -> *mut cmsghdr {
+    pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         if cmsg.is_null() {
             return ::CMSG_FIRSTHDR(mhdr);
         };
-        let next = cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize)
+        let next = cmsg as usize
+            + CMSG_ALIGN((*cmsg).cmsg_len as usize)
             + CMSG_ALIGN(::mem::size_of::<::cmsghdr>());
-        let max = (*mhdr).msg_control as usize
-            + (*mhdr).msg_controllen as usize;
+        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next > max {
             0 as *mut ::cmsghdr
         } else {
-            (cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize))
-                as *mut ::cmsghdr
+            (cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut ::cmsghdr
         }
     }
 
@@ -1606,20 +1604,20 @@ f! {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
-        return
+        return;
     }
 
     pub fn FD_ISSET(fd: ::c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
-        return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0
+        return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: ::c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
-        return
+        return;
     }
 
     pub fn FD_ZERO(set: *mut fd_set) -> () {

--- a/src/unix/haiku/native.rs
+++ b/src/unix/haiku/native.rs
@@ -51,7 +51,7 @@ e! {
         B_THREAD_RECEIVING,
         B_THREAD_ASLEEP,
         B_THREAD_SUSPENDED,
-        B_THREAD_WAITING
+        B_THREAD_WAITING,
     }
 
     // kernel/image.h
@@ -59,7 +59,7 @@ e! {
         B_APP_IMAGE = 1,
         B_LIBRARY_IMAGE,
         B_ADD_ON_IMAGE,
-        B_SYSTEM_IMAGE
+        B_SYSTEM_IMAGE,
     }
 
     // kernel/scheduler.h
@@ -221,7 +221,7 @@ e! {
         B_CPU_MIPS,
         B_CPU_SH,
         B_CPU_SPARC,
-        B_CPU_RISC_V
+        B_CPU_RISC_V,
     }
 
     pub enum cpu_vendor {
@@ -239,7 +239,7 @@ e! {
         B_CPU_VENDOR_NEC,
         B_CPU_VENDOR_HYGON,
         B_CPU_VENDOR_SUN,
-        B_CPU_VENDOR_FUJITSU
+        B_CPU_VENDOR_FUJITSU,
     }
 }
 
@@ -256,7 +256,7 @@ s! {
         pub copy_count: u32,
         pub in_count: u32,
         pub out_count: u32,
-        pub address: *mut ::c_void
+        pub address: *mut ::c_void,
     }
 
     pub struct port_info {
@@ -272,7 +272,7 @@ s! {
         pub size: ::size_t,
         pub sender: ::uid_t,
         pub sender_group: ::gid_t,
-        pub sender_team: ::team_id
+        pub sender_team: ::team_id,
     }
 
     pub struct team_info {
@@ -285,7 +285,7 @@ s! {
         pub argc: i32,
         pub args: [::c_char; 64],
         pub uid: ::uid_t,
-        pub gid: ::gid_t
+        pub gid: ::gid_t,
     }
 
     pub struct sem_info {
@@ -293,12 +293,12 @@ s! {
         pub team: team_id,
         pub name: [::c_char; B_OS_NAME_LENGTH],
         pub count: i32,
-        pub latest_holder: thread_id
+        pub latest_holder: thread_id,
     }
 
     pub struct team_usage_info {
         pub user_time: bigtime_t,
-        pub kernel_time: bigtime_t
+        pub kernel_time: bigtime_t,
     }
 
     pub struct thread_info {
@@ -311,13 +311,13 @@ s! {
         pub user_time: bigtime_t,
         pub kernel_time: bigtime_t,
         pub stack_base: *mut ::c_void,
-        pub stack_end: *mut ::c_void
+        pub stack_end: *mut ::c_void,
     }
 
     pub struct cpu_info {
         pub active_time: bigtime_t,
         pub enabled: bool,
-        pub current_frequency: u64
+        pub current_frequency: u64,
     }
 
     pub struct system_info {
@@ -345,13 +345,13 @@ s! {
         pub kernel_build_date: [::c_char; B_OS_NAME_LENGTH],
         pub kernel_build_time: [::c_char; B_OS_NAME_LENGTH],
         pub kernel_version: i64,
-        pub abi: u32
+        pub abi: u32,
     }
 
     pub struct object_wait_info {
         pub object: i32,
         pub type_: u16,
-        pub events: u16
+        pub events: u16,
     }
 
     pub struct cpu_topology_root_info {
@@ -370,7 +370,7 @@ s! {
     // kernel/fs_attr.h
     pub struct attr_info {
         pub type_: u32,
-        pub size: ::off_t
+        pub size: ::off_t,
     }
 
     // kernel/fs_index.h
@@ -380,7 +380,7 @@ s! {
         pub modification_time: ::time_t,
         pub creation_time: ::time_t,
         pub uid: ::uid_t,
-        pub gid: ::gid_t
+        pub gid: ::gid_t,
     }
 
     //kernel/fs_info.h
@@ -396,7 +396,7 @@ s! {
         pub free_nodes: ::off_t,
         pub device_name: [::c_char; 128],
         pub volume_name: [::c_char; B_FILE_NAME_LENGTH],
-        pub fsh_name: [::c_char; B_OS_NAME_LENGTH]
+        pub fsh_name: [::c_char; B_OS_NAME_LENGTH],
     }
 
     // kernel/image.h
@@ -415,7 +415,7 @@ s! {
         pub text_size: i32,
         pub data_size: i32,
         pub api_version: i32,
-        pub abi: i32
+        pub abi: i32,
     }
 
     pub struct __c_anonymous_eax_0 {
@@ -488,12 +488,12 @@ cfg_if! {
         impl PartialEq for cpuid_info {
             fn eq(&self, other: &cpuid_info) -> bool {
                 unsafe {
-                self.eax_0 == other.eax_0
-                    || self.eax_1 == other.eax_1
-                    || self.eax_2 == other.eax_2
-                    || self.eax_3 == other.eax_3
-                    || self.as_chars == other.as_chars
-                    || self.regs == other.regs
+                    self.eax_0 == other.eax_0
+                        || self.eax_1 == other.eax_1
+                        || self.eax_2 == other.eax_2
+                        || self.eax_3 == other.eax_3
+                        || self.as_chars == other.as_chars
+                        || self.regs == other.regs
                 }
             }
         }
@@ -501,14 +501,14 @@ cfg_if! {
         impl ::fmt::Debug for cpuid_info {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
-                f.debug_struct("cpuid_info")
-                    .field("eax_0", &self.eax_0)
-                    .field("eax_1", &self.eax_1)
-                    .field("eax_2", &self.eax_2)
-                    .field("eax_3", &self.eax_3)
-                    .field("as_chars", &self.as_chars)
-                    .field("regs", &self.regs)
-                    .finish()
+                    f.debug_struct("cpuid_info")
+                        .field("eax_0", &self.eax_0)
+                        .field("eax_1", &self.eax_1)
+                        .field("eax_2", &self.eax_2)
+                        .field("eax_3", &self.eax_3)
+                        .field("as_chars", &self.as_chars)
+                        .field("regs", &self.regs)
+                        .finish()
                 }
             }
         }
@@ -516,9 +516,9 @@ cfg_if! {
         impl PartialEq for __c_anonymous_cpu_topology_info_data {
             fn eq(&self, other: &__c_anonymous_cpu_topology_info_data) -> bool {
                 unsafe {
-                self.root == other.root
-                    || self.package == other.package
-                    || self.core == other.core
+                    self.root == other.root
+                        || self.package == other.package
+                        || self.core == other.core
                 }
             }
         }
@@ -526,20 +526,18 @@ cfg_if! {
         impl ::fmt::Debug for __c_anonymous_cpu_topology_info_data {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
-                f.debug_struct("__c_anonymous_cpu_topology_info_data")
-                    .field("root", &self.root)
-                    .field("package", &self.package)
-                    .field("core", &self.core)
-                    .finish()
+                    f.debug_struct("__c_anonymous_cpu_topology_info_data")
+                        .field("root", &self.root)
+                        .field("package", &self.package)
+                        .field("core", &self.core)
+                        .finish()
                 }
             }
         }
 
         impl PartialEq for cpu_topology_node_info {
             fn eq(&self, other: &cpu_topology_node_info) -> bool {
-                self.id == other.id
-                    && self.type_ == other.type_
-                    && self.level == other.level
+                self.id == other.id && self.type_ == other.type_ && self.level == other.level
             }
         }
 

--- a/src/unix/haiku/x86_64.rs
+++ b/src/unix/haiku/x86_64.rs
@@ -67,12 +67,17 @@ cfg_if! {
                     && self.rdp == other.rdp
                     && self.mxcsr == other.mxcsr
                     && self.mscsr_mask == other.mscsr_mask
-                    && self._fpreg.iter().zip(other._fpreg.iter()).all(|(a, b)| a == b)
+                    && self
+                        ._fpreg
+                        .iter()
+                        .zip(other._fpreg.iter())
+                        .all(|(a, b)| a == b)
                     && self._xmm.iter().zip(other._xmm.iter()).all(|(a, b)| a == b)
-                    && self._reserved_416_511.
-                        iter().
-                        zip(other._reserved_416_511.iter()).
-                        all(|(a, b)| a == b)
+                    && self
+                        ._reserved_416_511
+                        .iter()
+                        .zip(other._reserved_416_511.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for fpu_state {}
@@ -113,7 +118,11 @@ cfg_if! {
             fn eq(&self, other: &xstate_hdr) -> bool {
                 self.bv == other.bv
                     && self.xcomp_bv == other.xcomp_bv
-                    && self._reserved.iter().zip(other._reserved.iter()).all(|(a, b)| a == b)
+                    && self
+                        ._reserved
+                        .iter()
+                        .zip(other._reserved.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for xstate_hdr {}
@@ -138,7 +147,11 @@ cfg_if! {
             fn eq(&self, other: &savefpu) -> bool {
                 self.fp_fxsave == other.fp_fxsave
                     && self.fp_xstate == other.fp_xstate
-                    && self._fp_ymm.iter().zip(other._fp_ymm.iter()).all(|(a, b)| a == b)
+                    && self
+                        ._fp_ymm
+                        .iter()
+                        .zip(other._fp_ymm.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for savefpu {}
@@ -206,7 +219,6 @@ cfg_if! {
                     .field("rflags", &self.rflags)
                     .field("fpu", &self.fpu)
                     .finish()
-
             }
         }
         impl ::hash::Hash for mcontext_t {

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -427,7 +427,7 @@ s! {
         pub sigev_value: ::sigval,
         pub sigev_signo: ::c_int,
         pub sigev_notify: ::c_int,
-        __unused1: *mut ::c_void,       //actually a function pointer
+        __unused1: *mut ::c_void, //actually a function pointer
         pub sigev_notify_attributes: *mut pthread_attr_t,
     }
 
@@ -558,7 +558,7 @@ s! {
         pub f_favail: __fsfilcnt64_t,
         pub f_frsize: ::c_ulong,
         pub f_flag: ::c_ulong,
-        pub f_spare: [::c_uint ; 3usize],
+        pub f_spare: [::c_uint; 3usize],
     }
 
     pub struct statvfs {
@@ -608,7 +608,7 @@ s! {
         pub aio_offset: off_t,
         #[cfg(all(not(target_arch = "x86_64"), target_pointer_width = "32"))]
         __unused1: [::c_char; 4],
-        __glibc_reserved: [::c_char; 32]
+        __glibc_reserved: [::c_char; 32],
     }
 
     pub struct mq_attr {
@@ -623,10 +623,8 @@ s! {
         pub e_exit: ::c_short,
     }
 
-    #[cfg_attr(target_pointer_width = "32",
-               repr(align(4)))]
-    #[cfg_attr(target_pointer_width = "64",
-               repr(align(8)))]
+    #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+    #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
     pub struct sem_t {
         __size: [::c_char; 20usize],
     }
@@ -816,7 +814,7 @@ s! {
         pub ifa_addr: *mut ::sockaddr,
         pub ifa_netmask: *mut ::sockaddr,
         pub ifa_ifu: *mut ::sockaddr, // FIXME This should be a union
-        pub ifa_data: *mut ::c_void
+        pub ifa_data: *mut ::c_void,
     }
 
     pub struct arpreq {
@@ -885,7 +883,7 @@ s! {
     }
 
     pub struct stack_t {
-        pub ss_sp: * mut ::c_void,
+        pub ss_sp: *mut ::c_void,
         pub ss_size: ::size_t,
         pub ss_flags: ::c_int,
     }
@@ -903,30 +901,30 @@ s! {
 
     pub struct flock {
         #[cfg(target_pointer_width = "32")]
-        pub l_type : ::c_int,
+        pub l_type: ::c_int,
         #[cfg(target_pointer_width = "32")]
-        pub l_whence : ::c_int,
+        pub l_whence: ::c_int,
         #[cfg(target_pointer_width = "64")]
-        pub l_type : ::c_short,
+        pub l_type: ::c_short,
         #[cfg(target_pointer_width = "64")]
-        pub l_whence : ::c_short,
-        pub l_start : __off_t,
-        pub l_len : __off_t,
-        pub l_pid : __pid_t,
+        pub l_whence: ::c_short,
+        pub l_start: __off_t,
+        pub l_len: __off_t,
+        pub l_pid: __pid_t,
     }
 
     pub struct flock64 {
         #[cfg(target_pointer_width = "32")]
-        pub l_type : ::c_int,
+        pub l_type: ::c_int,
         #[cfg(target_pointer_width = "32")]
-        pub l_whence : ::c_int,
+        pub l_whence: ::c_int,
         #[cfg(target_pointer_width = "64")]
-        pub l_type : ::c_short,
+        pub l_type: ::c_short,
         #[cfg(target_pointer_width = "64")]
-        pub l_whence : ::c_short,
-        pub l_start : __off_t,
-        pub l_len : __off64_t,
-        pub l_pid : __pid_t,
+        pub l_whence: ::c_short,
+        pub l_start: __off_t,
+        pub l_len: __off64_t,
+        pub l_pid: __pid_t,
     }
 
     pub struct glob_t {
@@ -967,11 +965,9 @@ s! {
     }
 
     pub struct cpu_set_t {
-        #[cfg(all(target_pointer_width = "32",
-                  not(target_arch = "x86_64")))]
+        #[cfg(all(target_pointer_width = "32", not(target_arch = "x86_64")))]
         bits: [u32; 32],
-        #[cfg(not(all(target_pointer_width = "32",
-                      not(target_arch = "x86_64"))))]
+        #[cfg(not(all(target_pointer_width = "32", not(target_arch = "x86_64"))))]
         bits: [u64; 16],
     }
 
@@ -1035,7 +1031,6 @@ s! {
         pub flag: *mut ::c_int,
         pub val: ::c_int,
     }
-
 }
 
 s_no_extra_traits! {
@@ -1049,18 +1044,14 @@ s_no_extra_traits! {
         pub ut_host: [::c_char; __UT_HOSTSIZE],
         pub ut_exit: __exit_status,
 
-        #[cfg(any( all(target_pointer_width = "32",
-                      not(target_arch = "x86_64"))))]
+        #[cfg(any(all(target_pointer_width = "32", not(target_arch = "x86_64"))))]
         pub ut_session: ::c_long,
-        #[cfg(any(all(target_pointer_width = "32",
-                      not(target_arch = "x86_64"))))]
+        #[cfg(any(all(target_pointer_width = "32", not(target_arch = "x86_64"))))]
         pub ut_tv: ::timeval,
 
-        #[cfg(not(any(all(target_pointer_width = "32",
-                          not(target_arch = "x86_64")))))]
+        #[cfg(not(any(all(target_pointer_width = "32", not(target_arch = "x86_64")))))]
         pub ut_session: i32,
-        #[cfg(not(any(all(target_pointer_width = "32",
-                          not(target_arch = "x86_64")))))]
+        #[cfg(not(any(all(target_pointer_width = "32", not(target_arch = "x86_64")))))]
         pub ut_tv: __timeval,
 
         pub ut_addr_v6: [i32; 4],
@@ -1078,10 +1069,10 @@ cfg_if! {
                     && self.ut_id == other.ut_id
                     && self.ut_user == other.ut_user
                     && self
-                    .ut_host
-                    .iter()
-                    .zip(other.ut_host.iter())
-                    .all(|(a,b)| a == b)
+                        .ut_host
+                        .iter()
+                        .zip(other.ut_host.iter())
+                        .all(|(a, b)| a == b)
                     && self.ut_exit == other.ut_exit
                     && self.ut_session == other.ut_session
                     && self.ut_tv == other.ut_tv
@@ -1100,7 +1091,7 @@ cfg_if! {
                     .field("ut_line", &self.ut_line)
                     .field("ut_id", &self.ut_id)
                     .field("ut_user", &self.ut_user)
-                // FIXME: .field("ut_host", &self.ut_host)
+                    // FIXME: .field("ut_host", &self.ut_host)
                     .field("ut_exit", &self.ut_exit)
                     .field("ut_session", &self.ut_session)
                     .field("ut_tv", &self.ut_tv)
@@ -3459,26 +3450,21 @@ f! {
     }
 
     pub {const} fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(::mem::size_of::<cmsghdr>()))
-            as ::c_uint
+        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(::mem::size_of::<cmsghdr>())) as ::c_uint
     }
 
     pub {const} fn CMSG_LEN(length: ::c_uint) -> ::c_uint {
         CMSG_ALIGN(::mem::size_of::<cmsghdr>()) as ::c_uint + length
     }
 
-    pub fn CMSG_NXTHDR(mhdr: *const msghdr,
-                       cmsg: *const cmsghdr) -> *mut cmsghdr {
+    pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         if ((*cmsg).cmsg_len as usize) < ::mem::size_of::<cmsghdr>() {
             return 0 as *mut cmsghdr;
         };
-        let next = (cmsg as usize +
-                    CMSG_ALIGN((*cmsg).cmsg_len as usize))
-            as *mut cmsghdr;
-        let max = (*mhdr).msg_control as usize
-            + (*mhdr).msg_controllen as usize;
-        if (next.offset(1)) as usize > max ||
-            next as usize + CMSG_ALIGN((*next).cmsg_len as usize) > max
+        let next = (cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr;
+        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
+        if (next.offset(1)) as usize > max
+            || next as usize + CMSG_ALIGN((*next).cmsg_len as usize) > max
         {
             0 as *mut cmsghdr
         } else {
@@ -3499,16 +3485,14 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits
-            = 8 * ::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * ::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] |= 1 << offset;
         ()
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits
-            = 8 * ::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * ::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] &= !(1 << offset);
         ()
@@ -3525,7 +3509,7 @@ f! {
         let size_of_mask = ::mem::size_of_val(&cpuset.bits[0]);
         for i in cpuset.bits[..(size / size_of_mask)].iter() {
             s += i.count_ones();
-        };
+        }
         s as ::c_int
     }
 
@@ -3538,7 +3522,7 @@ f! {
     }
 
     pub fn major(dev: ::dev_t) -> ::c_uint {
-         ((dev >> 8) & 0xff) as ::c_uint
+        ((dev >> 8) & 0xff) as ::c_uint
     }
 
     pub fn minor(dev: ::dev_t) -> ::c_uint {
@@ -3557,20 +3541,20 @@ f! {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
-        return
+        return;
     }
 
     pub fn FD_ISSET(fd: ::c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
-        return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0
+        return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: ::c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
-        return
+        return;
     }
 
     pub fn FD_ZERO(set: *mut fd_set) -> () {

--- a/src/unix/linux_like/android/b32/arm.rs
+++ b/src/unix/linux_like/android/b32/arm.rs
@@ -58,11 +58,9 @@ s_no_extra_traits! {
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         impl PartialEq for __c_anonymous_uc_sigmask_with_padding {
-            fn eq(
-                &self, other: &__c_anonymous_uc_sigmask_with_padding
-            ) -> bool {
+            fn eq(&self, other: &__c_anonymous_uc_sigmask_with_padding) -> bool {
                 self.uc_sigmask == other.uc_sigmask
-                    // Ignore padding
+                // Ignore padding
             }
         }
         impl Eq for __c_anonymous_uc_sigmask_with_padding {}
@@ -77,7 +75,7 @@ cfg_if! {
         impl ::hash::Hash for __c_anonymous_uc_sigmask_with_padding {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 self.uc_sigmask.hash(state)
-                    // Ignore padding
+                // Ignore padding
             }
         }
 
@@ -106,10 +104,9 @@ cfg_if! {
                     && self.uc_link == other.uc_link
                     && self.uc_stack == other.uc_stack
                     && self.uc_mcontext == other.uc_mcontext
-                    && self.uc_sigmask__c_anonymous_union
-                        == other.uc_sigmask__c_anonymous_union
+                    && self.uc_sigmask__c_anonymous_union == other.uc_sigmask__c_anonymous_union
                     && &self.uc_regspace[..] == &other.uc_regspace[..]
-                    // Ignore padding field
+                // Ignore padding field
             }
         }
         impl Eq for ucontext_t {}
@@ -122,7 +119,7 @@ cfg_if! {
                     .field("uc_mcontext", &self.uc_mcontext)
                     .field(
                         "uc_sigmask__c_anonymous_union",
-                        &self.uc_sigmask__c_anonymous_union
+                        &self.uc_sigmask__c_anonymous_union,
                     )
                     .field("uc_regspace", &&self.uc_regspace[..])
                     // Ignore padding field
@@ -558,7 +555,7 @@ f! {
         fd: ::c_int,
         addr: *mut ::sockaddr,
         len: *mut ::socklen_t,
-        flg: ::c_int
+        flg: ::c_int,
     ) -> ::c_int {
         ::syscall(SYS_accept4, fd, addr, len, flg) as ::c_int
     }

--- a/src/unix/linux_like/android/b32/mod.rs
+++ b/src/unix/linux_like/android/b32/mod.rs
@@ -16,7 +16,7 @@ s! {
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: ::sigset_t,
         pub sa_flags: ::c_int,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
     }
 
     pub struct rlimit64 {
@@ -106,9 +106,13 @@ s! {
         pub sched_priority: i32,
     }
 
-    pub struct pthread_mutex_t { value: ::c_int }
+    pub struct pthread_mutex_t {
+        value: ::c_int,
+    }
 
-    pub struct pthread_cond_t { value: ::c_int }
+    pub struct pthread_cond_t {
+        value: ::c_int,
+    }
 
     pub struct pthread_rwlock_t {
         lock: pthread_mutex_t,
@@ -173,7 +177,7 @@ s! {
 
 s_no_extra_traits! {
     pub struct sigset64_t {
-        __bits: [::c_ulong; 2]
+        __bits: [::c_ulong; 2],
     }
 }
 

--- a/src/unix/linux_like/android/b32/x86/mod.rs
+++ b/src/unix/linux_like/android/b32/x86/mod.rs
@@ -53,18 +53,16 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
-        priv_: [f64; 2]
+        priv_: [f64; 2],
     }
 }
 
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         impl PartialEq for __c_anonymous_uc_sigmask_with_padding {
-            fn eq(
-                &self, other: &__c_anonymous_uc_sigmask_with_padding
-            ) -> bool {
+            fn eq(&self, other: &__c_anonymous_uc_sigmask_with_padding) -> bool {
                 self.uc_sigmask == other.uc_sigmask
-                    // Ignore padding
+                // Ignore padding
             }
         }
         impl Eq for __c_anonymous_uc_sigmask_with_padding {}
@@ -79,7 +77,7 @@ cfg_if! {
         impl ::hash::Hash for __c_anonymous_uc_sigmask_with_padding {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 self.uc_sigmask.hash(state)
-                    // Ignore padding
+                // Ignore padding
             }
         }
 
@@ -108,9 +106,8 @@ cfg_if! {
                     && self.uc_link == other.uc_link
                     && self.uc_stack == other.uc_stack
                     && self.uc_mcontext == other.uc_mcontext
-                    && self.uc_sigmask__c_anonymous_union
-                        == other.uc_sigmask__c_anonymous_union
-                    // Ignore padding field
+                    && self.uc_sigmask__c_anonymous_union == other.uc_sigmask__c_anonymous_union
+                // Ignore padding field
             }
         }
         impl Eq for ucontext_t {}
@@ -123,7 +120,7 @@ cfg_if! {
                     .field("uc_mcontext", &self.uc_mcontext)
                     .field(
                         "uc_sigmask__c_anonymous_union",
-                        &self.uc_sigmask__c_anonymous_union
+                        &self.uc_sigmask__c_anonymous_union,
                     )
                     // Ignore padding field
                     .finish()
@@ -624,7 +621,7 @@ f! {
         fd: ::c_int,
         addr: *mut ::sockaddr,
         len: *mut ::socklen_t,
-        flg: ::c_int
+        flg: ::c_int,
     ) -> ::c_int {
         // Arguments are passed as array of `long int`
         // (which is big enough on x86 for a pointer).

--- a/src/unix/linux_like/android/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/android/b64/aarch64/mod.rs
@@ -86,7 +86,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
-        priv_: [f32; 8]
+        priv_: [f32; 8],
     }
 }
 

--- a/src/unix/linux_like/android/b64/mod.rs
+++ b/src/unix/linux_like/android/b64/mod.rs
@@ -16,7 +16,7 @@ s! {
         pub sa_flags: ::c_int,
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: ::sigset_t,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
     }
 
     pub struct rlimit64 {
@@ -136,7 +136,7 @@ s_no_extra_traits! {
     }
 
     pub struct sigset64_t {
-        __bits: [::c_ulong; 1]
+        __bits: [::c_ulong; 1],
     }
 }
 
@@ -146,10 +146,10 @@ cfg_if! {
             fn eq(&self, other: &pthread_mutex_t) -> bool {
                 self.value == other.value
                     && self
-                    .__reserved
-                    .iter()
-                    .zip(other.__reserved.iter())
-                    .all(|(a,b)| a == b)
+                        .__reserved
+                        .iter()
+                        .zip(other.__reserved.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -175,10 +175,10 @@ cfg_if! {
             fn eq(&self, other: &pthread_cond_t) -> bool {
                 self.value == other.value
                     && self
-                    .__reserved
-                    .iter()
-                    .zip(other.__reserved.iter())
-                    .all(|(a,b)| a == b)
+                        .__reserved
+                        .iter()
+                        .zip(other.__reserved.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -208,10 +208,10 @@ cfg_if! {
                     && self.pendingWriters == other.pendingWriters
                     && self.attr == other.attr
                     && self
-                    .__reserved
-                    .iter()
-                    .zip(other.__reserved.iter())
-                    .all(|(a,b)| a == b)
+                        .__reserved
+                        .iter()
+                        .zip(other.__reserved.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -298,7 +298,7 @@ f! {
         fd: ::c_int,
         addr: *mut ::sockaddr,
         len: *mut ::socklen_t,
-        flg: ::c_int
+        flg: ::c_int,
     ) -> ::c_int {
         ::syscall(SYS_accept4, fd, addr, len, flg) as ::c_int
     }

--- a/src/unix/linux_like/android/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/android/b64/riscv64/mod.rs
@@ -56,7 +56,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
-        priv_: [f32; 8]
+        priv_: [f32; 8],
     }
 }
 

--- a/src/unix/linux_like/android/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/android/b64/x86_64/mod.rs
@@ -102,7 +102,6 @@ s! {
         pub error_code: ::c_ulong,
         pub fault_address: ::c_ulong,
     }
-
 }
 
 s_no_extra_traits! {
@@ -114,7 +113,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
-        priv_: [f64; 4]
+        priv_: [f64; 4],
     }
 }
 
@@ -196,9 +195,8 @@ cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         impl PartialEq for _libc_fpxreg {
             fn eq(&self, other: &Self) -> bool {
-                self.significand == other.significand
-                    && self.exponent == other.exponent
-                    // Ignore padding field
+                self.significand == other.significand && self.exponent == other.exponent
+                // Ignore padding field
             }
         }
         impl Eq for _libc_fpxreg {}
@@ -231,7 +229,7 @@ cfg_if! {
                     && self.mxcr_mask == other.mxcr_mask
                     && self._st == other._st
                     && self._xmm == other._xmm
-                    // Ignore padding field
+                // Ignore padding field
             }
         }
         impl Eq for _libc_fpstate {}
@@ -270,9 +268,8 @@ cfg_if! {
 
         impl PartialEq for mcontext_t {
             fn eq(&self, other: &Self) -> bool {
-                self.gregs == other.gregs
-                    && self.fpregs == other.fpregs
-                    // Ignore padding field
+                self.gregs == other.gregs && self.fpregs == other.fpregs
+                // Ignore padding field
             }
         }
         impl Eq for mcontext_t {}
@@ -300,7 +297,7 @@ cfg_if! {
                     && self.uc_stack == other.uc_stack
                     && self.uc_mcontext == other.uc_mcontext
                     && self.uc_sigmask64 == other.uc_sigmask64
-                    // Ignore padding field
+                // Ignore padding field
             }
         }
         impl Eq for ucontext_t {}
@@ -339,10 +336,10 @@ cfg_if! {
                     && self.mxcr_mask == other.mxcr_mask
                     && self.st_space == other.st_space
                     && self
-                    .xmm_space
-                    .iter()
-                    .zip(other.xmm_space.iter())
-                    .all(|(a,b)| a == b)
+                        .xmm_space
+                        .iter()
+                        .zip(other.xmm_space.iter())
+                        .all(|(a, b)| a == b)
                 // Ignore padding field
             }
         }
@@ -361,8 +358,8 @@ cfg_if! {
                     .field("mxcsr", &self.mxcsr)
                     .field("mxcr_mask", &self.mxcr_mask)
                     .field("st_space", &self.st_space)
-                // FIXME: .field("xmm_space", &self.xmm_space)
-                // Ignore padding field
+                    // FIXME: .field("xmm_space", &self.xmm_space)
+                    // Ignore padding field
                     .finish()
             }
         }

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -56,7 +56,7 @@ s! {
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 
     pub struct __fsid_t {
@@ -251,7 +251,7 @@ s! {
         pub wd: ::c_int,
         pub mask: u32,
         pub cookie: u32,
-        pub len: u32
+        pub len: u32,
     }
 
     pub struct sock_extended_err {
@@ -281,7 +281,7 @@ s! {
         pub svm_reserved1: ::c_ushort,
         pub svm_port: ::c_uint,
         pub svm_cid: ::c_uint,
-        pub svm_zero: [u8; 4]
+        pub svm_zero: [u8; 4],
     }
 
     // linux/elf.h
@@ -511,9 +511,9 @@ s! {
     }
 
     pub struct in6_ifreq {
-       pub ifr6_addr: ::in6_addr,
-       pub ifr6_prefixlen: u32,
-       pub ifr6_ifindex: ::c_int,
+        pub ifr6_addr: ::in6_addr,
+        pub ifr6_prefixlen: u32,
+        pub ifr6_ifindex: ::c_int,
     }
 
     pub struct statx {
@@ -555,7 +555,7 @@ s_no_extra_traits! {
         pub nl_family: ::sa_family_t,
         nl_pad: ::c_ushort,
         pub nl_pid: u32,
-        pub nl_groups: u32
+        pub nl_groups: u32,
     }
 
     pub struct dirent {
@@ -669,16 +669,15 @@ s_no_extra_traits! {
         pub ifc_len: ::c_int,
         pub ifc_ifcu: __c_anonymous_ifc_ifcu,
     }
-
 }
 
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         impl PartialEq for sockaddr_nl {
             fn eq(&self, other: &sockaddr_nl) -> bool {
-                self.nl_family == other.nl_family &&
-                    self.nl_pid == other.nl_pid &&
-                    self.nl_groups == other.nl_groups
+                self.nl_family == other.nl_family
+                    && self.nl_pid == other.nl_pid
+                    && self.nl_groups == other.nl_groups
             }
         }
         impl Eq for sockaddr_nl {}
@@ -706,10 +705,10 @@ cfg_if! {
                     && self.d_reclen == other.d_reclen
                     && self.d_type == other.d_type
                     && self
-                    .d_name
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                        .d_name
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -722,7 +721,7 @@ cfg_if! {
                     .field("d_off", &self.d_off)
                     .field("d_reclen", &self.d_reclen)
                     .field("d_type", &self.d_type)
-                // FIXME: .field("d_name", &self.d_name)
+                    // FIXME: .field("d_name", &self.d_name)
                     .finish()
             }
         }
@@ -744,10 +743,10 @@ cfg_if! {
                     && self.d_reclen == other.d_reclen
                     && self.d_type == other.d_type
                     && self
-                    .d_name
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                        .d_name
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -760,7 +759,7 @@ cfg_if! {
                     .field("d_off", &self.d_off)
                     .field("d_reclen", &self.d_reclen)
                     .field("d_type", &self.d_type)
-                // FIXME: .field("d_name", &self.d_name)
+                    // FIXME: .field("d_name", &self.d_name)
                     .finish()
             }
         }
@@ -793,8 +792,8 @@ cfg_if! {
                     .field("si_signo", &self.si_signo)
                     .field("si_errno", &self.si_errno)
                     .field("si_code", &self.si_code)
-                // Ignore _pad
-                // Ignore _align
+                    // Ignore _pad
+                    // Ignore _align
                     .finish()
             }
         }
@@ -813,15 +812,15 @@ cfg_if! {
             fn eq(&self, other: &lastlog) -> bool {
                 self.ll_time == other.ll_time
                     && self
-                    .ll_line
-                    .iter()
-                    .zip(other.ll_line.iter())
-                    .all(|(a,b)| a == b)
+                        .ll_line
+                        .iter()
+                        .zip(other.ll_line.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .ll_host
-                    .iter()
-                    .zip(other.ll_host.iter())
-                    .all(|(a,b)| a == b)
+                        .ll_host
+                        .iter()
+                        .zip(other.ll_host.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -832,7 +831,7 @@ cfg_if! {
                 f.debug_struct("lastlog")
                     .field("ll_time", &self.ll_time)
                     .field("ll_line", &self.ll_line)
-                // FIXME: .field("ll_host", &self.ll_host)
+                    // FIXME: .field("ll_host", &self.ll_host)
                     .finish()
             }
         }
@@ -850,21 +849,21 @@ cfg_if! {
                 self.ut_type == other.ut_type
                     && self.ut_pid == other.ut_pid
                     && self
-                    .ut_line
-                    .iter()
-                    .zip(other.ut_line.iter())
-                    .all(|(a,b)| a == b)
+                        .ut_line
+                        .iter()
+                        .zip(other.ut_line.iter())
+                        .all(|(a, b)| a == b)
                     && self.ut_id == other.ut_id
                     && self
-                    .ut_user
-                    .iter()
-                    .zip(other.ut_user.iter())
-                    .all(|(a,b)| a == b)
+                        .ut_user
+                        .iter()
+                        .zip(other.ut_user.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .ut_host
-                    .iter()
-                    .zip(other.ut_host.iter())
-                    .all(|(a,b)| a == b)
+                        .ut_host
+                        .iter()
+                        .zip(other.ut_host.iter())
+                        .all(|(a, b)| a == b)
                     && self.ut_exit == other.ut_exit
                     && self.ut_session == other.ut_session
                     && self.ut_tv == other.ut_tv
@@ -883,7 +882,7 @@ cfg_if! {
                     .field("ut_line", &self.ut_line)
                     .field("ut_id", &self.ut_id)
                     .field("ut_user", &self.ut_user)
-                // FIXME: .field("ut_host", &self.ut_host)
+                    // FIXME: .field("ut_host", &self.ut_host)
                     .field("ut_exit", &self.ut_exit)
                     .field("ut_session", &self.ut_session)
                     .field("ut_tv", &self.ut_tv)
@@ -913,18 +912,18 @@ cfg_if! {
             fn eq(&self, other: &sockaddr_alg) -> bool {
                 self.salg_family == other.salg_family
                     && self
-                    .salg_type
-                    .iter()
-                    .zip(other.salg_type.iter())
-                    .all(|(a, b)| a == b)
+                        .salg_type
+                        .iter()
+                        .zip(other.salg_type.iter())
+                        .all(|(a, b)| a == b)
                     && self.salg_feat == other.salg_feat
                     && self.salg_mask == other.salg_mask
                     && self
-                    .salg_name
-                    .iter()
-                    .zip(other.salg_name.iter())
-                    .all(|(a, b)| a == b)
-           }
+                        .salg_name
+                        .iter()
+                        .zip(other.salg_name.iter())
+                        .all(|(a, b)| a == b)
+            }
         }
 
         impl Eq for sockaddr_alg {}
@@ -956,7 +955,7 @@ cfg_if! {
                 self.id == other.id
                     && self.name[..] == other.name[..]
                     && self.ff_effects_max == other.ff_effects_max
-           }
+            }
         }
         impl Eq for uinput_setup {}
 
@@ -980,14 +979,14 @@ cfg_if! {
 
         impl PartialEq for uinput_user_dev {
             fn eq(&self, other: &uinput_user_dev) -> bool {
-                 self.name[..] == other.name[..]
+                self.name[..] == other.name[..]
                     && self.id == other.id
                     && self.ff_effects_max == other.ff_effects_max
                     && self.absmax[..] == other.absmax[..]
                     && self.absmin[..] == other.absmin[..]
                     && self.absfuzz[..] == other.absfuzz[..]
                     && self.absflat[..] == other.absflat[..]
-           }
+            }
         }
         impl Eq for uinput_user_dev {}
 
@@ -1064,9 +1063,9 @@ cfg_if! {
 
         impl PartialEq for prop_info {
             fn eq(&self, other: &prop_info) -> bool {
-                self.__name == other.__name &&
-                    self.__serial == other.__serial &&
-                    self.__value == other.__value
+                self.__name == other.__name
+                    && self.__serial == other.__serial
+                    && self.__value == other.__value
             }
         }
         impl Eq for prop_info {}
@@ -1708,18 +1707,22 @@ pub const TIOCCONS: ::c_int = 0x541D;
 pub const TIOCSBRK: ::c_int = 0x5427;
 pub const TIOCCBRK: ::c_int = 0x5428;
 cfg_if! {
-    if #[cfg(any(target_arch = "x86",
-                 target_arch = "x86_64",
-                 target_arch = "arm",
-                 target_arch = "aarch64",
-                 target_arch = "riscv64",
-                 target_arch = "s390x"))] {
+    if #[cfg(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "s390x"
+    ))] {
         pub const FICLONE: ::c_int = 0x40049409;
         pub const FICLONERANGE: ::c_int = 0x4020940D;
-    } else if #[cfg(any(target_arch = "mips",
-                        target_arch = "mips64",
-                        target_arch = "powerpc",
-                        target_arch = "powerpc64"))] {
+    } else if #[cfg(any(
+        target_arch = "mips",
+        target_arch = "mips64",
+        target_arch = "powerpc",
+        target_arch = "powerpc64"
+    ))] {
         pub const FICLONE: ::c_int = 0x80049409;
         pub const FICLONERANGE: ::c_int = 0x8020940D;
     }
@@ -1921,7 +1924,11 @@ cfg_if! {
         pub const FS_IOC32_SETFLAGS: ::c_int = 0x40046602;
         pub const FS_IOC32_GETVERSION: ::c_int = 0x80047601;
         pub const FS_IOC32_SETVERSION: ::c_int = 0x40047602;
-    } else if #[cfg(any(target_arch = "x86_64", target_arch = "riscv64", target_arch = "aarch64"))] {
+    } else if #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "riscv64",
+        target_arch = "aarch64"
+    ))] {
         pub const FS_IOC_GETFLAGS: ::c_int = 0x80086601;
         pub const FS_IOC_SETFLAGS: ::c_int = 0x40086602;
         pub const FS_IOC_GETVERSION: ::c_int = 0x80087601;
@@ -3589,13 +3596,9 @@ cfg_if! {
 }
 
 f! {
-    pub fn CMSG_NXTHDR(mhdr: *const msghdr,
-                       cmsg: *const cmsghdr) -> *mut cmsghdr {
-        let next = (cmsg as usize
-                    + super::CMSG_ALIGN((*cmsg).cmsg_len as usize))
-            as *mut cmsghdr;
-        let max = (*mhdr).msg_control as usize
-            + (*mhdr).msg_controllen as usize;
+    pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
+        let next = (cmsg as usize + super::CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr;
+        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if (next.offset(1)) as usize > max {
             0 as *mut cmsghdr
         } else {
@@ -3616,16 +3619,14 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits
-            = 8 * ::mem::size_of_val(&cpuset.__bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * ::mem::size_of_val(&cpuset.__bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.__bits[idx] |= 1 << offset;
         ()
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits
-            = 8 * ::mem::size_of_val(&cpuset.__bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * ::mem::size_of_val(&cpuset.__bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.__bits[idx] &= !(1 << offset);
         ()
@@ -3642,7 +3643,7 @@ f! {
         let size_of_mask = ::mem::size_of_val(&cpuset.__bits[0]);
         for i in cpuset.__bits[..(size / size_of_mask)].iter() {
             s += i.count_ones();
-        };
+        }
         s as ::c_int
     }
 
@@ -3661,7 +3662,7 @@ f! {
         ((dev & 0xff) | ((dev >> 12) & 0xfff00)) as ::c_int
     }
     pub fn NLA_ALIGN(len: ::c_int) -> ::c_int {
-        return ((len) + NLA_ALIGNTO - 1) & !(NLA_ALIGNTO - 1)
+        return ((len) + NLA_ALIGNTO - 1) & !(NLA_ALIGNTO - 1);
     }
 
     pub fn SO_EE_OFFENDER(ee: *const ::sock_extended_err) -> *mut ::sockaddr {
@@ -3675,7 +3676,6 @@ safe_f! {
         let mi = mi as ::dev_t;
         ((ma & 0xfff) << 8) | (mi & 0xff) | ((mi & 0xfff00) << 12)
     }
-
 }
 
 extern "C" {

--- a/src/unix/linux_like/linux/arch/generic/mod.rs
+++ b/src/unix/linux_like/linux/arch/generic/mod.rs
@@ -92,12 +92,16 @@ pub const SO_BINDTOIFINDEX: ::c_int = 62;
 cfg_if! {
     // Some of these platforms in CI already have these constants.
     // But they may still not have those _OLD ones.
-    if #[cfg(all(any(target_arch = "x86",
-                     target_arch = "x86_64",
-                     target_arch = "aarch64",
-                     target_arch = "csky",
-                     target_arch = "loongarch64"),
-                 not(any(target_env = "musl", target_env = "ohos"))))] {
+    if #[cfg(all(
+        any(
+            target_arch = "x86",
+            target_arch = "x86_64",
+            target_arch = "aarch64",
+            target_arch = "csky",
+            target_arch = "loongarch64"
+        ),
+        not(any(target_env = "musl", target_env = "ohos"))
+    ))] {
         pub const SO_TIMESTAMP_NEW: ::c_int = 63;
         pub const SO_TIMESTAMPNS_NEW: ::c_int = 64;
         pub const SO_TIMESTAMPING_NEW: ::c_int = 65;
@@ -110,14 +114,16 @@ cfg_if! {
 // pub const SO_BUSY_POLL_BUDGET: ::c_int = 70;
 
 cfg_if! {
-    if #[cfg(any(target_arch = "x86",
-                 target_arch = "x86_64",
-                 target_arch = "arm",
-                 target_arch = "aarch64",
-                 target_arch = "riscv64",
-                 target_arch = "s390x",
-                 target_arch = "csky",
-                 target_arch = "loongarch64"))] {
+    if #[cfg(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "s390x",
+        target_arch = "csky",
+        target_arch = "loongarch64"
+    ))] {
         pub const FICLONE: ::c_ulong = 0x40049409;
         pub const FICLONERANGE: ::c_ulong = 0x4020940D;
     }
@@ -246,7 +252,11 @@ cfg_if! {
     // where S stands for size (int, long, struct...)
     // where T stands for type ('f','v','X'...)
     // where N stands for NR (NumbeR)
-    if #[cfg(any(target_arch = "x86", target_arch = "arm", target_arch = "csky"))] {
+    if #[cfg(any(
+        target_arch = "x86",
+        target_arch = "arm",
+        target_arch = "csky"
+    ))] {
         pub const FS_IOC_GETFLAGS: ::Ioctl = 0x80046601;
         pub const FS_IOC_SETFLAGS: ::Ioctl = 0x40046602;
         pub const FS_IOC_GETVERSION: ::Ioctl = 0x80047601;
@@ -258,11 +268,13 @@ cfg_if! {
         pub const TUNATTACHFILTER: ::Ioctl = 0x400854d5;
         pub const TUNDETACHFILTER: ::Ioctl = 0x400854d6;
         pub const TUNGETFILTER: ::Ioctl = 0x800854db;
-    } else if #[cfg(any(target_arch = "x86_64",
-                        target_arch = "riscv64",
-                        target_arch = "aarch64",
-                        target_arch = "s390x",
-                        target_arch = "loongarch64"))] {
+    } else if #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "riscv64",
+        target_arch = "aarch64",
+        target_arch = "s390x",
+        target_arch = "loongarch64"
+    ))] {
         pub const FS_IOC_GETFLAGS: ::Ioctl = 0x80086601;
         pub const FS_IOC_SETFLAGS: ::Ioctl = 0x40086602;
         pub const FS_IOC_GETVERSION: ::Ioctl = 0x80087601;
@@ -278,8 +290,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(any(target_arch = "arm",
-                 target_arch = "s390x"))] {
+    if #[cfg(any(target_arch = "arm", target_arch = "s390x"))] {
         pub const FIOQSIZE: ::Ioctl = 0x545E;
     } else {
         pub const FIOQSIZE: ::Ioctl = 0x5460;
@@ -304,9 +315,7 @@ pub const IBSHIFT: ::tcflag_t = 16;
 // RLIMIT Constants
 
 cfg_if! {
-    if #[cfg(any(target_env = "gnu",
-                 target_env = "uclibc"))] {
-
+    if #[cfg(any(target_env = "gnu", target_env = "uclibc"))] {
         pub const RLIMIT_CPU: ::__rlimit_resource_t = 0;
         pub const RLIMIT_FSIZE: ::__rlimit_resource_t = 1;
         pub const RLIMIT_DATA: ::__rlimit_resource_t = 2;
@@ -326,9 +335,7 @@ cfg_if! {
         #[allow(deprecated)]
         #[deprecated(since = "0.2.64", note = "Not stable across OS versions")]
         pub const RLIMIT_NLIMITS: ::__rlimit_resource_t = RLIM_NLIMITS;
-
     } else if #[cfg(any(target_env = "musl", target_env = "ohos"))] {
-
         pub const RLIMIT_CPU: ::c_int = 0;
         pub const RLIMIT_FSIZE: ::c_int = 1;
         pub const RLIMIT_DATA: ::c_int = 2;
@@ -357,8 +364,7 @@ cfg_if! {
     if #[cfg(target_env = "gnu")] {
         #[deprecated(since = "0.2.64", note = "Not stable across OS versions")]
         pub const RLIM_NLIMITS: ::__rlimit_resource_t = 16;
-    }
-    else if #[cfg(target_env = "uclibc")] {
+    } else if #[cfg(target_env = "uclibc")] {
         #[deprecated(since = "0.2.64", note = "Not stable across OS versions")]
         pub const RLIM_NLIMITS: ::__rlimit_resource_t = 15;
     }

--- a/src/unix/linux_like/linux/arch/mips/mod.rs
+++ b/src/unix/linux_like/linux/arch/mips/mod.rs
@@ -280,9 +280,7 @@ pub const IBSHIFT: ::tcflag_t = 16;
 // RLIMIT Constants
 
 cfg_if! {
-    if #[cfg(any(target_env = "gnu",
-                 target_env = "uclibc"))] {
-
+    if #[cfg(any(target_env = "gnu", target_env = "uclibc"))] {
         pub const RLIMIT_CPU: ::__rlimit_resource_t = 0;
         pub const RLIMIT_FSIZE: ::__rlimit_resource_t = 1;
         pub const RLIMIT_DATA: ::__rlimit_resource_t = 2;
@@ -302,9 +300,7 @@ cfg_if! {
         #[allow(deprecated)]
         #[deprecated(since = "0.2.64", note = "Not stable across OS versions")]
         pub const RLIMIT_NLIMITS: ::__rlimit_resource_t = RLIM_NLIMITS;
-
     } else if #[cfg(target_env = "musl")] {
-
         pub const RLIMIT_CPU: ::c_int = 0;
         pub const RLIMIT_FSIZE: ::c_int = 1;
         pub const RLIMIT_DATA: ::c_int = 2;
@@ -341,17 +337,19 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"),
-         any(target_env = "gnu",
-             target_env = "uclibc"))] {
+    if #[cfg(
+        any(target_arch = "mips64", target_arch = "mips64r6"),
+        any(target_env = "gnu", target_env = "uclibc")
+    )] {
         pub const RLIM_INFINITY: ::rlim_t = !0;
     }
 }
 
 cfg_if! {
-    if #[cfg(any(target_arch = "mips", target_arch = "mips32r6"),
-         any(target_env = "gnu",
-             target_env = "uclibc"))] {
+    if #[cfg(
+        any(target_arch = "mips", target_arch = "mips32r6"),
+        any(target_env = "gnu", target_env = "uclibc")
+    )] {
         pub const RLIM_INFINITY: ::rlim_t = 0x7fffffff;
     }
 }

--- a/src/unix/linux_like/linux/arch/mod.rs
+++ b/src/unix/linux_like/linux/arch/mod.rs
@@ -1,8 +1,10 @@
 cfg_if! {
-    if #[cfg(any(target_arch = "mips",
-                 target_arch = "mips32r6",
-                 target_arch = "mips64",
-                 target_arch = "mips64r6"))] {
+    if #[cfg(any(
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "mips64",
+        target_arch = "mips64r6"
+    ))] {
         mod mips;
         pub use self::mips::*;
     } else if #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))] {

--- a/src/unix/linux_like/linux/arch/powerpc/mod.rs
+++ b/src/unix/linux_like/linux/arch/powerpc/mod.rs
@@ -260,7 +260,6 @@ pub const IBSHIFT: ::tcflag_t = 16;
 
 cfg_if! {
     if #[cfg(target_env = "gnu")] {
-
         pub const RLIMIT_CPU: ::__rlimit_resource_t = 0;
         pub const RLIMIT_FSIZE: ::__rlimit_resource_t = 1;
         pub const RLIMIT_DATA: ::__rlimit_resource_t = 2;
@@ -282,9 +281,7 @@ cfg_if! {
         #[allow(deprecated)]
         #[deprecated(since = "0.2.64", note = "Not stable across OS versions")]
         pub const RLIMIT_NLIMITS: ::__rlimit_resource_t = RLIM_NLIMITS;
-
     } else if #[cfg(target_env = "musl")] {
-
         pub const RLIMIT_CPU: ::c_int = 0;
         pub const RLIMIT_FSIZE: ::c_int = 1;
         pub const RLIMIT_DATA: ::c_int = 2;

--- a/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
@@ -6,7 +6,7 @@ s! {
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: ::sigset_t,
         pub sa_flags: ::c_int,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
     }
 
     pub struct statfs {
@@ -53,7 +53,7 @@ s! {
         pub __seq: ::c_ushort,
         __pad2: ::c_ushort,
         __unused1: ::c_ulong,
-        __unused2: ::c_ulong
+        __unused2: ::c_ulong,
     }
 
     pub struct stat64 {
@@ -122,7 +122,7 @@ s! {
         pub shm_lpid: ::pid_t,
         pub shm_nattch: ::shmatt_t,
         __unused4: ::c_ulong,
-        __unused5: ::c_ulong
+        __unused5: ::c_ulong,
     }
 
     pub struct msqid_ds {
@@ -148,8 +148,8 @@ s! {
         pub si_code: ::c_int,
         #[doc(hidden)]
         #[deprecated(
-            since="0.2.54",
-            note="Please leave a comment on \
+            since = "0.2.54",
+            note = "Please leave a comment on \
                   https://github.com/rust-lang/libc/pull/1316 if you're using \
                   this field"
         )]
@@ -160,7 +160,7 @@ s! {
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 
     pub struct mcontext_t {
@@ -213,7 +213,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
-        priv_: [i64; 2]
+        priv_: [i64; 2],
     }
 
     #[allow(missing_debug_implementations)]

--- a/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
@@ -6,7 +6,7 @@ s! {
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: ::sigset_t,
         pub sa_flags: ::c_int,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
     }
 
     pub struct statfs {
@@ -52,7 +52,7 @@ s! {
         pub __seq: ::c_ushort,
         __pad2: ::c_ushort,
         __unused1: ::c_ulong,
-        __unused2: ::c_ulong
+        __unused2: ::c_ulong,
     }
 
     pub struct stat64 {
@@ -121,7 +121,7 @@ s! {
         pub shm_lpid: ::pid_t,
         pub shm_nattch: ::shmatt_t,
         __unused4: ::c_ulong,
-        __unused5: ::c_ulong
+        __unused5: ::c_ulong,
     }
 
     pub struct msqid_ds {
@@ -147,8 +147,8 @@ s! {
         pub si_code: ::c_int,
         #[doc(hidden)]
         #[deprecated(
-            since="0.2.54",
-            note="Please leave a comment on \
+            since = "0.2.54",
+            note = "Please leave a comment on \
                   https://github.com/rust-lang/libc/pull/1316 if you're using \
                   this field"
         )]
@@ -159,7 +159,7 @@ s! {
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 }
 
@@ -167,7 +167,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
-        priv_: [i64; 2]
+        priv_: [i64; 2],
     }
 }
 

--- a/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
@@ -6,7 +6,7 @@ s! {
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: ::sigset_t,
         pub sa_flags: ::c_int,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
     }
 
     pub struct statfs {
@@ -152,7 +152,7 @@ s! {
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 }
 
@@ -160,7 +160,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(2))]
     pub struct max_align_t {
-        priv_: [i8; 20]
+        priv_: [i8; 20],
     }
 }
 

--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -76,7 +76,7 @@ s! {
         pub sa_flags: ::c_int,
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: ::sigset_t,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
         _resv: [::c_int; 1],
     }
 
@@ -103,7 +103,7 @@ s! {
         pub __seq: ::c_ushort,
         __pad1: ::c_ushort,
         __unused1: ::c_ulong,
-        __unused2: ::c_ulong
+        __unused2: ::c_ulong,
     }
 
     pub struct shmid_ds {
@@ -116,7 +116,7 @@ s! {
         pub shm_lpid: ::pid_t,
         pub shm_nattch: ::shmatt_t,
         __unused4: ::c_ulong,
-        __unused5: ::c_ulong
+        __unused5: ::c_ulong,
     }
 
     pub struct msqid_ds {
@@ -160,7 +160,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
-        priv_: [f32; 4]
+        priv_: [f32; 4],
     }
 }
 

--- a/src/unix/linux_like/linux/gnu/b32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mod.rs
@@ -107,7 +107,7 @@ s! {
     }
 
     pub struct pthread_attr_t {
-        __size: [u32; 9]
+        __size: [u32; 9],
     }
 
     pub struct sigset_t {
@@ -140,12 +140,20 @@ s! {
         #[cfg(target_arch = "powerpc")]
         __reserved: ::__syscall_ulong_t,
         pub sem_otime: ::time_t,
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6", target_arch = "powerpc")))]
+        #[cfg(not(any(
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "powerpc"
+        )))]
         __reserved: ::__syscall_ulong_t,
         #[cfg(target_arch = "powerpc")]
         __reserved2: ::__syscall_ulong_t,
         pub sem_ctime: ::time_t,
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6", target_arch = "powerpc")))]
+        #[cfg(not(any(
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "powerpc"
+        )))]
         __reserved2: ::__syscall_ulong_t,
         pub sem_nsems: ::__syscall_ulong_t,
         __glibc_reserved3: ::__syscall_ulong_t,

--- a/src/unix/linux_like/linux/gnu/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/gnu/b32/powerpc.rs
@@ -6,7 +6,7 @@ s! {
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: ::sigset_t,
         pub sa_flags: ::c_int,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
     }
 
     pub struct statfs {
@@ -148,8 +148,8 @@ s! {
         pub si_code: ::c_int,
         #[doc(hidden)]
         #[deprecated(
-            since="0.2.54",
-            note="Please leave a comment on \
+            since = "0.2.54",
+            note = "Please leave a comment on \
                   https://github.com/rust-lang/libc/pull/1316 if you're using \
                   this field"
         )]
@@ -160,7 +160,7 @@ s! {
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 }
 

--- a/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
@@ -132,8 +132,8 @@ s! {
         pub si_code: ::c_int,
         #[doc(hidden)]
         #[deprecated(
-            since="0.2.54",
-            note="Please leave a comment on \
+            since = "0.2.54",
+            note = "Please leave a comment on \
                   https://github.com/rust-lang/libc/pull/1316 if you're using \
                   this field"
         )]

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -8,7 +8,7 @@ s! {
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: ::sigset_t,
         pub sa_flags: ::c_int,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
     }
 
     pub struct statfs {
@@ -49,13 +49,13 @@ s! {
         pub l_start: ::off64_t,
         pub l_len: ::off64_t,
         pub l_pid: ::pid_t,
-        __reserved:  ::c_short,
+        __reserved: ::c_short,
     }
 
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 
     pub struct stat {
@@ -197,7 +197,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
-        priv_: [i64; 3]
+        priv_: [i64; 3],
     }
 }
 

--- a/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
@@ -7,7 +7,7 @@ s! {
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: ::sigset_t,
         pub sa_flags: ::c_int,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
     }
 
     pub struct statfs {
@@ -127,7 +127,7 @@ s! {
         pub __seq: ::c_ushort,
         __pad2: ::c_ushort,
         __unused1: ::c_ulong,
-        __unused2: ::c_ulong
+        __unused2: ::c_ulong,
     }
 
     pub struct stat64 {
@@ -196,7 +196,7 @@ s! {
         pub shm_lpid: ::pid_t,
         pub shm_nattch: ::shmatt_t,
         __unused4: ::c_ulong,
-        __unused5: ::c_ulong
+        __unused5: ::c_ulong,
     }
 
     pub struct msqid_ds {
@@ -222,8 +222,8 @@ s! {
         pub si_code: ::c_int,
         #[doc(hidden)]
         #[deprecated(
-            since="0.2.54",
-            note="Please leave a comment on \
+            since = "0.2.54",
+            note = "Please leave a comment on \
                   https://github.com/rust-lang/libc/pull/1316 if you're using \
                   this field"
         )]
@@ -234,9 +234,8 @@ s! {
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
-
 }
 
 s_no_extra_traits! {
@@ -269,7 +268,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
-        priv_: [f64; 6]
+        priv_: [f64; 6],
     }
 }
 
@@ -307,10 +306,10 @@ cfg_if! {
                     .field("foo", &self.foo)
                     .field("fos", &self.fos)
                     .field("mxcsr", &self.mxcsr)
-                // Ignore __reserved field
+                    // Ignore __reserved field
                     .field("st_space", &self.st_space)
                     .field("xmm_space", &self.xmm_space)
-                // Ignore padding field
+                    // Ignore padding field
                     .finish()
             }
         }
@@ -354,7 +353,7 @@ cfg_if! {
                     .field("uc_stack", &self.uc_stack)
                     .field("uc_mcontext", &self.uc_mcontext)
                     .field("uc_sigmask", &self.uc_sigmask)
-                // Ignore __private field
+                    // Ignore __private field
                     .finish()
             }
         }

--- a/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
@@ -15,7 +15,7 @@ s! {
         #[cfg(target_arch = "sparc64")]
         __reserved0: ::c_int,
         pub sa_flags: ::c_int,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
     }
 
     pub struct statfs {
@@ -140,7 +140,7 @@ s! {
     }
 
     pub struct pthread_attr_t {
-        __size: [usize; 8]
+        __size: [usize; 8],
     }
 
     pub struct user_regs_struct {
@@ -160,7 +160,7 @@ s! {
         pub __seq: ::c_ushort,
         __pad1: ::c_ushort,
         __unused1: ::c_ulong,
-        __unused2: ::c_ulong
+        __unused2: ::c_ulong,
     }
 
     pub struct shmid_ds {
@@ -173,7 +173,7 @@ s! {
         pub shm_lpid: ::pid_t,
         pub shm_nattch: ::shmatt_t,
         __unused4: ::c_ulong,
-        __unused5: ::c_ulong
+        __unused5: ::c_ulong,
     }
 
     pub struct siginfo_t {
@@ -182,8 +182,8 @@ s! {
         pub si_code: ::c_int,
         #[doc(hidden)]
         #[deprecated(
-            since="0.2.54",
-            note="Please leave a comment on \
+            since = "0.2.54",
+            note = "Please leave a comment on \
                   https://github.com/rust-lang/libc/pull/1316 if you're using \
                   this field"
         )]
@@ -194,7 +194,7 @@ s! {
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 
     pub struct ucontext_t {
@@ -241,7 +241,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
-        priv_: [f32; 8]
+        priv_: [f32; 8],
     }
 }
 

--- a/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
@@ -71,7 +71,7 @@ s! {
         pub f_spare: [::__fsword_t; 4],
     }
 
-        pub struct statfs64 {
+    pub struct statfs64 {
         pub f_type: ::__fsword_t,
         pub f_bsize: ::__fsword_t,
         pub f_blocks: u64,
@@ -133,14 +133,14 @@ s! {
     }
 
     pub struct pthread_attr_t {
-        __size: [::c_ulong; 7]
+        __size: [::c_ulong; 7],
     }
 
     pub struct sigaction {
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: ::sigset_t,
         pub sa_flags: ::c_int,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
     }
 
     pub struct stack_t {
@@ -155,8 +155,8 @@ s! {
         pub si_code: ::c_int,
         #[doc(hidden)]
         #[deprecated(
-            since="0.2.54",
-            note="Please leave a comment on \
+            since = "0.2.54",
+            note = "Please leave a comment on \
                   https://github.com/rust-lang/libc/pull/1316 if you're using \
                   this field"
         )]
@@ -174,7 +174,7 @@ s! {
         pub __seq: ::c_ushort,
         __pad2: ::c_ushort,
         __unused1: ::c_ulong,
-        __unused2: ::c_ulong
+        __unused2: ::c_ulong,
     }
 
     pub struct shmid_ds {
@@ -187,7 +187,7 @@ s! {
         pub shm_lpid: ::pid_t,
         pub shm_nattch: ::shmatt_t,
         __unused4: ::c_ulong,
-        __unused5: ::c_ulong
+        __unused5: ::c_ulong,
     }
 
     pub struct user_regs_struct {
@@ -196,7 +196,6 @@ s! {
         pub csr_era: u64,
         pub csr_badv: u64,
         pub reserved: [u64; 10],
-
     }
 
     pub struct user_fp_struct {
@@ -241,7 +240,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
-        priv_: [f64; 4]
+        priv_: [f64; 4],
     }
 }
 

--- a/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
@@ -135,14 +135,14 @@ s! {
     }
 
     pub struct pthread_attr_t {
-        __size: [::c_ulong; 7]
+        __size: [::c_ulong; 7],
     }
 
     pub struct sigaction {
         pub sa_flags: ::c_int,
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: ::sigset_t,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
     }
 
     pub struct stack_t {
@@ -169,7 +169,7 @@ s! {
         pub __seq: ::c_ushort,
         __pad1: ::c_ushort,
         __unused1: ::c_ulong,
-        __unused2: ::c_ulong
+        __unused2: ::c_ulong,
     }
 
     pub struct shmid_ds {
@@ -182,7 +182,7 @@ s! {
         pub shm_lpid: ::pid_t,
         pub shm_nattch: ::shmatt_t,
         __unused4: ::c_ulong,
-        __unused5: ::c_ulong
+        __unused5: ::c_ulong,
     }
 }
 
@@ -190,7 +190,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
-        priv_: [f64; 4]
+        priv_: [f64; 4],
     }
 }
 

--- a/src/unix/linux_like/linux/gnu/b64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mod.rs
@@ -75,7 +75,8 @@ s! {
             target_arch = "mips64r6",
             target_arch = "powerpc64",
             target_arch = "riscv64",
-            target_arch = "sparc64")))]
+            target_arch = "sparc64"
+        )))]
         __reserved: ::__syscall_ulong_t,
         pub sem_ctime: ::time_t,
         #[cfg(not(any(
@@ -85,7 +86,8 @@ s! {
             target_arch = "mips64r6",
             target_arch = "powerpc64",
             target_arch = "riscv64",
-            target_arch = "sparc64")))]
+            target_arch = "sparc64"
+        )))]
         __reserved2: ::__syscall_ulong_t,
         pub sem_nsems: ::__syscall_ulong_t,
         __glibc_reserved3: ::__syscall_ulong_t,

--- a/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
@@ -19,7 +19,7 @@ s! {
         #[cfg(target_arch = "sparc64")]
         __reserved0: ::c_int,
         pub sa_flags: ::c_int,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
     }
 
     pub struct statfs {
@@ -142,7 +142,7 @@ s! {
     }
 
     pub struct pthread_attr_t {
-        __size: [u64; 7]
+        __size: [u64; 7],
     }
 
     pub struct ipc_perm {
@@ -168,7 +168,7 @@ s! {
         pub shm_lpid: ::pid_t,
         pub shm_nattch: ::shmatt_t,
         __unused4: ::c_ulong,
-        __unused5: ::c_ulong
+        __unused5: ::c_ulong,
     }
 
     pub struct siginfo_t {
@@ -177,8 +177,8 @@ s! {
         pub si_code: ::c_int,
         #[doc(hidden)]
         #[deprecated(
-            since="0.2.54",
-            note="Please leave a comment on \
+            since = "0.2.54",
+            note = "Please leave a comment on \
                   https://github.com/rust-lang/libc/pull/1316 if you're using \
                   this field"
         )]
@@ -189,7 +189,7 @@ s! {
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 }
 
@@ -197,7 +197,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
-        priv_: [i64; 4]
+        priv_: [i64; 4],
     }
 }
 

--- a/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
@@ -128,8 +128,8 @@ s! {
         pub si_code: ::c_int,
         #[doc(hidden)]
         #[deprecated(
-            since="0.2.54",
-            note="Please leave a comment on \
+            since = "0.2.54",
+            note = "Please leave a comment on \
                   https://github.com/rust-lang/libc/pull/1316 if you're using \
                   this field"
         )]

--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -18,7 +18,7 @@ s! {
         pub sa_sigaction: ::sighandler_t,
         __glibc_reserved0: ::c_int,
         pub sa_flags: ::c_int,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
         pub sa_mask: ::sigset_t,
     }
 
@@ -64,7 +64,7 @@ s! {
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 
     pub struct stat {
@@ -110,7 +110,7 @@ s! {
     }
 
     pub struct pthread_attr_t {
-        __size: [::c_ulong; 7]
+        __size: [::c_ulong; 7],
     }
 
     pub struct ipc_perm {
@@ -123,7 +123,7 @@ s! {
         pub __seq: ::c_ushort,
         __pad1: ::c_ushort,
         __unused1: ::c_ulong,
-        __unused2: ::c_ulong
+        __unused2: ::c_ulong,
     }
 
     pub struct shmid_ds {
@@ -136,7 +136,7 @@ s! {
         pub shm_lpid: ::pid_t,
         pub shm_nattch: ::shmatt_t,
         __unused4: ::c_ulong,
-        __unused5: ::c_ulong
+        __unused5: ::c_ulong,
     }
 
     pub struct statvfs {
@@ -231,9 +231,7 @@ cfg_if! {
 
         impl ::fmt::Debug for fpreg_t {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                f.debug_struct("fpreg_t")
-                    .field("d", &self.d)
-                    .finish()
+                f.debug_struct("fpreg_t").field("d", &self.d).finish()
             }
         }
 

--- a/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
@@ -19,7 +19,7 @@ s! {
         #[cfg(target_arch = "sparc64")]
         __reserved0: ::c_int,
         pub sa_flags: ::c_int,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
     }
 
     pub struct statfs {
@@ -44,8 +44,8 @@ s! {
         pub si_code: ::c_int,
         #[doc(hidden)]
         #[deprecated(
-            since="0.2.54",
-            note="Please leave a comment on \
+            since = "0.2.54",
+            note = "Please leave a comment on \
                   https://github.com/rust-lang/libc/pull/1316 if you're using \
                   this field"
         )]
@@ -67,13 +67,13 @@ s! {
         pub l_start: ::off64_t,
         pub l_len: ::off64_t,
         pub l_pid: ::pid_t,
-        __reserved:  ::c_short,
+        __reserved: ::c_short,
     }
 
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 
     pub struct stat {
@@ -166,7 +166,7 @@ s! {
     }
 
     pub struct pthread_attr_t {
-        __size: [u64; 7]
+        __size: [u64; 7],
     }
 
     pub struct ipc_perm {
@@ -192,7 +192,7 @@ s! {
         pub shm_lpid: ::pid_t,
         pub shm_nattch: ::shmatt_t,
         __reserved1: ::c_ulong,
-        __reserved2: ::c_ulong
+        __reserved2: ::c_ulong,
     }
 }
 
@@ -200,7 +200,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
-        priv_: [i64; 4]
+        priv_: [i64; 4],
     }
 }
 

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -16,7 +16,7 @@ s! {
         #[cfg(target_arch = "sparc64")]
         __reserved0: ::c_int,
         pub sa_flags: ::c_int,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
     }
 
     pub struct statfs {
@@ -57,8 +57,8 @@ s! {
         pub si_code: ::c_int,
         #[doc(hidden)]
         #[deprecated(
-            since="0.2.54",
-            note="Please leave a comment on \
+            since = "0.2.54",
+            note = "Please leave a comment on \
                   https://github.com/rust-lang/libc/pull/1316 if you're using \
                   this field"
         )]
@@ -69,7 +69,7 @@ s! {
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 
     pub struct stat {
@@ -148,7 +148,7 @@ s! {
         #[cfg(target_pointer_width = "32")]
         __size: [u32; 8],
         #[cfg(target_pointer_width = "64")]
-        __size: [u64; 7]
+        __size: [u64; 7],
     }
 
     pub struct _libc_fpxreg {
@@ -244,7 +244,7 @@ s! {
         pub __seq: ::c_ushort,
         __pad2: ::c_ushort,
         __unused1: u64,
-        __unused2: u64
+        __unused2: u64,
     }
 
     pub struct shmid_ds {
@@ -257,7 +257,7 @@ s! {
         pub shm_lpid: ::pid_t,
         pub shm_nattch: ::shmatt_t,
         __unused4: u64,
-        __unused5: u64
+        __unused5: u64,
     }
 
     pub struct ptrace_rseq_configuration {
@@ -316,7 +316,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
-        priv_: [f64; 4]
+        priv_: [f64; 4],
     }
 }
 
@@ -334,10 +334,10 @@ cfg_if! {
                     && self.mxcr_mask == other.mxcr_mask
                     && self.st_space == other.st_space
                     && self
-                    .xmm_space
-                    .iter()
-                    .zip(other.xmm_space.iter())
-                    .all(|(a,b)| a == b)
+                        .xmm_space
+                        .iter()
+                        .zip(other.xmm_space.iter())
+                        .all(|(a, b)| a == b)
                 // Ignore padding field
             }
         }
@@ -355,8 +355,8 @@ cfg_if! {
                     .field("mxcsr", &self.mxcsr)
                     .field("mxcr_mask", &self.mxcr_mask)
                     .field("st_space", &self.st_space)
-                // FIXME: .field("xmm_space", &self.xmm_space)
-                // Ignore padding field
+                    // FIXME: .field("xmm_space", &self.xmm_space)
+                    // Ignore padding field
                     .finish()
             }
         }
@@ -397,7 +397,7 @@ cfg_if! {
                     .field("uc_stack", &self.uc_stack)
                     .field("uc_mcontext", &self.uc_mcontext)
                     .field("uc_sigmask", &self.uc_sigmask)
-                // Ignore __private field
+                    // Ignore __private field
                     .finish()
             }
         }

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -64,7 +64,7 @@ s! {
         pub aio_offset: off_t,
         #[cfg(all(not(target_arch = "x86_64"), target_pointer_width = "32"))]
         __unused1: [::c_char; 4],
-        __glibc_reserved: [::c_char; 32]
+        __glibc_reserved: [::c_char; 32],
     }
 
     pub struct __exit_status {
@@ -119,7 +119,8 @@ s! {
             target_arch = "mips",
             target_arch = "mips32r6",
             target_arch = "mips64",
-            target_arch = "mips64r6")))]
+            target_arch = "mips64r6"
+        )))]
         pub c_ispeed: ::speed_t,
         #[cfg(not(any(
             target_arch = "sparc",
@@ -127,7 +128,8 @@ s! {
             target_arch = "mips",
             target_arch = "mips32r6",
             target_arch = "mips64",
-            target_arch = "mips64r6")))]
+            target_arch = "mips64r6"
+        )))]
         pub c_ospeed: ::speed_t,
     }
 
@@ -504,10 +506,8 @@ s! {
     }
 
     // FIXME(1.0) this is actually a union
-    #[cfg_attr(target_pointer_width = "32",
-               repr(align(4)))]
-    #[cfg_attr(target_pointer_width = "64",
-               repr(align(8)))]
+    #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+    #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
     pub struct sem_t {
         #[cfg(target_pointer_width = "32")]
         __size: [::c_char; 16],
@@ -623,30 +623,34 @@ s_no_extra_traits! {
         pub ut_host: [::c_char; __UT_HOSTSIZE],
         pub ut_exit: __exit_status,
 
-        #[cfg(any(target_arch = "aarch64",
-                  target_arch = "s390x",
-                  target_arch = "loongarch64",
-                  all(target_pointer_width = "32",
-                      not(target_arch = "x86_64"))))]
+        #[cfg(any(
+            target_arch = "aarch64",
+            target_arch = "s390x",
+            target_arch = "loongarch64",
+            all(target_pointer_width = "32", not(target_arch = "x86_64"))
+        ))]
         pub ut_session: ::c_long,
-        #[cfg(any(target_arch = "aarch64",
-                  target_arch = "s390x",
-                  target_arch = "loongarch64",
-                  all(target_pointer_width = "32",
-                      not(target_arch = "x86_64"))))]
+        #[cfg(any(
+            target_arch = "aarch64",
+            target_arch = "s390x",
+            target_arch = "loongarch64",
+            all(target_pointer_width = "32", not(target_arch = "x86_64"))
+        ))]
         pub ut_tv: ::timeval,
 
-        #[cfg(not(any(target_arch = "aarch64",
-                      target_arch = "s390x",
-                      target_arch = "loongarch64",
-                      all(target_pointer_width = "32",
-                          not(target_arch = "x86_64")))))]
+        #[cfg(not(any(
+            target_arch = "aarch64",
+            target_arch = "s390x",
+            target_arch = "loongarch64",
+            all(target_pointer_width = "32", not(target_arch = "x86_64"))
+        )))]
         pub ut_session: i32,
-        #[cfg(not(any(target_arch = "aarch64",
-                      target_arch = "s390x",
-                      target_arch = "loongarch64",
-                      all(target_pointer_width = "32",
-                          not(target_arch = "x86_64")))))]
+        #[cfg(not(any(
+            target_arch = "aarch64",
+            target_arch = "s390x",
+            target_arch = "loongarch64",
+            all(target_pointer_width = "32", not(target_arch = "x86_64"))
+        )))]
         pub ut_tv: __timeval,
 
         pub ut_addr_v6: [i32; 4],
@@ -664,10 +668,10 @@ cfg_if! {
                     && self.ut_id == other.ut_id
                     && self.ut_user == other.ut_user
                     && self
-                    .ut_host
-                    .iter()
-                    .zip(other.ut_host.iter())
-                    .all(|(a,b)| a == b)
+                        .ut_host
+                        .iter()
+                        .zip(other.ut_host.iter())
+                        .all(|(a, b)| a == b)
                     && self.ut_exit == other.ut_exit
                     && self.ut_session == other.ut_session
                     && self.ut_tv == other.ut_tv
@@ -686,7 +690,7 @@ cfg_if! {
                     .field("ut_line", &self.ut_line)
                     .field("ut_id", &self.ut_id)
                     .field("ut_user", &self.ut_user)
-                // FIXME: .field("ut_host", &self.ut_host)
+                    // FIXME: .field("ut_host", &self.ut_host)
                     .field("ut_exit", &self.ut_exit)
                     .field("ut_session", &self.ut_session)
                     .field("ut_tv", &self.ut_tv)
@@ -715,9 +719,9 @@ cfg_if! {
         impl PartialEq for __c_anonymous_ptrace_syscall_info_data {
             fn eq(&self, other: &__c_anonymous_ptrace_syscall_info_data) -> bool {
                 unsafe {
-                self.entry == other.entry ||
-                    self.exit == other.exit ||
-                    self.seccomp == other.seccomp
+                    self.entry == other.entry
+                        || self.exit == other.exit
+                        || self.seccomp == other.seccomp
                 }
             }
         }
@@ -727,11 +731,11 @@ cfg_if! {
         impl ::fmt::Debug for __c_anonymous_ptrace_syscall_info_data {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
-                f.debug_struct("__c_anonymous_ptrace_syscall_info_data")
-                    .field("entry", &self.entry)
-                    .field("exit", &self.exit)
-                    .field("seccomp", &self.seccomp)
-                    .finish()
+                    f.debug_struct("__c_anonymous_ptrace_syscall_info_data")
+                        .field("entry", &self.entry)
+                        .field("exit", &self.exit)
+                        .field("seccomp", &self.seccomp)
+                        .finish()
                 }
             }
         }
@@ -739,9 +743,9 @@ cfg_if! {
         impl ::hash::Hash for __c_anonymous_ptrace_syscall_info_data {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
-                self.entry.hash(state);
-                self.exit.hash(state);
-                self.seccomp.hash(state);
+                    self.entry.hash(state);
+                    self.exit.hash(state);
+                    self.seccomp.hash(state);
                 }
             }
         }
@@ -1128,10 +1132,12 @@ pub const KEYCTL_SUPPORTS_DECRYPT: u32 = 0x02;
 pub const KEYCTL_SUPPORTS_SIGN: u32 = 0x04;
 pub const KEYCTL_SUPPORTS_VERIFY: u32 = 0x08;
 cfg_if! {
-    if #[cfg(not(any(target_arch = "mips",
-                     target_arch = "mips32r6",
-                     target_arch = "mips64",
-                     target_arch = "mips64r6")))] {
+    if #[cfg(not(any(
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "mips64",
+        target_arch = "mips64r6"
+    )))] {
         pub const KEYCTL_MOVE: u32 = 30;
         pub const KEYCTL_CAPABILITIES: u32 = 31;
 
@@ -1285,10 +1291,7 @@ cfg_if! {
         target_arch = "riscv32"
     ))] {
         pub const PTHREAD_STACK_MIN: ::size_t = 16384;
-    } else if #[cfg(any(
-               target_arch = "sparc",
-               target_arch = "sparc64"
-           ))] {
+    } else if #[cfg(any(target_arch = "sparc", target_arch = "sparc64"))] {
         pub const PTHREAD_STACK_MIN: ::size_t = 0x6000;
     } else {
         pub const PTHREAD_STACK_MIN: ::size_t = 131072;
@@ -1303,21 +1306,25 @@ pub const REG_ESIZE: ::c_int = 15;
 pub const REG_ERPAREN: ::c_int = 16;
 
 cfg_if! {
-    if #[cfg(any(target_arch = "x86",
-                 target_arch = "x86_64",
-                 target_arch = "arm",
-                 target_arch = "aarch64",
-                 target_arch = "loongarch64",
-                 target_arch = "riscv64",
-                 target_arch = "s390x"))] {
+    if #[cfg(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "loongarch64",
+        target_arch = "riscv64",
+        target_arch = "s390x"
+    ))] {
         pub const TUNSETCARRIER: ::Ioctl = 0x400454e2;
         pub const TUNGETDEVNETNS: ::Ioctl = 0x54e3;
-    } else if #[cfg(any(target_arch = "mips",
-                        target_arch = "mips64",
-                        target_arch = "powerpc",
-                        target_arch = "powerpc64",
-                        target_arch = "sparc",
-                        target_arch = "sparc64"))] {
+    } else if #[cfg(any(
+        target_arch = "mips",
+        target_arch = "mips64",
+        target_arch = "powerpc",
+        target_arch = "powerpc64",
+        target_arch = "sparc",
+        target_arch = "sparc64"
+    ))] {
         pub const TUNSETCARRIER: ::Ioctl = 0x800454e2;
         pub const TUNGETDEVNETNS: ::Ioctl = 0x200054e3;
     } else {
@@ -1610,26 +1617,30 @@ extern "C" {
 }
 
 cfg_if! {
-    if #[cfg(any(target_arch = "x86",
-                 target_arch = "arm",
-                 target_arch = "m68k",
-                 target_arch = "csky",
-                 target_arch = "mips",
-                 target_arch = "mips32r6",
-                 target_arch = "powerpc",
-                 target_arch = "sparc",
-                 target_arch = "riscv32"))] {
+    if #[cfg(any(
+        target_arch = "x86",
+        target_arch = "arm",
+        target_arch = "m68k",
+        target_arch = "csky",
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "powerpc",
+        target_arch = "sparc",
+        target_arch = "riscv32"
+    ))] {
         mod b32;
         pub use self::b32::*;
-    } else if #[cfg(any(target_arch = "x86_64",
-                        target_arch = "aarch64",
-                        target_arch = "powerpc64",
-                        target_arch = "mips64",
-                        target_arch = "mips64r6",
-                        target_arch = "s390x",
-                        target_arch = "sparc64",
-                        target_arch = "riscv64",
-                        target_arch = "loongarch64"))] {
+    } else if #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "powerpc64",
+        target_arch = "mips64",
+        target_arch = "mips64r6",
+        target_arch = "s390x",
+        target_arch = "sparc64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
+    ))] {
         mod b64;
         pub use self::b64::*;
     } else {

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -293,11 +293,9 @@ s! {
     }
 
     pub struct cpu_set_t {
-        #[cfg(all(target_pointer_width = "32",
-                  not(target_arch = "x86_64")))]
+        #[cfg(all(target_pointer_width = "32", not(target_arch = "x86_64")))]
         bits: [u32; 32],
-        #[cfg(not(all(target_pointer_width = "32",
-                      not(target_arch = "x86_64"))))]
+        #[cfg(not(all(target_pointer_width = "32", not(target_arch = "x86_64"))))]
         bits: [u64; 16],
     }
 
@@ -656,7 +654,7 @@ s! {
         pub wd: ::c_int,
         pub mask: u32,
         pub cookie: u32,
-        pub len: u32
+        pub len: u32,
     }
 
     pub struct fanotify_response {
@@ -682,7 +680,7 @@ s! {
         pub svm_port: ::c_uint,
         pub svm_cid: ::c_uint,
         pub svm_flags: u8,
-        pub svm_zero: [u8; 3]
+        pub svm_zero: [u8; 3],
     }
 
     pub struct regmatch_t {
@@ -810,11 +808,11 @@ s! {
         pub port: ::c_uchar,
     }
 
-   pub struct in6_ifreq {
-       pub ifr6_addr: ::in6_addr,
-       pub ifr6_prefixlen: u32,
-       pub ifr6_ifindex: ::c_int,
-   }
+    pub struct in6_ifreq {
+        pub ifr6_addr: ::in6_addr,
+        pub ifr6_prefixlen: u32,
+        pub ifr6_ifindex: ::c_int,
+    }
 
     pub struct option {
         pub name: *const ::c_char,
@@ -984,7 +982,7 @@ s! {
         pub addr: ::sockaddr,
         pub alg: __u16,
         pub key_len: __u16,
-        pub key: [__u8;0],
+        pub key: [__u8; 0],
     }
 
     pub struct iw_pmksa {
@@ -1036,7 +1034,7 @@ s! {
         pub encoding_login_index: __u8,
         pub txpower_capa: __u16,
         pub num_txpower: __u8,
-        pub txpower: [__s32;IW_MAX_TXPOWER],
+        pub txpower: [__s32; IW_MAX_TXPOWER],
         pub we_version_compiled: __u8,
         pub we_version_source: __u8,
         pub retry_capa: __u16,
@@ -1068,41 +1066,55 @@ s! {
         pub __pad: u8, // Must be zero
     }
 
-    #[cfg_attr(any(target_pointer_width = "32",
-                   target_arch = "x86_64",
-                   target_arch = "powerpc64",
-                   target_arch = "mips64",
-                   target_arch = "mips64r6",
-                   target_arch = "s390x",
-                   target_arch = "sparc64",
-                   target_arch = "aarch64",
-                   target_arch = "riscv64",
-                   target_arch = "riscv32",
-                   target_arch = "loongarch64"),
-               repr(align(4)))]
-    #[cfg_attr(not(any(target_pointer_width = "32",
-                       target_arch = "x86_64",
-                       target_arch = "powerpc64",
-                       target_arch = "mips64",
-                       target_arch = "mips64r6",
-                       target_arch = "s390x",
-                       target_arch = "sparc64",
-                       target_arch = "aarch64",
-                       target_arch = "riscv64",
-                       target_arch = "riscv32",
-                       target_arch = "loongarch64")),
-               repr(align(8)))]
+    #[cfg_attr(
+        any(
+            target_pointer_width = "32",
+            target_arch = "x86_64",
+            target_arch = "powerpc64",
+            target_arch = "mips64",
+            target_arch = "mips64r6",
+            target_arch = "s390x",
+            target_arch = "sparc64",
+            target_arch = "aarch64",
+            target_arch = "riscv64",
+            target_arch = "riscv32",
+            target_arch = "loongarch64"
+        ),
+        repr(align(4))
+    )]
+    #[cfg_attr(
+        not(any(
+            target_pointer_width = "32",
+            target_arch = "x86_64",
+            target_arch = "powerpc64",
+            target_arch = "mips64",
+            target_arch = "mips64r6",
+            target_arch = "s390x",
+            target_arch = "sparc64",
+            target_arch = "aarch64",
+            target_arch = "riscv64",
+            target_arch = "riscv32",
+            target_arch = "loongarch64"
+        )),
+        repr(align(8))
+    )]
     pub struct pthread_mutexattr_t {
         #[doc(hidden)]
         size: [u8; ::__SIZEOF_PTHREAD_MUTEXATTR_T],
     }
 
-    #[cfg_attr(any(target_env = "musl", target_env = "ohos", target_pointer_width = "32"),
-               repr(align(4)))]
-    #[cfg_attr(all(not(target_env = "musl"),
-                   not(target_env = "ohos"),
-                   target_pointer_width = "64"),
-               repr(align(8)))]
+    #[cfg_attr(
+        any(target_env = "musl", target_env = "ohos", target_pointer_width = "32"),
+        repr(align(4))
+    )]
+    #[cfg_attr(
+        all(
+            not(target_env = "musl"),
+            not(target_env = "ohos"),
+            target_pointer_width = "64"
+        ),
+        repr(align(8))
+    )]
     pub struct pthread_rwlockattr_t {
         #[doc(hidden)]
         size: [u8; ::__SIZEOF_PTHREAD_RWLOCKATTR_T],
@@ -1134,7 +1146,7 @@ s! {
 
 cfg_if! {
     if #[cfg(not(target_arch = "sparc64"))] {
-        s!{
+        s! {
             pub struct iw_thrspy {
                 pub addr: ::sockaddr,
                 pub qual: iw_quality,
@@ -1174,7 +1186,7 @@ s_no_extra_traits! {
         pub nl_family: ::sa_family_t,
         nl_pad: ::c_ushort,
         pub nl_pid: u32,
-        pub nl_groups: u32
+        pub nl_groups: u32,
     }
 
     pub struct dirent {
@@ -1319,103 +1331,155 @@ s_no_extra_traits! {
         pub hdr: ::tpacket_bd_header_u,
     }
 
-    #[cfg_attr(all(any(target_env = "musl", target_env = "ohos"),
-                   target_pointer_width = "32"),
-               repr(align(4)))]
-    #[cfg_attr(all(any(target_env = "musl", target_env = "ohos"),
-                   target_pointer_width = "64"),
-               repr(align(8)))]
-    #[cfg_attr(all(not(any(target_env = "musl", target_env = "ohos")),
-                   target_arch = "x86"),
-               repr(align(4)))]
-    #[cfg_attr(all(not(any(target_env = "musl", target_env = "ohos")),
-                   not(target_arch = "x86")),
-               repr(align(8)))]
+    #[cfg_attr(
+        all(
+            any(target_env = "musl", target_env = "ohos"),
+            target_pointer_width = "32"
+        ),
+        repr(align(4))
+    )]
+    #[cfg_attr(
+        all(
+            any(target_env = "musl", target_env = "ohos"),
+            target_pointer_width = "64"
+        ),
+        repr(align(8))
+    )]
+    #[cfg_attr(
+        all(
+            not(any(target_env = "musl", target_env = "ohos")),
+            target_arch = "x86"
+        ),
+        repr(align(4))
+    )]
+    #[cfg_attr(
+        all(
+            not(any(target_env = "musl", target_env = "ohos")),
+            not(target_arch = "x86")
+        ),
+        repr(align(8))
+    )]
     pub struct pthread_cond_t {
         #[doc(hidden)]
         size: [u8; ::__SIZEOF_PTHREAD_COND_T],
     }
 
-    #[cfg_attr(all(target_pointer_width = "32",
-                   any(target_arch = "mips",
-                       target_arch = "mips32r6",
-                       target_arch = "arm",
-                       target_arch = "hexagon",
-                       target_arch = "m68k",
-                       target_arch = "csky",
-                       target_arch = "powerpc",
-                       target_arch = "sparc",
-                       target_arch = "x86_64",
-                       target_arch = "x86")),
-               repr(align(4)))]
-    #[cfg_attr(any(target_pointer_width = "64",
-                   not(any(target_arch = "mips",
-                           target_arch = "mips32r6",
-                           target_arch = "arm",
-                           target_arch = "hexagon",
-                           target_arch = "m68k",
-                           target_arch = "csky",
-                           target_arch = "powerpc",
-                           target_arch = "sparc",
-                           target_arch = "x86_64",
-                           target_arch = "x86"))),
-               repr(align(8)))]
+    #[cfg_attr(
+        all(
+            target_pointer_width = "32",
+            any(
+                target_arch = "mips",
+                target_arch = "mips32r6",
+                target_arch = "arm",
+                target_arch = "hexagon",
+                target_arch = "m68k",
+                target_arch = "csky",
+                target_arch = "powerpc",
+                target_arch = "sparc",
+                target_arch = "x86_64",
+                target_arch = "x86"
+            )
+        ),
+        repr(align(4))
+    )]
+    #[cfg_attr(
+        any(
+            target_pointer_width = "64",
+            not(any(
+                target_arch = "mips",
+                target_arch = "mips32r6",
+                target_arch = "arm",
+                target_arch = "hexagon",
+                target_arch = "m68k",
+                target_arch = "csky",
+                target_arch = "powerpc",
+                target_arch = "sparc",
+                target_arch = "x86_64",
+                target_arch = "x86"
+            ))
+        ),
+        repr(align(8))
+    )]
     pub struct pthread_mutex_t {
         #[doc(hidden)]
         size: [u8; ::__SIZEOF_PTHREAD_MUTEX_T],
     }
 
-    #[cfg_attr(all(target_pointer_width = "32",
-                   any(target_arch = "mips",
-                       target_arch = "mips32r6",
-                       target_arch = "arm",
-                       target_arch = "hexagon",
-                       target_arch = "m68k",
-                       target_arch = "csky",
-                       target_arch = "powerpc",
-                       target_arch = "sparc",
-                       target_arch = "x86_64",
-                       target_arch = "x86")),
-               repr(align(4)))]
-    #[cfg_attr(any(target_pointer_width = "64",
-                   not(any(target_arch = "mips",
-                           target_arch = "mips32r6",
-                           target_arch = "arm",
-                           target_arch = "hexagon",
-                           target_arch = "m68k",
-                           target_arch = "powerpc",
-                           target_arch = "sparc",
-                           target_arch = "x86_64",
-                           target_arch = "x86"))),
-               repr(align(8)))]
+    #[cfg_attr(
+        all(
+            target_pointer_width = "32",
+            any(
+                target_arch = "mips",
+                target_arch = "mips32r6",
+                target_arch = "arm",
+                target_arch = "hexagon",
+                target_arch = "m68k",
+                target_arch = "csky",
+                target_arch = "powerpc",
+                target_arch = "sparc",
+                target_arch = "x86_64",
+                target_arch = "x86"
+            )
+        ),
+        repr(align(4))
+    )]
+    #[cfg_attr(
+        any(
+            target_pointer_width = "64",
+            not(any(
+                target_arch = "mips",
+                target_arch = "mips32r6",
+                target_arch = "arm",
+                target_arch = "hexagon",
+                target_arch = "m68k",
+                target_arch = "powerpc",
+                target_arch = "sparc",
+                target_arch = "x86_64",
+                target_arch = "x86"
+            ))
+        ),
+        repr(align(8))
+    )]
     pub struct pthread_rwlock_t {
         size: [u8; ::__SIZEOF_PTHREAD_RWLOCK_T],
     }
 
-    #[cfg_attr(all(target_pointer_width = "32",
-                   any(target_arch = "mips",
-                       target_arch = "mips32r6",
-                       target_arch = "arm",
-                       target_arch = "hexagon",
-                       target_arch = "m68k",
-                       target_arch = "csky",
-                       target_arch = "powerpc",
-                       target_arch = "sparc",
-                       target_arch = "x86_64",
-                       target_arch = "x86")),
-               repr(align(4)))]
-    #[cfg_attr(any(target_pointer_width = "64",
-                   not(any(target_arch = "mips",
-                           target_arch = "mips32r6",
-                           target_arch = "arm",
-                           target_arch = "hexagon",
-                           target_arch = "m68k",
-                           target_arch = "csky",
-                           target_arch = "powerpc",
-                           target_arch = "sparc",
-                           target_arch = "x86_64",
-                           target_arch = "x86"))),
-               repr(align(8)))]
+    #[cfg_attr(
+        all(
+            target_pointer_width = "32",
+            any(
+                target_arch = "mips",
+                target_arch = "mips32r6",
+                target_arch = "arm",
+                target_arch = "hexagon",
+                target_arch = "m68k",
+                target_arch = "csky",
+                target_arch = "powerpc",
+                target_arch = "sparc",
+                target_arch = "x86_64",
+                target_arch = "x86"
+            )
+        ),
+        repr(align(4))
+    )]
+    #[cfg_attr(
+        any(
+            target_pointer_width = "64",
+            not(any(
+                target_arch = "mips",
+                target_arch = "mips32r6",
+                target_arch = "arm",
+                target_arch = "hexagon",
+                target_arch = "m68k",
+                target_arch = "csky",
+                target_arch = "powerpc",
+                target_arch = "sparc",
+                target_arch = "x86_64",
+                target_arch = "x86"
+            ))
+        ),
+        repr(align(8))
+    )]
     pub struct pthread_barrier_t {
         size: [u8; ::__SIZEOF_PTHREAD_BARRIER_T],
     }
@@ -1476,24 +1540,24 @@ s_no_extra_traits! {
 
     // linux/wireless.h
     pub union iwreq_data {
-            pub name: [c_char; ::IFNAMSIZ],
-            pub essid: iw_point,
-            pub nwid: iw_param,
-            pub freq: iw_freq,
-            pub sens: iw_param,
-            pub bitrate: iw_param,
-            pub txpower: iw_param,
-            pub rts: iw_param,
-            pub frag: iw_param,
-            pub mode: __u32,
-            pub retry: iw_param,
-            pub encoding: iw_point,
-            pub power: iw_param,
-            pub qual: iw_quality,
-            pub ap_addr: ::sockaddr,
-            pub addr: ::sockaddr,
-            pub param: iw_param,
-            pub data: iw_point,
+        pub name: [c_char; ::IFNAMSIZ],
+        pub essid: iw_point,
+        pub nwid: iw_param,
+        pub freq: iw_freq,
+        pub sens: iw_param,
+        pub bitrate: iw_param,
+        pub txpower: iw_param,
+        pub rts: iw_param,
+        pub frag: iw_param,
+        pub mode: __u32,
+        pub retry: iw_param,
+        pub encoding: iw_point,
+        pub power: iw_param,
+        pub qual: iw_quality,
+        pub ap_addr: ::sockaddr,
+        pub addr: ::sockaddr,
+        pub param: iw_param,
+        pub data: iw_point,
     }
 
     pub struct iw_event {
@@ -1516,9 +1580,9 @@ cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         impl PartialEq for sockaddr_nl {
             fn eq(&self, other: &sockaddr_nl) -> bool {
-                self.nl_family == other.nl_family &&
-                    self.nl_pid == other.nl_pid &&
-                    self.nl_groups == other.nl_groups
+                self.nl_family == other.nl_family
+                    && self.nl_pid == other.nl_pid
+                    && self.nl_groups == other.nl_groups
             }
         }
         impl Eq for sockaddr_nl {}
@@ -1546,10 +1610,10 @@ cfg_if! {
                     && self.d_reclen == other.d_reclen
                     && self.d_type == other.d_type
                     && self
-                    .d_name
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                        .d_name
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -1562,7 +1626,7 @@ cfg_if! {
                     .field("d_off", &self.d_off)
                     .field("d_reclen", &self.d_reclen)
                     .field("d_type", &self.d_type)
-                // FIXME: .field("d_name", &self.d_name)
+                    // FIXME: .field("d_name", &self.d_name)
                     .finish()
             }
         }
@@ -1584,10 +1648,10 @@ cfg_if! {
                     && self.d_reclen == other.d_reclen
                     && self.d_type == other.d_type
                     && self
-                    .d_name
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                        .d_name
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -1600,7 +1664,7 @@ cfg_if! {
                     .field("d_off", &self.d_off)
                     .field("d_reclen", &self.d_reclen)
                     .field("d_type", &self.d_type)
-                // FIXME: .field("d_name", &self.d_name)
+                    // FIXME: .field("d_name", &self.d_name)
                     .finish()
             }
         }
@@ -1617,7 +1681,7 @@ cfg_if! {
 
         impl PartialEq for pthread_cond_t {
             fn eq(&self, other: &pthread_cond_t) -> bool {
-                self.size.iter().zip(other.size.iter()).all(|(a,b)| a == b)
+                self.size.iter().zip(other.size.iter()).all(|(a, b)| a == b)
             }
         }
 
@@ -1626,7 +1690,7 @@ cfg_if! {
         impl ::fmt::Debug for pthread_cond_t {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("pthread_cond_t")
-                // FIXME: .field("size", &self.size)
+                    // FIXME: .field("size", &self.size)
                     .finish()
             }
         }
@@ -1639,7 +1703,7 @@ cfg_if! {
 
         impl PartialEq for pthread_mutex_t {
             fn eq(&self, other: &pthread_mutex_t) -> bool {
-                self.size.iter().zip(other.size.iter()).all(|(a,b)| a == b)
+                self.size.iter().zip(other.size.iter()).all(|(a, b)| a == b)
             }
         }
 
@@ -1648,7 +1712,7 @@ cfg_if! {
         impl ::fmt::Debug for pthread_mutex_t {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("pthread_mutex_t")
-                // FIXME: .field("size", &self.size)
+                    // FIXME: .field("size", &self.size)
                     .finish()
             }
         }
@@ -1661,7 +1725,7 @@ cfg_if! {
 
         impl PartialEq for pthread_rwlock_t {
             fn eq(&self, other: &pthread_rwlock_t) -> bool {
-                self.size.iter().zip(other.size.iter()).all(|(a,b)| a == b)
+                self.size.iter().zip(other.size.iter()).all(|(a, b)| a == b)
             }
         }
 
@@ -1670,7 +1734,7 @@ cfg_if! {
         impl ::fmt::Debug for pthread_rwlock_t {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("pthread_rwlock_t")
-                // FIXME: .field("size", &self.size)
+                    // FIXME: .field("size", &self.size)
                     .finish()
             }
         }
@@ -1683,7 +1747,7 @@ cfg_if! {
 
         impl PartialEq for pthread_barrier_t {
             fn eq(&self, other: &pthread_barrier_t) -> bool {
-                self.size.iter().zip(other.size.iter()).all(|(a,b)| a == b)
+                self.size.iter().zip(other.size.iter()).all(|(a, b)| a == b)
             }
         }
 
@@ -1707,18 +1771,18 @@ cfg_if! {
             fn eq(&self, other: &sockaddr_alg) -> bool {
                 self.salg_family == other.salg_family
                     && self
-                    .salg_type
-                    .iter()
-                    .zip(other.salg_type.iter())
-                    .all(|(a, b)| a == b)
+                        .salg_type
+                        .iter()
+                        .zip(other.salg_type.iter())
+                        .all(|(a, b)| a == b)
                     && self.salg_feat == other.salg_feat
                     && self.salg_mask == other.salg_mask
                     && self
-                    .salg_name
-                    .iter()
-                    .zip(other.salg_name.iter())
-                    .all(|(a, b)| a == b)
-           }
+                        .salg_name
+                        .iter()
+                        .zip(other.salg_name.iter())
+                        .all(|(a, b)| a == b)
+            }
         }
 
         impl Eq for sockaddr_alg {}
@@ -1750,7 +1814,7 @@ cfg_if! {
                 self.id == other.id
                     && self.name[..] == other.name[..]
                     && self.ff_effects_max == other.ff_effects_max
-           }
+            }
         }
         impl Eq for uinput_setup {}
 
@@ -1774,14 +1838,14 @@ cfg_if! {
 
         impl PartialEq for uinput_user_dev {
             fn eq(&self, other: &uinput_user_dev) -> bool {
-                 self.name[..] == other.name[..]
+                self.name[..] == other.name[..]
                     && self.id == other.id
                     && self.ff_effects_max == other.ff_effects_max
                     && self.absmax[..] == other.absmax[..]
                     && self.absmin[..] == other.absmin[..]
                     && self.absfuzz[..] == other.absfuzz[..]
                     && self.absflat[..] == other.absflat[..]
-           }
+            }
         }
         impl Eq for uinput_user_dev {}
 
@@ -1813,10 +1877,10 @@ cfg_if! {
 
         impl PartialEq for mq_attr {
             fn eq(&self, other: &mq_attr) -> bool {
-                self.mq_flags == other.mq_flags &&
-                self.mq_maxmsg == other.mq_maxmsg &&
-                self.mq_msgsize == other.mq_msgsize &&
-                self.mq_curmsgs == other.mq_curmsgs
+                self.mq_flags == other.mq_flags
+                    && self.mq_maxmsg == other.mq_maxmsg
+                    && self.mq_msgsize == other.mq_msgsize
+                    && self.mq_curmsgs == other.mq_curmsgs
             }
         }
         impl Eq for mq_attr {}
@@ -1893,9 +1957,9 @@ cfg_if! {
         }
         impl PartialEq for hwtstamp_config {
             fn eq(&self, other: &hwtstamp_config) -> bool {
-                self.flags == other.flags &&
-                self.tx_type == other.tx_type &&
-                self.rx_filter == other.rx_filter
+                self.flags == other.flags
+                    && self.tx_type == other.tx_type
+                    && self.rx_filter == other.rx_filter
             }
         }
         impl Eq for hwtstamp_config {}
@@ -1923,14 +1987,14 @@ cfg_if! {
         }
         impl PartialEq for sched_attr {
             fn eq(&self, other: &sched_attr) -> bool {
-                self.size == other.size &&
-                self.sched_policy == other.sched_policy &&
-                self.sched_flags == other.sched_flags &&
-                self.sched_nice == other.sched_nice &&
-                self.sched_priority == other.sched_priority &&
-                self.sched_runtime == other.sched_runtime &&
-                self.sched_deadline == other.sched_deadline &&
-                self.sched_period == other.sched_period
+                self.size == other.size
+                    && self.sched_policy == other.sched_policy
+                    && self.sched_flags == other.sched_flags
+                    && self.sched_nice == other.sched_nice
+                    && self.sched_priority == other.sched_priority
+                    && self.sched_runtime == other.sched_runtime
+                    && self.sched_deadline == other.sched_deadline
+                    && self.sched_period == other.sched_period
             }
         }
         impl Eq for sched_attr {}
@@ -1975,9 +2039,9 @@ cfg_if! {
         impl ::fmt::Debug for iw_event {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("iw_event")
-                    .field("len", &self.len )
-                    .field("cmd", &self.cmd )
-                    .field("u", &self.u )
+                    .field("len", &self.len)
+                    .field("cmd", &self.cmd)
+                    .field("u", &self.u)
                     .finish()
             }
         }
@@ -1993,8 +2057,8 @@ cfg_if! {
         impl ::fmt::Debug for iwreq {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("iwreq")
-                    .field("ifr_ifrn", &self.ifr_ifrn )
-                    .field("u", &self.u )
+                    .field("ifr_ifrn", &self.ifr_ifrn)
+                    .field("u", &self.u)
                     .finish()
             }
         }
@@ -2002,8 +2066,10 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(all(any(target_env = "gnu", target_env = "musl", target_env = "ohos"),
-                 any(target_arch = "x86_64", target_arch = "x86")))] {
+    if #[cfg(all(
+        any(target_env = "gnu", target_env = "musl", target_env = "ohos"),
+        any(target_arch = "x86_64", target_arch = "x86")
+    ))] {
         extern "C" {
             pub fn iopl(level: ::c_int) -> ::c_int;
             pub fn ioperm(from: ::c_ulong, num: ::c_ulong, turn_on: ::c_int) -> ::c_int;
@@ -2012,7 +2078,11 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(any(target_env = "gnu", target_env = "musl", target_env = "ohos"))] {
+    if #[cfg(any(
+        target_env = "gnu",
+        target_env = "musl",
+        target_env = "ohos"
+    ))] {
         pub const ABDAY_1: ::nl_item = 0x20000;
         pub const ABDAY_2: ::nl_item = 0x20001;
         pub const ABDAY_3: ::nl_item = 0x20002;
@@ -5450,21 +5520,17 @@ pub const EPIOCGPARAMS: ::Ioctl = 0x80088a02;
 
 f! {
     pub fn NLA_ALIGN(len: ::c_int) -> ::c_int {
-        return ((len) + NLA_ALIGNTO - 1) & !(NLA_ALIGNTO - 1)
+        return ((len) + NLA_ALIGNTO - 1) & !(NLA_ALIGNTO - 1);
     }
 
-    pub fn CMSG_NXTHDR(mhdr: *const msghdr,
-                       cmsg: *const cmsghdr) -> *mut cmsghdr {
+    pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         if ((*cmsg).cmsg_len as usize) < ::mem::size_of::<cmsghdr>() {
             return 0 as *mut cmsghdr;
         };
-        let next = (cmsg as usize +
-                    super::CMSG_ALIGN((*cmsg).cmsg_len as usize))
-            as *mut cmsghdr;
-        let max = (*mhdr).msg_control as usize
-            + (*mhdr).msg_controllen as usize;
-        if (next.wrapping_offset(1)) as usize > max ||
-            next as usize + super::CMSG_ALIGN((*next).cmsg_len as usize) > max
+        let next = (cmsg as usize + super::CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr;
+        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
+        if (next.wrapping_offset(1)) as usize > max
+            || next as usize + super::CMSG_ALIGN((*next).cmsg_len as usize) > max
         {
             0 as *mut cmsghdr
         } else {
@@ -5485,16 +5551,14 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits
-            = 8 * ::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * ::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] |= 1 << offset;
         ()
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits
-            = 8 * ::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * ::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] &= !(1 << offset);
         ()
@@ -5511,7 +5575,7 @@ f! {
         let size_of_mask = ::mem::size_of_val(&cpuset.bits[0]);
         for i in cpuset.bits[..(size / size_of_mask)].iter() {
             s += i.count_ones();
-        };
+        }
         s as ::c_int
     }
 
@@ -5588,11 +5652,21 @@ f! {
     }
 
     pub fn BPF_STMT(code: ::__u16, k: ::__u32) -> sock_filter {
-        sock_filter{code: code, jt: 0, jf: 0, k: k}
+        sock_filter {
+            code: code,
+            jt: 0,
+            jf: 0,
+            k: k,
+        }
     }
 
     pub fn BPF_JUMP(code: ::__u16, k: ::__u32, jt: ::__u8, jf: ::__u8) -> sock_filter {
-        sock_filter{code: code, jt: jt, jf: jf, k: k}
+        sock_filter {
+            code: code,
+            jt: jt,
+            jf: jf,
+            k: k,
+        }
     }
 
     pub fn ELF32_R_SYM(val: Elf32_Word) -> Elf32_Word {
@@ -5693,10 +5767,7 @@ cfg_if! {
                 servlen: ::socklen_t,
                 flags: ::c_int,
             ) -> ::c_int;
-            pub fn getloadavg(
-                loadavg: *mut ::c_double,
-                nelem: ::c_int
-            ) -> ::c_int;
+            pub fn getloadavg(loadavg: *mut ::c_double, nelem: ::c_int) -> ::c_int;
             pub fn process_vm_readv(
                 pid: ::pid_t,
                 local_iov: *const ::iovec,
@@ -5713,10 +5784,7 @@ cfg_if! {
                 riovcnt: ::c_ulong,
                 flags: ::c_ulong,
             ) -> isize;
-            pub fn futimes(
-                fd: ::c_int,
-                times: *const ::timeval
-            ) -> ::c_int;
+            pub fn futimes(fd: ::c_int, times: *const ::timeval) -> ::c_int;
         }
     }
 }
@@ -5769,7 +5837,7 @@ cfg_if! {
             pub fn mq_setattr(
                 mqd: ::mqd_t,
                 newattr: *const ::mq_attr,
-                oldattr: *mut ::mq_attr
+                oldattr: *mut ::mq_attr,
             ) -> ::c_int;
 
             pub fn pthread_mutex_consistent(mutex: *mut pthread_mutex_t) -> ::c_int;
@@ -6447,7 +6515,7 @@ cfg_if! {
                 fd: ::c_int,
                 mode: ::c_int,
                 offset: ::off64_t,
-                len: ::off64_t
+                len: ::off64_t,
             ) -> ::c_int;
             pub fn fgetpos64(stream: *mut ::FILE, ptr: *mut fpos64_t) -> ::c_int;
             pub fn fopen64(filename: *const c_char, mode: *const c_char) -> *mut ::FILE;

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -49,7 +49,7 @@ s! {
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 
     pub struct ipc_perm {
@@ -61,7 +61,7 @@ s! {
         pub mode: ::mode_t,
         pub __seq: ::c_int,
         __unused1: ::c_long,
-        __unused2: ::c_long
+        __unused2: ::c_long,
     }
 
     pub struct shmid_ds {
@@ -190,7 +190,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
-        priv_: (i64, i64)
+        priv_: (i64, i64),
     }
 }
 

--- a/src/unix/linux_like/linux/musl/b32/hexagon.rs
+++ b/src/unix/linux_like/linux/musl/b32/hexagon.rs
@@ -3,7 +3,6 @@ pub type wchar_t = u32;
 pub type stat64 = ::stat;
 
 s! {
-
     pub struct stat {
         pub st_dev: ::dev_t,
         pub st_ino: ::c_ulonglong,
@@ -24,13 +23,13 @@ s! {
         pub st_ctime: ::time_t,
         pub st_ctime_nsec: ::c_long,
 
-        __unused: [::c_int;2],
+        __unused: [::c_int; 2],
     }
 
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 
     pub struct ipc_perm {

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -63,7 +63,7 @@ s! {
         pub mode: ::mode_t,
         pub __seq: ::c_int,
         __unused1: ::c_long,
-        __unused2: ::c_long
+        __unused2: ::c_long,
     }
 
     pub struct shmid_ds {
@@ -167,7 +167,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
-        priv_: [f32; 4]
+        priv_: [f32; 4],
     }
 }
 

--- a/src/unix/linux_like/linux/musl/b32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mod.rs
@@ -8,7 +8,7 @@ pub type regoff_t = ::c_int;
 
 s! {
     pub struct pthread_attr_t {
-        __size: [u32; 9]
+        __size: [u32; 9],
     }
 
     pub struct sigset_t {

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -47,7 +47,7 @@ s! {
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 
     pub struct ipc_perm {
@@ -60,7 +60,7 @@ s! {
         pub __seq: ::c_int,
         __pad1: ::c_int,
         __pad2: ::c_longlong,
-        __pad3: ::c_longlong
+        __pad3: ::c_longlong,
     }
 
     pub struct shmid_ds {

--- a/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
@@ -119,8 +119,8 @@ s! {
         pub si_code: ::c_int,
         #[doc(hidden)]
         #[deprecated(
-            since="0.2.54",
-            note="Please leave a comment on \
+            since = "0.2.54",
+            note = "Please leave a comment on \
                   https://github.com/rust-lang/libc/pull/1316 if you're using \
                   this field"
         )]
@@ -190,7 +190,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
-        priv_: (i64, f64)
+        priv_: (i64, f64),
     }
 }
 

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -49,7 +49,7 @@ s! {
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 
     pub struct ipc_perm {
@@ -61,7 +61,7 @@ s! {
         pub mode: ::mode_t,
         pub __seq: ::c_int,
         __unused1: ::c_long,
-        __unused2: ::c_long
+        __unused2: ::c_long,
     }
 
     pub struct shmid_ds {
@@ -113,7 +113,7 @@ s! {
     }
 
     pub struct mcontext_t {
-        __private: [u32; 22]
+        __private: [u32; 22],
     }
 
     pub struct siginfo_t {
@@ -185,7 +185,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
-        priv_: [f64; 3]
+        priv_: [f64; 3],
     }
 }
 
@@ -223,10 +223,10 @@ cfg_if! {
                     .field("foo", &self.foo)
                     .field("fos", &self.fos)
                     .field("mxcsr", &self.mxcsr)
-                // Ignore __reserved field
+                    // Ignore __reserved field
                     .field("st_space", &self.st_space)
                     .field("xmm_space", &self.xmm_space)
-                // Ignore padding field
+                    // Ignore padding field
                     .finish()
             }
         }
@@ -257,10 +257,10 @@ cfg_if! {
                     && self.uc_mcontext == other.uc_mcontext
                     && self.uc_sigmask == other.uc_sigmask
                     && self
-                    .__private
-                    .iter()
-                    .zip(other.__private.iter())
-                    .all(|(a,b)| a == b)
+                        .__private
+                        .iter()
+                        .zip(other.__private.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -274,7 +274,7 @@ cfg_if! {
                     .field("uc_stack", &self.uc_stack)
                     .field("uc_mcontext", &self.uc_mcontext)
                     .field("uc_sigmask", &self.uc_sigmask)
-                // Ignore __private field
+                    // Ignore __private field
                     .finish()
             }
         }

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -113,7 +113,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
-        priv_: [f32; 8]
+        priv_: [f32; 8],
     }
 }
 

--- a/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
@@ -108,7 +108,6 @@ s! {
         pub csr_era: u64,
         pub csr_badv: u64,
         pub reserved: [u64; 10],
-
     }
 
     pub struct user_fp_struct {
@@ -153,7 +152,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
-        priv_: [f64; 4]
+        priv_: [f64; 4],
     }
 }
 

--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -94,7 +94,7 @@ s! {
         pub __seq: ::c_int,
         __pad1: ::c_int,
         __unused1: ::c_ulong,
-        __unused2: ::c_ulong
+        __unused2: ::c_ulong,
     }
 }
 

--- a/src/unix/linux_like/linux/musl/b64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/mod.rs
@@ -36,11 +36,11 @@ s! {
     pub struct stack_t {
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 
     pub struct pthread_attr_t {
-        __size: [u64; 7]
+        __size: [u64; 7],
     }
 
     pub struct sigset_t {

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -57,7 +57,7 @@ s! {
         pub mode: ::mode_t,
         pub __seq: ::c_int,
         __unused1: ::c_long,
-        __unused2: ::c_long
+        __unused2: ::c_long,
     }
 }
 

--- a/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
@@ -125,8 +125,8 @@ s! {
         pub si_code: ::c_int,
         #[doc(hidden)]
         #[deprecated(
-            since="0.2.54",
-            note="Please leave a comment on \
+            since = "0.2.54",
+            note = "Please leave a comment on \
                   https://github.com/rust-lang/libc/pull/1316 if you're using \
                   this field"
         )]

--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -110,9 +110,7 @@ cfg_if! {
 
         impl ::fmt::Debug for fpreg_t {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
-                f.debug_struct("fpreg_t")
-                    .field("d", &self.d)
-                    .finish()
+                f.debug_struct("fpreg_t").field("d", &self.d).finish()
             }
         }
 

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -118,7 +118,7 @@ s! {
         pub mode: ::mode_t,
         pub __seq: ::c_int,
         __unused1: ::c_long,
-        __unused2: ::c_long
+        __unused2: ::c_long,
     }
 
     #[repr(align(8))]
@@ -164,7 +164,7 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
-        priv_: [f64; 4]
+        priv_: [f64; 4],
     }
 }
 
@@ -182,10 +182,10 @@ cfg_if! {
                     && self.mxcr_mask == other.mxcr_mask
                     && self.st_space == other.st_space
                     && self
-                    .xmm_space
-                    .iter()
-                    .zip(other.xmm_space.iter())
-                    .all(|(a,b)| a == b)
+                        .xmm_space
+                        .iter()
+                        .zip(other.xmm_space.iter())
+                        .all(|(a, b)| a == b)
                 // Ignore padding field
             }
         }
@@ -203,8 +203,8 @@ cfg_if! {
                     .field("mxcsr", &self.mxcsr)
                     .field("mxcr_mask", &self.mxcr_mask)
                     .field("st_space", &self.st_space)
-                // FIXME: .field("xmm_space", &self.xmm_space)
-                // Ignore padding field
+                    // FIXME: .field("xmm_space", &self.xmm_space)
+                    // Ignore padding field
                     .finish()
             }
         }
@@ -232,10 +232,10 @@ cfg_if! {
                     && self.uc_mcontext == other.uc_mcontext
                     && self.uc_sigmask == other.uc_sigmask
                     && self
-                    .__private
-                    .iter()
-                    .zip(other.__private.iter())
-                    .all(|(a,b)| a == b)
+                        .__private
+                        .iter()
+                        .zip(other.__private.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -249,7 +249,7 @@ cfg_if! {
                     .field("uc_stack", &self.uc_stack)
                     .field("uc_mcontext", &self.uc_mcontext)
                     .field("uc_sigmask", &self.uc_sigmask)
-                // Ignore __private field
+                    // Ignore __private field
                     .finish()
             }
         }

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -141,7 +141,7 @@ s! {
         pub sa_sigaction: ::sighandler_t,
         pub sa_mask: ::sigset_t,
         pub sa_flags: ::c_int,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
     }
 
     pub struct statvfs {
@@ -492,7 +492,7 @@ cfg_if! {
                         .__reserved
                         .iter()
                         .zip(other.__reserved.iter())
-                        .all(|(a,b)| a == b)
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -1007,22 +1007,27 @@ mod lfs64;
 pub use self::lfs64::*;
 
 cfg_if! {
-    if #[cfg(any(target_arch = "x86_64",
-                 target_arch = "aarch64",
-                 target_arch = "mips64",
-                 target_arch = "powerpc64",
-                 target_arch = "s390x",
-                 target_arch = "riscv64",
-                 target_arch = "loongarch64"))] {
+    if #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "mips64",
+        target_arch = "powerpc64",
+        target_arch = "s390x",
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
+    ))] {
         mod b64;
         pub use self::b64::*;
-    } else if #[cfg(any(target_arch = "x86",
-                        target_arch = "mips",
-                        target_arch = "powerpc",
-                        target_arch = "hexagon",
-                        target_arch = "riscv32",
-                        target_arch = "arm"))] {
+    } else if #[cfg(any(
+        target_arch = "x86",
+        target_arch = "mips",
+        target_arch = "powerpc",
+        target_arch = "hexagon",
+        target_arch = "riscv32",
+        target_arch = "arm"
+    ))] {
         mod b32;
         pub use self::b32::*;
-    } else { }
+    } else {
+    }
 }

--- a/src/unix/linux_like/linux/uclibc/arm/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/arm/mod.rs
@@ -65,8 +65,7 @@ s! {
         __unused5: ::c_ulong,
     }
 
-    pub struct stat64
-    {
+    pub struct stat64 {
         pub st_dev: ::c_ulonglong,
         pub __pad1: ::c_uint,
         pub __st_ino: ::ino_t,
@@ -167,7 +166,7 @@ s! {
     pub struct sigaction {
         pub sa_sigaction: ::sighandler_t,
         pub sa_flags: ::c_ulong,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
         pub sa_mask: sigset_t,
     }
 
@@ -243,10 +242,8 @@ s! {
     }
 
     // FIXME(1.0) this is actually a union
-    #[cfg_attr(target_pointer_width = "32",
-               repr(align(4)))]
-    #[cfg_attr(target_pointer_width = "64",
-               repr(align(8)))]
+    #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+    #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
     pub struct sem_t {
         #[cfg(target_pointer_width = "32")]
         __size: [::c_char; 16],

--- a/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
@@ -81,7 +81,7 @@ s! {
     }
 
     pub struct pthread_attr_t {
-        __size: [u32; 9]
+        __size: [u32; 9],
     }
 
     pub struct sigaction {
@@ -131,7 +131,7 @@ s! {
         pub __seq: ::c_ushort,
         __pad1: ::c_ushort,
         __unused1: ::c_ulong,
-        __unused2: ::c_ulong
+        __unused2: ::c_ulong,
     }
 
     pub struct shmid_ds {
@@ -144,7 +144,7 @@ s! {
         pub shm_lpid: ::pid_t,
         pub shm_nattch: ::shmatt_t,
         __unused4: ::c_ulong,
-        __unused5: ::c_ulong
+        __unused5: ::c_ulong,
     }
 
     pub struct msqid_ds {
@@ -256,10 +256,8 @@ s! {
     }
 
     // FIXME(1.0): this is actually a union
-    #[cfg_attr(target_pointer_width = "32",
-               repr(align(4)))]
-    #[cfg_attr(target_pointer_width = "64",
-               repr(align(8)))]
+    #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+    #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
     pub struct sem_t {
         #[cfg(target_pointer_width = "32")]
         __size: [::c_char; 16],

--- a/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
@@ -61,7 +61,7 @@ s! {
     }
 
     pub struct pthread_attr_t {
-        __size: [::c_ulong; 7]
+        __size: [::c_ulong; 7],
     }
 
     pub struct sigaction {
@@ -99,7 +99,7 @@ s! {
         pub __seq: ::c_ushort,
         __pad1: ::c_ushort,
         __unused1: ::c_ulong,
-        __unused2: ::c_ulong
+        __unused2: ::c_ulong,
     }
 
     pub struct shmid_ds {
@@ -112,7 +112,7 @@ s! {
         pub shm_lpid: ::pid_t,
         pub shm_nattch: ::shmatt_t,
         __unused4: ::c_ulong,
-        __unused5: ::c_ulong
+        __unused5: ::c_ulong,
     }
 
     pub struct msqid_ds {
@@ -187,10 +187,8 @@ s! {
     }
 
     // FIXME(1.0): this is actually a union
-    #[cfg_attr(target_pointer_width = "32",
-               repr(align(4)))]
-    #[cfg_attr(target_pointer_width = "64",
-               repr(align(8)))]
+    #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+    #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
     pub struct sem_t {
         __size: [::c_char; 32],
     }

--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -17,7 +17,8 @@ cfg_if! {
 }
 
 s! {
-    pub struct statvfs {  // Different than GNU!
+    pub struct statvfs {
+        // Different than GNU!
         pub f_bsize: ::c_ulong,
         pub f_frsize: ::c_ulong,
         pub f_blocks: ::fsblkcnt_t,
@@ -80,20 +81,28 @@ s! {
         pub nr: ::__s32,
     }
 
-    #[cfg_attr(any(target_pointer_width = "32",
-                   target_arch = "x86_64",
-                   target_arch = "powerpc64",
-                   target_arch = "mips64",
-                   target_arch = "s390x",
-                   target_arch = "sparc64"),
-               repr(align(4)))]
-    #[cfg_attr(not(any(target_pointer_width = "32",
-                       target_arch = "x86_64",
-                       target_arch = "powerpc64",
-                       target_arch = "mips64",
-                       target_arch = "s390x",
-                       target_arch = "sparc64")),
-               repr(align(8)))]
+    #[cfg_attr(
+        any(
+            target_pointer_width = "32",
+            target_arch = "x86_64",
+            target_arch = "powerpc64",
+            target_arch = "mips64",
+            target_arch = "s390x",
+            target_arch = "sparc64"
+        ),
+        repr(align(4))
+    )]
+    #[cfg_attr(
+        not(any(
+            target_pointer_width = "32",
+            target_arch = "x86_64",
+            target_arch = "powerpc64",
+            target_arch = "mips64",
+            target_arch = "s390x",
+            target_arch = "sparc64"
+        )),
+        repr(align(8))
+    )]
     pub struct pthread_mutexattr_t {
         size: [u8; ::__SIZEOF_PTHREAD_MUTEXATTR_T],
     }

--- a/src/unix/linux_like/linux/uclibc/x86_64/l4re.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/l4re.rs
@@ -20,9 +20,9 @@ s! {
         /// | MSB              |                 LSB |
         /// | ---------------- | ------------------- |
         /// | 8bit granularity | 24bit offset ..     |
-        gran_offset: l4_umword_t ,
+        gran_offset: l4_umword_t,
         /// Bitmap of CPUs.
-        map: l4_umword_t ,
+        map: l4_umword_t,
     }
 }
 

--- a/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
@@ -34,7 +34,7 @@ s! {
         pub __seq: ::c_ushort,
         __pad2: ::c_ushort,
         __unused1: ::c_ulong,
-        __unused2: ::c_ulong
+        __unused2: ::c_ulong,
     }
 
     #[cfg(not(target_os = "l4re"))]
@@ -55,9 +55,9 @@ s! {
     }
 
     pub struct siginfo_t {
-        si_signo: ::c_int, // signal number
-        si_errno: ::c_int, // if not zero: error value of signal, see errno.h
-        si_code: ::c_int,  // signal code
+        si_signo: ::c_int,       // signal number
+        si_errno: ::c_int,       // if not zero: error value of signal, see errno.h
+        si_code: ::c_int,        // signal code
         pub _pad: [::c_int; 28], // unported union
         _align: [usize; 0],
     }
@@ -72,7 +72,7 @@ s! {
         pub shm_lpid: ::pid_t,
         pub shm_nattch: ::shmatt_t,
         __unused1: ::c_ulong,
-        __unused2: ::c_ulong
+        __unused2: ::c_ulong,
     }
 
     pub struct msqid_ds {
@@ -119,7 +119,7 @@ s! {
         pub st_uid: ::uid_t,
         pub st_gid: ::gid_t,
         pub st_rdev: ::c_ulong, // dev_t
-        pub st_size: off_t, // file size
+        pub st_size: off_t,     // file size
         pub st_blksize: ::blksize_t,
         pub st_blocks: ::blkcnt_t,
         pub st_atime: ::time_t,
@@ -128,23 +128,25 @@ s! {
         pub st_mtime_nsec: ::c_ulong,
         pub st_ctime: ::time_t,
         pub st_ctime_nsec: ::c_ulong,
-        st_pad4: [::c_long; 3]
+        st_pad4: [::c_long; 3],
     }
 
     pub struct sigaction {
         pub sa_handler: ::sighandler_t,
         pub sa_flags: ::c_ulong,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
         pub sa_mask: ::sigset_t,
     }
 
-    pub struct stack_t { // FIXME
+    pub struct stack_t {
+        // FIXME
         pub ss_sp: *mut ::c_void,
         pub ss_flags: ::c_int,
-        pub ss_size: ::size_t
+        pub ss_size: ::size_t,
     }
 
-    pub struct statfs { // FIXME
+    pub struct statfs {
+        // FIXME
         pub f_type: fsword_t,
         pub f_bsize: fsword_t,
         pub f_blocks: ::fsblkcnt_t,
@@ -189,7 +191,8 @@ s! {
         __f_spare: [::c_int; 6],
     }
 
-    pub struct msghdr { // FIXME
+    pub struct msghdr {
+        // FIXME
         pub msg_name: *mut ::c_void,
         pub msg_namelen: ::socklen_t,
         pub msg_iov: *mut ::iovec,
@@ -199,7 +202,8 @@ s! {
         pub msg_flags: ::c_int,
     }
 
-    pub struct termios { // FIXME
+    pub struct termios {
+        // FIXME
         pub c_iflag: ::tcflag_t,
         pub c_oflag: ::tcflag_t,
         pub c_cflag: ::tcflag_t,
@@ -208,11 +212,13 @@ s! {
         pub c_cc: [::cc_t; ::NCCS],
     }
 
-    pub struct sigset_t { // FIXME
+    pub struct sigset_t {
+        // FIXME
         __val: [::c_ulong; 16],
     }
 
-    pub struct sysinfo { // FIXME
+    pub struct sysinfo {
+        // FIXME
         pub uptime: ::c_long,
         pub loads: [::c_ulong; 3],
         pub totalram: ::c_ulong,
@@ -229,7 +235,8 @@ s! {
         pub _f: [::c_char; 0],
     }
 
-    pub struct glob_t { // FIXME
+    pub struct glob_t {
+        // FIXME
         pub gl_pathc: ::size_t,
         pub gl_pathv: *mut *mut c_char,
         pub gl_offs: ::size_t,
@@ -241,14 +248,16 @@ s! {
         __unused5: *mut ::c_void,
     }
 
-    pub struct cpu_set_t { // FIXME
+    pub struct cpu_set_t {
+        // FIXME
         #[cfg(target_pointer_width = "32")]
         bits: [u32; 32],
         #[cfg(target_pointer_width = "64")]
         bits: [u64; 16],
     }
 
-    pub struct fsid_t { // FIXME
+    pub struct fsid_t {
+        // FIXME
         __val: [::c_int; 2],
     }
 

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -62,8 +62,7 @@ s! {
         pub ai_protocol: ::c_int,
         pub ai_addrlen: socklen_t,
 
-        #[cfg(any(target_os = "linux",
-                  target_os = "emscripten"))]
+        #[cfg(any(target_os = "linux", target_os = "emscripten"))]
         pub ai_addr: *mut ::sockaddr,
 
         pub ai_canonname: *mut c_char,
@@ -81,7 +80,7 @@ s! {
         pub sll_hatype: ::c_ushort,
         pub sll_pkttype: ::c_uchar,
         pub sll_halen: ::c_uchar,
-        pub sll_addr: [::c_uchar; 8]
+        pub sll_addr: [::c_uchar; 8],
     }
 
     pub struct fd_set {
@@ -161,7 +160,7 @@ s! {
         pub ifa_addr: *mut ::sockaddr,
         pub ifa_netmask: *mut ::sockaddr,
         pub ifa_ifu: *mut ::sockaddr, // FIXME This should be a union
-        pub ifa_data: *mut ::c_void
+        pub ifa_data: *mut ::c_void,
     }
 
     pub struct in6_rtmsg {
@@ -212,9 +211,12 @@ s_no_extra_traits! {
             all(
                 target_arch = "x86",
                 not(target_env = "musl"),
-                not(target_os = "android")),
-            target_arch = "x86_64"),
-        repr(packed))]
+                not(target_os = "android")
+            ),
+            target_arch = "x86_64"
+        ),
+        repr(packed)
+    )]
     pub struct epoll_event {
         pub events: u32,
         pub u64: u64,
@@ -222,7 +224,7 @@ s_no_extra_traits! {
 
     pub struct sockaddr_un {
         pub sun_family: sa_family_t,
-        pub sun_path: [::c_char; 108]
+        pub sun_path: [::c_char; 108],
     }
 
     pub struct sockaddr_storage {
@@ -240,7 +242,7 @@ s_no_extra_traits! {
         pub release: [::c_char; 65],
         pub version: [::c_char; 65],
         pub machine: [::c_char; 65],
-        pub domainname: [::c_char; 65]
+        pub domainname: [::c_char; 65],
     }
 
     pub struct sigevent {
@@ -253,7 +255,7 @@ s_no_extra_traits! {
         #[cfg(target_pointer_width = "64")]
         __unused1: [::c_int; 11],
         #[cfg(target_pointer_width = "32")]
-        __unused1: [::c_int; 12]
+        __unused1: [::c_int; 12],
     }
 }
 
@@ -261,8 +263,7 @@ cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         impl PartialEq for epoll_event {
             fn eq(&self, other: &epoll_event) -> bool {
-                self.events == other.events
-                    && self.u64 == other.u64
+                self.events == other.events && self.u64 == other.u64
             }
         }
         impl Eq for epoll_event {}
@@ -289,10 +290,10 @@ cfg_if! {
             fn eq(&self, other: &sockaddr_un) -> bool {
                 self.sun_family == other.sun_family
                     && self
-                    .sun_path
-                    .iter()
-                    .zip(other.sun_path.iter())
-                    .all(|(a, b)| a == b)
+                        .sun_path
+                        .iter()
+                        .zip(other.sun_path.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for sockaddr_un {}
@@ -300,7 +301,7 @@ cfg_if! {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("sockaddr_un")
                     .field("sun_family", &self.sun_family)
-                // FIXME: .field("sun_path", &self.sun_path)
+                    // FIXME: .field("sun_path", &self.sun_path)
                     .finish()
             }
         }
@@ -315,10 +316,10 @@ cfg_if! {
             fn eq(&self, other: &sockaddr_storage) -> bool {
                 self.ss_family == other.ss_family
                     && self
-                    .__ss_pad2
-                    .iter()
-                    .zip(other.__ss_pad2.iter())
-                    .all(|(a, b)| a == b)
+                        .__ss_pad2
+                        .iter()
+                        .zip(other.__ss_pad2.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -329,7 +330,7 @@ cfg_if! {
                 f.debug_struct("sockaddr_storage")
                     .field("ss_family", &self.ss_family)
                     .field("__ss_align", &self.__ss_align)
-                // FIXME: .field("__ss_pad2", &self.__ss_pad2)
+                    // FIXME: .field("__ss_pad2", &self.__ss_pad2)
                     .finish()
             }
         }
@@ -348,30 +349,30 @@ cfg_if! {
                     .zip(other.sysname.iter())
                     .all(|(a, b)| a == b)
                     && self
-                    .nodename
-                    .iter()
-                    .zip(other.nodename.iter())
-                    .all(|(a, b)| a == b)
+                        .nodename
+                        .iter()
+                        .zip(other.nodename.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .release
-                    .iter()
-                    .zip(other.release.iter())
-                    .all(|(a, b)| a == b)
+                        .release
+                        .iter()
+                        .zip(other.release.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .version
-                    .iter()
-                    .zip(other.version.iter())
-                    .all(|(a, b)| a == b)
+                        .version
+                        .iter()
+                        .zip(other.version.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .machine
-                    .iter()
-                    .zip(other.machine.iter())
-                    .all(|(a, b)| a == b)
+                        .machine
+                        .iter()
+                        .zip(other.machine.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .domainname
-                    .iter()
-                    .zip(other.domainname.iter())
-                    .all(|(a, b)| a == b)
+                        .domainname
+                        .iter()
+                        .zip(other.domainname.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -380,12 +381,12 @@ cfg_if! {
         impl ::fmt::Debug for utsname {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("utsname")
-                // FIXME: .field("sysname", &self.sysname)
-                // FIXME: .field("nodename", &self.nodename)
-                // FIXME: .field("release", &self.release)
-                // FIXME: .field("version", &self.version)
-                // FIXME: .field("machine", &self.machine)
-                // FIXME: .field("domainname", &self.domainname)
+                    // FIXME: .field("sysname", &self.sysname)
+                    // FIXME: .field("nodename", &self.nodename)
+                    // FIXME: .field("release", &self.release)
+                    // FIXME: .field("version", &self.version)
+                    // FIXME: .field("machine", &self.machine)
+                    // FIXME: .field("domainname", &self.domainname)
                     .finish()
             }
         }
@@ -406,8 +407,7 @@ cfg_if! {
                 self.sigev_value == other.sigev_value
                     && self.sigev_signo == other.sigev_signo
                     && self.sigev_notify == other.sigev_notify
-                    && self.sigev_notify_thread_id
-                        == other.sigev_notify_thread_id
+                    && self.sigev_notify_thread_id == other.sigev_notify_thread_id
             }
         }
         impl Eq for sigevent {}
@@ -417,8 +417,7 @@ cfg_if! {
                     .field("sigev_value", &self.sigev_value)
                     .field("sigev_signo", &self.sigev_signo)
                     .field("sigev_notify", &self.sigev_notify)
-                    .field("sigev_notify_thread_id",
-                           &self.sigev_notify_thread_id)
+                    .field("sigev_notify_thread_id", &self.sigev_notify_thread_id)
                     .finish()
             }
         }
@@ -1006,11 +1005,10 @@ pub const TCP_QUICKACK: ::c_int = 12;
 pub const TCP_CONGESTION: ::c_int = 13;
 pub const TCP_MD5SIG: ::c_int = 14;
 cfg_if! {
-    if #[cfg(all(target_os = "linux", any(
-            target_env = "gnu",
-            target_env = "musl",
-            target_env = "ohos"
-        )))] {
+    if #[cfg(all(
+        target_os = "linux",
+        any(target_env = "gnu", target_env = "musl", target_env = "ohos")
+    ))] {
         // WARN: deprecated
         pub const TCP_COOKIE_TRANSACTIONS: ::c_int = 15;
     }
@@ -1551,8 +1549,7 @@ f! {
     }
 
     pub {const} fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(::mem::size_of::<cmsghdr>()))
-            as ::c_uint
+        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(::mem::size_of::<cmsghdr>())) as ::c_uint
     }
 
     pub {const} fn CMSG_LEN(length: ::c_uint) -> ::c_uint {
@@ -1563,20 +1560,20 @@ f! {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
-        return
+        return;
     }
 
     pub fn FD_ISSET(fd: ::c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
-        return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0
+        return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: ::c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
-        return
+        return;
     }
 
     pub fn FD_ZERO(set: *mut fd_set) -> () {
@@ -1657,10 +1654,11 @@ safe_f! {
 
     #[allow(ellipsis_inclusive_range_patterns)]
     pub {const} fn KERNEL_VERSION(a: u32, b: u32, c: u32) -> u32 {
-        ((a << 16) + (b << 8)) + match c {
-            0 ... 255 => c,
-            _ => 255,
-        }
+        ((a << 16) + (b << 8))
+            + match c {
+                0...255 => c,
+                _ => 255,
+            }
     }
 }
 
@@ -1825,7 +1823,7 @@ cfg_if! {
                 fd: ::c_int,
                 buf: *mut ::c_void,
                 count: ::size_t,
-                offset: off64_t
+                offset: off64_t,
             ) -> ::ssize_t;
             pub fn pwrite64(
                 fd: ::c_int,
@@ -1846,7 +1844,11 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(not(any(target_env = "uclibc", target_env = "musl", target_os = "emscripten")))] {
+    if #[cfg(not(any(
+        target_env = "uclibc",
+        target_env = "musl",
+        target_os = "emscripten"
+    )))] {
         extern "C" {
             pub fn preadv64(
                 fd: ::c_int,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -31,7 +31,11 @@ pub type sighandler_t = ::size_t;
 pub type cc_t = ::c_uchar;
 
 cfg_if! {
-    if #[cfg(any(target_os = "espidf", target_os = "horizon", target_os = "vita"))] {
+    if #[cfg(any(
+        target_os = "espidf",
+        target_os = "horizon",
+        target_os = "vita"
+    ))] {
         pub type uid_t = ::c_ushort;
         pub type gid_t = ::c_ushort;
     } else if #[cfg(target_os = "nto")] {
@@ -173,7 +177,7 @@ s! {
 
     pub struct sigval {
         // Actually a union of an int and a void*
-        pub sival_ptr: *mut ::c_void
+        pub sival_ptr: *mut ::c_void,
     }
 
     // <sys/time.h>
@@ -235,8 +239,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(not(target_os = "nto"))]
-    {
+    if #[cfg(not(target_os = "nto"))] {
         pub const USRQUOTA: ::c_int = 0;
         pub const GRPQUOTA: ::c_int = 1;
     }
@@ -248,8 +251,11 @@ pub const S_ISGID: ::mode_t = 0o2000;
 pub const S_ISVTX: ::mode_t = 0o1000;
 
 cfg_if! {
-    if #[cfg(not(any(target_os = "haiku", target_os = "illumos",
-                     target_os = "solaris")))] {
+    if #[cfg(not(any(
+        target_os = "haiku",
+        target_os = "illumos",
+        target_os = "solaris"
+    )))] {
         pub const IF_NAMESIZE: ::size_t = 16;
         pub const IFNAMSIZ: ::size_t = IF_NAMESIZE;
     }
@@ -295,8 +301,7 @@ pub const LOG_PRIMASK: ::c_int = 7;
 pub const LOG_FACMASK: ::c_int = 0x3f8;
 
 cfg_if! {
-    if #[cfg(not(target_os = "nto"))]
-    {
+    if #[cfg(not(target_os = "nto"))] {
         pub const PRIO_MIN: ::c_int = -20;
         pub const PRIO_MAX: ::c_int = 20;
     }
@@ -333,10 +338,7 @@ pub const FNM_PERIOD: c_int = 1 << 2;
 pub const FNM_NOMATCH: c_int = 1;
 
 cfg_if! {
-    if #[cfg(any(
-        target_os = "illumos",
-        target_os = "solaris",
-    ))] {
+    if #[cfg(any(target_os = "illumos", target_os = "solaris",))] {
         pub const FNM_CASEFOLD: c_int = 1 << 3;
     } else {
         pub const FNM_CASEFOLD: c_int = 1 << 4;
@@ -364,7 +366,11 @@ extern "C" {
 }
 
 cfg_if! {
-    if #[cfg(any(target_os = "l4re", target_os = "espidf", target_os = "nuttx"))] {
+    if #[cfg(any(
+        target_os = "l4re",
+        target_os = "espidf",
+        target_os = "nuttx"
+    ))] {
         // required libraries are linked externally for these platforms:
         // * L4Re
         // * ESP-IDF
@@ -372,95 +378,158 @@ cfg_if! {
     } else if #[cfg(feature = "std")] {
         // cargo build, don't pull in anything extra as the std dep
         // already pulls in all libs.
-    } else if #[cfg(all(target_os = "linux",
-                        any(target_env = "gnu", target_env = "uclibc"),
-                        feature = "rustc-dep-of-std"))] {
-        #[link(name = "util", kind = "static", modifiers = "-bundle",
-            cfg(target_feature = "crt-static"))]
-        #[link(name = "rt", kind = "static", modifiers = "-bundle",
-            cfg(target_feature = "crt-static"))]
-        #[link(name = "pthread", kind = "static", modifiers = "-bundle",
-            cfg(target_feature = "crt-static"))]
-        #[link(name = "m", kind = "static", modifiers = "-bundle",
-            cfg(target_feature = "crt-static"))]
-        #[link(name = "dl", kind = "static", modifiers = "-bundle",
-            cfg(target_feature = "crt-static"))]
-        #[link(name = "c", kind = "static", modifiers = "-bundle",
-            cfg(target_feature = "crt-static"))]
-        #[link(name = "gcc_eh", kind = "static", modifiers = "-bundle",
-            cfg(target_feature = "crt-static"))]
-        #[link(name = "gcc", kind = "static", modifiers = "-bundle",
-            cfg(target_feature = "crt-static"))]
-        #[link(name = "c", kind = "static", modifiers = "-bundle",
-            cfg(target_feature = "crt-static"))]
+    } else if #[cfg(all(
+        target_os = "linux",
+        any(target_env = "gnu", target_env = "uclibc"),
+        feature = "rustc-dep-of-std"
+    ))] {
+        #[link(
+            name = "util",
+            kind = "static",
+            modifiers = "-bundle",
+            cfg(target_feature = "crt-static")
+        )]
+        #[link(
+            name = "rt",
+            kind = "static",
+            modifiers = "-bundle",
+            cfg(target_feature = "crt-static")
+        )]
+        #[link(
+            name = "pthread",
+            kind = "static",
+            modifiers = "-bundle",
+            cfg(target_feature = "crt-static")
+        )]
+        #[link(
+            name = "m",
+            kind = "static",
+            modifiers = "-bundle",
+            cfg(target_feature = "crt-static")
+        )]
+        #[link(
+            name = "dl",
+            kind = "static",
+            modifiers = "-bundle",
+            cfg(target_feature = "crt-static")
+        )]
+        #[link(
+            name = "c",
+            kind = "static",
+            modifiers = "-bundle",
+            cfg(target_feature = "crt-static")
+        )]
+        #[link(
+            name = "gcc_eh",
+            kind = "static",
+            modifiers = "-bundle",
+            cfg(target_feature = "crt-static")
+        )]
+        #[link(
+            name = "gcc",
+            kind = "static",
+            modifiers = "-bundle",
+            cfg(target_feature = "crt-static")
+        )]
+        #[link(
+            name = "c",
+            kind = "static",
+            modifiers = "-bundle",
+            cfg(target_feature = "crt-static")
+        )]
         #[link(name = "util", cfg(not(target_feature = "crt-static")))]
         #[link(name = "rt", cfg(not(target_feature = "crt-static")))]
         #[link(name = "pthread", cfg(not(target_feature = "crt-static")))]
         #[link(name = "m", cfg(not(target_feature = "crt-static")))]
         #[link(name = "dl", cfg(not(target_feature = "crt-static")))]
         #[link(name = "c", cfg(not(target_feature = "crt-static")))]
-        extern {}
+        extern "C" {}
     } else if #[cfg(any(target_env = "musl", target_env = "ohos"))] {
-        #[cfg_attr(feature = "rustc-dep-of-std",
-                   link(name = "c", kind = "static", modifiers = "-bundle",
-                        cfg(target_feature = "crt-static")))]
-        #[cfg_attr(feature = "rustc-dep-of-std",
-                   link(name = "c", cfg(not(target_feature = "crt-static"))))]
-        extern {}
+        #[cfg_attr(
+            feature = "rustc-dep-of-std",
+            link(
+                name = "c",
+                kind = "static",
+                modifiers = "-bundle",
+                cfg(target_feature = "crt-static")
+            )
+        )]
+        #[cfg_attr(
+            feature = "rustc-dep-of-std",
+            link(name = "c", cfg(not(target_feature = "crt-static")))
+        )]
+        extern "C" {}
     } else if #[cfg(target_os = "emscripten")] {
         // Don't pass -lc to Emscripten, it breaks. See:
         // https://github.com/emscripten-core/emscripten/issues/22758
     } else if #[cfg(all(target_os = "android", feature = "rustc-dep-of-std"))] {
-        #[link(name = "c", kind = "static", modifiers = "-bundle",
-            cfg(target_feature = "crt-static"))]
-        #[link(name = "m", kind = "static", modifiers = "-bundle",
-            cfg(target_feature = "crt-static"))]
+        #[link(
+            name = "c",
+            kind = "static",
+            modifiers = "-bundle",
+            cfg(target_feature = "crt-static")
+        )]
+        #[link(
+            name = "m",
+            kind = "static",
+            modifiers = "-bundle",
+            cfg(target_feature = "crt-static")
+        )]
         #[link(name = "m", cfg(not(target_feature = "crt-static")))]
         #[link(name = "c", cfg(not(target_feature = "crt-static")))]
-        extern {}
-    } else if #[cfg(any(target_os = "macos",
-                        target_os = "ios",
-                        target_os = "tvos",
-                        target_os = "watchos",
-                        target_os = "visionos",
-                        target_os = "android",
-                        target_os = "openbsd",
-                        target_os = "nto",
-                    ))] {
+        extern "C" {}
+    } else if #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+        target_os = "android",
+        target_os = "openbsd",
+        target_os = "nto",
+    ))] {
         #[link(name = "c")]
         #[link(name = "m")]
-        extern {}
+        extern "C" {}
     } else if #[cfg(target_os = "haiku")] {
         #[link(name = "root")]
         #[link(name = "network")]
-        extern {}
+        extern "C" {}
     } else if #[cfg(target_env = "newlib")] {
         #[link(name = "c")]
         #[link(name = "m")]
-        extern {}
+        extern "C" {}
     } else if #[cfg(target_env = "illumos")] {
         #[link(name = "c")]
         #[link(name = "m")]
-        extern {}
+        extern "C" {}
     } else if #[cfg(target_os = "redox")] {
-        #[cfg_attr(feature = "rustc-dep-of-std",
-                   link(name = "c", kind = "static", modifiers = "-bundle",
-                        cfg(target_feature = "crt-static")))]
-        #[cfg_attr(feature = "rustc-dep-of-std",
-                   link(name = "c", cfg(not(target_feature = "crt-static"))))]
-        extern {}
+        #[cfg_attr(
+            feature = "rustc-dep-of-std",
+            link(
+                name = "c",
+                kind = "static",
+                modifiers = "-bundle",
+                cfg(target_feature = "crt-static")
+            )
+        )]
+        #[cfg_attr(
+            feature = "rustc-dep-of-std",
+            link(name = "c", cfg(not(target_feature = "crt-static")))
+        )]
+        extern "C" {}
     } else if #[cfg(target_os = "aix")] {
         #[link(name = "c")]
         #[link(name = "m")]
         #[link(name = "bsd")]
         #[link(name = "pthread")]
-        extern {}
+        extern "C" {}
     } else {
         #[link(name = "c")]
         #[link(name = "m")]
         #[link(name = "rt")]
         #[link(name = "pthread")]
-        extern {}
+        extern "C" {}
     }
 }
 
@@ -1464,11 +1533,13 @@ safe_f! {
 }
 
 cfg_if! {
-    if #[cfg(not(any(target_os = "emscripten",
-                     target_os = "android",
-                     target_os = "haiku",
-                     target_os = "nto",
-                     target_os = "solaris")))] {
+    if #[cfg(not(any(
+        target_os = "emscripten",
+        target_os = "android",
+        target_os = "haiku",
+        target_os = "nto",
+        target_os = "solaris"
+    )))] {
         extern "C" {
             pub fn adjtime(delta: *const timeval, olddelta: *mut timeval) -> ::c_int;
         }
@@ -1480,9 +1551,11 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(not(any(target_os = "emscripten",
-                     target_os = "android",
-                     target_os = "nto")))] {
+    if #[cfg(not(any(
+        target_os = "emscripten",
+        target_os = "android",
+        target_os = "nto"
+    )))] {
         extern "C" {
             pub fn stpncpy(dst: *mut c_char, src: *const c_char, n: size_t) -> *mut c_char;
         }
@@ -1496,9 +1569,7 @@ cfg_if! {
                 all(target_os = "macos", target_arch = "x86"),
                 link_name = "confstr$UNIX2003"
             )]
-            #[cfg_attr(target_os = "solaris",
-                link_name = "__confstr_xpg7"
-            )]
+            #[cfg_attr(target_os = "solaris", link_name = "__confstr_xpg7")]
             pub fn confstr(name: ::c_int, buf: *mut ::c_char, len: ::size_t) -> ::size_t;
         }
     }
@@ -1523,35 +1594,43 @@ cfg_if! {
 cfg_if! {
     if #[cfg(not(any(target_env = "uclibc", target_os = "nto")))] {
         extern "C" {
-            pub fn open_wmemstream(
-                ptr: *mut *mut wchar_t,
-                sizeloc: *mut size_t,
-            ) -> *mut FILE;
+            pub fn open_wmemstream(ptr: *mut *mut wchar_t, sizeloc: *mut size_t) -> *mut FILE;
         }
     }
 }
 
 cfg_if! {
     if #[cfg(not(target_os = "redox"))] {
-        extern {
+        extern "C" {
             pub fn getsid(pid: pid_t) -> pid_t;
-            #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
-                       link_name = "pause$UNIX2003")]
+            #[cfg_attr(
+                all(target_os = "macos", target_arch = "x86"),
+                link_name = "pause$UNIX2003"
+            )]
             pub fn pause() -> ::c_int;
 
-            pub fn mkdirat(dirfd: ::c_int, pathname: *const ::c_char,
-                          mode: ::mode_t) -> ::c_int;
-            pub fn openat(dirfd: ::c_int, pathname: *const ::c_char,
-                          flags: ::c_int, ...) -> ::c_int;
+            pub fn mkdirat(dirfd: ::c_int, pathname: *const ::c_char, mode: ::mode_t) -> ::c_int;
+            pub fn openat(
+                dirfd: ::c_int,
+                pathname: *const ::c_char,
+                flags: ::c_int,
+                ...
+            ) -> ::c_int;
 
-            #[cfg_attr(all(target_os = "macos", target_arch = "x86_64"),
-                       link_name = "fdopendir$INODE64")]
-            #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
-                       link_name = "fdopendir$INODE64$UNIX2003")]
+            #[cfg_attr(
+                all(target_os = "macos", target_arch = "x86_64"),
+                link_name = "fdopendir$INODE64"
+            )]
+            #[cfg_attr(
+                all(target_os = "macos", target_arch = "x86"),
+                link_name = "fdopendir$INODE64$UNIX2003"
+            )]
             pub fn fdopendir(fd: ::c_int) -> *mut ::DIR;
 
-            #[cfg_attr(all(target_os = "macos", not(target_arch = "aarch64")),
-                       link_name = "readdir_r$INODE64")]
+            #[cfg_attr(
+                all(target_os = "macos", not(target_arch = "aarch64")),
+                link_name = "readdir_r$INODE64"
+            )]
             #[cfg_attr(target_os = "netbsd", link_name = "__readdir_r30")]
             #[cfg_attr(
                 all(target_os = "freebsd", any(freebsd11, freebsd10)),
@@ -1564,19 +1643,24 @@ cfg_if! {
             /// https://illumos.org/man/3lib/libc
             /// https://docs.oracle.com/cd/E36784_01/html/E36873/libc-3lib.html
             /// https://www.unix.com/man-page/opensolaris/3LIB/libc/
-            pub fn readdir_r(dirp: *mut ::DIR, entry: *mut ::dirent,
-                             result: *mut *mut ::dirent) -> ::c_int;
+            pub fn readdir_r(
+                dirp: *mut ::DIR,
+                entry: *mut ::dirent,
+                result: *mut *mut ::dirent,
+            ) -> ::c_int;
         }
     }
 }
 
 cfg_if! {
     if #[cfg(target_os = "nto")] {
-        extern {
-            pub fn readlinkat(dirfd: ::c_int,
+        extern "C" {
+            pub fn readlinkat(
+                dirfd: ::c_int,
                 pathname: *const ::c_char,
                 buf: *mut ::c_char,
-                bufsiz: ::size_t) -> ::c_int;
+                bufsiz: ::size_t,
+            ) -> ::c_int;
             pub fn readlink(path: *const c_char, buf: *mut c_char, bufsz: ::size_t) -> ::c_int;
             pub fn pselect(
                 nfds: ::c_int,
@@ -1589,15 +1673,17 @@ cfg_if! {
             pub fn sigaction(
                 signum: ::c_int,
                 act: *const sigaction,
-                oldact: *mut sigaction
+                oldact: *mut sigaction,
             ) -> ::c_int;
         }
     } else {
-        extern {
-            pub fn readlinkat(dirfd: ::c_int,
+        extern "C" {
+            pub fn readlinkat(
+                dirfd: ::c_int,
                 pathname: *const ::c_char,
                 buf: *mut ::c_char,
-                bufsiz: ::size_t) -> ::ssize_t;
+                bufsiz: ::size_t,
+            ) -> ::ssize_t;
             pub fn fmemopen(buf: *mut c_void, size: size_t, mode: *const c_char) -> *mut FILE;
             pub fn open_memstream(ptr: *mut *mut c_char, sizeloc: *mut size_t) -> *mut FILE;
             pub fn atexit(cb: extern "C" fn()) -> c_int;
@@ -1605,7 +1691,7 @@ cfg_if! {
             pub fn sigaction(
                 signum: ::c_int,
                 act: *const sigaction,
-                oldact: *mut sigaction
+                oldact: *mut sigaction,
             ) -> ::c_int;
             pub fn readlink(path: *const c_char, buf: *mut c_char, bufsz: ::size_t) -> ::ssize_t;
             #[cfg_attr(
@@ -1630,16 +1716,16 @@ cfg_if! {
 }
 
 cfg_if! {
-   if #[cfg(not(any(target_os = "solaris",
-                    target_os = "illumos",
-                    target_os = "nto",
-                )))] {
-        extern {
+    if #[cfg(not(any(
+        target_os = "solaris",
+        target_os = "illumos",
+        target_os = "nto",
+    )))] {
+        extern "C" {
             pub fn cfmakeraw(termios: *mut ::termios);
-            pub fn cfsetspeed(termios: *mut ::termios,
-                              speed: ::speed_t) -> ::c_int;
+            pub fn cfsetspeed(termios: *mut ::termios, speed: ::speed_t) -> ::c_int;
         }
-   }
+    }
 }
 
 extern "C" {
@@ -1650,25 +1736,28 @@ cfg_if! {
     if #[cfg(target_env = "newlib")] {
         mod newlib;
         pub use self::newlib::*;
-    } else if #[cfg(any(target_os = "linux",
-                        target_os = "l4re",
-                        target_os = "android",
-                        target_os = "emscripten"))] {
+    } else if #[cfg(any(
+        target_os = "linux",
+        target_os = "l4re",
+        target_os = "android",
+        target_os = "emscripten"
+    ))] {
         mod linux_like;
         pub use self::linux_like::*;
-    } else if #[cfg(any(target_os = "macos",
-                        target_os = "ios",
-                        target_os = "tvos",
-                        target_os = "watchos",
-                        target_os = "visionos",
-                        target_os = "freebsd",
-                        target_os = "dragonfly",
-                        target_os = "openbsd",
-                        target_os = "netbsd"))] {
+    } else if #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "openbsd",
+        target_os = "netbsd"
+    ))] {
         mod bsd;
         pub use self::bsd::*;
-    } else if #[cfg(any(target_os = "solaris",
-                        target_os = "illumos"))] {
+    } else if #[cfg(any(target_os = "solaris", target_os = "illumos"))] {
         mod solarish;
         pub use self::solarish::*;
     } else if #[cfg(target_os = "haiku")] {

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -52,7 +52,10 @@ cfg_if! {
 pub type useconds_t = u32;
 
 cfg_if! {
-    if #[cfg(any(target_os = "horizon", all(target_os = "espidf", not(espidf_time32))))] {
+    if #[cfg(any(
+        target_os = "horizon",
+        all(target_os = "espidf", not(espidf_time32))
+    ))] {
         pub type time_t = ::c_longlong;
     } else {
         pub type time_t = i32;
@@ -61,7 +64,7 @@ cfg_if! {
 
 cfg_if! {
     if #[cfg(not(target_os = "horizon"))] {
-        s!{
+        s! {
             pub struct hostent {
                 pub h_name: *mut ::c_char,
                 pub h_aliases: *mut *mut ::c_char,
@@ -91,7 +94,8 @@ s! {
 
         #[cfg(not(any(
             target_os = "espidf",
-            all(target_arch = "powerpc", target_vendor = "nintendo"))))]
+            all(target_arch = "powerpc", target_vendor = "nintendo")
+        )))]
         pub ai_addr: *mut sockaddr,
 
         pub ai_next: *mut addrinfo,
@@ -171,7 +175,7 @@ s! {
     }
 
     pub struct sigaction {
-        pub sa_handler: extern fn(arg1: ::c_int),
+        pub sa_handler: extern "C" fn(arg1: ::c_int),
         pub sa_mask: sigset_t,
         pub sa_flags: ::c_int,
     }
@@ -182,11 +186,13 @@ s! {
         pub ss_size: usize,
     }
 
-    pub struct fd_set { // Unverified
+    pub struct fd_set {
+        // Unverified
         fds_bits: [::c_ulong; FD_SETSIZE as usize / ULONG_SIZE],
     }
 
-    pub struct passwd { // Unverified
+    pub struct passwd {
+        // Unverified
         pub pw_name: *mut ::c_char,
         pub pw_passwd: *mut ::c_char,
         pub pw_uid: ::uid_t,
@@ -196,7 +202,8 @@ s! {
         pub pw_shell: *mut ::c_char,
     }
 
-    pub struct termios { // Unverified
+    pub struct termios {
+        // Unverified
         pub c_iflag: ::tcflag_t,
         pub c_oflag: ::tcflag_t,
         pub c_cflag: ::tcflag_t,
@@ -209,31 +216,36 @@ s! {
         pub c_ospeed: u32,
     }
 
-    pub struct sem_t { // Unverified
+    pub struct sem_t {
+        // Unverified
         __size: [::c_char; 16],
     }
 
-    pub struct Dl_info { // Unverified
+    pub struct Dl_info {
+        // Unverified
         pub dli_fname: *const ::c_char,
         pub dli_fbase: *mut ::c_void,
         pub dli_sname: *const ::c_char,
         pub dli_saddr: *mut ::c_void,
     }
 
-    pub struct utsname { // Unverified
+    pub struct utsname {
+        // Unverified
         pub sysname: [::c_char; 65],
         pub nodename: [::c_char; 65],
         pub release: [::c_char; 65],
         pub version: [::c_char; 65],
         pub machine: [::c_char; 65],
-        pub domainname: [::c_char; 65]
+        pub domainname: [::c_char; 65],
     }
 
-    pub struct cpu_set_t { // Unverified
+    pub struct cpu_set_t {
+        // Unverified
         bits: [u32; 32],
     }
 
-    pub struct pthread_attr_t { // Unverified
+    pub struct pthread_attr_t {
+        // Unverified
         #[cfg(not(target_os = "espidf"))]
         __size: [u8; __SIZEOF_PTHREAD_ATTR_T],
         #[cfg(target_os = "espidf")]
@@ -254,63 +266,85 @@ s! {
         pub detachstate: i32,
     }
 
-    pub struct pthread_rwlockattr_t { // Unverified
-        __size: [u8; __SIZEOF_PTHREAD_RWLOCKATTR_T]
+    pub struct pthread_rwlockattr_t {
+        // Unverified
+        __size: [u8; __SIZEOF_PTHREAD_RWLOCKATTR_T],
     }
 
-    #[cfg_attr(all(target_pointer_width = "32",
-                   any(target_arch = "mips",
-                       target_arch = "arm",
-                       target_arch = "powerpc")),
-               repr(align(4)))]
-    #[cfg_attr(any(target_pointer_width = "64",
-                   not(any(target_arch = "mips",
-                           target_arch = "arm",
-                           target_arch = "powerpc"))),
-               repr(align(8)))]
-    pub struct pthread_mutex_t { // Unverified
+    #[cfg_attr(
+        all(
+            target_pointer_width = "32",
+            any(target_arch = "mips", target_arch = "arm", target_arch = "powerpc")
+        ),
+        repr(align(4))
+    )]
+    #[cfg_attr(
+        any(
+            target_pointer_width = "64",
+            not(any(target_arch = "mips", target_arch = "arm", target_arch = "powerpc"))
+        ),
+        repr(align(8))
+    )]
+    pub struct pthread_mutex_t {
+        // Unverified
         size: [u8; ::__SIZEOF_PTHREAD_MUTEX_T],
     }
 
-    #[cfg_attr(all(target_pointer_width = "32",
-                   any(target_arch = "mips",
-                       target_arch = "arm",
-                       target_arch = "powerpc")),
-               repr(align(4)))]
-    #[cfg_attr(any(target_pointer_width = "64",
-                   not(any(target_arch = "mips",
-                           target_arch = "arm",
-                           target_arch = "powerpc"))),
-               repr(align(8)))]
-    pub struct pthread_rwlock_t { // Unverified
+    #[cfg_attr(
+        all(
+            target_pointer_width = "32",
+            any(target_arch = "mips", target_arch = "arm", target_arch = "powerpc")
+        ),
+        repr(align(4))
+    )]
+    #[cfg_attr(
+        any(
+            target_pointer_width = "64",
+            not(any(target_arch = "mips", target_arch = "arm", target_arch = "powerpc"))
+        ),
+        repr(align(8))
+    )]
+    pub struct pthread_rwlock_t {
+        // Unverified
         size: [u8; ::__SIZEOF_PTHREAD_RWLOCK_T],
     }
 
-    #[cfg_attr(any(target_pointer_width = "32",
-                   target_arch = "x86_64",
-                   target_arch = "powerpc64",
-                   target_arch = "mips64",
-                   target_arch = "s390x",
-                   target_arch = "sparc64"),
-               repr(align(4)))]
-    #[cfg_attr(not(any(target_pointer_width = "32",
-                       target_arch = "x86_64",
-                       target_arch = "powerpc64",
-                       target_arch = "mips64",
-                       target_arch = "s390x",
-                       target_arch = "sparc64")),
-               repr(align(8)))]
-    pub struct pthread_mutexattr_t { // Unverified
+    #[cfg_attr(
+        any(
+            target_pointer_width = "32",
+            target_arch = "x86_64",
+            target_arch = "powerpc64",
+            target_arch = "mips64",
+            target_arch = "s390x",
+            target_arch = "sparc64"
+        ),
+        repr(align(4))
+    )]
+    #[cfg_attr(
+        not(any(
+            target_pointer_width = "32",
+            target_arch = "x86_64",
+            target_arch = "powerpc64",
+            target_arch = "mips64",
+            target_arch = "s390x",
+            target_arch = "sparc64"
+        )),
+        repr(align(8))
+    )]
+    pub struct pthread_mutexattr_t {
+        // Unverified
         size: [u8; ::__SIZEOF_PTHREAD_MUTEXATTR_T],
     }
 
     #[repr(align(8))]
-    pub struct pthread_cond_t { // Unverified
+    pub struct pthread_cond_t {
+        // Unverified
         size: [u8; ::__SIZEOF_PTHREAD_COND_T],
     }
 
     #[repr(align(4))]
-    pub struct pthread_condattr_t { // Unverified
+    pub struct pthread_condattr_t {
+        // Unverified
         size: [u8; ::__SIZEOF_PTHREAD_CONDATTR_T],
     }
 }
@@ -739,7 +773,6 @@ cfg_if! {
         pub const NO_DATA: ::c_int = 211;
         pub const NO_RECOVERY: ::c_int = 212;
         pub const TRY_AGAIN: ::c_int = 213;
-
     } else {
         pub const HOST_NOT_FOUND: ::c_int = 1;
         pub const NO_DATA: ::c_int = 2;
@@ -804,20 +837,20 @@ f! {
         let bits = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] &= !(1 << (fd % bits));
-        return
+        return;
     }
 
     pub fn FD_ISSET(fd: ::c_int, set: *const fd_set) -> bool {
         let bits = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
-        return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0
+        return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0;
     }
 
     pub fn FD_SET(fd: ::c_int, set: *mut fd_set) -> () {
         let bits = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] |= 1 << (fd % bits);
-        return
+        return;
     }
 
     pub fn FD_ZERO(set: *mut fd_set) -> () {

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -102,9 +102,9 @@ s! {
         pub st_nblocks: i32,
         pub st_blksize: ::blksize_t,
         pub st_blocks: ::blkcnt_t,
-        pub st_mtim:    ::timespec,
-        pub st_atim:    ::timespec,
-        pub st_ctim:    ::timespec,
+        pub st_mtim: ::timespec,
+        pub st_atim: ::timespec,
+        pub st_ctim: ::timespec,
     }
 
     pub struct ip_mreq {
@@ -230,7 +230,7 @@ s! {
         pub _Nostr: *mut ::c_char,
         pub _Yesstr: *mut ::c_char,
         pub _Reserved: [*mut ::c_char; 8],
-        }
+    }
 
     pub struct in_pktinfo {
         pub ipi_addr: ::in_addr,
@@ -244,7 +244,7 @@ s! {
         pub ifa_addr: *mut ::sockaddr,
         pub ifa_netmask: *mut ::sockaddr,
         pub ifa_dstaddr: *mut ::sockaddr,
-        pub ifa_data: *mut ::c_void
+        pub ifa_data: *mut ::c_void,
     }
 
     pub struct arpreq {
@@ -437,7 +437,7 @@ s! {
         pub wd: ::c_int,
         pub mask: u32,
         pub cookie: u32,
-        pub len: u32
+        pub len: u32,
     }
 
     pub struct regmatch_t {
@@ -534,7 +534,7 @@ s! {
 
     pub struct pthread_attr_t {
         __data1: ::c_long,
-        __data2: [u8; 96]
+        __data2: [u8; 96],
     }
 
     pub struct ipc_perm {
@@ -647,7 +647,7 @@ s_no_extra_traits! {
     pub struct sockaddr_un {
         pub sun_len: u8,
         pub sun_family: sa_family_t,
-        pub sun_path: [::c_char; 104]
+        pub sun_path: [::c_char; 104],
     }
 
     pub struct sockaddr_storage {
@@ -673,7 +673,6 @@ s_no_extra_traits! {
         pub __padding2: ::c_int,
         pub sigev_value: ::sigval,
         __sigev_un2: usize, // union
-
     }
     pub struct dirent {
         pub d_ino: ::ino_t,
@@ -734,13 +733,14 @@ s_no_extra_traits! {
     }
 
     pub struct sync_t {
-        __u: ::c_uint,                     // union
+        __u: ::c_uint, // union
         pub __owner: ::c_uint,
     }
 
     #[repr(align(4))]
-    pub struct pthread_barrier_t {         // union
-        __pad: [u8; 28],                   // union
+    pub struct pthread_barrier_t {
+        // union
+        __pad: [u8; 28], // union
     }
 
     pub struct pthread_rwlock_t {
@@ -748,9 +748,9 @@ s_no_extra_traits! {
         pub __blockedwriters: ::c_int,
         pub __blockedreaders: ::c_int,
         pub __heavy: ::c_int,
-        pub __lock: ::pthread_mutex_t,     // union
-        pub __rcond: ::pthread_cond_t,     // union
-        pub __wcond: ::pthread_cond_t,     // union
+        pub __lock: ::pthread_mutex_t, // union
+        pub __rcond: ::pthread_cond_t, // union
+        pub __wcond: ::pthread_cond_t, // union
         pub __owner: ::c_uint,
         pub __spare: ::c_uint,
     }
@@ -764,8 +764,7 @@ cfg_if! {
                 self.sigev_notify == other.sigev_notify
                     && self.sigev_signo == other.sigev_signo
                     && self.sigev_value == other.sigev_value
-                    && self.__sigev_un2
-                        == other.__sigev_un2
+                    && self.__sigev_un2 == other.__sigev_un2
             }
         }
         impl Eq for sigevent {}
@@ -775,8 +774,7 @@ cfg_if! {
                     .field("sigev_notify", &self.sigev_notify)
                     .field("sigev_signo", &self.sigev_signo)
                     .field("sigev_value", &self.sigev_value)
-                    .field("__sigev_un2",
-                        &self.__sigev_un2)
+                    .field("__sigev_un2", &self.__sigev_un2)
                     .finish()
             }
         }
@@ -794,10 +792,10 @@ cfg_if! {
                 self.sun_len == other.sun_len
                     && self.sun_family == other.sun_family
                     && self
-                    .sun_path
-                    .iter()
-                    .zip(other.sun_path.iter())
-                    .all(|(a,b)| a == b)
+                        .sun_path
+                        .iter()
+                        .zip(other.sun_path.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for sockaddr_un {}
@@ -847,7 +845,7 @@ cfg_if! {
                     .field("msg_type", &self.msg_type)
                     .field("msg_ts", &self.msg_ts)
                     .field("msg_spot", &self.msg_spot)
-                .finish()
+                    .finish()
             }
         }
 
@@ -894,10 +892,10 @@ cfg_if! {
                     && self.sdl_alen == other.sdl_alen
                     && self.sdl_slen == other.sdl_slen
                     && self
-                    .sdl_data
-                    .iter()
-                    .zip(other.sdl_data.iter())
-                    .all(|(a,b)| a == b)
+                        .sdl_data
+                        .iter()
+                        .zip(other.sdl_data.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for sockaddr_dl {}
@@ -946,7 +944,7 @@ cfg_if! {
                     .field("__wcond", &self.__wcond)
                     .field("__owner", &self.__owner)
                     .field("__spare", &self.__spare)
-                .finish()
+                    .finish()
             }
         }
 
@@ -986,27 +984,27 @@ cfg_if! {
                 self.sysname
                     .iter()
                     .zip(other.sysname.iter())
-                    .all(|(a,b)| a == b)
+                    .all(|(a, b)| a == b)
                     && self
-                    .nodename
-                    .iter()
-                    .zip(other.nodename.iter())
-                    .all(|(a,b)| a == b)
+                        .nodename
+                        .iter()
+                        .zip(other.nodename.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .release
-                    .iter()
-                    .zip(other.release.iter())
-                    .all(|(a,b)| a == b)
+                        .release
+                        .iter()
+                        .zip(other.release.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .version
-                    .iter()
-                    .zip(other.version.iter())
-                    .all(|(a,b)| a == b)
+                        .version
+                        .iter()
+                        .zip(other.version.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .machine
-                    .iter()
-                    .zip(other.machine.iter())
-                    .all(|(a,b)| a == b)
+                        .machine
+                        .iter()
+                        .zip(other.machine.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -1015,11 +1013,11 @@ cfg_if! {
         impl ::fmt::Debug for utsname {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("utsname")
-                // FIXME: .field("sysname", &self.sysname)
-                // FIXME: .field("nodename", &self.nodename)
-                // FIXME: .field("release", &self.release)
-                // FIXME: .field("version", &self.version)
-                // FIXME: .field("machine", &self.machine)
+                    // FIXME: .field("sysname", &self.sysname)
+                    // FIXME: .field("nodename", &self.nodename)
+                    // FIXME: .field("release", &self.release)
+                    // FIXME: .field("version", &self.version)
+                    // FIXME: .field("machine", &self.machine)
                     .finish()
             }
         }
@@ -1036,13 +1034,13 @@ cfg_if! {
 
         impl PartialEq for mq_attr {
             fn eq(&self, other: &mq_attr) -> bool {
-                self.mq_maxmsg == other.mq_maxmsg &&
-                self.mq_msgsize == other.mq_msgsize &&
-                self.mq_flags == other.mq_flags &&
-                self.mq_curmsgs == other.mq_curmsgs &&
-                self.mq_msgsize == other.mq_msgsize &&
-                self.mq_sendwait == other.mq_sendwait &&
-                self.mq_recvwait == other.mq_recvwait
+                self.mq_maxmsg == other.mq_maxmsg
+                    && self.mq_msgsize == other.mq_msgsize
+                    && self.mq_flags == other.mq_flags
+                    && self.mq_curmsgs == other.mq_curmsgs
+                    && self.mq_msgsize == other.mq_msgsize
+                    && self.mq_sendwait == other.mq_sendwait
+                    && self.mq_recvwait == other.mq_recvwait
             }
         }
 
@@ -1079,10 +1077,10 @@ cfg_if! {
                     && self.__ss_pad1 == other.__ss_pad1
                     && self.__ss_align == other.__ss_align
                     && self
-                    .__ss_pad2
-                    .iter()
-                    .zip(other.__ss_pad2.iter())
-                    .all(|(a, b)| a == b)
+                        .__ss_pad2
+                        .iter()
+                        .zip(other.__ss_pad2.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -1116,11 +1114,10 @@ cfg_if! {
                     && self.d_offset == other.d_offset
                     && self.d_reclen == other.d_reclen
                     && self.d_namelen == other.d_namelen
-                    && self
-                    .d_name[..self.d_namelen as _]
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                    && self.d_name[..self.d_namelen as _]
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -2714,7 +2711,7 @@ const_fn! {
     }
 
     {const} fn _ALIGN(p: usize, b: usize) -> usize {
-        (p + b - 1) & !(b-1)
+        (p + b - 1) & !(b - 1)
     }
 }
 
@@ -2727,21 +2724,18 @@ f! {
         }
     }
 
-    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr, cmsg: *const ::cmsghdr)
-        -> *mut ::cmsghdr
-    {
+    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr, cmsg: *const ::cmsghdr) -> *mut ::cmsghdr {
         let msg = _CMSG_ALIGN((*cmsg).cmsg_len as usize);
         let next = cmsg as usize + msg + _CMSG_ALIGN(::mem::size_of::<::cmsghdr>());
         if next > (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize {
-           0 as *mut ::cmsghdr
+            0 as *mut ::cmsghdr
         } else {
             (cmsg as usize + msg) as *mut ::cmsghdr
         }
     }
 
     pub fn CMSG_DATA(cmsg: *const ::cmsghdr) -> *mut ::c_uchar {
-        (cmsg as *mut ::c_uchar)
-            .offset(_CMSG_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
+        (cmsg as *mut ::c_uchar).offset(_CMSG_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_LEN(length: ::c_uint) -> ::c_uint {
@@ -2749,28 +2743,27 @@ f! {
     }
 
     pub {const} fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
-        (_CMSG_ALIGN(::mem::size_of::<cmsghdr>()) + _CMSG_ALIGN(length as usize) )
-            as ::c_uint
+        (_CMSG_ALIGN(::mem::size_of::<cmsghdr>()) + _CMSG_ALIGN(length as usize)) as ::c_uint
     }
 
     pub fn FD_CLR(fd: ::c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
-        return
+        return;
     }
 
     pub fn FD_ISSET(fd: ::c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
-        return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0
+        return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: ::c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
-        return
+        return;
     }
 
     pub fn FD_ZERO(set: *mut fd_set) -> () {
@@ -2799,16 +2792,13 @@ f! {
 
     pub fn _DEXTRA_NEXT(_x: *const ::dirent_extra) -> *mut ::dirent_extra {
         _ALIGN(
-            _x as usize + ::mem::size_of::<::dirent_extra>() + (*_x).d_datalen as usize, 8
+            _x as usize + ::mem::size_of::<::dirent_extra>() + (*_x).d_datalen as usize,
+            8,
         ) as *mut ::dirent_extra
     }
 
     pub fn SOCKCREDSIZE(ngrps: usize) -> usize {
-        let ngrps = if ngrps > 0 {
-            ngrps - 1
-        } else {
-            0
-        };
+        let ngrps = if ngrps > 0 { ngrps - 1 } else { 0 };
         ::mem::size_of::<sockcred>() + ::mem::size_of::<::gid_t>() * ngrps
     }
 
@@ -3498,12 +3488,10 @@ cfg_if! {
     if #[cfg(target_arch = "x86_64")] {
         mod x86_64;
         pub use self::x86_64::*;
-    }
-    else if #[cfg(target_arch = "aarch64")] {
+    } else if #[cfg(target_arch = "aarch64")] {
         mod aarch64;
         pub use self::aarch64::*;
-    }
-    else {
+    } else {
         panic!("Unsupported arch");
     }
 }

--- a/src/unix/nto/neutrino.rs
+++ b/src/unix/nto/neutrino.rs
@@ -16,7 +16,7 @@ s! {
     }
 
     pub struct iov_t {
-        pub iov_base: *mut ::c_void,  // union
+        pub iov_base: *mut ::c_void, // union
         pub iov_len: ::size_t,
     }
 
@@ -130,7 +130,8 @@ s! {
         pub coid: ::c_int,
     }
 
-    pub struct _channel_connect_attr {  // union
+    pub struct _channel_connect_attr {
+        // union
         pub ev: ::__c_anonymous_struct_ev,
     }
 
@@ -180,7 +181,7 @@ s! {
         pub flags: u32,
         pub rr_interval_mul: u32,
         pub timer_load_hi: u32,
-        pub nsec_stable: u64,      // volatile
+        pub nsec_stable: u64, // volatile
         pub timer_load_max: u64,
         pub timer_prog_time: u32,
         spare: [u32; 7],
@@ -212,7 +213,6 @@ s! {
 }
 
 s_no_extra_traits! {
-
     #[repr(align(8))]
     pub struct syspage_entry {
         pub size: u16,

--- a/src/unix/nto/x86_64.rs
+++ b/src/unix/nto/x86_64.rs
@@ -52,7 +52,7 @@ s! {
         pub fpu_op: u32,
         pub fpu_ds: u32,
         pub st_regs: [u8; 80],
-   }
+    }
 
     pub struct fxsave_area_64 {
         pub fpu_control_word: u16,

--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -63,18 +63,28 @@ s! {
         pub pw_gecos: *const c_char,
         pub pw_dir: *const c_char,
         pub pw_shell: *const c_char,
-        __reserved: [usize; __DEFAULT_RESERVED_SIZE__]
+        __reserved: [usize; __DEFAULT_RESERVED_SIZE__],
     }
 
-    pub struct sem_t { __val: [usize; __SEM_SIZE__] }
+    pub struct sem_t {
+        __val: [usize; __SEM_SIZE__],
+    }
 
-    pub struct pthread_attr_t { __val: [usize; __PTHREAD_ATTR_SIZE__] }
+    pub struct pthread_attr_t {
+        __val: [usize; __PTHREAD_ATTR_SIZE__],
+    }
 
-    pub struct pthread_mutex_t { __val: [usize; __PTHREAD_MUTEX_SIZE__] }
+    pub struct pthread_mutex_t {
+        __val: [usize; __PTHREAD_MUTEX_SIZE__],
+    }
 
-    pub struct pthread_cond_t { __val: [usize; __PTHREAD_COND_SIZE__] }
+    pub struct pthread_cond_t {
+        __val: [usize; __PTHREAD_COND_SIZE__],
+    }
 
-    pub struct pthread_condattr_t { __val: [usize; __PTHREAD_CONDATTR_SIZE__] }
+    pub struct pthread_condattr_t {
+        __val: [usize; __PTHREAD_CONDATTR_SIZE__],
+    }
 
     pub struct Dl_info {
         pub dli_fname: *const c_char,

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -75,17 +75,13 @@ s_no_extra_traits! {
 
     pub struct sockaddr_un {
         pub sun_family: ::sa_family_t,
-        pub sun_path: [::c_char; 108]
+        pub sun_path: [::c_char; 108],
     }
 
     pub struct sockaddr_storage {
         pub ss_family: ::sa_family_t,
-        __ss_padding: [
-            u8;
-            128 -
-            ::core::mem::size_of::<sa_family_t>() -
-            ::core::mem::size_of::<c_ulong>()
-        ],
+        __ss_padding:
+            [u8; 128 - ::core::mem::size_of::<sa_family_t>() - ::core::mem::size_of::<c_ulong>()],
         __ss_align: ::c_ulong,
     }
 }
@@ -162,7 +158,7 @@ s! {
     pub struct sigaction {
         pub sa_sigaction: ::sighandler_t,
         pub sa_flags: ::c_ulong,
-        pub sa_restorer: ::Option<extern fn()>,
+        pub sa_restorer: ::Option<extern "C" fn()>,
         pub sa_mask: ::sigset_t,
     }
 
@@ -1022,20 +1018,20 @@ f! {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
-        return
+        return;
     }
 
     pub fn FD_ISSET(fd: ::c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
-        return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0
+        return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: ::c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
         let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
-        return
+        return;
     }
 
     pub fn FD_ZERO(set: *mut fd_set) -> () {
@@ -1268,10 +1264,10 @@ cfg_if! {
                     && self.d_reclen == other.d_reclen
                     && self.d_type == other.d_type
                     && self
-                    .d_name
-                    .iter()
-                    .zip(other.d_name.iter())
-                    .all(|(a,b)| a == b)
+                        .d_name
+                        .iter()
+                        .zip(other.d_name.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -1284,7 +1280,7 @@ cfg_if! {
                     .field("d_off", &self.d_off)
                     .field("d_reclen", &self.d_reclen)
                     .field("d_type", &self.d_type)
-                // FIXME: .field("d_name", &self.d_name)
+                    // FIXME: .field("d_name", &self.d_name)
                     .finish()
             }
         }
@@ -1303,10 +1299,10 @@ cfg_if! {
             fn eq(&self, other: &sockaddr_un) -> bool {
                 self.sun_family == other.sun_family
                     && self
-                    .sun_path
-                    .iter()
-                    .zip(other.sun_path.iter())
-                    .all(|(a,b)| a == b)
+                        .sun_path
+                        .iter()
+                        .zip(other.sun_path.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -1316,7 +1312,7 @@ cfg_if! {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("sockaddr_un")
                     .field("sun_family", &self.sun_family)
-                // FIXME: .field("sun_path", &self.sun_path)
+                    // FIXME: .field("sun_path", &self.sun_path)
                     .finish()
             }
         }
@@ -1333,10 +1329,10 @@ cfg_if! {
                 self.ss_family == other.ss_family
                     && self.__ss_align == self.__ss_align
                     && self
-                    .__ss_padding
-                    .iter()
-                    .zip(other.__ss_padding.iter())
-                    .all(|(a,b)| a == b)
+                        .__ss_padding
+                        .iter()
+                        .zip(other.__ss_padding.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -1347,7 +1343,7 @@ cfg_if! {
                 f.debug_struct("sockaddr_storage")
                     .field("ss_family", &self.ss_family)
                     .field("__ss_align", &self.__ss_align)
-                // FIXME: .field("__ss_padding", &self.__ss_padding)
+                    // FIXME: .field("__ss_padding", &self.__ss_padding)
                     .finish()
             }
         }
@@ -1367,30 +1363,30 @@ cfg_if! {
                     .zip(other.sysname.iter())
                     .all(|(a, b)| a == b)
                     && self
-                    .nodename
-                    .iter()
-                    .zip(other.nodename.iter())
-                    .all(|(a, b)| a == b)
+                        .nodename
+                        .iter()
+                        .zip(other.nodename.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .release
-                    .iter()
-                    .zip(other.release.iter())
-                    .all(|(a, b)| a == b)
+                        .release
+                        .iter()
+                        .zip(other.release.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .version
-                    .iter()
-                    .zip(other.version.iter())
-                    .all(|(a, b)| a == b)
+                        .version
+                        .iter()
+                        .zip(other.version.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .machine
-                    .iter()
-                    .zip(other.machine.iter())
-                    .all(|(a, b)| a == b)
+                        .machine
+                        .iter()
+                        .zip(other.machine.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .domainname
-                    .iter()
-                    .zip(other.domainname.iter())
-                    .all(|(a, b)| a == b)
+                        .domainname
+                        .iter()
+                        .zip(other.domainname.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -1399,12 +1395,12 @@ cfg_if! {
         impl ::fmt::Debug for utsname {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("utsname")
-                // FIXME: .field("sysname", &self.sysname)
-                // FIXME: .field("nodename", &self.nodename)
-                // FIXME: .field("release", &self.release)
-                // FIXME: .field("version", &self.version)
-                // FIXME: .field("machine", &self.machine)
-                // FIXME: .field("domainname", &self.domainname)
+                    // FIXME: .field("sysname", &self.sysname)
+                    // FIXME: .field("nodename", &self.nodename)
+                    // FIXME: .field("release", &self.release)
+                    // FIXME: .field("version", &self.version)
+                    // FIXME: .field("machine", &self.machine)
+                    // FIXME: .field("domainname", &self.domainname)
                     .finish()
             }
         }

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -82,10 +82,10 @@ cfg_if! {
                     && self.ut_syslen == other.ut_syslen
                     && self.ut_pad == other.ut_pad
                     && self
-                    .ut_host
-                    .iter()
-                    .zip(other.ut_host.iter())
-                    .all(|(a,b)| a == b)
+                        .ut_host
+                        .iter()
+                        .zip(other.ut_host.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 
@@ -127,8 +127,7 @@ cfg_if! {
 
         impl PartialEq for epoll_event {
             fn eq(&self, other: &epoll_event) -> bool {
-                self.events == other.events
-                    && self.u64 == other.u64
+                self.events == other.events && self.u64 == other.u64
             }
         }
         impl Eq for epoll_event {}

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -106,7 +106,7 @@ s! {
         pub sin_family: sa_family_t,
         pub sin_port: ::in_port_t,
         pub sin_addr: ::in_addr,
-        pub sin_zero: [::c_char; 8]
+        pub sin_zero: [::c_char; 8],
     }
 
     pub struct sockaddr_in6 {
@@ -115,7 +115,7 @@ s! {
         pub sin6_flowinfo: u32,
         pub sin6_addr: ::in6_addr,
         pub sin6_scope_id: u32,
-        pub __sin6_src_id: u32
+        pub __sin6_src_id: u32,
     }
 
     pub struct in_pktinfo {
@@ -138,7 +138,7 @@ s! {
         pub pw_comment: *mut ::c_char,
         pub pw_gecos: *mut ::c_char,
         pub pw_dir: *mut ::c_char,
-        pub pw_shell: *mut ::c_char
+        pub pw_shell: *mut ::c_char,
     }
 
     pub struct ifaddrs {
@@ -148,7 +148,7 @@ s! {
         pub ifa_addr: *mut ::sockaddr,
         pub ifa_netmask: *mut ::sockaddr,
         pub ifa_dstaddr: *mut ::sockaddr,
-        pub ifa_data: *mut ::c_void
+        pub ifa_data: *mut ::c_void,
     }
 
     pub struct itimerspec {
@@ -165,10 +165,10 @@ s! {
         pub tm_year: ::c_int,
         pub tm_wday: ::c_int,
         pub tm_yday: ::c_int,
-        pub tm_isdst: ::c_int
+        pub tm_isdst: ::c_int,
     }
 
-     pub struct msghdr {
+    pub struct msghdr {
         pub msg_name: *mut ::c_void,
         pub msg_namelen: ::socklen_t,
         pub msg_iov: *mut ::iovec,
@@ -185,7 +185,7 @@ s! {
     }
 
     pub struct pthread_attr_t {
-        __pthread_attrp: *mut ::c_void
+        __pthread_attrp: *mut ::c_void,
     }
 
     pub struct pthread_mutex_t {
@@ -195,18 +195,18 @@ s! {
         __pthread_mutex_type: u16,
         __pthread_mutex_magic: u16,
         __pthread_mutex_lock: u64,
-        __pthread_mutex_data: u64
+        __pthread_mutex_data: u64,
     }
 
     pub struct pthread_mutexattr_t {
-        __pthread_mutexattrp: *mut ::c_void
+        __pthread_mutexattrp: *mut ::c_void,
     }
 
     pub struct pthread_cond_t {
         __pthread_cond_flag: [u8; 4],
         __pthread_cond_type: u16,
         __pthread_cond_magic: u16,
-        __pthread_cond_data: u64
+        __pthread_cond_data: u64,
     }
 
     pub struct pthread_condattr_t {
@@ -219,7 +219,7 @@ s! {
         __pthread_rwlock_magic: u16,
         __pthread_rwlock_mutex: ::pthread_mutex_t,
         __pthread_rwlock_readercv: ::pthread_cond_t,
-        __pthread_rwlock_writercv: ::pthread_cond_t
+        __pthread_rwlock_writercv: ::pthread_cond_t,
     }
 
     pub struct pthread_rwlockattr_t {
@@ -230,12 +230,12 @@ s! {
         pub d_ino: ::ino_t,
         pub d_off: ::off_t,
         pub d_reclen: u16,
-        pub d_name: [::c_char; 3]
+        pub d_name: [::c_char; 3],
     }
 
     pub struct glob_t {
         pub gl_pathc: ::size_t,
-        pub gl_pathv:  *mut *mut ::c_char,
+        pub gl_pathv: *mut *mut ::c_char,
         pub gl_offs: ::size_t,
         __unused1: *mut ::c_void,
         __unused2: ::c_int,
@@ -299,7 +299,7 @@ s! {
         pub f_basetype: [::c_char; 16],
         pub f_flag: ::c_ulong,
         pub f_namemax: ::c_ulong,
-        pub f_fstr: [::c_char; 32]
+        pub f_fstr: [::c_char; 32],
     }
 
     pub struct sendfilevec_t {
@@ -311,7 +311,7 @@ s! {
 
     pub struct sched_param {
         pub sched_priority: ::c_int,
-        sched_pad: [::c_int; 8]
+        sched_pad: [::c_int; 8],
     }
 
     pub struct Dl_info {
@@ -338,7 +338,7 @@ s! {
         pub st_ctime_nsec: ::c_long,
         pub st_blksize: ::blksize_t,
         pub st_blocks: ::blkcnt_t,
-        __unused: [::c_char; 16]
+        __unused: [::c_char; 16],
     }
 
     pub struct termios {
@@ -346,7 +346,7 @@ s! {
         pub c_oflag: ::tcflag_t,
         pub c_cflag: ::tcflag_t,
         pub c_lflag: ::tcflag_t,
-        pub c_cc: [::cc_t; ::NCCS]
+        pub c_cc: [::cc_t; ::NCCS],
     }
 
     pub struct lconv {
@@ -381,7 +381,7 @@ s! {
         pub sem_type: u16,
         pub sem_magic: u16,
         pub sem_pad1: [u64; 3],
-        pub sem_pad2: [u64; 2]
+        pub sem_pad2: [u64; 2],
     }
 
     pub struct flock {
@@ -391,7 +391,7 @@ s! {
         pub l_len: ::off_t,
         pub l_sysid: ::c_int,
         pub l_pid: ::pid_t,
-        pub l_pad: [::c_long; 4]
+        pub l_pad: [::c_long; 4],
     }
 
     pub struct if_nameindex {
@@ -404,7 +404,7 @@ s! {
         pub mq_maxmsg: ::c_long,
         pub mq_msgsize: ::c_long,
         pub mq_curmsgs: ::c_long,
-        _pad: [::c_int; 12]
+        _pad: [::c_int; 12],
     }
 
     pub struct port_event {
@@ -500,7 +500,7 @@ s! {
 s_no_extra_traits! {
     pub struct sockaddr_un {
         pub sun_family: sa_family_t,
-        pub sun_path: [c_char; 108]
+        pub sun_path: [c_char; 108],
     }
 
     pub struct utsname {
@@ -574,10 +574,10 @@ cfg_if! {
             fn eq(&self, other: &sockaddr_un) -> bool {
                 self.sun_family == other.sun_family
                     && self
-                    .sun_path
-                    .iter()
-                    .zip(other.sun_path.iter())
-                    .all(|(a, b)| a == b)
+                        .sun_path
+                        .iter()
+                        .zip(other.sun_path.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for sockaddr_un {}
@@ -603,25 +603,25 @@ cfg_if! {
                     .zip(other.sysname.iter())
                     .all(|(a, b)| a == b)
                     && self
-                    .nodename
-                    .iter()
-                    .zip(other.nodename.iter())
-                    .all(|(a, b)| a == b)
+                        .nodename
+                        .iter()
+                        .zip(other.nodename.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .release
-                    .iter()
-                    .zip(other.release.iter())
-                    .all(|(a, b)| a == b)
+                        .release
+                        .iter()
+                        .zip(other.release.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .version
-                    .iter()
-                    .zip(other.version.iter())
-                    .all(|(a, b)| a == b)
+                        .version
+                        .iter()
+                        .zip(other.version.iter())
+                        .all(|(a, b)| a == b)
                     && self
-                    .machine
-                    .iter()
-                    .zip(other.machine.iter())
-                    .all(|(a, b)| a == b)
+                        .machine
+                        .iter()
+                        .zip(other.machine.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for utsname {}
@@ -674,10 +674,10 @@ cfg_if! {
                     && self.__ss_pad1 == other.__ss_pad1
                     && self.__ss_align == other.__ss_align
                     && self
-                    .__ss_pad2
-                    .iter()
-                    .zip(other.__ss_pad2.iter())
-                    .all(|(a, b)| a == b)
+                        .__ss_pad2
+                        .iter()
+                        .zip(other.__ss_pad2.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for sockaddr_storage {}
@@ -734,15 +734,16 @@ cfg_if! {
             fn eq(&self, other: &siginfo_t) -> bool {
                 if self.si_signo == other.si_signo
                     && self.si_code == other.si_code
-                    && self.si_errno == other.si_errno {
-                        // FIXME: The `si_pad` field in the 64-bit version of the struct is ignored
-                        // (for now) when doing comparisons.
+                    && self.si_errno == other.si_errno
+                {
+                    // FIXME: The `si_pad` field in the 64-bit version of the struct is ignored
+                    // (for now) when doing comparisons.
 
-                        let field_count = self.data_field_count();
-                        self.__data_pad[..field_count]
-                            .iter()
-                            .zip(other.__data_pad[..field_count].iter())
-                            .all(|(a, b)| a == b)
+                    let field_count = self.data_field_count();
+                    self.__data_pad[..field_count]
+                        .iter()
+                        .zip(other.__data_pad[..field_count].iter())
+                        .all(|(a, b)| a == b)
                 } else {
                     false
                 }
@@ -782,10 +783,10 @@ cfg_if! {
                     && self.sdl_alen == other.sdl_alen
                     && self.sdl_slen == other.sdl_slen
                     && self
-                    .sdl_data
-                    .iter()
-                    .zip(other.sdl_data.iter())
-                    .all(|(a,b)| a == b)
+                        .sdl_data
+                        .iter()
+                        .zip(other.sdl_data.iter())
+                        .all(|(a, b)| a == b)
             }
         }
         impl Eq for sockaddr_dl {}
@@ -820,8 +821,7 @@ cfg_if! {
                     && self.sigev_signo == other.sigev_signo
                     && self.sigev_value == other.sigev_value
                     && self.ss_sp == other.ss_sp
-                    && self.sigev_notify_attributes
-                        == other.sigev_notify_attributes
+                    && self.sigev_notify_attributes == other.sigev_notify_attributes
             }
         }
         impl Eq for sigevent {}
@@ -832,8 +832,7 @@ cfg_if! {
                     .field("sigev_signo", &self.sigev_signo)
                     .field("sigev_value", &self.sigev_value)
                     .field("ss_sp", &self.ss_sp)
-                    .field("sigev_notify_attributes",
-                           &self.sigev_notify_attributes)
+                    .field("sigev_notify_attributes", &self.sigev_notify_attributes)
                     .finish()
             }
         }
@@ -850,7 +849,7 @@ cfg_if! {
         impl PartialEq for pad128_t {
             fn eq(&self, other: &pad128_t) -> bool {
                 unsafe {
-                // FIXME: self._q == other._q ||
+                    // FIXME: self._q == other._q ||
                     self._l == other._l
                 }
             }
@@ -859,25 +858,25 @@ cfg_if! {
         impl ::fmt::Debug for pad128_t {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
-                f.debug_struct("pad128_t")
-                    // FIXME: .field("_q", &{self._q})
-                    .field("_l", &{self._l})
-                    .finish()
+                    f.debug_struct("pad128_t")
+                        // FIXME: .field("_q", &{self._q})
+                        .field("_l", &{ self._l })
+                        .finish()
                 }
             }
         }
         impl ::hash::Hash for pad128_t {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
-                // FIXME: state.write_i64(self._q as i64);
-                self._l.hash(state);
+                    // FIXME: state.write_i64(self._q as i64);
+                    self._l.hash(state);
                 }
             }
         }
         impl PartialEq for upad128_t {
             fn eq(&self, other: &upad128_t) -> bool {
                 unsafe {
-                // FIXME: self._q == other._q ||
+                    // FIXME: self._q == other._q ||
                     self._l == other._l
                 }
             }
@@ -886,18 +885,18 @@ cfg_if! {
         impl ::fmt::Debug for upad128_t {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
-                f.debug_struct("upad128_t")
-                    // FIXME: .field("_q", &{self._q})
-                    .field("_l", &{self._l})
-                    .finish()
+                    f.debug_struct("upad128_t")
+                        // FIXME: .field("_q", &{self._q})
+                        .field("_l", &{ self._l })
+                        .finish()
                 }
             }
         }
         impl ::hash::Hash for upad128_t {
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
-                // FIXME: state.write_i64(self._q as i64);
-                self._l.hash(state);
+                    // FIXME: state.write_i64(self._q as i64);
+                    self._l.hash(state);
                 }
             }
         }
@@ -2491,47 +2490,43 @@ f! {
         }
     }
 
-    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr, cmsg: *const ::cmsghdr)
-        -> *mut ::cmsghdr
-    {
+    pub fn CMSG_NXTHDR(mhdr: *const ::msghdr, cmsg: *const ::cmsghdr) -> *mut ::cmsghdr {
         if cmsg.is_null() {
             return ::CMSG_FIRSTHDR(mhdr);
         };
-        let next = _CMSG_HDR_ALIGN(cmsg as usize + (*cmsg).cmsg_len as usize
-            + ::mem::size_of::<::cmsghdr>());
-        let max = (*mhdr).msg_control as usize
-            + (*mhdr).msg_controllen as usize;
+        let next = _CMSG_HDR_ALIGN(
+            cmsg as usize + (*cmsg).cmsg_len as usize + ::mem::size_of::<::cmsghdr>(),
+        );
+        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next > max {
             0 as *mut ::cmsghdr
         } else {
-            _CMSG_HDR_ALIGN(cmsg as usize + (*cmsg).cmsg_len as usize)
-                as *mut ::cmsghdr
+            _CMSG_HDR_ALIGN(cmsg as usize + (*cmsg).cmsg_len as usize) as *mut ::cmsghdr
         }
     }
 
     pub {const} fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
-        _CMSG_HDR_ALIGN(::mem::size_of::<::cmsghdr>() as usize
-            + length as usize) as ::c_uint
+        _CMSG_HDR_ALIGN(::mem::size_of::<::cmsghdr>() as usize + length as usize) as ::c_uint
     }
 
     pub fn FD_CLR(fd: ::c_int, set: *mut fd_set) -> () {
         let bits = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] &= !(1 << (fd % bits));
-        return
+        return;
     }
 
     pub fn FD_ISSET(fd: ::c_int, set: *const fd_set) -> bool {
         let bits = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
-        return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0
+        return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0;
     }
 
     pub fn FD_SET(fd: ::c_int, set: *mut fd_set) -> () {
         let bits = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] |= 1 << (fd % bits);
-        return
+        return;
     }
 
     pub fn FD_ZERO(set: *mut fd_set) -> () {

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -64,7 +64,7 @@ s_no_extra_traits! {
     #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
     pub struct door_desc_t__d_data__d_desc {
         pub d_descriptor: ::c_int,
-        pub d_id: ::door_id_t
+        pub d_id: ::door_id_t,
     }
 
     #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
@@ -102,7 +102,6 @@ s_no_extra_traits! {
         pub ut_syslen: ::c_short,
         pub ut_host: [::c_char; 257],
     }
-
 }
 
 cfg_if! {
@@ -120,10 +119,10 @@ cfg_if! {
                     && self.ut_syslen == other.ut_syslen
                     && self.pad == other.pad
                     && self
-                    .ut_host
-                    .iter()
-                    .zip(other.ut_host.iter())
-                    .all(|(a,b)| a == b)
+                        .ut_host
+                        .iter()
+                        .zip(other.ut_host.iter())
+                        .all(|(a, b)| a == b)
             }
         }
 

--- a/src/unix/solarish/x86_64.rs
+++ b/src/unix/solarish/x86_64.rs
@@ -98,12 +98,12 @@ cfg_if! {
         impl PartialEq for __c_anonymous_fp_reg_set {
             fn eq(&self, other: &__c_anonymous_fp_reg_set) -> bool {
                 unsafe {
-                self.fpchip_state == other.fpchip_state ||
-                    self.
-                    f_fpregs.
-                    iter().
-                    zip(other.f_fpregs.iter()).
-                    all(|(a, b)| a == b)
+                    self.fpchip_state == other.fpchip_state
+                        || self
+                            .f_fpregs
+                            .iter()
+                            .zip(other.f_fpregs.iter())
+                            .all(|(a, b)| a == b)
                 }
             }
         }
@@ -111,10 +111,10 @@ cfg_if! {
         impl ::fmt::Debug for __c_anonymous_fp_reg_set {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 unsafe {
-                f.debug_struct("__c_anonymous_fp_reg_set")
-                    .field("fpchip_state", &{self.fpchip_state})
-                    .field("f_fpregs", &{self.f_fpregs})
-                    .finish()
+                    f.debug_struct("__c_anonymous_fp_reg_set")
+                        .field("fpchip_state", &{ self.fpchip_state })
+                        .field("f_fpregs", &{ self.f_fpregs })
+                        .finish()
                 }
             }
         }
@@ -125,7 +125,7 @@ cfg_if! {
         }
         impl Eq for fpregset_t {}
         impl ::fmt::Debug for fpregset_t {
-            fn fmt(&self, f:&mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("fpregset_t")
                     .field("fp_reg_set", &self.fp_reg_set)
                     .finish()
@@ -133,13 +133,12 @@ cfg_if! {
         }
         impl PartialEq for mcontext_t {
             fn eq(&self, other: &mcontext_t) -> bool {
-                self.gregs == other.gregs &&
-                    self.fpregs == other.fpregs
+                self.gregs == other.gregs && self.fpregs == other.fpregs
             }
         }
         impl Eq for mcontext_t {}
         impl ::fmt::Debug for mcontext_t {
-            fn fmt(&self, f:&mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("mcontext_t")
                     .field("gregs", &self.gregs)
                     .field("fpregs", &self.fpregs)
@@ -158,7 +157,7 @@ cfg_if! {
         }
         impl Eq for ucontext_t {}
         impl ::fmt::Debug for ucontext_t {
-            fn fmt(&self, f:&mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 f.debug_struct("ucontext_t")
                     .field("uc_flags", &self.uc_flags)
                     .field("uc_link", &self.uc_link)
@@ -169,7 +168,6 @@ cfg_if! {
                     .finish()
             }
         }
-
     }
 }
 

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -145,14 +145,14 @@ s! {
     }
 
     // b_pthread_cond_t.h
-    pub struct pthread_cond_t{
+    pub struct pthread_cond_t {
         pub condSemId: ::_Vx_SEM_ID,
         pub condValid: ::c_int,
         pub condInitted: ::c_int,
         pub condRefCount: ::c_int,
         pub condMutex: *mut ::pthread_mutex_t,
         pub condAttr: ::pthread_condattr_t,
-        pub condSemName: [::c_char; _PTHREAD_SHARED_SEM_NAME_MAX]
+        pub condSemName: [::c_char; _PTHREAD_SHARED_SEM_NAME_MAX],
     }
 
     // b_pthread_rwlockattr_t.h
@@ -165,12 +165,12 @@ s! {
 
     // b_pthread_rwlock_t.h
     pub struct pthread_rwlock_t {
-        pub rwlockSemId: :: _Vx_SEM_ID,
+        pub rwlockSemId: ::_Vx_SEM_ID,
         pub rwlockReadersRefCount: ::c_uint,
         pub rwlockValid: ::c_int,
         pub rwlockInitted: ::c_int,
         pub rwlockAttr: ::pthread_rwlockattr_t,
-        pub rwlockSemName: [::c_char; _PTHREAD_SHARED_SEM_NAME_MAX]
+        pub rwlockSemName: [::c_char; _PTHREAD_SHARED_SEM_NAME_MAX],
     }
 
     // b_struct_timeval.h
@@ -186,9 +186,9 @@ s! {
     }
 
     pub struct sockaddr {
-        pub sa_len    : ::c_uchar,
-        pub sa_family : sa_family_t,
-        pub sa_data   : [::c_char; 14],
+        pub sa_len: ::c_uchar,
+        pub sa_family: sa_family_t,
+        pub sa_data: [::c_char; 14],
     }
 
     pub struct iovec {
@@ -214,91 +214,90 @@ s! {
 
     // poll.h
     pub struct pollfd {
-        pub fd      : ::c_int,
-        pub events  : ::c_short,
-        pub revents : ::c_short,
+        pub fd: ::c_int,
+        pub events: ::c_short,
+        pub revents: ::c_short,
     }
 
     // resource.h
     pub struct rlimit {
-                           pub rlim_cur : ::rlim_t,
-                           pub rlim_max : ::rlim_t,
+        pub rlim_cur: ::rlim_t,
+        pub rlim_max: ::rlim_t,
     }
 
     // stat.h
     pub struct stat {
-                         pub st_dev       : ::dev_t,
-                         pub st_ino       : ::ino_t,
-                         pub st_mode      : ::mode_t,
-                         pub st_nlink     : ::nlink_t,
-                         pub st_uid       : ::uid_t,
-                         pub st_gid       : ::gid_t,
-                         pub st_rdev      : ::dev_t,
-                         pub st_size      : ::off_t,
-                         pub st_atime     : ::time_t,
-                         pub st_mtime     : ::time_t,
-                         pub st_ctime     : ::time_t,
-                         pub st_blksize   : ::blksize_t,
-                         pub st_blocks    : ::blkcnt_t,
-                         pub st_attrib    : ::c_uchar,
-                         pub st_reserved1 : ::c_int,
-                         pub st_reserved2 : ::c_int,
-                         pub st_reserved3 : ::c_int,
-                         pub st_reserved4 : ::c_int,
+        pub st_dev: ::dev_t,
+        pub st_ino: ::ino_t,
+        pub st_mode: ::mode_t,
+        pub st_nlink: ::nlink_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        pub st_size: ::off_t,
+        pub st_atime: ::time_t,
+        pub st_mtime: ::time_t,
+        pub st_ctime: ::time_t,
+        pub st_blksize: ::blksize_t,
+        pub st_blocks: ::blkcnt_t,
+        pub st_attrib: ::c_uchar,
+        pub st_reserved1: ::c_int,
+        pub st_reserved2: ::c_int,
+        pub st_reserved3: ::c_int,
+        pub st_reserved4: ::c_int,
     }
 
     //b_struct__Timespec.h
     pub struct _Timespec {
-        pub tv_sec  : ::time_t,
-        pub tv_nsec : ::c_long,
+        pub tv_sec: ::time_t,
+        pub tv_nsec: ::c_long,
     }
 
     // b_struct__Sched_param.h
     pub struct sched_param {
-        pub sched_priority: ::c_int, /* scheduling priority */
+        pub sched_priority: ::c_int,           /* scheduling priority */
         pub sched_ss_low_priority: ::c_int,    /* low scheduling priority */
         pub sched_ss_repl_period: ::_Timespec, /* replenishment period */
         pub sched_ss_init_budget: ::_Timespec, /* initial budget */
         pub sched_ss_max_repl: ::c_int,        /* max pending replenishment */
-
     }
 
     // b_pthread_attr_t.h
     pub struct pthread_attr_t {
-        pub threadAttrStatus          : ::c_int,
-        pub threadAttrStacksize       : ::size_t,
-        pub threadAttrStackaddr       : *mut ::c_void,
-        pub threadAttrGuardsize       : ::size_t,
-        pub threadAttrDetachstate     : ::c_int,
-        pub threadAttrContentionscope : ::c_int,
-        pub threadAttrInheritsched    : ::c_int,
-        pub threadAttrSchedpolicy     : ::c_int,
-        pub threadAttrName            : *mut ::c_char,
-        pub threadAttrOptions         : ::c_int,
-        pub threadAttrSchedparam      : ::sched_param,
+        pub threadAttrStatus: ::c_int,
+        pub threadAttrStacksize: ::size_t,
+        pub threadAttrStackaddr: *mut ::c_void,
+        pub threadAttrGuardsize: ::size_t,
+        pub threadAttrDetachstate: ::c_int,
+        pub threadAttrContentionscope: ::c_int,
+        pub threadAttrInheritsched: ::c_int,
+        pub threadAttrSchedpolicy: ::c_int,
+        pub threadAttrName: *mut ::c_char,
+        pub threadAttrOptions: ::c_int,
+        pub threadAttrSchedparam: ::sched_param,
     }
 
     // signal.h
 
     pub struct sigaction {
-        pub sa_u     : ::sa_u_t,
-        pub sa_mask  : ::sigset_t,
-        pub sa_flags : ::c_int,
+        pub sa_u: ::sa_u_t,
+        pub sa_mask: ::sigset_t,
+        pub sa_flags: ::c_int,
     }
 
     // b_stack_t.h
     pub struct stack_t {
-        pub ss_sp    : *mut ::c_void,
-        pub ss_size  : ::size_t,
-        pub ss_flags : ::c_int,
+        pub ss_sp: *mut ::c_void,
+        pub ss_size: ::size_t,
+        pub ss_flags: ::c_int,
     }
 
     // signal.h
     pub struct siginfo_t {
-        pub si_signo : ::c_int,
-        pub si_code  : ::c_int,
-        pub si_value : ::sigval,
-        pub si_errno : ::c_int,
+        pub si_signo: ::c_int,
+        pub si_code: ::c_int,
+        pub si_value: ::sigval,
+        pub si_errno: ::c_int,
         pub si_status: ::c_int,
         pub si_addr: *mut ::c_void,
         pub si_uid: ::uid_t,
@@ -308,16 +307,16 @@ s! {
     // pthread.h (krnl)
     // b_pthread_mutexattr_t.h (usr)
     pub struct pthread_mutexattr_t {
-        mutexAttrStatus      : ::c_int,
-        mutexAttrPshared     : ::c_int,
-        mutexAttrProtocol    : ::c_int,
-        mutexAttrPrioceiling : ::c_int,
-        mutexAttrType        : ::c_int,
+        mutexAttrStatus: ::c_int,
+        mutexAttrPshared: ::c_int,
+        mutexAttrProtocol: ::c_int,
+        mutexAttrPrioceiling: ::c_int,
+        mutexAttrType: ::c_int,
     }
 
     // pthread.h (krnl)
     // b_pthread_mutex_t.h (usr)
-    pub struct pthread_mutex_t  {
+    pub struct pthread_mutex_t {
         pub mutexSemId: ::_Vx_SEM_ID, /*_Vx_SEM_ID ..*/
         pub mutexValid: ::c_int,
         pub mutexInitted: ::c_int,
@@ -371,32 +370,32 @@ s! {
 
     // netdb.h
     pub struct addrinfo {
-        pub ai_flags    : ::c_int,
-        pub ai_family   : ::c_int,
-        pub ai_socktype : ::c_int,
-        pub ai_protocol : ::c_int,
-        pub ai_addrlen  : ::size_t,
+        pub ai_flags: ::c_int,
+        pub ai_family: ::c_int,
+        pub ai_socktype: ::c_int,
+        pub ai_protocol: ::c_int,
+        pub ai_addrlen: ::size_t,
         pub ai_canonname: *mut ::c_char,
-        pub ai_addr     : *mut ::sockaddr,
-        pub ai_next     : *mut ::addrinfo,
+        pub ai_addr: *mut ::sockaddr,
+        pub ai_next: *mut ::addrinfo,
     }
 
     // in.h
     pub struct sockaddr_in {
-        pub sin_len   : u8,
+        pub sin_len: u8,
         pub sin_family: u8,
-        pub sin_port  : u16,
-        pub sin_addr  : ::in_addr,
-        pub sin_zero  : [::c_char; 8],
+        pub sin_port: u16,
+        pub sin_addr: ::in_addr,
+        pub sin_zero: [::c_char; 8],
     }
 
     // in6.h
     pub struct sockaddr_in6 {
-        pub sin6_len     : u8,
-        pub sin6_family  : u8,
-        pub sin6_port    : u16,
+        pub sin6_len: u8,
+        pub sin6_family: u8,
+        pub sin6_port: u16,
         pub sin6_flowinfo: u32,
-        pub sin6_addr    : ::in6_addr,
+        pub sin6_addr: ::in6_addr,
         pub sin6_scope_id: u32,
     }
 
@@ -408,9 +407,9 @@ s! {
     }
 
     pub struct mq_attr {
-        pub mq_maxmsg:  ::c_long,
+        pub mq_maxmsg: ::c_long,
         pub mq_msgsize: ::c_long,
-        pub mq_flags:   ::c_long,
+        pub mq_flags: ::c_long,
         pub mq_curmsgs: ::c_long,
     }
 }
@@ -418,47 +417,46 @@ s! {
 s_no_extra_traits! {
     // dirent.h
     pub struct dirent {
-        pub d_ino  : ::ino_t,
-        pub d_name : [::c_char; _PARM_NAME_MAX as usize + 1],
+        pub d_ino: ::ino_t,
+        pub d_name: [::c_char; _PARM_NAME_MAX as usize + 1],
     }
 
     pub struct sockaddr_un {
         pub sun_len: u8,
         pub sun_family: sa_family_t,
-        pub sun_path: [::c_char; 104]
+        pub sun_path: [::c_char; 104],
     }
 
     // rtpLibCommon.h
     pub struct RTP_DESC {
-        pub status    : ::c_int,
-        pub options   : u32,
-        pub entrAddr  : *mut ::c_void,
+        pub status: ::c_int,
+        pub options: u32,
+        pub entrAddr: *mut ::c_void,
         pub initTaskId: ::TASK_ID,
-        pub parentId  : ::RTP_ID,
-        pub pathName  : [::c_char; VX_RTP_NAME_LENGTH as usize + 1],
-        pub taskCnt   : ::c_int,
-        pub textStart : *mut ::c_void,
-        pub textEnd   : *mut ::c_void,
+        pub parentId: ::RTP_ID,
+        pub pathName: [::c_char; VX_RTP_NAME_LENGTH as usize + 1],
+        pub taskCnt: ::c_int,
+        pub textStart: *mut ::c_void,
+        pub textEnd: *mut ::c_void,
     }
     // socket.h
     pub struct sockaddr_storage {
-        pub ss_len     : ::c_uchar,
-        pub ss_family  : ::sa_family_t,
-        pub __ss_pad1  : [::c_char; _SS_PAD1SIZE],
-        pub __ss_align : i32,
-        pub __ss_pad2  : [::c_char; _SS_PAD2SIZE],
+        pub ss_len: ::c_uchar,
+        pub ss_family: ::sa_family_t,
+        pub __ss_pad1: [::c_char; _SS_PAD1SIZE],
+        pub __ss_align: i32,
+        pub __ss_pad2: [::c_char; _SS_PAD2SIZE],
     }
 
     pub union sa_u_t {
-        pub sa_handler : ::Option<unsafe extern "C" fn(::c_int) -> !>,
-        pub sa_sigaction: ::Option<unsafe extern "C" fn(::c_int,
-                                                        *mut ::siginfo_t,
-                                                        *mut ::c_void) -> !>,
+        pub sa_handler: ::Option<unsafe extern "C" fn(::c_int) -> !>,
+        pub sa_sigaction:
+            ::Option<unsafe extern "C" fn(::c_int, *mut ::siginfo_t, *mut ::c_void) -> !>,
     }
 
     pub union sigval {
-        pub sival_int : ::c_int,
-        pub sival_ptr : *mut ::c_void,
+        pub sival_int: ::c_int,
+        pub sival_ptr: *mut ::c_void,
     }
 }
 
@@ -534,9 +532,7 @@ cfg_if! {
                         None => 0 as usize,
                     };
 
-                    f.debug_struct("sa_u_t")
-                        .field("sa_handler", &h)
-                        .finish()
+                    f.debug_struct("sa_u_t").field("sa_handler", &h).finish()
                 }
             }
         }
@@ -1100,22 +1096,20 @@ f! {
         len + ::mem::size_of::<usize>() - 1 & !(::mem::size_of::<usize>() - 1)
     }
 
-    pub fn CMSG_NXTHDR(mhdr: *const msghdr,
-                       cmsg: *const cmsghdr) -> *mut cmsghdr {
-        let next = cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize)
+    pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
+        let next = cmsg as usize
+            + CMSG_ALIGN((*cmsg).cmsg_len as usize)
             + CMSG_ALIGN(::mem::size_of::<::cmsghdr>());
-        let max = (*mhdr).msg_control as usize
-            + (*mhdr).msg_controllen as usize;
+        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next <= max {
-            (cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize))
-                as *mut ::cmsghdr
+            (cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut ::cmsghdr
         } else {
             0 as *mut ::cmsghdr
         }
     }
 
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize > 0  {
+        if (*mhdr).msg_controllen as usize > 0 {
             (*mhdr).msg_control as *mut cmsghdr
         } else {
             0 as *mut cmsghdr
@@ -1123,13 +1117,11 @@ f! {
     }
 
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut ::c_uchar {
-        (cmsg as *mut ::c_uchar)
-            .offset(CMSG_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
+        (cmsg as *mut ::c_uchar).offset(CMSG_ALIGN(::mem::size_of::<::cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_SPACE(length: ::c_uint) -> ::c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(::mem::size_of::<cmsghdr>()))
-            as ::c_uint
+        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(::mem::size_of::<cmsghdr>())) as ::c_uint
     }
 
     pub {const} fn CMSG_LEN(length: ::c_uint) -> ::c_uint {
@@ -2021,7 +2013,7 @@ cfg_if! {
     } else if #[cfg(target_arch = "arm")] {
         mod arm;
         pub use self::arm::*;
-    }  else if #[cfg(target_arch = "x86")] {
+    } else if #[cfg(target_arch = "x86")] {
         mod x86;
         pub use self::x86::*;
     } else if #[cfg(target_arch = "x86_64")] {

--- a/src/wasi/mod.rs
+++ b/src/wasi/mod.rs
@@ -50,7 +50,7 @@ s_no_extra_traits! {
     #[repr(align(16))]
     #[allow(missing_debug_implementations)]
     pub struct max_align_t {
-        priv_: [f64; 4]
+        priv_: [f64; 4],
     }
 }
 
@@ -383,14 +383,12 @@ cfg_if! {
     } else {
         // unsafe code here is required in the stable, but not in nightly
         #[allow(unused_unsafe)]
-        pub static CLOCK_MONOTONIC: clockid_t =
-            clockid_t(core::ptr::addr_of!(_CLOCK_MONOTONIC));
+        pub static CLOCK_MONOTONIC: clockid_t = clockid_t(core::ptr::addr_of!(_CLOCK_MONOTONIC));
         #[allow(unused_unsafe)]
         pub static CLOCK_PROCESS_CPUTIME_ID: clockid_t =
             clockid_t(core::ptr::addr_of!(_CLOCK_PROCESS_CPUTIME_ID));
         #[allow(unused_unsafe)]
-        pub static CLOCK_REALTIME: clockid_t =
-            clockid_t(core::ptr::addr_of!(_CLOCK_REALTIME));
+        pub static CLOCK_REALTIME: clockid_t = clockid_t(core::ptr::addr_of!(_CLOCK_REALTIME));
         #[allow(unused_unsafe)]
         pub static CLOCK_THREAD_CPUTIME_ID: clockid_t =
             clockid_t(core::ptr::addr_of!(_CLOCK_THREAD_CPUTIME_ID));
@@ -466,7 +464,7 @@ f! {
     pub fn FD_ISSET(fd: ::c_int, set: *const fd_set) -> bool {
         let set = &*set;
         let n = set.__nfds;
-        return set.__fds[..n].iter().any(|p| *p == fd)
+        return set.__fds[..n].iter().any(|p| *p == fd);
     }
 
     pub fn FD_SET(fd: ::c_int, set: *mut fd_set) -> () {
@@ -480,7 +478,7 @@ f! {
 
     pub fn FD_ZERO(set: *mut fd_set) -> () {
         (*set).__nfds = 0;
-        return
+        return;
     }
 }
 

--- a/src/windows/gnu/mod.rs
+++ b/src/windows/gnu/mod.rs
@@ -4,7 +4,7 @@ cfg_if! {
             #[allow(missing_debug_implementations)]
             #[repr(align(16))]
             pub struct max_align_t {
-                priv_: [f64; 4]
+                priv_: [f64; 4],
             }
         }
     } else if #[cfg(target_pointer_width = "32")] {
@@ -12,7 +12,7 @@ cfg_if! {
             #[allow(missing_debug_implementations)]
             #[repr(align(16))]
             pub struct max_align_t {
-                priv_: [i64; 6]
+                priv_: [i64; 6],
             }
         }
     }


### PR DESCRIPTION
We have a lot of syntax contained within macro bodies, which `rustfmt` doesn't touch. Add a hack that replaces relevant macro invocations with functions, formats, then resets.