### PR TITLE
fix(wasi): Add back unsafe block for clockid_t static variables

### DIFF
--- a/ci/verify-build.sh
+++ b/ci/verify-build.sh
@@ -95,6 +95,8 @@ sparc64-unknown-linux-gnu \
 sparcv9-sun-solaris \
 wasm32-unknown-emscripten \
 wasm32-unknown-unknown \
+wasm32-wasip1 \
+wasm32-wasip2 \
 x86_64-linux-android \
 x86_64-unknown-freebsd \
 x86_64-unknown-linux-gnu \
@@ -227,12 +229,29 @@ else
     no_dist_targets=""
 fi
 
+case "$rust" in
+    "stable") supports_wasi_pn=1 ;;
+    "beta") supports_wasi_pn=1 ;;
+    "nightly") supports_wasi_pn=1 ;;
+    *) supports_wasi_pn=0 ;;
+esac
+
 for target in $targets; do
     if echo "$target" | grep -q "$filter"; then
         if [ "$os" = "windows" ]; then
             TARGET="$target" ./ci/install-rust.sh
             test_target "$target"
         else
+            # `wasm32-wasip1` was renamed from `wasm32-wasi`
+            if [ "$target" = "wasm32-wasip1" ] && [ "$supports_wasi_pn" = "0" ]; then
+                target="wasm32-wasi"
+            fi
+
+            # `wasm32-wasip2` only exists in recent versions of Rust
+            if [ "$target" = "wasm32-wasip2" ] && [ "$supports_wasi_pn" = "0" ]; then
+                continue
+            fi
+            
             test_target "$target"
         fi
 

--- a/src/wasi/mod.rs
+++ b/src/wasi/mod.rs
@@ -384,15 +384,17 @@ cfg_if! {
     } else {
         // unsafe code here is required in the stable, but not in nightly
         #[allow(unused_unsafe)]
-        pub static CLOCK_MONOTONIC: clockid_t = clockid_t(core::ptr::addr_of!(_CLOCK_MONOTONIC));
+        pub static CLOCK_MONOTONIC: clockid_t =
+            unsafe { clockid_t(core::ptr::addr_of!(_CLOCK_MONOTONIC)) };
         #[allow(unused_unsafe)]
         pub static CLOCK_PROCESS_CPUTIME_ID: clockid_t =
-            clockid_t(core::ptr::addr_of!(_CLOCK_PROCESS_CPUTIME_ID));
+            unsafe { clockid_t(core::ptr::addr_of!(_CLOCK_PROCESS_CPUTIME_ID)) };
         #[allow(unused_unsafe)]
-        pub static CLOCK_REALTIME: clockid_t = clockid_t(core::ptr::addr_of!(_CLOCK_REALTIME));
+        pub static CLOCK_REALTIME: clockid_t =
+            unsafe { clockid_t(core::ptr::addr_of!(_CLOCK_REALTIME)) };
         #[allow(unused_unsafe)]
         pub static CLOCK_THREAD_CPUTIME_ID: clockid_t =
-            clockid_t(core::ptr::addr_of!(_CLOCK_THREAD_CPUTIME_ID));
+            unsafe { clockid_t(core::ptr::addr_of!(_CLOCK_THREAD_CPUTIME_ID)) };
     }
 }
 


### PR DESCRIPTION
The MSRV is still far before 1.82.0

# Description

Version 0.2.166 can not be built for the wasm32-wasi target caused by the removed `unsafe` block.
This commit is taking them back.

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
