### PR TITLE
Fix usage with `rustc-dep-of-std`

### DIFF
--- a/ci/verify-build.sh
+++ b/ci/verify-build.sh
@@ -69,6 +69,11 @@ test_target() {
     $cmd --no-default-features
     $cmd --no-default-features --features extra_traits
 
+    # Ensure the crate will build when used with `std`
+    if [ "$rust" = "nightly" ]; then
+        $cmd --no-default-features --features rustc-dep-of-std
+    fi
+
     # For tier 2 freebsd targets, check with the different versions we support
     # if on nightly or stable
     case "$rust-$target" in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 #![cfg_attr(libc_deny_warnings, deny(warnings))]
 // Attributes needed when building as part of the standard library
 #![cfg_attr(feature = "rustc-dep-of-std", feature(link_cfg, no_core))]
+#![cfg_attr(feature = "rustc-dep-of-std", allow(internal_features))]
 // Enable extra lints:
 #![cfg_attr(feature = "extra_traits", deny(missing_debug_implementations))]
 #![deny(missing_copy_implementations, safe_packed_borrows)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -70,13 +70,13 @@ macro_rules! prelude {
         mod prelude {
             // Exports from `core`
             #[allow(unused_imports)]
-            pub(crate) use core::clone::Clone;
+            pub(crate) use ::core::clone::Clone;
             #[allow(unused_imports)]
-            pub(crate) use core::marker::{Copy, Send, Sync};
+            pub(crate) use ::core::marker::{Copy, Send, Sync};
             #[allow(unused_imports)]
-            pub(crate) use core::option::Option;
+            pub(crate) use ::core::option::Option;
             #[allow(unused_imports)]
-            pub(crate) use core::{fmt, hash, iter, mem};
+            pub(crate) use ::core::{fmt, hash, iter, mem};
 
             // Commonly used types defined in this crate
             #[allow(unused_imports)]
@@ -108,8 +108,11 @@ macro_rules! s {
     (it: $(#[$attr:meta])* pub struct $i:ident { $($field:tt)* }) => (
         __item! {
             #[repr(C)]
-            #[cfg_attr(feature = "extra_traits", derive(Debug, Eq, Hash, PartialEq))]
-            #[derive(Copy, Clone)]
+            #[cfg_attr(
+                feature = "extra_traits",
+                ::core::prelude::v1::derive(Debug, Eq, Hash, PartialEq)
+            )]
+            #[::core::prelude::v1::derive(::core::clone::Clone, ::core::marker::Copy)]
             #[allow(deprecated)]
             $(#[$attr])*
             pub struct $i { $($field)* }
@@ -127,8 +130,11 @@ macro_rules! s_paren {
         pub struct $i:ident ( $($field:tt)* );
     )*) => ($(
         __item! {
-            #[cfg_attr(feature = "extra_traits", derive(Debug, Eq, Hash, PartialEq))]
-            #[derive(Copy, Clone)]
+            #[cfg_attr(
+                feature = "extra_traits",
+                ::core::prelude::v1::derive(Debug, Eq, Hash, PartialEq)
+            )]
+            #[::core::prelude::v1::derive(::core::clone::Clone, ::core::marker::Copy)]
             $(#[$attr])*
             pub struct $i ( $($field)* );
         }
@@ -149,7 +155,7 @@ macro_rules! s_no_extra_traits {
     (it: $(#[$attr:meta])* pub union $i:ident { $($field:tt)* }) => (
         __item! {
             #[repr(C)]
-            #[derive(Copy, Clone)]
+            #[::core::prelude::v1::derive(::core::clone::Clone, ::core::marker::Copy)]
             $(#[$attr])*
             pub union $i { $($field)* }
         }
@@ -158,7 +164,7 @@ macro_rules! s_no_extra_traits {
     (it: $(#[$attr:meta])* pub struct $i:ident { $($field:tt)* }) => (
         __item! {
             #[repr(C)]
-            #[derive(Copy, Clone)]
+            #[::core::prelude::v1::derive(::core::clone::Clone, ::core::marker::Copy)]
             $(#[$attr])*
             pub struct $i { $($field)* }
         }
@@ -186,8 +192,11 @@ macro_rules! e {
         pub enum $i:ident { $($field:tt)* }
     )*) => ($(
         __item! {
-            #[cfg_attr(feature = "extra_traits", derive(Debug, Eq, Hash, PartialEq))]
-            #[derive(Copy, Clone)]
+            #[cfg_attr(
+                feature = "extra_traits",
+                ::core::prelude::v1::derive(Debug, Eq, Hash, PartialEq)
+            )]
+            #[::core::prelude::v1::derive(::core::clone::Clone, ::core::marker::Copy)]
             $(#[$attr])*
             pub enum $i { $($field)* }
         }


### PR DESCRIPTION
Since https://github.com/rust-lang/libc/pull/4038 we use derive macros rather than manually implementing `Clone`
and `Copy`. However, this caused the build in `std` to start failing since the `core` prelude is not available. This provides the derive macros as well as `derive` itself.

Resolve this by using complete paths. Additionally allow `internal_features` to suppress the warning using `link_cfg`.

Includes a test that verifies build with `rustc-dep-of-std` enabled.