### PR TITLE
ci: Update or patch Docker images

### DIFF
--- a/ci/docker/aarch64-linux-android/Dockerfile
+++ b/ci/docker/aarch64-linux-android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
 
 RUN dpkg --add-architecture i386
 RUN apt-get update
@@ -8,7 +8,6 @@ RUN apt-get install -y --no-install-recommends \
   wget \
   ca-certificates \
   python3 \
-  python3-distutils \
   unzip \
   expect \
   openjdk-8-jre \

--- a/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc libc6-dev ca-certificates \
   gcc-aarch64-linux-gnu libc6-dev-arm64-cross qemu-user

--- a/ci/docker/aarch64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc make libc6-dev git curl ca-certificates \

--- a/ci/docker/arm-linux-androideabi/Dockerfile
+++ b/ci/docker/arm-linux-androideabi/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
 
 RUN dpkg --add-architecture i386
 RUN apt-get update
@@ -8,7 +8,6 @@ RUN apt-get install -y --no-install-recommends \
   wget \
   ca-certificates \
   python3 \
-  python3-distutils \
   unzip \
   expect \
   openjdk-8-jre \

--- a/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -1,7 +1,11 @@
 FROM ubuntu:23.10
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  gcc libc6-dev ca-certificates \
-  gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user
+
+# FIXME(time): we are using an EOL release because 24.04 changes to 64-bit time
+RUN sed -i -E 's/(archive|security)\.ubuntu\.com/old-releases.ubuntu.com/g' \
+        /etc/apt/sources.list && \
+    apt-get update && apt-get install -y --no-install-recommends \
+        gcc libc6-dev ca-certificates \
+        gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUNNER="qemu-arm -L /usr/arm-linux-gnueabihf" \
     PATH=$PATH:/rust/bin

--- a/ci/docker/arm-unknown-linux-musleabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-musleabihf/Dockerfile
@@ -1,8 +1,11 @@
 FROM ubuntu:23.10
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  gcc make libc6-dev git curl ca-certificates \
-  gcc-arm-linux-gnueabihf qemu-user
+# FIXME(time): we are using an EOL release because 24.04 changes to 64-bit time
+RUN sed -i -E 's/(archive|security)\.ubuntu\.com/old-releases.ubuntu.com/g' \
+        /etc/apt/sources.list && \
+    apt-get update && apt-get install -y --no-install-recommends \
+        gcc make libc6-dev git curl ca-certificates \
+        gcc-arm-linux-gnueabihf qemu-user
 
 COPY install-musl.sh /
 RUN sh /install-musl.sh arm

--- a/ci/docker/armv7-unknown-linux-uclibceabihf/Dockerfile
+++ b/ci/docker/armv7-unknown-linux-uclibceabihf/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:23.10
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# FIXME(time): we are using an EOL release because 24.04 changes to 64-bit time
+RUN sed -i -E 's/(archive|security)\.ubuntu\.com/old-releases.ubuntu.com/g' \
+        /etc/apt/sources.list && \
+    apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates qemu-system-arm curl \
         xz-utils patch file
 

--- a/ci/docker/asmjs-unknown-emscripten/Dockerfile
+++ b/ci/docker/asmjs-unknown-emscripten/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
 
 # This is a workaround to avoid the interaction with tzdata.
 ENV DEBIAN_FRONTEND=noninteractive
@@ -14,7 +14,6 @@ RUN apt-get install -y --no-install-recommends \
     libc6-dev \
     libxml2 \
     python3 \
-    python3-distutils \
     xz-utils \
     bzip2
 

--- a/ci/docker/i686-linux-android/Dockerfile
+++ b/ci/docker/i686-linux-android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
 
 RUN dpkg --add-architecture i386
 RUN apt-get update
@@ -8,7 +8,6 @@ RUN apt-get install -y --no-install-recommends \
   wget \
   ca-certificates \
   python3 \
