### PR TITLE
use `qemu-sparc64` to run sparc64 tests

### DIFF
--- a/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
@@ -12,14 +12,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev \
         gcc-sparc64-linux-gnu libc6-dev-sparc64-cross \
         qemu-system-sparc64 openbios-sparc seabios ipxe-qemu \
-        p7zip-full cpio linux-libc-dev-sparc64-cross
+        p7zip-full cpio linux-libc-dev-sparc64-cross qemu-user
 
 COPY linux-sparc64.sh /
 RUN /linux-sparc64.sh
 
-COPY test-runner-linux /
-
 ENV CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_LINKER=sparc64-linux-gnu-gcc \
-    CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_RUNNER="/test-runner-linux sparc64" \
+    CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_RUNNER="qemu-sparc64 -L /usr/sparc64-linux-gnu" \
     CC_sparc64_unknown_linux_gnu=sparc64-linux-gnu-gcc \
     PATH=$PATH:/rust/bin


### PR DESCRIPTION
fixes https://github.com/rust-lang/libc/issues/4061

# Description

uses `qemu-sparc64` to run the sparc64 tests. That is (for some reason) much faster than the `test-runner-linux` script that uses `qemu-system-sparc64` under the hood. It runs the test suite locally in ~3 minutes, similar to the other targets.

I added some things to make this work, I'm not sure if other things should be removed that are now no longer needed.

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

r? @tgross35 