### PR TITLE
apple: remove `if_family_id`

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1257,12 +1257,6 @@ s! {
         pub dot3Compliance: u32,
     }
 
-    pub struct if_family_id {
-        pub iffmid_len: u32,
-        pub iffmid_id: u32,
-        pub iffmid_str: [::c_char; 1],
-    }
-
     // kern_control.h
     pub struct ctl_info {
         pub ctl_id: u32,


### PR DESCRIPTION
This API appears to not be available in more recent MacOS SDKs, and there aren't any functions that use it. Since this hasn't yet made it into a release, remove it.

Link: https://github.com/rust-lang/libc/pull/4022

Cc @GuillaumeGomez