-  python3-distutils \
   unzip \
   expect \
   openjdk-8-jre \

--- a/ci/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/i686-unknown-linux-gnu/Dockerfile
@@ -1,5 +1,10 @@
 FROM ubuntu:23.10
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-  gcc-multilib libc6-dev ca-certificates
+
+
+# FIXME(time): we are using an EOL release because 24.04 changes to 64-bit time
+RUN sed -i -E 's/(archive|security)\.ubuntu\.com/old-releases.ubuntu.com/g' \
+        /etc/apt/sources.list && \
+    apt-get update && apt-get install -y --no-install-recommends \
+        gcc-multilib libc6-dev ca-certificates
+
 ENV PATH=$PATH:/rust/bin

--- a/ci/docker/i686-unknown-linux-musl/Dockerfile
+++ b/ci/docker/i686-unknown-linux-musl/Dockerfile
@@ -1,9 +1,12 @@
 FROM ubuntu:23.10
 
-RUN dpkg --add-architecture i386
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-  gcc-multilib make libc6-dev git curl ca-certificates libc6-i386
+
+# FIXME(time): we are using an EOL release because 24.04 changes to 64-bit time
+RUN sed -i -E 's/(archive|security)\.ubuntu\.com/old-releases.ubuntu.com/g' \
+        /etc/apt/sources.list && \
+    dpkg --add-architecture i386 && \
+    apt-get update && apt-get install -y --no-install-recommends \
+        gcc-multilib make libc6-dev git curl ca-certificates libc6-i386
 
 COPY install-musl.sh /
 RUN sh /install-musl.sh i686

--- a/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:24.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/ci/docker/loongarch64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/loongarch64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:24.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates curl gcc git libc6-dev make qemu-user xz-utils

--- a/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:23.10
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# FIXME(time): we are using an EOL release because 24.04 changes to 64-bit time
+RUN sed -i -E 's/(archive|security)\.ubuntu\.com/old-releases.ubuntu.com/g' \
+        /etc/apt/sources.list && \
+    apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \
         gcc-powerpc-linux-gnu libc6-dev-powerpc-cross \
         qemu-system-ppc

--- a/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/ci/docker/s390x-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/s390x-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl ca-certificates \

--- a/ci/docker/s390x-unknown-linux-musl/Dockerfile
+++ b/ci/docker/s390x-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl ca-certificates \

--- a/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
@@ -1,3 +1,10 @@
+# FIXME(sparc): newer versions of Ubuntu get the following errors
+# ```
+# /prog: /lib/sparc64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by /prog)
+# /prog: /lib/sparc64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /prog)
+# ```
+# Not sure if this is a problem from rustc, our libc, or Ubuntu so we just
+# stick with an old LTS for now.
 FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/ci/docker/wasm32-unknown-emscripten/Dockerfile
+++ b/ci/docker/wasm32-unknown-emscripten/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
 
 # This is a workaround to avoid the interaction with tzdata.
 ENV DEBIAN_FRONTEND=noninteractive
@@ -17,7 +17,6 @@ RUN apt-get install -y --no-install-recommends \
     libc6-dev \
     libxml2 \
     python3 \
-    python3-distutils \
     cmake \
     sudo \
     gdb \

--- a/ci/docker/wasm32-wasip1/Dockerfile
+++ b/ci/docker/wasm32-wasip1/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:24.10
 
 COPY wasi.sh /
 RUN bash /wasi.sh

--- a/ci/docker/wasm32-wasip2/Dockerfile
+++ b/ci/docker/wasm32-wasip2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:24.10
 
 COPY wasi.sh /
 RUN bash /wasi.sh

--- a/ci/docker/x86_64-linux-android/Dockerfile
+++ b/ci/docker/x86_64-linux-android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -7,7 +7,6 @@ RUN apt-get update && \
   gcc \
   libc-dev \
   python3 \
