### PR TITLE
[0.2]: Expose `len8_dlc` field of `can_frame` struct.

### DIFF
--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1586,10 +1586,11 @@ s_no_extra_traits! {
     #[allow(missing_debug_implementations)]
     pub struct can_frame {
         pub can_id: canid_t,
+        // FIXME(1.0): this field was renamed to `len` in Linux 5.11
         pub can_dlc: u8,
         __pad: u8,
         __res0: u8,
-        __res1: u8,
+        pub len8_dlc: u8,
         pub data: [u8; CAN_MAX_DLEN],
     }
 


### PR DESCRIPTION
(backport <https://github.com/rust-lang/libc/pull/3357>)
(cherry picked from commit 48bdb18dfb9db4e6d229c3620fa19993b35d0f10)