### PR TITLE
Add a `.git-blame-ingore-revs` entry for edition 2021 changes

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Format macro bodies
 a0c7f8017b964a2de8bc3aabebdabd4a8f2c0905
+
+# Automated changes to upgrade to the 2021 edition
+20f6aa4c8135ba5e2c079ff21b20f0a1be87e1c4


### PR DESCRIPTION
Ignore 20f6aa4c8 ("Automatic migration to Rust edition 2021") since this performed a lot of trivial changes to a large percent of the repository.