-  python3-distutils \
   unzip
 
 WORKDIR /android/

--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
+
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
   gcc libc6-dev ca-certificates linux-headers-generic

--- a/ci/docker/x86_64-unknown-linux-gnux32/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnux32/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
+
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
   gcc-multilib libc6-dev ca-certificates

--- a/ci/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \

--- a/ci/style.sh
+++ b/ci/style.sh
@@ -14,6 +14,9 @@ rustc ci/style.rs && ./style src
 command -v rustfmt
 rustfmt -V
 
+# Run once to cover everything that isn't in `src/`
+cargo fmt
+
 # Save a list of all source files
 tmpfile="file-list~" # trailing tilde for gitignore
 find src -name '*.rs' > "$tmpfile"

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4496,7 +4496,10 @@ fn test_linux(target: &str) {
         // `handle` is a VLA
         (struct_ == "fanotify_event_info_fid" && field == "handle") ||
         // invalid application of 'sizeof' to incomplete type 'long unsigned int[]'
-        (musl && struct_ == "mcontext_t" && field == "__extcontext" && loongarch64)
+        (musl && struct_ == "mcontext_t" && field == "__extcontext" && loongarch64) ||
+        // FIXME(#4121): a new field was added from `f_spare`
+        (struct_ == "statvfs" && field == "__f_spare") ||
+        (struct_ == "statvfs64" && field == "__f_spare")
     });
 
     cfg.skip_roundtrip(move |s| match s {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -197,13 +197,14 @@ macro_rules! e {
 
 // FIXME(ctest): ctest can't handle `const extern` functions, we should be able to remove this
 // cfg completely.
+// FIXME(ctest): ctest can't handle `$(,)?` so we use `$(,)*` which isn't quite correct.
 cfg_if! {
     if #[cfg(feature = "const-extern-fn")] {
         /// Define an `unsafe` function that is const as long as `const-extern-fn` is enabled.
         macro_rules! f {
             ($(
                 $(#[$attr:meta])*
-                pub $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)?) -> $ret:ty
+                pub $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)*) -> $ret:ty
                     $body:block
             )*) => ($(
                 #[inline]
@@ -217,7 +218,7 @@ cfg_if! {
         macro_rules! safe_f {
             ($(
                 $(#[$attr:meta])*
-                pub $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)?) -> $ret:ty
+                pub $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)*) -> $ret:ty
                     $body:block
             )*) => ($(
                 #[inline]
@@ -231,7 +232,7 @@ cfg_if! {
         macro_rules! const_fn {
             ($(
                 $(#[$attr:meta])*
-                $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)?) -> $ret:ty
+                $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)*) -> $ret:ty
                     $body:block
             )*) => ($(
                 #[inline]
@@ -245,7 +246,7 @@ cfg_if! {
         macro_rules! f {
             ($(
                 $(#[$attr:meta])*
-                pub $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)?) -> $ret:ty
+                pub $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)*) -> $ret:ty
                     $body:block
             )*) => ($(
                 #[inline]
@@ -259,7 +260,7 @@ cfg_if! {
         macro_rules! safe_f {
             ($(
                 $(#[$attr:meta])*
-                pub $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)?) -> $ret:ty
+                pub $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)*) -> $ret:ty
                     $body:block
             )*) => ($(
                 #[inline]
@@ -273,7 +274,7 @@ cfg_if! {
         macro_rules! const_fn {
             ($(
                 $(#[$attr:meta])*
-                $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)?) -> $ret:ty
+                $({$constness:ident})* fn $i:ident($($arg:ident: $argty:ty),* $(,)*) -> $ret:ty
                     $body:block
             )*) => ($(
                 #[inline]


### PR DESCRIPTION
Take 2 at https://github.com/rust-lang/libc/pull/4119: upgrade 64-bit Docker to 24:10, but just enable using the old repos on 32-bit so we don't need to worry about the time_t change right away.