### PR TITLE
fix: make sure the `const-extern-fn` feature is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ cargo-args = ["-Zbuild-std=core"]
 rustc-std-workspace-core = { version = "1.0.0", optional = true }
 
 [features]
-default = ["std"]
+default = ["const-extern-fn", "std"]
 std = []
 rustc-dep-of-std = ["rustc-std-workspace-core"]
 extra_traits = []

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -83,7 +83,13 @@ fi
 cmd="cargo test --target $target ${LIBC_CI_ZBUILD_STD+"-Zbuild-std"}"
 
 # Run tests in the `libc` crate
-$cmd
+case "$target" in
+    # FIXME(android): unit tests fail to start on Android
+    # FIXME(s390x): unit tests fail to locate glibc
+    *android*) ;;
+    *s390x*) ;;
+    *) $cmd
+esac
 
 # Everything else is in `libc-test`
 cmd="$cmd --manifest-path libc-test/Cargo.toml"

--- a/tests/const_fn.rs
+++ b/tests/const_fn.rs
@@ -1,0 +1,3 @@
+#[cfg(target_os = "linux")]
+const _FOO: libc::c_uint = unsafe { libc::CMSG_SPACE(1) };
+//^ if CMSG_SPACE is not const, this will fail to compile


### PR DESCRIPTION
This was dropped in fa554bc4f8 on `main` and 674cc1f47f on `libc-0.2` ("Drop the libc_const_extern_fn conditional"). Unfortunately, this meant that functions were incorrectly never getting marked `const`, which showed up with `CMSG_SPACE` https://github.com/rust-lang/libc/issues/4115.

Instead of the fix here, I attempted to just use `cfg(not(libc_ctest))` instead of a Cargo feature to enable `const` extern functions; however, this seemed extremely problematic with `ctest` for some reason [2]. Instead, leave the feature as-is and just make it enabled by default.

Fixes: https://github.com/rust-lang/libc/issues/4115

[2]: https://github.com/rust-lang/libc/pull/4134