### PR TITLE
style: Allow rustfmt to organize imports

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,5 @@
-use std::env;
 use std::process::{Command, Output};
-use std::str;
+use std::{env, str};
 
 // List of cfgs this build script is allowed to set. The list is needed to support check-cfg, as we
 // need to know all the possible cfgs that this script will set. If you need to set another cfg

--- a/libc-test/test/cmsg.rs
+++ b/libc-test/test/cmsg.rs
@@ -4,8 +4,9 @@
 #[cfg(unix)]
 mod t {
 
-    use libc::{self, c_uchar, c_uint, c_void, cmsghdr, msghdr};
     use std::mem;
+
+    use libc::{self, c_uchar, c_uint, c_void, cmsghdr, msghdr};
 
     extern "C" {
         pub fn cmsg_firsthdr(msgh: *const msghdr) -> *mut cmsghdr;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,4 @@
-error_on_line_overflow = true
 edition = "2021"
+error_on_line_overflow = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ cfg_if! {
 use core::clone::Clone;
 #[allow(unused_imports)]
 use core::ffi;
+pub use core::ffi::c_void;
 #[allow(unused_imports)]
 use core::fmt;
 #[allow(unused_imports)]
@@ -60,8 +61,6 @@ use core::num;
 #[doc(hidden)]
 #[allow(unused_imports)]
 use core::option::Option;
-
-pub use core::ffi::c_void;
 
 cfg_if! {
     if #[cfg(windows)] {

--- a/src/unix/linux_like/emscripten/lfs64.rs
+++ b/src/unix/linux_like/emscripten/lfs64.rs
@@ -106,8 +106,7 @@ pub unsafe extern "C" fn mmap64(
 //
 // These aliases are mostly fine though, neither function takes a LFS64-namespaced type as an
 // argument, nor do their names clash with any declared types.
-pub use open as open64;
-pub use openat as openat64;
+pub use {open as open64, openat as openat64};
 
 #[inline]
 pub unsafe extern "C" fn posix_fadvise64(

--- a/src/unix/linux_like/linux/musl/lfs64.rs
+++ b/src/unix/linux_like/linux/musl/lfs64.rs
@@ -114,8 +114,7 @@ pub unsafe extern "C" fn mmap64(
 //
 // These aliases are mostly fine though, neither function takes a LFS64-namespaced type as an
 // argument, nor do their names clash with any declared types.
-pub use open as open64;
-pub use openat as openat64;
+pub use {open as open64, openat as openat64};
 
 #[inline]
 pub unsafe extern "C" fn posix_fadvise64(

--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -1,8 +1,4 @@
-use c_void;
-use in6_addr;
-use in_addr_t;
-use timespec;
-use DIR;
+use {c_void, in6_addr, in_addr_t, timespec, DIR};
 
 pub type nlink_t = u16;
 pub type ino_t = u16;

--- a/src/unix/solarish/compat.rs
+++ b/src/unix/solarish/compat.rs
@@ -2,6 +2,7 @@
 // Solaris, but often needed by other crates.
 
 use core::cmp::min;
+
 use unix::solarish::*;
 
 const PTEM: &[u8] = b"ptem\0";

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -1,10 +1,7 @@
-use exit_status;
-use NET_MAC_AWARE;
-use NET_MAC_AWARE_INHERIT;
-use PRIV_AWARE_RESET;
-use PRIV_DEBUG;
-use PRIV_PFEXEC;
-use PRIV_XPOLICY;
+use {
+    exit_status, NET_MAC_AWARE, NET_MAC_AWARE_INHERIT, PRIV_AWARE_RESET, PRIV_DEBUG, PRIV_PFEXEC,
+    PRIV_XPOLICY,
+};
 
 pub type lgrp_rsrc_t = ::c_int;
 pub type lgrp_affinity_t = ::c_int;

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -1,10 +1,7 @@
-use exit_status;
-use NET_MAC_AWARE;
-use NET_MAC_AWARE_INHERIT;
-use PRIV_AWARE_RESET;
-use PRIV_DEBUG;
-use PRIV_PFEXEC;
-use PRIV_XPOLICY;
+use {
+    exit_status, NET_MAC_AWARE, NET_MAC_AWARE_INHERIT, PRIV_AWARE_RESET, PRIV_DEBUG, PRIV_PFEXEC,
+    PRIV_XPOLICY,
+};
 
 pub type door_attr_t = ::c_uint;
 pub type door_id_t = ::c_ulonglong;

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -1,8 +1,9 @@
 //! Interface to VxWorks C library
 
-use c_void;
 use core::mem::size_of;
 use core::ptr::null_mut;
+
+use c_void;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum DIR {}

--- a/src/wasi/mod.rs
+++ b/src/wasi/mod.rs
@@ -3,9 +3,11 @@
 //! `wasi-libc` project provides multiple libraries including emulated features, but we list only
 //! basic features with `libc.a` here.
 
-use super::{Send, Sync};
-use c_void;
 use core::iter::Iterator;
+
+use c_void;
+
+use super::{Send, Sync};
 
 pub type c_char = i8;
 pub type c_uchar = u8;


### PR DESCRIPTION
Add `group_imports` and `import_granularity` to our rustfmt config. These values are the same as in rust-lang/rust.