### PR TITLE
Create an internal prelude

### DIFF
--- a/src/fuchsia/aarch64.rs
+++ b/src/fuchsia/aarch64.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_uint, c_ulong, c_ulonglong, c_ushort, off_t, size_t};
+use crate::off_t;
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type __u64 = c_ulonglong;

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -3,7 +3,7 @@
 //! More functions and definitions can be found in the more specific modules
 //! according to the platform in question.
 
-use crate::c_void;
+use crate::prelude::*;
 
 // PUB_TYPE
 
@@ -1073,8 +1073,8 @@ cfg_if! {
             }
         }
         impl Eq for sysinfo {}
-        impl crate::fmt::Debug for sysinfo {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sysinfo {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sysinfo")
                     .field("uptime", &self.uptime)
                     .field("loads", &self.loads)
@@ -1093,8 +1093,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sysinfo {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sysinfo {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uptime.hash(state);
                 self.loads.hash(state);
                 self.totalram.hash(state);
@@ -1123,16 +1123,16 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_un {}
-        impl crate::fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_un {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_un")
                     .field("sun_family", &self.sun_family)
                     // FIXME: .field("sun_path", &self.sun_path)
                     .finish()
             }
         }
-        impl crate::hash::Hash for sockaddr_un {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_un {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sun_family.hash(state);
                 self.sun_path.hash(state);
             }
@@ -1150,8 +1150,8 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_storage {}
-        impl crate::fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_storage {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_storage")
                     .field("ss_family", &self.ss_family)
                     .field("__ss_align", &self.__ss_align)
@@ -1159,8 +1159,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sockaddr_storage {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_storage {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_family.hash(state);
                 self.__ss_align.hash(state);
                 self.__ss_pad2.hash(state);
@@ -1196,8 +1196,8 @@ cfg_if! {
             }
         }
         impl Eq for utsname {}
-        impl crate::fmt::Debug for utsname {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utsname {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utsname")
                     // FIXME: .field("sysname", &self.sysname)
                     // FIXME: .field("nodename", &self.nodename)
@@ -1207,8 +1207,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for utsname {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utsname {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sysname.hash(state);
                 self.nodename.hash(state);
                 self.release.hash(state);
@@ -1231,8 +1231,8 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_ino", &self.d_ino)
                     .field("d_off", &self.d_off)
@@ -1242,8 +1242,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for dirent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
                 self.d_off.hash(state);
                 self.d_reclen.hash(state);
@@ -1266,8 +1266,8 @@ cfg_if! {
             }
         }
         impl Eq for dirent64 {}
-        impl crate::fmt::Debug for dirent64 {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent64 {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent64")
                     .field("d_ino", &self.d_ino)
                     .field("d_off", &self.d_off)
@@ -1277,8 +1277,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for dirent64 {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent64 {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
                 self.d_off.hash(state);
                 self.d_reclen.hash(state);
@@ -1296,8 +1296,8 @@ cfg_if! {
             }
         }
         impl Eq for mq_attr {}
-        impl crate::fmt::Debug for mq_attr {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mq_attr {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mq_attr")
                     .field("mq_flags", &self.mq_flags)
                     .field("mq_maxmsg", &self.mq_maxmsg)
@@ -1306,8 +1306,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for mq_attr {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mq_attr {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mq_flags.hash(state);
                 self.mq_maxmsg.hash(state);
                 self.mq_msgsize.hash(state);
@@ -1323,8 +1323,8 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_nl {}
-        impl crate::fmt::Debug for sockaddr_nl {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_nl {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_nl")
                     .field("nl_family", &self.nl_family)
                     .field("nl_pid", &self.nl_pid)
@@ -1332,8 +1332,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sockaddr_nl {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_nl {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.nl_family.hash(state);
                 self.nl_pid.hash(state);
                 self.nl_groups.hash(state);
@@ -1350,8 +1350,8 @@ cfg_if! {
             }
         }
         impl Eq for sigevent {}
-        impl crate::fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sigevent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sigevent")
                     .field("sigev_value", &self.sigev_value)
                     .field("sigev_signo", &self.sigev_signo)
@@ -1361,8 +1361,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sigevent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sigevent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sigev_value.hash(state);
                 self.sigev_signo.hash(state);
                 self.sigev_notify.hash(state);
@@ -1377,15 +1377,15 @@ cfg_if! {
             }
         }
         impl Eq for pthread_cond_t {}
-        impl crate::fmt::Debug for pthread_cond_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_cond_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_cond_t")
                     // FIXME: .field("size", &self.size)
                     .finish()
             }
         }
-        impl crate::hash::Hash for pthread_cond_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_cond_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.size.hash(state);
             }
         }
@@ -1396,15 +1396,15 @@ cfg_if! {
             }
         }
         impl Eq for pthread_mutex_t {}
-        impl crate::fmt::Debug for pthread_mutex_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_mutex_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_mutex_t")
                     // FIXME: .field("size", &self.size)
                     .finish()
             }
         }
-        impl crate::hash::Hash for pthread_mutex_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_mutex_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.size.hash(state);
             }
         }
@@ -1415,15 +1415,15 @@ cfg_if! {
             }
         }
         impl Eq for pthread_rwlock_t {}
-        impl crate::fmt::Debug for pthread_rwlock_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_rwlock_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_rwlock_t")
                     // FIXME: .field("size", &self.size)
                     .finish()
             }
         }
-        impl crate::hash::Hash for pthread_rwlock_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_rwlock_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.size.hash(state);
             }
         }
@@ -3372,20 +3372,20 @@ cfg_if! {
 f! {
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
         return;
     }
@@ -3403,21 +3403,21 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * crate::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] |= 1 << offset;
         ()
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * crate::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] &= !(1 << offset);
         ()
     }
 
     pub fn CPU_ISSET(cpu: usize, cpuset: &cpu_set_t) -> bool {
-        let size_in_bits = 8 * crate::mem::size_of_val(&cpuset.bits[0]);
+        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]);
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         0 != (cpuset.bits[idx] & (1 << offset))
     }
@@ -3445,9 +3445,9 @@ f! {
     }
 
     pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        if ((*cmsg).cmsg_len as size_t) < crate::mem::size_of::<cmsghdr>() {
+        if ((*cmsg).cmsg_len as size_t) < mem::size_of::<cmsghdr>() {
             0 as *mut cmsghdr
-        } else if __CMSG_NEXT(cmsg).add(crate::mem::size_of::<cmsghdr>()) >= __MHDR_END(mhdr) {
+        } else if __CMSG_NEXT(cmsg).add(mem::size_of::<cmsghdr>()) >= __MHDR_END(mhdr) {
             0 as *mut cmsghdr
         } else {
             __CMSG_NEXT(cmsg).cast()
@@ -3455,7 +3455,7 @@ f! {
     }
 
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as size_t >= crate::mem::size_of::<cmsghdr>() {
+        if (*mhdr).msg_controllen as size_t >= mem::size_of::<cmsghdr>() {
             (*mhdr).msg_control.cast()
         } else {
             0 as *mut cmsghdr
@@ -3463,15 +3463,15 @@ f! {
     }
 
     pub {const} fn CMSG_ALIGN(len: size_t) -> size_t {
-        (len + crate::mem::size_of::<size_t>() - 1) & !(crate::mem::size_of::<size_t>() - 1)
+        (len + mem::size_of::<size_t>() - 1) & !(mem::size_of::<size_t>() - 1)
     }
 
     pub {const} fn CMSG_SPACE(len: c_uint) -> c_uint {
-        (CMSG_ALIGN(len as size_t) + CMSG_ALIGN(crate::mem::size_of::<cmsghdr>())) as c_uint
+        (CMSG_ALIGN(len as size_t) + CMSG_ALIGN(mem::size_of::<cmsghdr>())) as c_uint
     }
 
     pub {const} fn CMSG_LEN(len: c_uint) -> c_uint {
-        (CMSG_ALIGN(crate::mem::size_of::<cmsghdr>()) + len as size_t) as c_uint
+        (CMSG_ALIGN(mem::size_of::<cmsghdr>()) + len as size_t) as c_uint
     }
 }
 
@@ -3525,8 +3525,8 @@ safe_f! {
 }
 
 fn __CMSG_LEN(cmsg: *const cmsghdr) -> ssize_t {
-    ((unsafe { (*cmsg).cmsg_len as size_t } + crate::mem::size_of::<c_long>() - 1)
-        & !(crate::mem::size_of::<c_long>() - 1)) as ssize_t
+    ((unsafe { (*cmsg).cmsg_len as size_t } + mem::size_of::<c_long>() - 1)
+        & !(mem::size_of::<c_long>() - 1)) as ssize_t
 }
 
 fn __CMSG_NEXT(cmsg: *const cmsghdr) -> *mut c_uchar {

--- a/src/fuchsia/riscv64.rs
+++ b/src/fuchsia/riscv64.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_ulong, c_ulonglong, c_ushort, off_t};
+use crate::off_t;
+use crate::prelude::*;
 
 // From psABI Calling Convention for RV64
 pub type c_char = u8;

--- a/src/fuchsia/x86_64.rs
+++ b/src/fuchsia/x86_64.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_ulong, c_ulonglong, off_t, size_t};
+use crate::off_t;
+use crate::prelude::*;
 
 pub type c_char = i8;
 pub type wchar_t = i32;
@@ -94,8 +95,8 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl crate::fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ucontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ucontext_t")
                     .field("uc_flags", &self.uc_flags)
                     .field("uc_link", &self.uc_link)
@@ -106,8 +107,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for ucontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ucontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_flags.hash(state);
                 self.uc_link.hash(state);
                 self.uc_stack.hash(state);

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -1,6 +1,6 @@
 //! Hermit C type definitions
 
-use crate::c_void;
+use crate::prelude::*;
 
 cfg_if! {
     if #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,35 +32,10 @@ mod macros;
 cfg_if! {
     if #[cfg(feature = "rustc-dep-of-std")] {
         extern crate rustc_std_workspace_core as core;
-        #[allow(unused_imports)]
-        use core::iter;
-        #[allow(unused_imports)]
-        use core::ops;
-        #[allow(unused_imports)]
-        use core::option;
     }
 }
 
-#[doc(hidden)]
-#[allow(unused_imports)]
-use core::clone::Clone;
-#[allow(unused_imports)]
-use core::ffi;
 pub use core::ffi::c_void;
-#[allow(unused_imports)]
-use core::fmt;
-#[allow(unused_imports)]
-use core::hash;
-#[doc(hidden)]
-#[allow(unused_imports)]
-use core::marker::{Copy, Send, Sync};
-#[allow(unused_imports)]
-use core::mem;
-#[allow(unused_imports)]
-use core::num;
-#[doc(hidden)]
-#[allow(unused_imports)]
-use core::option::Option;
 
 cfg_if! {
     if #[cfg(windows)] {
@@ -69,72 +44,96 @@ cfg_if! {
 
         mod windows;
         pub use crate::windows::*;
+
+        prelude!();
     } else if #[cfg(target_os = "fuchsia")] {
         mod fixed_width_ints;
         pub use crate::fixed_width_ints::*;
 
         mod fuchsia;
         pub use crate::fuchsia::*;
+
+        prelude!();
     } else if #[cfg(target_os = "switch")] {
         mod fixed_width_ints;
         pub use fixed_width_ints::*;
 
         mod switch;
         pub use switch::*;
+
+        prelude!();
     } else if #[cfg(target_os = "vxworks")] {
         mod fixed_width_ints;
         pub use crate::fixed_width_ints::*;
 
         mod vxworks;
         pub use crate::vxworks::*;
+
+        prelude!();
     } else if #[cfg(target_os = "solid_asp3")] {
         mod fixed_width_ints;
         pub use crate::fixed_width_ints::*;
 
         mod solid;
         pub use crate::solid::*;
+
+        prelude!();
     } else if #[cfg(unix)] {
         mod fixed_width_ints;
         pub use crate::fixed_width_ints::*;
 
         mod unix;
         pub use crate::unix::*;
+
+        prelude!();
     } else if #[cfg(target_os = "hermit")] {
         mod fixed_width_ints;
         pub use crate::fixed_width_ints::*;
 
         mod hermit;
         pub use crate::hermit::*;
+
+        prelude!();
     } else if #[cfg(target_os = "teeos")] {
         mod fixed_width_ints;
         pub use fixed_width_ints::*;
 
         mod teeos;
         pub use teeos::*;
+
+        prelude!();
     } else if #[cfg(target_os = "trusty")] {
         mod fixed_width_ints;
         pub use crate::fixed_width_ints::*;
 
         mod trusty;
         pub use crate::trusty::*;
+
+        prelude!();
     } else if #[cfg(all(target_env = "sgx", target_vendor = "fortanix"))] {
         mod fixed_width_ints;
         pub use crate::fixed_width_ints::*;
 
         mod sgx;
         pub use crate::sgx::*;
+
+        prelude!();
     } else if #[cfg(any(target_env = "wasi", target_os = "wasi"))] {
         mod fixed_width_ints;
         pub use crate::fixed_width_ints::*;
 
         mod wasi;
         pub use crate::wasi::*;
+
+        prelude!();
     } else if #[cfg(target_os = "xous")] {
         mod fixed_width_ints;
         pub use crate::fixed_width_ints::*;
 
         mod xous;
         pub use crate::xous::*;
+
+        prelude!();
     } else {
         // non-supported targets: empty...
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -61,6 +61,33 @@ macro_rules! cfg_if {
     };
 }
 
+/// Create an internal crate prelude with `core` reexports and common types.
+macro_rules! prelude {
+    () => {
+        /// Frequently-used types that are available on all platforms
+        ///
+        /// We need to reexport the core types so this works with `rust-dep-of-std`.
+        mod prelude {
+            // Exports from `core`
+            #[allow(unused_imports)]
+            pub(crate) use core::clone::Clone;
+            #[allow(unused_imports)]
+            pub(crate) use core::marker::{Copy, Send, Sync};
+            #[allow(unused_imports)]
+            pub(crate) use core::option::Option;
+            #[allow(unused_imports)]
+            pub(crate) use core::{fmt, hash, iter, mem};
+
+            // Commonly used types defined in this crate
+            #[allow(unused_imports)]
+            pub(crate) use crate::{
+                c_char, c_double, c_float, c_int, c_long, c_longlong, c_short, c_uchar, c_uint,
+                c_ulong, c_ulonglong, c_ushort, c_void, intptr_t, size_t, ssize_t, uintptr_t,
+            };
+        }
+    };
+}
+
 /// Implement `Clone` and `Copy` for a struct, as well as `Debug`, `Eq`, `Hash`, and
 /// `PartialEq` if the `extra_traits` feature is enabled.
 ///

--- a/src/solid/mod.rs
+++ b/src/solid/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! [SOLID]: https://solid.kmckk.com/
 
-use crate::c_void;
+use crate::prelude::*;
 
 pub type c_schar = i8;
 pub type c_uchar = u8;

--- a/src/teeos/mod.rs
+++ b/src/teeos/mod.rs
@@ -8,7 +8,7 @@
 // only supported on Rust > 1.59, so we can directly reexport c_void from core.
 pub use core::ffi::c_void;
 
-use Option;
+use crate::prelude::*;
 
 pub type c_schar = i8;
 

--- a/src/trusty.rs
+++ b/src/trusty.rs
@@ -43,6 +43,9 @@ pub type c_int16_t = i16;
 pub type c_int32_t = i32;
 pub type c_int64_t = i64;
 
+pub type intptr_t = isize;
+pub type uintptr_t = usize;
+
 pub type c_float = f32;
 pub type c_double = f64;
 

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -1,7 +1,4 @@
-use crate::{
-    c_double, c_int, c_longlong, c_short, c_uchar, c_uint, c_ulonglong, c_ushort, c_void, intptr_t,
-    size_t, ssize_t,
-};
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type caddr_t = *mut c_char;
@@ -578,16 +575,16 @@ cfg_if! {
             }
         }
         impl Eq for __sigaction_sa_union {}
-        impl crate::fmt::Debug for __sigaction_sa_union {
-            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
+        impl fmt::Debug for __sigaction_sa_union {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_struct("__sigaction_sa_union")
                     .field("__su_handler", unsafe { &self.__su_handler })
                     .field("__su_sigaction", unsafe { &self.__su_sigaction })
                     .finish()
             }
         }
-        impl crate::hash::Hash for __sigaction_sa_union {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __sigaction_sa_union {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self.__su_handler.hash(state);
                     self.__su_sigaction.hash(state);
@@ -603,8 +600,8 @@ cfg_if! {
             }
         }
         impl Eq for sigaction {}
-        impl crate::fmt::Debug for sigaction {
-            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
+        impl fmt::Debug for sigaction {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_struct("sigaction")
                     .field("sa_union", &self.sa_union)
                     .field("sa_mask", &self.sa_mask)
@@ -612,8 +609,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sigaction {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sigaction {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sa_union.hash(state);
                 self.sa_mask.hash(state);
                 self.sa_flags.hash(state);
@@ -630,8 +627,8 @@ cfg_if! {
             }
         }
         impl Eq for __poll_ctl_ext_u {}
-        impl crate::fmt::Debug for __poll_ctl_ext_u {
-            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
+        impl fmt::Debug for __poll_ctl_ext_u {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_struct("__poll_ctl_ext_u")
                     .field("addr", unsafe { &self.addr })
                     .field("data32", unsafe { &self.data32 })
@@ -639,8 +636,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for __poll_ctl_ext_u {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __poll_ctl_ext_u {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self.addr.hash(state);
                     self.data32.hash(state);
@@ -660,8 +657,8 @@ cfg_if! {
             }
         }
         impl Eq for poll_ctl_ext {}
-        impl crate::fmt::Debug for poll_ctl_ext {
-            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
+        impl fmt::Debug for poll_ctl_ext {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_struct("poll_ctl_ext")
                     .field("version", &self.version)
                     .field("command", &self.command)
@@ -672,8 +669,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for poll_ctl_ext {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for poll_ctl_ext {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.version.hash(state);
                 self.command.hash(state);
                 self.events.hash(state);
@@ -2507,7 +2504,7 @@ pub const ACCOUNTING: c_short = 9;
 
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= crate::mem::size_of::<cmsghdr>() {
+        if (*mhdr).msg_controllen as usize >= mem::size_of::<cmsghdr>() {
             (*mhdr).msg_control as *mut cmsghdr
         } else {
             0 as *mut cmsghdr
@@ -2518,7 +2515,7 @@ f! {
         if cmsg.is_null() {
             CMSG_FIRSTHDR(mhdr)
         } else {
-            if (cmsg as usize + (*cmsg).cmsg_len as usize + crate::mem::size_of::<cmsghdr>())
+            if (cmsg as usize + (*cmsg).cmsg_len as usize + mem::size_of::<cmsghdr>())
                 > ((*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize)
             {
                 0 as *mut cmsghdr
@@ -2530,15 +2527,15 @@ f! {
     }
 
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(crate::mem::size_of::<cmsghdr>() as isize)
+        (cmsg as *mut c_uchar).offset(mem::size_of::<cmsghdr>() as isize)
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        crate::mem::size_of::<cmsghdr>() as c_uint + length
+        mem::size_of::<cmsghdr>() as c_uint + length
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        crate::mem::size_of::<cmsghdr>() as c_uint + length
+        mem::size_of::<cmsghdr>() as c_uint + length
     }
 
     pub fn FD_ZERO(set: *mut fd_set) -> () {
@@ -2548,21 +2545,21 @@ f! {
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
-        let bits = crate::mem::size_of::<c_long>() * 8;
+        let bits = mem::size_of::<c_long>() * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] |= 1 << (fd % bits);
         return;
     }
 
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
-        let bits = crate::mem::size_of::<c_long>() * 8;
+        let bits = mem::size_of::<c_long>() * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] &= !(1 << (fd % bits));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
-        let bits = crate::mem::size_of::<c_long>() * 8;
+        let bits = mem::size_of::<c_long>() * 8;
         let fd = fd as usize;
         return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0;
     }

--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -1,7 +1,5 @@
-use crate::{
-    c_char, c_int, c_longlong, c_short, c_uint, c_ulonglong, c_ushort, c_void, off_t, size_t,
-    ssize_t,
-};
+use crate::off_t;
+use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
@@ -321,8 +319,8 @@ cfg_if! {
             }
         }
         impl Eq for siginfo_t {}
-        impl crate::fmt::Debug for siginfo_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
+        impl fmt::Debug for siginfo_t {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_struct("siginfo_t")
                     .field("si_signo", &self.si_signo)
                     .field("si_errno", &self.si_errno)
@@ -337,8 +335,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for siginfo_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for siginfo_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.si_signo.hash(state);
                 self.si_errno.hash(state);
                 self.si_code.hash(state);
@@ -358,16 +356,16 @@ cfg_if! {
             }
         }
         impl Eq for _kernel_simple_lock {}
-        impl crate::fmt::Debug for _kernel_simple_lock {
-            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
+        impl fmt::Debug for _kernel_simple_lock {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_struct("_kernel_simple_lock")
                     .field("_slock", unsafe { &self._slock })
                     .field("_slockp", unsafe { &self._slockp })
                     .finish()
             }
         }
-        impl crate::hash::Hash for _kernel_simple_lock {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for _kernel_simple_lock {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self._slock.hash(state);
                     self._slockp.hash(state);
@@ -385,8 +383,8 @@ cfg_if! {
             }
         }
         impl Eq for fileops_t {}
-        impl crate::fmt::Debug for fileops_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
+        impl fmt::Debug for fileops_t {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_struct("fileops_t")
                     .field("fo_rw", &self.fo_rw)
                     .field("fo_ioctl", &self.fo_ioctl)
@@ -396,8 +394,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for fileops_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for fileops_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.fo_rw.hash(state);
                 self.fo_ioctl.hash(state);
                 self.fo_select.hash(state);
@@ -426,8 +424,8 @@ cfg_if! {
             }
         }
         impl Eq for file {}
-        impl crate::fmt::Debug for file {
-            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
+        impl fmt::Debug for file {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_struct("file")
                     .field("f_flag", &self.f_flag)
                     .field("f_count", &self.f_count)
@@ -447,8 +445,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for file {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for file {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_flag.hash(state);
                 self.f_count.hash(state);
                 self.f_options.hash(state);
@@ -477,8 +475,8 @@ cfg_if! {
             }
         }
         impl Eq for __ld_info_file {}
-        impl crate::fmt::Debug for __ld_info_file {
-            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
+        impl fmt::Debug for __ld_info_file {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_struct("__ld_info_file")
                     .field("_ldinfo_fd", unsafe { &self._ldinfo_fd })
                     .field("_ldinfo_fp", unsafe { &self._ldinfo_fp })
@@ -486,8 +484,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for __ld_info_file {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __ld_info_file {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self._ldinfo_fd.hash(state);
                     self._ldinfo_fp.hash(state);
@@ -509,8 +507,8 @@ cfg_if! {
             }
         }
         impl Eq for ld_info {}
-        impl crate::fmt::Debug for ld_info {
-            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
+        impl fmt::Debug for ld_info {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_struct("ld_info")
                     .field("ldinfo_next", &self.ldinfo_next)
                     .field("ldinfo_flags", &self.ldinfo_flags)
@@ -523,8 +521,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for ld_info {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ld_info {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ldinfo_next.hash(state);
                 self.ldinfo_flags.hash(state);
                 self.ldinfo_textorg.hash(state);
@@ -546,8 +544,8 @@ cfg_if! {
             }
         }
         impl Eq for __pollfd_ext_u {}
-        impl crate::fmt::Debug for __pollfd_ext_u {
-            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
+        impl fmt::Debug for __pollfd_ext_u {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_struct("__pollfd_ext_u")
                     .field("addr", unsafe { &self.addr })
                     .field("data32", unsafe { &self.data32 })
@@ -555,8 +553,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for __pollfd_ext_u {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __pollfd_ext_u {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self.addr.hash(state);
                     self.data.hash(state);
@@ -574,8 +572,8 @@ cfg_if! {
             }
         }
         impl Eq for pollfd_ext {}
-        impl crate::fmt::Debug for pollfd_ext {
-            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
+        impl fmt::Debug for pollfd_ext {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_struct("pollfd_ext")
                     .field("fd", &self.fd)
                     .field("events", &self.events)
@@ -584,8 +582,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for pollfd_ext {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pollfd_ext {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.fd.hash(state);
                 self.events.hash(state);
                 self.revents.hash(state);

--- a/src/unix/bsd/apple/b32/mod.rs
+++ b/src/unix/bsd/apple/b32/mod.rs
@@ -1,6 +1,6 @@
 //! 32-bit specific Apple (ios/darwin) definitions
 
-use crate::{c_char, c_int, c_uchar, c_ushort};
+use crate::prelude::*;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
@@ -82,16 +82,16 @@ cfg_if! {
             }
         }
         impl Eq for pthread_attr_t {}
-        impl crate::fmt::Debug for pthread_attr_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_attr_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_attr_t")
                     .field("__sig", &self.__sig)
                     // FIXME: .field("__opaque", &self.__opaque)
                     .finish()
             }
         }
-        impl crate::hash::Hash for pthread_attr_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_attr_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__sig.hash(state);
                 self.__opaque.hash(state);
             }
@@ -107,15 +107,15 @@ cfg_if! {
             }
         }
         impl Eq for pthread_once_t {}
-        impl crate::fmt::Debug for pthread_once_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_once_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_once_t")
                     .field("__sig", &self.__sig)
                     .finish()
             }
         }
-        impl crate::hash::Hash for pthread_once_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_once_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__sig.hash(state);
                 self.__opaque.hash(state);
             }

--- a/src/unix/bsd/apple/b64/aarch64/mod.rs
+++ b/src/unix/bsd/apple/b64/aarch64/mod.rs
@@ -1,4 +1,4 @@
-use crate::c_int;
+use crate::prelude::*;
 
 pub type boolean_t = c_int;
 pub type mcontext_t = *mut __darwin_mcontext64;

--- a/src/unix/bsd/apple/b64/mod.rs
+++ b/src/unix/bsd/apple/b64/mod.rs
@@ -1,6 +1,6 @@
 //! 64-bit specific Apple (ios/darwin) definitions
 
-use crate::{c_char, c_int, c_uchar, c_uint, c_ushort};
+use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
@@ -76,16 +76,16 @@ cfg_if! {
             }
         }
         impl Eq for pthread_attr_t {}
-        impl crate::fmt::Debug for pthread_attr_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_attr_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_attr_t")
                     .field("__sig", &self.__sig)
                     // FIXME: .field("__opaque", &self.__opaque)
                     .finish()
             }
         }
-        impl crate::hash::Hash for pthread_attr_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_attr_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__sig.hash(state);
                 self.__opaque.hash(state);
             }
@@ -101,15 +101,15 @@ cfg_if! {
             }
         }
         impl Eq for pthread_once_t {}
-        impl crate::fmt::Debug for pthread_once_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_once_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_once_t")
                     .field("__sig", &self.__sig)
                     .finish()
             }
         }
-        impl crate::hash::Hash for pthread_once_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_once_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__sig.hash(state);
                 self.__opaque.hash(state);
             }

--- a/src/unix/bsd/apple/b64/x86_64/mod.rs
+++ b/src/unix/bsd/apple/b64/x86_64/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_char, c_int, c_short, c_uint, c_void, size_t};
+use crate::prelude::*;
 
 pub type boolean_t = c_uint;
 pub type mcontext_t = *mut __darwin_mcontext64;

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -2,10 +2,8 @@
 //!
 //! This covers *-apple-* triples currently
 
-use crate::{
-    c_int, c_longlong, c_short, c_uchar, c_uint, c_ulonglong, c_ushort, c_void, cmsghdr, intptr_t,
-    off_t, size_t, ssize_t,
-};
+use crate::prelude::*;
+use crate::{cmsghdr, off_t};
 
 pub type c_char = i8;
 pub type wchar_t = i32;
@@ -1682,15 +1680,15 @@ cfg_if! {
             }
         }
         impl Eq for semun {}
-        impl crate::fmt::Debug for semun {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for semun {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("semun")
                     .field("val", unsafe { &self.val })
                     .finish()
             }
         }
-        impl crate::hash::Hash for semun {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for semun {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe { self.val.hash(state) };
             }
         }
@@ -1710,8 +1708,8 @@ cfg_if! {
             }
         }
         impl Eq for kevent {}
-        impl crate::fmt::Debug for kevent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for kevent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let ident = self.ident;
                 let filter = self.filter;
                 let flags = self.flags;
@@ -1728,8 +1726,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for kevent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for kevent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let ident = self.ident;
                 let filter = self.filter;
                 let flags = self.flags;
@@ -1762,8 +1760,8 @@ cfg_if! {
             }
         }
         impl Eq for semid_ds {}
-        impl crate::fmt::Debug for semid_ds {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for semid_ds {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let sem_perm = self.sem_perm;
                 let sem_base = self.sem_base;
                 let sem_nsems = self.sem_nsems;
@@ -1784,8 +1782,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for semid_ds {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for semid_ds {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let sem_perm = self.sem_perm;
                 let sem_base = self.sem_base;
                 let sem_nsems = self.sem_nsems;
@@ -1821,8 +1819,8 @@ cfg_if! {
             }
         }
         impl Eq for shmid_ds {}
-        impl crate::fmt::Debug for shmid_ds {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for shmid_ds {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let shm_perm = self.shm_perm;
                 let shm_segsz = self.shm_segsz;
                 let shm_lpid = self.shm_lpid;
@@ -1845,8 +1843,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for shmid_ds {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for shmid_ds {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let shm_perm = self.shm_perm;
                 let shm_segsz = self.shm_segsz;
                 let shm_lpid = self.shm_lpid;
@@ -1888,8 +1886,8 @@ cfg_if! {
             }
         }
         impl Eq for proc_threadinfo {}
-        impl crate::fmt::Debug for proc_threadinfo {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for proc_threadinfo {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("proc_threadinfo")
                     .field("pth_user_time", &self.pth_user_time)
                     .field("pth_system_time", &self.pth_system_time)
@@ -1905,8 +1903,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for proc_threadinfo {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for proc_threadinfo {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.pth_user_time.hash(state);
                 self.pth_system_time.hash(state);
                 self.pth_cpu_usage.hash(state);
@@ -1951,8 +1949,8 @@ cfg_if! {
         }
 
         impl Eq for statfs {}
-        impl crate::fmt::Debug for statfs {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for statfs {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("statfs")
                     .field("f_bsize", &self.f_bsize)
                     .field("f_iosize", &self.f_iosize)
@@ -1974,8 +1972,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for statfs {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for statfs {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_bsize.hash(state);
                 self.f_iosize.hash(state);
                 self.f_blocks.hash(state);
@@ -2010,8 +2008,8 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_ino", &self.d_ino)
                     .field("d_seekoff", &self.d_seekoff)
@@ -2022,8 +2020,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for dirent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
                 self.d_seekoff.hash(state);
                 self.d_reclen.hash(state);
@@ -2043,16 +2041,16 @@ cfg_if! {
             }
         }
         impl Eq for pthread_rwlock_t {}
-        impl crate::fmt::Debug for pthread_rwlock_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_rwlock_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_rwlock_t")
                     .field("__sig", &self.__sig)
                     // FIXME: .field("__opaque", &self.__opaque)
                     .finish()
             }
         }
-        impl crate::hash::Hash for pthread_rwlock_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_rwlock_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__sig.hash(state);
                 self.__opaque.hash(state);
             }
@@ -2071,8 +2069,8 @@ cfg_if! {
 
         impl Eq for pthread_mutex_t {}
 
-        impl crate::fmt::Debug for pthread_mutex_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_mutex_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_mutex_t")
                     .field("__sig", &self.__sig)
                     // FIXME: .field("__opaque", &self.__opaque)
@@ -2080,8 +2078,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for pthread_mutex_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_mutex_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__sig.hash(state);
                 self.__opaque.hash(state);
             }
@@ -2100,8 +2098,8 @@ cfg_if! {
 
         impl Eq for pthread_cond_t {}
 
-        impl crate::fmt::Debug for pthread_cond_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_cond_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_cond_t")
                     .field("__sig", &self.__sig)
                     // FIXME: .field("__opaque", &self.__opaque)
@@ -2109,8 +2107,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for pthread_cond_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_cond_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__sig.hash(state);
                 self.__opaque.hash(state);
             }
@@ -2136,8 +2134,8 @@ cfg_if! {
 
         impl Eq for sockaddr_storage {}
 
-        impl crate::fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_storage {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_storage")
                     .field("ss_len", &self.ss_len)
                     .field("ss_family", &self.ss_family)
@@ -2148,8 +2146,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for sockaddr_storage {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_storage {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_len.hash(state);
                 self.ss_family.hash(state);
                 self.__ss_pad1.hash(state);
@@ -2180,8 +2178,8 @@ cfg_if! {
 
         impl Eq for utmpx {}
 
-        impl crate::fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utmpx {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utmpx")
                     // FIXME: .field("ut_user", &self.ut_user)
                     .field("ut_id", &self.ut_id)
@@ -2195,8 +2193,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for utmpx {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utmpx {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_user.hash(state);
                 self.ut_id.hash(state);
                 self.ut_line.hash(state);
@@ -2219,8 +2217,8 @@ cfg_if! {
 
         impl Eq for sigevent {}
 
-        impl crate::fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sigevent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sigevent")
                     .field("sigev_notify", &self.sigev_notify)
                     .field("sigev_signo", &self.sigev_signo)
@@ -2230,8 +2228,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for sigevent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sigevent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sigev_notify.hash(state);
                 self.sigev_signo.hash(state);
                 self.sigev_value.hash(state);
@@ -2245,15 +2243,15 @@ cfg_if! {
             }
         }
         impl Eq for processor_cpu_load_info {}
-        impl crate::fmt::Debug for processor_cpu_load_info {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for processor_cpu_load_info {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("processor_cpu_load_info")
                     .field("cpu_ticks", &self.cpu_ticks)
                     .finish()
             }
         }
-        impl crate::hash::Hash for processor_cpu_load_info {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for processor_cpu_load_info {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cpu_ticks.hash(state);
             }
         }
@@ -2268,8 +2266,8 @@ cfg_if! {
             }
         }
         impl Eq for processor_basic_info {}
-        impl crate::fmt::Debug for processor_basic_info {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for processor_basic_info {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("processor_basic_info")
                     .field("cpu_type", &self.cpu_type)
                     .field("cpu_subtype", &self.cpu_subtype)
@@ -2279,8 +2277,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for processor_basic_info {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for processor_basic_info {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cpu_type.hash(state);
                 self.cpu_subtype.hash(state);
                 self.running.hash(state);
@@ -2296,16 +2294,16 @@ cfg_if! {
             }
         }
         impl Eq for processor_set_basic_info {}
-        impl crate::fmt::Debug for processor_set_basic_info {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for processor_set_basic_info {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("processor_set_basic_info")
                     .field("processor_count", &self.processor_count)
                     .field("default_policy", &self.default_policy)
                     .finish()
             }
         }
-        impl crate::hash::Hash for processor_set_basic_info {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for processor_set_basic_info {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.processor_count.hash(state);
                 self.default_policy.hash(state);
             }
@@ -2320,8 +2318,8 @@ cfg_if! {
             }
         }
         impl Eq for processor_set_load_info {}
-        impl crate::fmt::Debug for processor_set_load_info {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for processor_set_load_info {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("processor_set_load_info")
                     .field("task_count", &self.task_count)
                     .field("thread_count", &self.thread_count)
@@ -2330,8 +2328,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for processor_set_load_info {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for processor_set_load_info {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.task_count.hash(state);
                 self.thread_count.hash(state);
                 self.load_average.hash(state);
@@ -2345,16 +2343,16 @@ cfg_if! {
             }
         }
         impl Eq for time_value_t {}
-        impl crate::fmt::Debug for time_value_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for time_value_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("time_value_t")
                     .field("seconds", &self.seconds)
                     .field("microseconds", &self.microseconds)
                     .finish()
             }
         }
-        impl crate::hash::Hash for time_value_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for time_value_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.seconds.hash(state);
                 self.microseconds.hash(state);
             }
@@ -2372,8 +2370,8 @@ cfg_if! {
             }
         }
         impl Eq for thread_basic_info {}
-        impl crate::fmt::Debug for thread_basic_info {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for thread_basic_info {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("thread_basic_info")
                     .field("user_time", &self.user_time)
                     .field("system_time", &self.system_time)
@@ -2386,8 +2384,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for thread_basic_info {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for thread_basic_info {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.user_time.hash(state);
                 self.system_time.hash(state);
                 self.cpu_usage.hash(state);
@@ -2418,8 +2416,8 @@ cfg_if! {
             }
         }
         impl Eq for thread_extended_info {}
-        impl crate::fmt::Debug for thread_extended_info {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for thread_extended_info {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("proc_threadinfo")
                     .field("pth_user_time", &self.pth_user_time)
                     .field("pth_system_time", &self.pth_system_time)
@@ -2435,8 +2433,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for thread_extended_info {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for thread_extended_info {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.pth_user_time.hash(state);
                 self.pth_system_time.hash(state);
                 self.pth_cpu_usage.hash(state);
@@ -2458,8 +2456,8 @@ cfg_if! {
             }
         }
         impl Eq for thread_identifier_info {}
-        impl crate::fmt::Debug for thread_identifier_info {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for thread_identifier_info {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("thread_identifier_info")
                     .field("thread_id", &self.thread_id)
                     .field("thread_handle", &self.thread_handle)
@@ -2467,8 +2465,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for thread_identifier_info {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for thread_identifier_info {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.thread_id.hash(state);
                 self.thread_handle.hash(state);
                 self.dispatch_qaddr.hash(state);
@@ -2504,8 +2502,8 @@ cfg_if! {
             }
         }
         impl Eq for if_data64 {}
-        impl crate::fmt::Debug for if_data64 {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for if_data64 {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let ifi_type = self.ifi_type;
                 let ifi_typelen = self.ifi_typelen;
                 let ifi_physical = self.ifi_physical;
@@ -2560,8 +2558,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for if_data64 {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for if_data64 {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let ifi_type = self.ifi_type;
                 let ifi_typelen = self.ifi_typelen;
                 let ifi_physical = self.ifi_physical;
@@ -2630,8 +2628,8 @@ cfg_if! {
             }
         }
         impl Eq for if_msghdr2 {}
-        impl crate::fmt::Debug for if_msghdr2 {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for if_msghdr2 {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let ifm_msglen = self.ifm_msglen;
                 let ifm_version = self.ifm_version;
                 let ifm_type = self.ifm_type;
@@ -2658,8 +2656,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for if_msghdr2 {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for if_msghdr2 {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let ifm_msglen = self.ifm_msglen;
                 let ifm_version = self.ifm_version;
                 let ifm_type = self.ifm_type;
@@ -2715,8 +2713,8 @@ cfg_if! {
             }
         }
         impl Eq for vm_statistics64 {}
-        impl crate::fmt::Debug for vm_statistics64 {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for vm_statistics64 {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let free_count = self.free_count;
                 let active_count = self.active_count;
                 let inactive_count = self.inactive_count;
@@ -2773,8 +2771,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for vm_statistics64 {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for vm_statistics64 {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let free_count = self.free_count;
                 let active_count = self.active_count;
                 let inactive_count = self.inactive_count;
@@ -2839,8 +2837,8 @@ cfg_if! {
             }
         }
         impl Eq for mach_task_basic_info {}
-        impl crate::fmt::Debug for mach_task_basic_info {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mach_task_basic_info {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let virtual_size = self.virtual_size;
                 let resident_size = self.resident_size;
                 let resident_size_max = self.resident_size_max;
@@ -2859,8 +2857,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for mach_task_basic_info {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mach_task_basic_info {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let virtual_size = self.virtual_size;
                 let resident_size = self.resident_size;
                 let resident_size_max = self.resident_size_max;
@@ -2886,8 +2884,8 @@ cfg_if! {
             }
         }
         impl Eq for log2phys {}
-        impl crate::fmt::Debug for log2phys {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for log2phys {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let l2p_flags = self.l2p_flags;
                 let l2p_contigbytes = self.l2p_contigbytes;
                 let l2p_devoffset = self.l2p_devoffset;
@@ -2898,8 +2896,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for log2phys {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for log2phys {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let l2p_flags = self.l2p_flags;
                 let l2p_contigbytes = self.l2p_contigbytes;
                 let l2p_devoffset = self.l2p_devoffset;
@@ -2916,16 +2914,16 @@ cfg_if! {
 
         impl Eq for os_unfair_lock {}
 
-        impl crate::fmt::Debug for os_unfair_lock {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for os_unfair_lock {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("os_unfair_lock")
                     .field("_os_unfair_lock_opaque", &self._os_unfair_lock_opaque)
                     .finish()
             }
         }
 
-        impl crate::hash::Hash for os_unfair_lock {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for os_unfair_lock {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self._os_unfair_lock_opaque.hash(state);
             }
         }
@@ -2942,8 +2940,8 @@ cfg_if! {
 
         impl Eq for sockaddr_vm {}
 
-        impl crate::fmt::Debug for sockaddr_vm {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_vm {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let svm_len = self.svm_len;
                 let svm_family = self.svm_family;
                 let svm_reserved1 = self.svm_reserved1;
@@ -2960,8 +2958,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for sockaddr_vm {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_vm {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let svm_len = self.svm_len;
                 let svm_family = self.svm_family;
                 let svm_reserved1 = self.svm_reserved1;
@@ -2986,8 +2984,8 @@ cfg_if! {
 
         impl Eq for ifdevmtu {}
 
-        impl crate::fmt::Debug for ifdevmtu {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ifdevmtu {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ifdevmtu")
                     .field("ifdm_current", &self.ifdm_current)
                     .field("ifdm_min", &self.ifdm_min)
@@ -2996,8 +2994,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for ifdevmtu {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ifdevmtu {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ifdm_current.hash(state);
                 self.ifdm_min.hash(state);
                 self.ifdm_max.hash(state);
@@ -3012,16 +3010,16 @@ cfg_if! {
 
         impl Eq for __c_anonymous_ifk_data {}
 
-        impl crate::fmt::Debug for __c_anonymous_ifk_data {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_ifk_data {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("__c_anonymous_ifk_data")
                     .field("ifk_ptr", unsafe { &self.ifk_ptr })
                     .field("ifk_value", unsafe { &self.ifk_value })
                     .finish()
             }
         }
-        impl crate::hash::Hash for __c_anonymous_ifk_data {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_ifk_data {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self.ifk_ptr.hash(state);
                     self.ifk_value.hash(state);
@@ -3037,8 +3035,8 @@ cfg_if! {
 
         impl Eq for ifkpi {}
 
-        impl crate::fmt::Debug for ifkpi {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ifkpi {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ifkpi")
                     .field("ifk_module_id", &self.ifk_module_id)
                     .field("ifk_type", &self.ifk_type)
@@ -3046,8 +3044,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for ifkpi {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ifkpi {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ifk_module_id.hash(state);
                 self.ifk_type.hash(state);
             }
@@ -3082,8 +3080,8 @@ cfg_if! {
 
         impl Eq for __c_anonymous_ifr_ifru {}
 
-        impl crate::fmt::Debug for __c_anonymous_ifr_ifru {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_ifr_ifru {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("__c_anonymous_ifr_ifru")
                     .field("ifru_addr", unsafe { &self.ifru_addr })
                     .field("ifru_dstaddr", unsafe { &self.ifru_dstaddr })
@@ -3107,8 +3105,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for __c_anonymous_ifr_ifru {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_ifr_ifru {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self.ifru_addr.hash(state);
                     self.ifru_dstaddr.hash(state);
@@ -3138,8 +3136,8 @@ cfg_if! {
 
         impl Eq for ifreq {}
 
-        impl crate::fmt::Debug for ifreq {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ifreq {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ifreq")
                     .field("ifr_name", &self.ifr_name)
                     .field("ifr_ifru", &self.ifr_ifru)
@@ -3147,21 +3145,21 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for ifreq {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ifreq {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ifr_name.hash(state);
                 self.ifr_ifru.hash(state);
             }
         }
 
-        impl crate::fmt::Debug for ifconf {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ifconf {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ifconf").finish_non_exhaustive()
             }
         }
 
-        impl crate::fmt::Debug for __c_anonymous_ifc_ifcu {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_ifc_ifcu {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ifc_ifcu").finish_non_exhaustive()
             }
         }
@@ -3187,8 +3185,8 @@ cfg_if! {
 
         impl Eq for __c_anonymous_ifr_ifru6 {}
 
-        impl crate::fmt::Debug for __c_anonymous_ifr_ifru6 {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_ifr_ifru6 {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("__c_anonymous_ifr_ifru6")
                     .field("ifru_addr", unsafe { &self.ifru_addr })
                     .field("ifru_dstaddr", unsafe { &self.ifru_dstaddr })
@@ -3202,8 +3200,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for __c_anonymous_ifr_ifru6 {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_ifr_ifru6 {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self.ifru_addr.hash(state);
                     self.ifru_dstaddr.hash(state);
@@ -3225,8 +3223,8 @@ cfg_if! {
 
         impl Eq for in6_ifreq {}
 
-        impl crate::fmt::Debug for in6_ifreq {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for in6_ifreq {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("in6_ifreq")
                     .field("ifr_name", &self.ifr_name)
                     .field("ifr_ifru", &self.ifr_ifru)
@@ -5506,51 +5504,48 @@ pub const VMADDR_CID_HOST: c_uint = 2;
 pub const VMADDR_PORT_ANY: c_uint = 0xFFFFFFFF;
 
 const fn __DARWIN_ALIGN32(p: usize) -> usize {
-    const __DARWIN_ALIGNBYTES32: usize = crate::mem::size_of::<u32>() - 1;
+    const __DARWIN_ALIGNBYTES32: usize = mem::size_of::<u32>() - 1;
     p + __DARWIN_ALIGNBYTES32 & !__DARWIN_ALIGNBYTES32
 }
 
 pub const THREAD_EXTENDED_POLICY_COUNT: mach_msg_type_number_t =
-    (crate::mem::size_of::<thread_extended_policy_data_t>() / crate::mem::size_of::<integer_t>())
+    (mem::size_of::<thread_extended_policy_data_t>() / mem::size_of::<integer_t>())
         as mach_msg_type_number_t;
 pub const THREAD_TIME_CONSTRAINT_POLICY_COUNT: mach_msg_type_number_t =
-    (crate::mem::size_of::<thread_time_constraint_policy_data_t>()
-        / crate::mem::size_of::<integer_t>()) as mach_msg_type_number_t;
+    (mem::size_of::<thread_time_constraint_policy_data_t>() / mem::size_of::<integer_t>())
+        as mach_msg_type_number_t;
 pub const THREAD_PRECEDENCE_POLICY_COUNT: mach_msg_type_number_t =
-    (crate::mem::size_of::<thread_precedence_policy_data_t>() / crate::mem::size_of::<integer_t>())
+    (mem::size_of::<thread_precedence_policy_data_t>() / mem::size_of::<integer_t>())
         as mach_msg_type_number_t;
 pub const THREAD_AFFINITY_POLICY_COUNT: mach_msg_type_number_t =
-    (crate::mem::size_of::<thread_affinity_policy_data_t>() / crate::mem::size_of::<integer_t>())
+    (mem::size_of::<thread_affinity_policy_data_t>() / mem::size_of::<integer_t>())
         as mach_msg_type_number_t;
 pub const THREAD_BACKGROUND_POLICY_COUNT: mach_msg_type_number_t =
-    (crate::mem::size_of::<thread_background_policy_data_t>() / crate::mem::size_of::<integer_t>())
+    (mem::size_of::<thread_background_policy_data_t>() / mem::size_of::<integer_t>())
         as mach_msg_type_number_t;
-pub const THREAD_LATENCY_QOS_POLICY_COUNT: mach_msg_type_number_t = (crate::mem::size_of::<
-    thread_latency_qos_policy_data_t,
->() / crate::mem::size_of::<
-    integer_t,
->()) as mach_msg_type_number_t;
+pub const THREAD_LATENCY_QOS_POLICY_COUNT: mach_msg_type_number_t =
+    (mem::size_of::<thread_latency_qos_policy_data_t>() / mem::size_of::<integer_t>())
+        as mach_msg_type_number_t;
 pub const THREAD_THROUGHPUT_QOS_POLICY_COUNT: mach_msg_type_number_t =
-    (crate::mem::size_of::<thread_throughput_qos_policy_data_t>()
-        / crate::mem::size_of::<integer_t>()) as mach_msg_type_number_t;
+    (mem::size_of::<thread_throughput_qos_policy_data_t>() / mem::size_of::<integer_t>())
+        as mach_msg_type_number_t;
 pub const THREAD_BASIC_INFO_COUNT: mach_msg_type_number_t =
-    (crate::mem::size_of::<thread_basic_info_data_t>() / crate::mem::size_of::<integer_t>())
+    (mem::size_of::<thread_basic_info_data_t>() / mem::size_of::<integer_t>())
         as mach_msg_type_number_t;
 pub const THREAD_IDENTIFIER_INFO_COUNT: mach_msg_type_number_t =
-    (crate::mem::size_of::<thread_identifier_info_data_t>() / crate::mem::size_of::<integer_t>())
+    (mem::size_of::<thread_identifier_info_data_t>() / mem::size_of::<integer_t>())
         as mach_msg_type_number_t;
 pub const THREAD_EXTENDED_INFO_COUNT: mach_msg_type_number_t =
-    (crate::mem::size_of::<thread_extended_info_data_t>() / crate::mem::size_of::<integer_t>())
+    (mem::size_of::<thread_extended_info_data_t>() / mem::size_of::<integer_t>())
         as mach_msg_type_number_t;
 
 pub const TASK_THREAD_TIMES_INFO_COUNT: u32 =
-    (crate::mem::size_of::<task_thread_times_info_data_t>() / crate::mem::size_of::<natural_t>())
-        as u32;
-pub const MACH_TASK_BASIC_INFO_COUNT: u32 = (crate::mem::size_of::<mach_task_basic_info_data_t>()
-    / crate::mem::size_of::<natural_t>()) as u32;
-pub const HOST_VM_INFO64_COUNT: mach_msg_type_number_t =
-    (crate::mem::size_of::<vm_statistics64_data_t>() / crate::mem::size_of::<integer_t>())
-        as mach_msg_type_number_t;
+    (mem::size_of::<task_thread_times_info_data_t>() / mem::size_of::<natural_t>()) as u32;
+pub const MACH_TASK_BASIC_INFO_COUNT: u32 =
+    (mem::size_of::<mach_task_basic_info_data_t>() / mem::size_of::<natural_t>()) as u32;
+pub const HOST_VM_INFO64_COUNT: mach_msg_type_number_t = (mem::size_of::<vm_statistics64_data_t>()
+    / mem::size_of::<integer_t>())
+    as mach_msg_type_number_t;
 
 // bsd/net/if_mib.h
 /// Non-interface-specific
@@ -5589,7 +5584,7 @@ f! {
         let cmsg_len = (*cmsg).cmsg_len as usize;
         let next = cmsg as usize + __DARWIN_ALIGN32(cmsg_len);
         let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
-        if next + __DARWIN_ALIGN32(crate::mem::size_of::<cmsghdr>()) > max {
+        if next + __DARWIN_ALIGN32(mem::size_of::<cmsghdr>()) > max {
             core::ptr::null_mut()
         } else {
             next as *mut cmsghdr
@@ -5597,16 +5592,15 @@ f! {
     }
 
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).add(__DARWIN_ALIGN32(crate::mem::size_of::<cmsghdr>()))
+        (cmsg as *mut c_uchar).add(__DARWIN_ALIGN32(mem::size_of::<cmsghdr>()))
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (__DARWIN_ALIGN32(crate::mem::size_of::<cmsghdr>()) + __DARWIN_ALIGN32(length as usize))
-            as c_uint
+        (__DARWIN_ALIGN32(mem::size_of::<cmsghdr>()) + __DARWIN_ALIGN32(length as usize)) as c_uint
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        (__DARWIN_ALIGN32(crate::mem::size_of::<cmsghdr>()) + length as usize) as c_uint
+        (__DARWIN_ALIGN32(mem::size_of::<cmsghdr>()) + length as usize) as c_uint
     }
 
     pub {const} fn VM_MAKE_TAG(id: u8) -> u32 {

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1,6 +1,5 @@
-use crate::{
-    c_int, c_short, c_uchar, c_uint, c_ushort, c_void, cmsghdr, intptr_t, off_t, size_t, ssize_t,
-};
+use crate::prelude::*;
+use crate::{cmsghdr, off_t};
 
 pub type dev_t = u32;
 pub type c_char = i8;
@@ -558,8 +557,8 @@ cfg_if! {
             }
         }
         impl Eq for utmpx {}
-        impl crate::fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utmpx {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utmpx")
                     .field("ut_name", &self.ut_name)
                     .field("ut_id", &self.ut_id)
@@ -576,8 +575,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for utmpx {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utmpx {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_name.hash(state);
                 self.ut_id.hash(state);
                 self.ut_line.hash(state);
@@ -601,8 +600,8 @@ cfg_if! {
             }
         }
         impl Eq for lastlogx {}
-        impl crate::fmt::Debug for lastlogx {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for lastlogx {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("lastlogx")
                     .field("ll_tv", &self.ll_tv)
                     .field("ll_line", &self.ll_line)
@@ -611,8 +610,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for lastlogx {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for lastlogx {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ll_tv.hash(state);
                 self.ll_line.hash(state);
                 self.ll_host.hash(state);
@@ -635,8 +634,8 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_fileno", &self.d_fileno)
                     .field("d_namlen", &self.d_namlen)
@@ -647,8 +646,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for dirent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_fileno.hash(state);
                 self.d_namlen.hash(state);
                 self.d_type.hash(state);
@@ -689,8 +688,8 @@ cfg_if! {
             }
         }
         impl Eq for statfs {}
-        impl crate::fmt::Debug for statfs {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for statfs {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("statfs")
                     .field("f_bsize", &self.f_bsize)
                     .field("f_iosize", &self.f_iosize)
@@ -712,8 +711,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for statfs {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for statfs {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_bsize.hash(state);
                 self.f_iosize.hash(state);
                 self.f_blocks.hash(state);
@@ -743,8 +742,8 @@ cfg_if! {
             }
         }
         impl Eq for sigevent {}
-        impl crate::fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sigevent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sigevent")
                     .field("sigev_notify", &self.sigev_notify)
                     .field("sigev_signo", &self.sigev_signo)
@@ -752,8 +751,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sigevent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sigevent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sigev_notify.hash(state);
                 self.sigev_signo.hash(state);
                 self.sigev_value.hash(state);
@@ -794,8 +793,8 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl crate::fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mcontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mcontext_t")
                     .field("mc_onstack", &self.mc_onstack)
                     .field("mc_rdi", &self.mc_rdi)
@@ -830,8 +829,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for mcontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mcontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mc_onstack.hash(state);
                 self.mc_rdi.hash(state);
                 self.mc_rsi.hash(state);
@@ -877,8 +876,8 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl crate::fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ucontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ucontext_t")
                     .field("uc_sigmask", &self.uc_sigmask)
                     .field("uc_mcontext", &self.uc_mcontext)
@@ -889,8 +888,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for ucontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ucontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_sigmask.hash(state);
                 self.uc_mcontext.hash(state);
                 self.uc_link.hash(state);
@@ -1069,7 +1068,7 @@ pub const CPUCTL_MSRSBIT: c_int = 0xc0106305;
 pub const CPUCTL_MSRCBIT: c_int = 0xc0106306;
 pub const CPUCTL_CPUID_COUNT: c_int = 0xc0106307;
 
-pub const CPU_SETSIZE: size_t = crate::mem::size_of::<crate::cpumask_t>() * 8;
+pub const CPU_SETSIZE: size_t = mem::size_of::<crate::cpumask_t>() * 8;
 
 pub const EVFILT_READ: i16 = -1;
 pub const EVFILT_WRITE: i16 = -2;
@@ -1541,23 +1540,23 @@ pub const RTAX_MAX: c_int = 11;
 
 const_fn! {
     {const} fn _CMSG_ALIGN(n: usize) -> usize {
-        (n + (crate::mem::size_of::<c_long>() - 1)) & !(crate::mem::size_of::<c_long>() - 1)
+        (n + (mem::size_of::<c_long>() - 1)) & !(mem::size_of::<c_long>() - 1)
     }
 }
 
 f! {
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(_CMSG_ALIGN(crate::mem::size_of::<cmsghdr>()) as isize)
+        (cmsg as *mut c_uchar).offset(_CMSG_ALIGN(mem::size_of::<cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        (_CMSG_ALIGN(crate::mem::size_of::<cmsghdr>()) + length as usize) as c_uint
+        (_CMSG_ALIGN(mem::size_of::<cmsghdr>()) + length as usize) as c_uint
     }
 
     pub fn CMSG_NXTHDR(mhdr: *const crate::msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         let next = cmsg as usize
             + _CMSG_ALIGN((*cmsg).cmsg_len as usize)
-            + _CMSG_ALIGN(crate::mem::size_of::<cmsghdr>());
+            + _CMSG_ALIGN(mem::size_of::<cmsghdr>());
         let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next <= max {
             (cmsg as usize + _CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr
@@ -1567,7 +1566,7 @@ f! {
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (_CMSG_ALIGN(crate::mem::size_of::<cmsghdr>()) + _CMSG_ALIGN(length as usize)) as c_uint
+        (_CMSG_ALIGN(mem::size_of::<cmsghdr>()) + _CMSG_ALIGN(length as usize)) as c_uint
     }
 
     pub fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {

--- a/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_longlong, size_t};
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type c_long = i64;
@@ -36,7 +36,7 @@ s_no_extra_traits! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_longlong>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_longlong>() - 1;
 
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
@@ -51,8 +51,8 @@ cfg_if! {
             }
         }
         impl Eq for gpregs {}
-        impl crate::fmt::Debug for gpregs {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for gpregs {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("gpregs")
                     .field("gp_x", &self.gp_x)
                     .field("gp_lr", &self.gp_lr)
@@ -63,8 +63,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for gpregs {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for gpregs {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.gp_x.hash(state);
                 self.gp_lr.hash(state);
                 self.gp_sp.hash(state);
@@ -83,8 +83,8 @@ cfg_if! {
             }
         }
         impl Eq for fpregs {}
-        impl crate::fmt::Debug for fpregs {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for fpregs {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("fpregs")
                     .field("fp_q", &self.fp_q)
                     .field("fp_sr", &self.fp_sr)
@@ -94,8 +94,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for fpregs {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for fpregs {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.fp_q.hash(state);
                 self.fp_sr.hash(state);
                 self.fp_cr.hash(state);
@@ -117,8 +117,8 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl crate::fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mcontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mcontext_t")
                     .field("mc_gpregs", &self.mc_gpregs)
                     .field("mc_fpregs", &self.mc_fpregs)
@@ -128,8 +128,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for mcontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mcontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mc_gpregs.hash(state);
                 self.mc_fpregs.hash(state);
                 self.mc_flags.hash(state);

--- a/src/unix/bsd/freebsdlike/freebsd/arm.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/arm.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_uint, c_void, size_t};
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type c_long = i32;
@@ -35,8 +35,8 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl crate::fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mcontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mcontext_t")
                     .field("__gregs", &self.__gregs)
                     .field("mc_vfp_size", &self.mc_vfp_size)
@@ -45,8 +45,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for mcontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mcontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__gregs.hash(state);
                 self.mc_vfp_size.hash(state);
                 self.mc_vfp_ptr.hash(state);
@@ -56,7 +56,7 @@ cfg_if! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_int>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_int>() - 1;
 
 pub const BIOCSRTIMEOUT: c_ulong = 0x8010426d;
 pub const BIOCGRTIMEOUT: c_ulong = 0x4010426e;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/b32.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/b32.rs
@@ -1,4 +1,5 @@
-use crate::{c_long, off_t};
+use crate::off_t;
+use crate::prelude::*;
 
 #[repr(C)]
 #[cfg_attr(feature = "extra_traits", derive(Debug, Eq, Hash, PartialEq))]

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/b64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/b64.rs
@@ -1,4 +1,5 @@
-use crate::{c_long, off_t};
+use crate::off_t;
+use crate::prelude::*;
 
 #[repr(C)]
 #[cfg_attr(feature = "extra_traits", derive(Debug, Eq, Hash, PartialEq))]

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ushort, c_void, intptr_t, size_t};
+use crate::prelude::*;
 
 // APIs that were changed after FreeBSD 11
 
@@ -297,8 +297,8 @@ cfg_if! {
             }
         }
         impl Eq for statfs {}
-        impl crate::fmt::Debug for statfs {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for statfs {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("statfs")
                     .field("f_bsize", &self.f_bsize)
                     .field("f_iosize", &self.f_iosize)
@@ -320,8 +320,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for statfs {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for statfs {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_version.hash(state);
                 self.f_type.hash(state);
                 self.f_flags.hash(state);
@@ -358,8 +358,8 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_fileno", &self.d_fileno)
                     .field("d_reclen", &self.d_reclen)
@@ -369,8 +369,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for dirent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_fileno.hash(state);
                 self.d_reclen.hash(state);
                 self.d_type.hash(state);
@@ -395,8 +395,8 @@ cfg_if! {
             }
         }
         impl Eq for vnstat {}
-        impl crate::fmt::Debug for vnstat {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for vnstat {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let self_vn_devname: &[c_char] = &self.vn_devname;
 
                 f.debug_struct("vnstat")
@@ -411,8 +411,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for vnstat {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for vnstat {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let self_vn_devname: &[c_char] = &self.vn_devname;
 
                 self.vn_fileid.hash(state);

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -1,7 +1,5 @@
-use crate::{
-    c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_ushort, c_void, off_t, size_t,
-    ssize_t,
-};
+use crate::off_t;
+use crate::prelude::*;
 
 // APIs in FreeBSD 12 that have changed since 11.
 
@@ -343,8 +341,8 @@ cfg_if! {
             }
         }
         impl Eq for statfs {}
-        impl crate::fmt::Debug for statfs {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for statfs {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("statfs")
                     .field("f_bsize", &self.f_bsize)
                     .field("f_iosize", &self.f_iosize)
@@ -366,8 +364,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for statfs {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for statfs {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_version.hash(state);
                 self.f_type.hash(state);
                 self.f_flags.hash(state);
@@ -406,8 +404,8 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_fileno", &self.d_fileno)
                     .field("d_off", &self.d_off)
@@ -418,8 +416,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for dirent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_fileno.hash(state);
                 self.d_off.hash(state);
                 self.d_reclen.hash(state);
@@ -445,8 +443,8 @@ cfg_if! {
             }
         }
         impl Eq for vnstat {}
-        impl crate::fmt::Debug for vnstat {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for vnstat {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let self_vn_devname: &[c_char] = &self.vn_devname;
 
                 f.debug_struct("vnstat")
@@ -461,8 +459,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for vnstat {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for vnstat {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let self_vn_devname: &[c_char] = &self.vn_devname;
 
                 self.vn_fileid.hash(state);

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/x86_64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/x86_64.rs
@@ -1,4 +1,4 @@
-use crate::c_int;
+use crate::prelude::*;
 
 pub const PROC_KPTI_CTL: c_int = crate::PROC_PROCCTL_MD_MIN;
 pub const PROC_KPTI_CTL_ENABLE_ON_EXEC: c_int = 1;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -1,7 +1,5 @@
-use crate::{
-    c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_ushort, c_void, off_t, size_t,
-    ssize_t,
-};
+use crate::off_t;
+use crate::prelude::*;
 
 // APIs in FreeBSD 13 that have changed since 11.
 
@@ -356,8 +354,8 @@ cfg_if! {
             }
         }
         impl Eq for statfs {}
-        impl crate::fmt::Debug for statfs {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for statfs {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("statfs")
                     .field("f_bsize", &self.f_bsize)
                     .field("f_iosize", &self.f_iosize)
@@ -379,8 +377,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for statfs {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for statfs {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_version.hash(state);
                 self.f_type.hash(state);
                 self.f_flags.hash(state);
@@ -419,8 +417,8 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_fileno", &self.d_fileno)
                     .field("d_off", &self.d_off)
@@ -431,8 +429,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for dirent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_fileno.hash(state);
                 self.d_off.hash(state);
                 self.d_reclen.hash(state);
@@ -458,8 +456,8 @@ cfg_if! {
             }
         }
         impl Eq for vnstat {}
-        impl crate::fmt::Debug for vnstat {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for vnstat {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let self_vn_devname: &[c_char] = &self.vn_devname;
 
                 f.debug_struct("vnstat")
@@ -474,8 +472,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for vnstat {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for vnstat {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let self_vn_devname: &[c_char] = &self.vn_devname;
 
                 self.vn_fileid.hash(state);

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/x86_64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/x86_64.rs
@@ -1,4 +1,4 @@
-use crate::c_int;
+use crate::prelude::*;
 
 pub const PROC_KPTI_CTL: c_int = crate::PROC_PROCCTL_MD_MIN;
 pub const PROC_KPTI_CTL_ENABLE_ON_EXEC: c_int = 1;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -1,7 +1,5 @@
-use crate::{
-    c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_ushort, c_void, off_t, size_t,
-    ssize_t,
-};
+use crate::off_t;
+use crate::prelude::*;
 
 // APIs in FreeBSD 14 that have changed since 11.
 
@@ -356,8 +354,8 @@ cfg_if! {
             }
         }
         impl Eq for statfs {}
-        impl crate::fmt::Debug for statfs {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for statfs {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("statfs")
                     .field("f_bsize", &self.f_bsize)
                     .field("f_iosize", &self.f_iosize)
@@ -379,8 +377,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for statfs {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for statfs {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_version.hash(state);
                 self.f_type.hash(state);
                 self.f_flags.hash(state);
@@ -419,8 +417,8 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_fileno", &self.d_fileno)
                     .field("d_off", &self.d_off)
@@ -431,8 +429,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for dirent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_fileno.hash(state);
                 self.d_off.hash(state);
                 self.d_reclen.hash(state);
@@ -458,8 +456,8 @@ cfg_if! {
             }
         }
         impl Eq for vnstat {}
-        impl crate::fmt::Debug for vnstat {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for vnstat {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let self_vn_devname: &[c_char] = &self.vn_devname;
 
                 f.debug_struct("vnstat")
@@ -474,8 +472,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for vnstat {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for vnstat {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let self_vn_devname: &[c_char] = &self.vn_devname;
 
                 self.vn_fileid.hash(state);

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/x86_64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/x86_64.rs
@@ -1,4 +1,4 @@
-use crate::c_int;
+use crate::prelude::*;
 
 pub const PROC_KPTI_CTL: c_int = crate::PROC_PROCCTL_MD_MIN;
 pub const PROC_KPTI_CTL_ENABLE_ON_EXEC: c_int = 1;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
@@ -1,7 +1,5 @@
-use crate::{
-    c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_ushort, c_void, off_t, size_t,
-    ssize_t,
-};
+use crate::off_t;
+use crate::prelude::*;
 
 // APIs in FreeBSD 15 that have changed since 11.
 
@@ -356,8 +354,8 @@ cfg_if! {
             }
         }
         impl Eq for statfs {}
-        impl crate::fmt::Debug for statfs {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for statfs {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("statfs")
                     .field("f_bsize", &self.f_bsize)
                     .field("f_iosize", &self.f_iosize)
@@ -379,8 +377,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for statfs {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for statfs {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_version.hash(state);
                 self.f_type.hash(state);
                 self.f_flags.hash(state);
@@ -419,8 +417,8 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_fileno", &self.d_fileno)
                     .field("d_off", &self.d_off)
@@ -431,8 +429,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for dirent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_fileno.hash(state);
                 self.d_off.hash(state);
                 self.d_reclen.hash(state);
@@ -458,8 +456,8 @@ cfg_if! {
             }
         }
         impl Eq for vnstat {}
-        impl crate::fmt::Debug for vnstat {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for vnstat {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let self_vn_devname: &[c_char] = &self.vn_devname;
 
                 f.debug_struct("vnstat")
@@ -474,8 +472,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for vnstat {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for vnstat {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let self_vn_devname: &[c_char] = &self.vn_devname;
 
                 self.vn_fileid.hash(state);

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd15/x86_64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd15/x86_64.rs
@@ -1,4 +1,4 @@
-use crate::c_int;
+use crate::prelude::*;
 
 pub const PROC_KPTI_CTL: c_int = crate::PROC_PROCCTL_MD_MIN;
 pub const PROC_KPTI_CTL_ENABLE_ON_EXEC: c_int = 1;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1,6 +1,5 @@
-use crate::{
-    c_int, c_longlong, c_short, c_uchar, c_uint, c_ushort, c_void, cmsghdr, off_t, size_t, ssize_t,
-};
+use crate::prelude::*;
+use crate::{cmsghdr, off_t};
 
 pub type fflags_t = u32;
 
@@ -1689,8 +1688,8 @@ cfg_if! {
             }
         }
         impl Eq for utmpx {}
-        impl crate::fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utmpx {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utmpx")
                     .field("ut_type", &self.ut_type)
                     .field("ut_tv", &self.ut_tv)
@@ -1703,8 +1702,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for utmpx {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utmpx {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_type.hash(state);
                 self.ut_tv.hash(state);
                 self.ut_id.hash(state);
@@ -1722,15 +1721,15 @@ cfg_if! {
             }
         }
         impl Eq for __c_anonymous_cr_pid {}
-        impl crate::fmt::Debug for __c_anonymous_cr_pid {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_cr_pid {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("cr_pid")
                     .field("cr_pid", unsafe { &self.cr_pid })
                     .finish()
             }
         }
-        impl crate::hash::Hash for __c_anonymous_cr_pid {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_cr_pid {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe { self.cr_pid.hash(state) };
             }
         }
@@ -1745,8 +1744,8 @@ cfg_if! {
             }
         }
         impl Eq for xucred {}
-        impl crate::fmt::Debug for xucred {
-            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
+        impl fmt::Debug for xucred {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_struct("xucred")
                     .field("cr_version", &self.cr_version)
                     .field("cr_uid", &self.cr_uid)
@@ -1756,8 +1755,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for xucred {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for xucred {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cr_version.hash(state);
                 self.cr_uid.hash(state);
                 self.cr_ngroups.hash(state);
@@ -1783,8 +1782,8 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_dl {}
-        impl crate::fmt::Debug for sockaddr_dl {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_dl {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_dl")
                     .field("sdl_len", &self.sdl_len)
                     .field("sdl_family", &self.sdl_family)
@@ -1797,8 +1796,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sockaddr_dl {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_dl {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sdl_len.hash(state);
                 self.sdl_family.hash(state);
                 self.sdl_index.hash(state);
@@ -1819,8 +1818,8 @@ cfg_if! {
             }
         }
         impl Eq for mq_attr {}
-        impl crate::fmt::Debug for mq_attr {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mq_attr {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mq_attr")
                     .field("mq_flags", &self.mq_flags)
                     .field("mq_maxmsg", &self.mq_maxmsg)
@@ -1829,8 +1828,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for mq_attr {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mq_attr {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mq_flags.hash(state);
                 self.mq_maxmsg.hash(state);
                 self.mq_msgsize.hash(state);
@@ -1838,8 +1837,8 @@ cfg_if! {
             }
         }
 
-        impl crate::fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sigevent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sigevent")
                     .field("sigev_notify", &self.sigev_notify)
                     .field("sigev_signo", &self.sigev_signo)
@@ -1859,8 +1858,8 @@ cfg_if! {
             }
         }
         impl Eq for ptsstat {}
-        impl crate::fmt::Debug for ptsstat {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ptsstat {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let self_devname: &[c_char] = &self.devname;
 
                 f.debug_struct("ptsstat")
@@ -1869,8 +1868,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for ptsstat {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ptsstat {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let self_devname: &[c_char] = &self.devname;
 
                 self.dev.hash(state);
@@ -1884,8 +1883,8 @@ cfg_if! {
             }
         }
         impl Eq for __c_anonymous_elf32_auxv_union {}
-        impl crate::fmt::Debug for __c_anonymous_elf32_auxv_union {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_elf32_auxv_union {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("a_val")
                     .field("a_val", unsafe { &self.a_val })
                     .finish()
@@ -1897,8 +1896,8 @@ cfg_if! {
             }
         }
         impl Eq for Elf32_Auxinfo {}
-        impl crate::fmt::Debug for Elf32_Auxinfo {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for Elf32_Auxinfo {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("Elf32_Auxinfo")
                     .field("a_type", &self.a_type)
                     .field("a_un", &self.a_un)
@@ -1928,8 +1927,8 @@ cfg_if! {
             }
         }
         impl Eq for __c_anonymous_ifr_ifru {}
-        impl crate::fmt::Debug for __c_anonymous_ifr_ifru {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_ifr_ifru {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ifr_ifru")
                     .field("ifru_addr", unsafe { &self.ifru_addr })
                     .field("ifru_dstaddr", unsafe { &self.ifru_dstaddr })
@@ -1949,8 +1948,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for __c_anonymous_ifr_ifru {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_ifr_ifru {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe { self.ifru_addr.hash(state) };
                 unsafe { self.ifru_dstaddr.hash(state) };
                 unsafe { self.ifru_broadaddr.hash(state) };
@@ -1975,16 +1974,16 @@ cfg_if! {
             }
         }
         impl Eq for ifreq {}
-        impl crate::fmt::Debug for ifreq {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ifreq {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ifreq")
                     .field("ifr_name", &self.ifr_name)
                     .field("ifr_ifru", &self.ifr_ifru)
                     .finish()
             }
         }
-        impl crate::hash::Hash for ifreq {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ifreq {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ifr_name.hash(state);
                 self.ifr_ifru.hash(state);
             }
@@ -1998,8 +1997,8 @@ cfg_if! {
             }
         }
 
-        impl crate::fmt::Debug for __c_anonymous_ifc_ifcu {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_ifc_ifcu {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ifc_ifcu")
                     .field("ifcu_buf", unsafe { &self.ifcu_buf })
                     .field("ifcu_req", unsafe { &self.ifcu_req })
@@ -2007,8 +2006,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for __c_anonymous_ifc_ifcu {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_ifc_ifcu {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe { self.ifcu_buf.hash(state) };
                 unsafe { self.ifcu_req.hash(state) };
             }
@@ -2023,8 +2022,8 @@ cfg_if! {
             }
         }
         impl Eq for ifstat {}
-        impl crate::fmt::Debug for ifstat {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ifstat {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let ascii: &[c_char] = &self.ascii;
 
                 f.debug_struct("ifstat")
@@ -2033,8 +2032,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for ifstat {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ifstat {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ifs_name.hash(state);
                 self.ascii.hash(state);
             }
@@ -2053,8 +2052,8 @@ cfg_if! {
             }
         }
         impl Eq for ifrsskey {}
-        impl crate::fmt::Debug for ifrsskey {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ifrsskey {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let ifrk_key: &[u8] = &self.ifrk_key;
 
                 f.debug_struct("ifrsskey")
@@ -2066,8 +2065,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for ifrsskey {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ifrsskey {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ifrk_name.hash(state);
                 self.ifrk_func.hash(state);
                 self.ifrk_spare0.hash(state);
@@ -2088,8 +2087,8 @@ cfg_if! {
             }
         }
         impl Eq for ifdownreason {}
-        impl crate::fmt::Debug for ifdownreason {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ifdownreason {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let ifdr_msg: &[c_char] = &self.ifdr_msg;
 
                 f.debug_struct("ifdownreason")
@@ -2100,8 +2099,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for ifdownreason {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ifdownreason {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ifdr_name.hash(state);
                 self.ifdr_reason.hash(state);
                 self.ifdr_vendor.hash(state);
@@ -2115,16 +2114,16 @@ cfg_if! {
             }
         }
         impl Eq for __c_anonymous_ifi_epoch {}
-        impl crate::fmt::Debug for __c_anonymous_ifi_epoch {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_ifi_epoch {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("__c_anonymous_ifi_epoch")
                     .field("tt", unsafe { &self.tt })
                     .field("ph", unsafe { &self.ph })
                     .finish()
             }
         }
-        impl crate::hash::Hash for __c_anonymous_ifi_epoch {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_ifi_epoch {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self.tt.hash(state);
                     self.ph.hash(state);
@@ -2138,16 +2137,16 @@ cfg_if! {
             }
         }
         impl Eq for __c_anonymous_ifi_lastchange {}
-        impl crate::fmt::Debug for __c_anonymous_ifi_lastchange {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_ifi_lastchange {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("__c_anonymous_ifi_lastchange")
                     .field("tv", unsafe { &self.tv })
                     .field("ph", unsafe { &self.ph })
                     .finish()
             }
         }
-        impl crate::hash::Hash for __c_anonymous_ifi_lastchange {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_ifi_lastchange {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self.tv.hash(state);
                     self.ph.hash(state);
@@ -2185,8 +2184,8 @@ cfg_if! {
             }
         }
         impl Eq for if_data {}
-        impl crate::fmt::Debug for if_data {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for if_data {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("if_data")
                     .field("ifi_type", &self.ifi_type)
                     .field("ifi_physical", &self.ifi_physical)
@@ -2216,8 +2215,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for if_data {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for if_data {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ifi_type.hash(state);
                 self.ifi_physical.hash(state);
                 self.ifi_addrlen.hash(state);
@@ -2255,8 +2254,8 @@ cfg_if! {
             }
         }
         impl Eq for sctphdr {}
-        impl crate::fmt::Debug for sctphdr {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sctphdr {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sctphdr")
                     .field("src_port", &{ self.src_port })
                     .field("dest_port", &{ self.dest_port })
@@ -2265,8 +2264,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sctphdr {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sctphdr {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.src_port }.hash(state);
                 { self.dest_port }.hash(state);
                 { self.v_tag }.hash(state);
@@ -2282,8 +2281,8 @@ cfg_if! {
             }
         }
         impl Eq for sctp_chunkhdr {}
-        impl crate::fmt::Debug for sctp_chunkhdr {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sctp_chunkhdr {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sctp_chunkhdr")
                     .field("chunk_type", &{ self.chunk_type })
                     .field("chunk_flags", &{ self.chunk_flags })
@@ -2291,8 +2290,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sctp_chunkhdr {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sctp_chunkhdr {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.chunk_type }.hash(state);
                 { self.chunk_flags }.hash(state);
                 { self.chunk_length }.hash(state);
@@ -2307,16 +2306,16 @@ cfg_if! {
             }
         }
         impl Eq for sctp_paramhdr {}
-        impl crate::fmt::Debug for sctp_paramhdr {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sctp_paramhdr {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sctp_paramhdr")
                     .field("param_type", &{ self.param_type })
                     .field("param_length", &{ self.param_length })
                     .finish()
             }
         }
-        impl crate::hash::Hash for sctp_paramhdr {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sctp_paramhdr {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.param_type }.hash(state);
                 { self.param_length }.hash(state);
             }
@@ -2333,8 +2332,8 @@ cfg_if! {
             }
         }
         impl Eq for sctp_gen_error_cause {}
-        impl crate::fmt::Debug for sctp_gen_error_cause {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sctp_gen_error_cause {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sctp_gen_error_cause")
                     .field("code", &{ self.code })
                     .field("length", &{ self.length })
@@ -2342,8 +2341,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sctp_gen_error_cause {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sctp_gen_error_cause {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.code }.hash(state);
                 { self.length }.hash(state);
                 { self.info }.hash(state);
@@ -2356,16 +2355,16 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_cause {}
-        impl crate::fmt::Debug for sctp_error_cause {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sctp_error_cause {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sctp_error_cause")
                     .field("code", &{ self.code })
                     .field("length", &{ self.length })
                     .finish()
             }
         }
-        impl crate::hash::Hash for sctp_error_cause {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sctp_error_cause {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.code }.hash(state);
                 { self.length }.hash(state);
             }
@@ -2379,16 +2378,16 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_invalid_stream {}
-        impl crate::fmt::Debug for sctp_error_invalid_stream {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sctp_error_invalid_stream {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sctp_error_invalid_stream")
                     .field("cause", &{ self.cause })
                     .field("stream_id", &{ self.stream_id })
                     .finish()
             }
         }
-        impl crate::hash::Hash for sctp_error_invalid_stream {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sctp_error_invalid_stream {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.cause }.hash(state);
                 { self.stream_id }.hash(state);
             }
@@ -2405,8 +2404,8 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_missing_param {}
-        impl crate::fmt::Debug for sctp_error_missing_param {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sctp_error_missing_param {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sctp_error_missing_param")
                     .field("cause", &{ self.cause })
                     .field("num_missing_params", &{ self.num_missing_params })
@@ -2414,8 +2413,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sctp_error_missing_param {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sctp_error_missing_param {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.cause }.hash(state);
                 { self.num_missing_params }.hash(state);
                 { self.tpe }.hash(state);
@@ -2430,16 +2429,16 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_stale_cookie {}
-        impl crate::fmt::Debug for sctp_error_stale_cookie {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sctp_error_stale_cookie {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sctp_error_stale_cookie")
                     .field("cause", &{ self.cause })
                     .field("stale_time", &{ self.stale_time })
                     .finish()
             }
         }
-        impl crate::hash::Hash for sctp_error_stale_cookie {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sctp_error_stale_cookie {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.cause }.hash(state);
                 { self.stale_time }.hash(state);
             }
@@ -2451,15 +2450,15 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_out_of_resource {}
-        impl crate::fmt::Debug for sctp_error_out_of_resource {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sctp_error_out_of_resource {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sctp_error_out_of_resource")
                     .field("cause", &{ self.cause })
                     .finish()
             }
         }
-        impl crate::hash::Hash for sctp_error_out_of_resource {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sctp_error_out_of_resource {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.cause }.hash(state);
             }
         }
@@ -2470,15 +2469,15 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_unresolv_addr {}
-        impl crate::fmt::Debug for sctp_error_unresolv_addr {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sctp_error_unresolv_addr {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sctp_error_unresolv_addr")
                     .field("cause", &{ self.cause })
                     .finish()
             }
         }
-        impl crate::hash::Hash for sctp_error_unresolv_addr {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sctp_error_unresolv_addr {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.cause }.hash(state);
             }
         }
@@ -2489,16 +2488,16 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_unrecognized_chunk {}
-        impl crate::fmt::Debug for sctp_error_unrecognized_chunk {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sctp_error_unrecognized_chunk {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sctp_error_unrecognized_chunk")
                     .field("cause", &{ self.cause })
                     .field("ch", &{ self.ch })
                     .finish()
             }
         }
-        impl crate::hash::Hash for sctp_error_unrecognized_chunk {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sctp_error_unrecognized_chunk {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.cause }.hash(state);
                 { self.ch }.hash(state);
             }
@@ -2510,16 +2509,16 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_no_user_data {}
-        impl crate::fmt::Debug for sctp_error_no_user_data {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sctp_error_no_user_data {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sctp_error_no_user_data")
                     .field("cause", &{ self.cause })
                     .field("tsn", &{ self.tsn })
                     .finish()
             }
         }
-        impl crate::hash::Hash for sctp_error_no_user_data {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sctp_error_no_user_data {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.cause }.hash(state);
                 { self.tsn }.hash(state);
             }
@@ -2531,16 +2530,16 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_auth_invalid_hmac {}
-        impl crate::fmt::Debug for sctp_error_auth_invalid_hmac {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sctp_error_auth_invalid_hmac {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sctp_error_invalid_hmac")
                     .field("cause", &{ self.cause })
                     .field("hmac_id", &{ self.hmac_id })
                     .finish()
             }
         }
-        impl crate::hash::Hash for sctp_error_auth_invalid_hmac {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sctp_error_auth_invalid_hmac {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.cause }.hash(state);
                 { self.hmac_id }.hash(state);
             }
@@ -2564,8 +2563,8 @@ cfg_if! {
             }
         }
         impl Eq for kinfo_file {}
-        impl crate::fmt::Debug for kinfo_file {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for kinfo_file {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("kinfo_file")
                     .field("kf_structsize", &self.kf_structsize)
                     .field("kf_type", &self.kf_type)
@@ -2579,8 +2578,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for kinfo_file {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for kinfo_file {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.kf_structsize.hash(state);
                 self.kf_type.hash(state);
                 self.kf_fd.hash(state);
@@ -2593,8 +2592,8 @@ cfg_if! {
             }
         }
 
-        impl crate::fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ucontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ucontext_t")
                     .field("uc_sigmask", &self.uc_sigmask)
                     .field("uc_mcontext", &self.uc_mcontext)
@@ -4901,20 +4900,19 @@ const_fn! {
 
 f! {
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(_ALIGN(crate::mem::size_of::<cmsghdr>()) as isize)
+        (cmsg as *mut c_uchar).offset(_ALIGN(mem::size_of::<cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        _ALIGN(crate::mem::size_of::<cmsghdr>()) as c_uint + length
+        _ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub fn CMSG_NXTHDR(mhdr: *const crate::msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         if cmsg.is_null() {
             return crate::CMSG_FIRSTHDR(mhdr);
         };
-        let next = cmsg as usize
-            + _ALIGN((*cmsg).cmsg_len as usize)
-            + _ALIGN(crate::mem::size_of::<cmsghdr>());
+        let next =
+            cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize) + _ALIGN(mem::size_of::<cmsghdr>());
         let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next > max {
             0 as *mut cmsghdr
@@ -4924,7 +4922,7 @@ f! {
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (_ALIGN(crate::mem::size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
+        (_ALIGN(mem::size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
     }
 
     pub fn MALLOCX_ALIGN(lg: c_uint) -> c_int {
@@ -4941,7 +4939,7 @@ f! {
 
     pub fn SOCKCREDSIZE(ngrps: usize) -> usize {
         let ngrps = if ngrps > 0 { ngrps - 1 } else { 0 };
-        crate::mem::size_of::<sockcred>() + crate::mem::size_of::<crate::gid_t>() * ngrps
+        mem::size_of::<sockcred>() + mem::size_of::<crate::gid_t>() * ngrps
     }
 
     pub fn uname(buf: *mut crate::utsname) -> c_int {
@@ -4961,29 +4959,29 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpuset_t) -> () {
-        let bitset_bits = 8 * crate::mem::size_of::<c_long>();
+        let bitset_bits = 8 * mem::size_of::<c_long>();
         let (idx, offset) = (cpu / bitset_bits, cpu % bitset_bits);
         cpuset.__bits[idx] |= 1 << offset;
         ()
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpuset_t) -> () {
-        let bitset_bits = 8 * crate::mem::size_of::<c_long>();
+        let bitset_bits = 8 * mem::size_of::<c_long>();
         let (idx, offset) = (cpu / bitset_bits, cpu % bitset_bits);
         cpuset.__bits[idx] &= !(1 << offset);
         ()
     }
 
     pub fn CPU_ISSET(cpu: usize, cpuset: &cpuset_t) -> bool {
-        let bitset_bits = 8 * crate::mem::size_of::<c_long>();
+        let bitset_bits = 8 * mem::size_of::<c_long>();
         let (idx, offset) = (cpu / bitset_bits, cpu % bitset_bits);
         0 != cpuset.__bits[idx] & (1 << offset)
     }
 
     pub fn CPU_COUNT(cpuset: &cpuset_t) -> c_int {
         let mut s: u32 = 0;
-        let cpuset_size = crate::mem::size_of::<cpuset_t>();
-        let bitset_size = crate::mem::size_of::<c_long>();
+        let cpuset_size = mem::size_of::<cpuset_t>();
+        let bitset_size = mem::size_of::<c_long>();
 
         for i in cpuset.__bits[..(cpuset_size / bitset_size)].iter() {
             s += i.count_ones();
@@ -4993,7 +4991,7 @@ f! {
 
     pub fn SOCKCRED2SIZE(ngrps: usize) -> usize {
         let ngrps = if ngrps > 0 { ngrps - 1 } else { 0 };
-        crate::mem::size_of::<sockcred2>() + crate::mem::size_of::<crate::gid_t>() * ngrps
+        mem::size_of::<sockcred2>() + mem::size_of::<crate::gid_t>() * ngrps
     }
 
     pub fn PROT_MAX(x: c_int) -> c_int {

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, size_t};
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type c_long = i32;
@@ -40,8 +40,8 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl crate::fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mcontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mcontext_t")
                     .field("mc_vers", &self.mc_vers)
                     .field("mc_flags", &self.mc_flags)
@@ -55,8 +55,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for mcontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mcontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mc_vers.hash(state);
                 self.mc_flags.hash(state);
                 self.mc_onstack.hash(state);
@@ -71,7 +71,7 @@ cfg_if! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_int>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_int>() - 1;
 
 pub const BIOCSRTIMEOUT: c_ulong = 0x8010426d;
 pub const BIOCGRTIMEOUT: c_ulong = 0x4010426e;

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, size_t};
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type c_long = i64;
@@ -40,8 +40,8 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl crate::fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mcontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mcontext_t")
                     .field("mc_vers", &self.mc_vers)
                     .field("mc_flags", &self.mc_flags)
@@ -55,8 +55,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for mcontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mcontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mc_vers.hash(state);
                 self.mc_flags.hash(state);
                 self.mc_onstack.hash(state);
@@ -71,7 +71,7 @@ cfg_if! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
 
 pub const BIOCSRTIMEOUT: c_ulong = 0x8010426d;
 pub const BIOCGRTIMEOUT: c_ulong = 0x4010426e;

--- a/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_longlong, size_t};
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type c_long = i64;
@@ -54,8 +54,8 @@ cfg_if! {
             }
         }
         impl Eq for gpregs {}
-        impl crate::fmt::Debug for gpregs {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for gpregs {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("gpregs")
                     .field("gp_ra", &self.gp_ra)
                     .field("gp_sp", &self.gp_sp)
@@ -69,8 +69,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for gpregs {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for gpregs {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.gp_ra.hash(state);
                 self.gp_sp.hash(state);
                 self.gp_gp.hash(state);
@@ -91,8 +91,8 @@ cfg_if! {
             }
         }
         impl Eq for fpregs {}
-        impl crate::fmt::Debug for fpregs {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for fpregs {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("fpregs")
                     .field("fp_x", &self.fp_x)
                     .field("fp_fcsr", &self.fp_fcsr)
@@ -101,8 +101,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for fpregs {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for fpregs {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.fp_x.hash(state);
                 self.fp_fcsr.hash(state);
                 self.fp_flags.hash(state);
@@ -123,8 +123,8 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl crate::fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mcontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mcontext_t")
                     .field("mc_gpregs", &self.mc_gpregs)
                     .field("mc_fpregs", &self.mc_fpregs)
@@ -134,8 +134,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for mcontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mcontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mc_gpregs.hash(state);
                 self.mc_fpregs.hash(state);
                 self.mc_flags.hash(state);
@@ -146,7 +146,7 @@ cfg_if! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_longlong>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_longlong>() - 1;
 
 pub const BIOCSRTIMEOUT: c_ulong = 0x8010426d;
 pub const BIOCGRTIMEOUT: c_ulong = 0x4010426e;

--- a/src/unix/bsd/freebsdlike/freebsd/x86.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, size_t};
+use crate::prelude::*;
 
 pub type c_char = i8;
 pub type c_long = i32;
@@ -45,7 +45,7 @@ s_no_extra_traits! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
 
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
@@ -92,8 +92,8 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl crate::fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mcontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mcontext_t")
                     .field("mc_onstack", &self.mc_onstack)
                     .field("mc_gs", &self.mc_gs)
@@ -128,8 +128,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for mcontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mcontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mc_onstack.hash(state);
                 self.mc_gs.hash(state);
                 self.mc_fs.hash(state);

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_void, size_t};
+use crate::prelude::*;
 
 pub type c_char = i8;
 pub type c_long = i64;
@@ -159,8 +159,8 @@ cfg_if! {
             }
         }
         impl Eq for fpreg32 {}
-        impl crate::fmt::Debug for fpreg32 {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for fpreg32 {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("fpreg32")
                     .field("fpr_env", &&self.fpr_env[..])
                     .field("fpr_acc", &self.fpr_acc)
@@ -169,8 +169,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for fpreg32 {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for fpreg32 {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.fpr_env.hash(state);
                 self.fpr_acc.hash(state);
                 self.fpr_ex_sw.hash(state);
@@ -187,8 +187,8 @@ cfg_if! {
             }
         }
         impl Eq for fpreg {}
-        impl crate::fmt::Debug for fpreg {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for fpreg {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("fpreg")
                     .field("fpr_env", &self.fpr_env)
                     .field("fpr_acc", &self.fpr_acc)
@@ -197,8 +197,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for fpreg {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for fpreg {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.fpr_env.hash(state);
                 self.fpr_acc.hash(state);
                 self.fpr_xacc.hash(state);
@@ -219,8 +219,8 @@ cfg_if! {
             }
         }
         impl Eq for xmmreg {}
-        impl crate::fmt::Debug for xmmreg {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for xmmreg {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("xmmreg")
                     .field("xmm_env", &self.xmm_env)
                     .field("xmm_acc", &self.xmm_acc)
@@ -229,8 +229,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for xmmreg {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for xmmreg {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.xmm_env.hash(state);
                 self.xmm_acc.hash(state);
                 self.xmm_reg.hash(state);
@@ -248,8 +248,8 @@ cfg_if! {
             }
         }
         impl Eq for __c_anonymous_elf64_auxv_union {}
-        impl crate::fmt::Debug for __c_anonymous_elf64_auxv_union {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_elf64_auxv_union {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("a_val")
                     .field("a_val", unsafe { &self.a_val })
                     .finish()
@@ -261,8 +261,8 @@ cfg_if! {
             }
         }
         impl Eq for Elf64_Auxinfo {}
-        impl crate::fmt::Debug for Elf64_Auxinfo {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for Elf64_Auxinfo {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("Elf64_Auxinfo")
                     .field("a_type", &self.a_type)
                     .field("a_un", &self.a_un)
@@ -317,8 +317,8 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl crate::fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mcontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mcontext_t")
                     .field("mc_onstack", &self.mc_onstack)
                     .field("mc_rdi", &self.mc_rdi)
@@ -361,8 +361,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for mcontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mcontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mc_onstack.hash(state);
                 self.mc_rdi.hash(state);
                 self.mc_rsi.hash(state);
@@ -406,7 +406,7 @@ cfg_if! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
 
 pub const BIOCSRTIMEOUT: c_ulong = 0x8010426d;
 pub const BIOCGRTIMEOUT: c_ulong = 0x4010426e;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1,7 +1,5 @@
-use crate::{
-    c_double, c_int, c_short, c_uchar, c_uint, c_ulonglong, c_ushort, c_void, off_t, size_t,
-    ssize_t,
-};
+use crate::off_t;
+use crate::prelude::*;
 
 pub type mode_t = u16;
 pub type pthread_attr_t = *mut c_void;
@@ -413,8 +411,8 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_storage {}
-        impl crate::fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_storage {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_storage")
                     .field("ss_len", &self.ss_len)
                     .field("ss_family", &self.ss_family)
@@ -424,8 +422,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sockaddr_storage {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_storage {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_len.hash(state);
                 self.ss_family.hash(state);
                 self.__ss_pad1.hash(state);
@@ -437,7 +435,7 @@ cfg_if! {
 }
 
 // Non-public helper constant
-const SIZEOF_LONG: usize = crate::mem::size_of::<c_long>();
+const SIZEOF_LONG: usize = mem::size_of::<c_long>();
 
 #[deprecated(
     since = "0.2.64",

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_double, c_int, c_short, c_uint, c_ushort, c_void, size_t, ssize_t};
+use crate::prelude::*;
 
 pub type off_t = i64;
 pub type useconds_t = u32;
@@ -180,8 +180,8 @@ cfg_if! {
 
         impl Eq for sockaddr_un {}
 
-        impl crate::fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_un {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_un")
                     .field("sun_len", &self.sun_len)
                     .field("sun_family", &self.sun_family)
@@ -190,8 +190,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for sockaddr_un {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_un {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sun_len.hash(state);
                 self.sun_family.hash(state);
                 self.sun_path.hash(state);
@@ -229,8 +229,8 @@ cfg_if! {
 
         impl Eq for utsname {}
 
-        impl crate::fmt::Debug for utsname {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utsname {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utsname")
                     // FIXME: .field("sysname", &self.sysname)
                     // FIXME: .field("nodename", &self.nodename)
@@ -241,8 +241,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for utsname {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utsname {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sysname.hash(state);
                 self.nodename.hash(state);
                 self.release.hash(state);
@@ -595,7 +595,7 @@ pub const RTAX_BRD: c_int = 7;
 
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const crate::msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= crate::mem::size_of::<cmsghdr>() {
+        if (*mhdr).msg_controllen as usize >= mem::size_of::<cmsghdr>() {
             (*mhdr).msg_control as *mut cmsghdr
         } else {
             core::ptr::null_mut()
@@ -603,20 +603,20 @@ f! {
     }
 
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
-        let bits = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] &= !(1 << (fd % bits));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
-        let bits = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
-        let bits = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] |= 1 << (fd % bits);
         return;

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_short, c_uint, c_ushort, c_void, off_t, size_t, ssize_t};
+use crate::off_t;
+use crate::prelude::*;
 
 pub type wchar_t = i32;
 pub type time_t = i64;

--- a/src/unix/bsd/netbsdlike/netbsd/aarch64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/aarch64.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_uchar, c_uint, PT_FIRSTMACH};
+use crate::prelude::*;
+use crate::PT_FIRSTMACH;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
@@ -53,8 +54,8 @@ cfg_if! {
             }
         }
         impl Eq for __c_anonymous__freg {}
-        impl crate::fmt::Debug for __c_anonymous__freg {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous__freg {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 unsafe {
                     f.debug_struct("__c_anonymous__freg")
                         .field("__b8", &self.__b8)
@@ -66,8 +67,8 @@ cfg_if! {
                 }
             }
         }
-        impl crate::hash::Hash for __c_anonymous__freg {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous__freg {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self.__b8.hash(state);
                     self.__h16.hash(state);
@@ -80,7 +81,7 @@ cfg_if! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_int>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_int>() - 1;
 
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 0;
 pub const PT_SETREGS: c_int = PT_FIRSTMACH + 1;

--- a/src/unix/bsd/netbsdlike/netbsd/arm.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/arm.rs
@@ -1,11 +1,12 @@
-use crate::{c_int, c_longlong, PT_FIRSTMACH};
+use crate::prelude::*;
+use crate::PT_FIRSTMACH;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type c_char = u8;
 pub type __cpu_simple_lock_nv_t = c_int;
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_longlong>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_longlong>() - 1;
 
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 1;
 pub const PT_SETREGS: c_int = PT_FIRSTMACH + 2;

--- a/src/unix/bsd/netbsdlike/netbsd/mips.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mips.rs
@@ -1,11 +1,12 @@
-use crate::{c_int, c_longlong, PT_FIRSTMACH};
+use crate::prelude::*;
+use crate::PT_FIRSTMACH;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type c_char = i8;
 pub type __cpu_simple_lock_nv_t = c_int;
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_longlong>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_longlong>() - 1;
 
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 1;
 pub const PT_SETREGS: c_int = PT_FIRSTMACH + 2;

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1,7 +1,5 @@
-use crate::{
-    c_int, c_short, c_uchar, c_uint, c_ulonglong, c_ushort, c_void, cmsghdr, intptr_t, off_t,
-    size_t, ssize_t,
-};
+use crate::prelude::*;
+use crate::{cmsghdr, off_t};
 
 pub type clock_t = c_uint;
 pub type suseconds_t = c_int;
@@ -941,8 +939,8 @@ cfg_if! {
 
         impl Eq for utmpx {}
 
-        impl crate::fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utmpx {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utmpx")
                     .field("ut_name", &self.ut_name)
                     .field("ut_id", &self.ut_id)
@@ -959,8 +957,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for utmpx {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utmpx {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_name.hash(state);
                 self.ut_type.hash(state);
                 self.ut_pid.hash(state);
@@ -990,8 +988,8 @@ cfg_if! {
 
         impl Eq for lastlogx {}
 
-        impl crate::fmt::Debug for lastlogx {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for lastlogx {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("lastlogx")
                     .field("ll_tv", &self.ll_tv)
                     .field("ll_line", &self.ll_line)
@@ -1001,8 +999,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for lastlogx {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for lastlogx {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ll_tv.hash(state);
                 self.ll_line.hash(state);
                 self.ll_host.hash(state);
@@ -1016,16 +1014,16 @@ cfg_if! {
             }
         }
         impl Eq for in_pktinfo {}
-        impl crate::fmt::Debug for in_pktinfo {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for in_pktinfo {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("in_pktinfo")
                     .field("ipi_addr", &self.ipi_addr)
                     .field("ipi_ifindex", &self.ipi_ifindex)
                     .finish()
             }
         }
-        impl crate::hash::Hash for in_pktinfo {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for in_pktinfo {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ipi_addr.hash(state);
                 self.ipi_ifindex.hash(state);
             }
@@ -1041,8 +1039,8 @@ cfg_if! {
             }
         }
         impl Eq for arphdr {}
-        impl crate::fmt::Debug for arphdr {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for arphdr {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let ar_hrd = self.ar_hrd;
                 let ar_pro = self.ar_pro;
                 let ar_op = self.ar_op;
@@ -1055,8 +1053,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for arphdr {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for arphdr {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let ar_hrd = self.ar_hrd;
                 let ar_pro = self.ar_pro;
                 let ar_op = self.ar_op;
@@ -1074,14 +1072,14 @@ cfg_if! {
             }
         }
         impl Eq for in_addr {}
-        impl crate::fmt::Debug for in_addr {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for in_addr {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let s_addr = self.s_addr;
                 f.debug_struct("in_addr").field("s_addr", &s_addr).finish()
             }
         }
-        impl crate::hash::Hash for in_addr {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for in_addr {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let s_addr = self.s_addr;
                 s_addr.hash(state);
             }
@@ -1094,16 +1092,16 @@ cfg_if! {
             }
         }
         impl Eq for ip_mreq {}
-        impl crate::fmt::Debug for ip_mreq {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ip_mreq {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ip_mreq")
                     .field("imr_multiaddr", &self.imr_multiaddr)
                     .field("imr_interface", &self.imr_interface)
                     .finish()
             }
         }
-        impl crate::hash::Hash for ip_mreq {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ip_mreq {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.imr_multiaddr.hash(state);
                 self.imr_interface.hash(state);
             }
@@ -1119,8 +1117,8 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_in {}
-        impl crate::fmt::Debug for sockaddr_in {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_in {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_in")
                     .field("sin_len", &self.sin_len)
                     .field("sin_family", &self.sin_family)
@@ -1130,8 +1128,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sockaddr_in {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_in {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sin_len.hash(state);
                 self.sin_family.hash(state);
                 self.sin_port.hash(state);
@@ -1154,8 +1152,8 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_fileno", &self.d_fileno)
                     .field("d_reclen", &self.d_reclen)
@@ -1165,8 +1163,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for dirent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_fileno.hash(state);
                 self.d_reclen.hash(state);
                 self.d_namlen.hash(state);
@@ -1212,8 +1210,8 @@ cfg_if! {
             }
         }
         impl Eq for statvfs {}
-        impl crate::fmt::Debug for statvfs {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for statvfs {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("statvfs")
                     .field("f_flag", &self.f_flag)
                     .field("f_bsize", &self.f_bsize)
@@ -1242,8 +1240,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for statvfs {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for statvfs {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_flag.hash(state);
                 self.f_bsize.hash(state);
                 self.f_frsize.hash(state);
@@ -1285,8 +1283,8 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_storage {}
-        impl crate::fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_storage {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_storage")
                     .field("ss_len", &self.ss_len)
                     .field("ss_family", &self.ss_family)
@@ -1296,8 +1294,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sockaddr_storage {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_storage {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_len.hash(state);
                 self.ss_family.hash(state);
                 self.__ss_pad1.hash(state);
@@ -1315,8 +1313,8 @@ cfg_if! {
             }
         }
         impl Eq for sigevent {}
-        impl crate::fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sigevent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sigevent")
                     .field("sigev_notify", &self.sigev_notify)
                     .field("sigev_signo", &self.sigev_signo)
@@ -1325,8 +1323,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sigevent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sigevent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sigev_notify.hash(state);
                 self.sigev_signo.hash(state);
                 self.sigev_value.hash(state);
@@ -1342,8 +1340,8 @@ cfg_if! {
             }
         }
 
-        impl crate::fmt::Debug for __c_anonymous_posix_spawn_fae {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_posix_spawn_fae {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 unsafe {
                     f.debug_struct("__c_anonymous_posix_fae")
                         .field("open", &self.open)
@@ -1353,8 +1351,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for __c_anonymous_posix_spawn_fae {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_posix_spawn_fae {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self.open.hash(state);
                     self.dup2.hash(state);
@@ -1370,8 +1368,8 @@ cfg_if! {
             }
         }
 
-        impl crate::fmt::Debug for __c_anonymous_ifc_ifcu {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_ifc_ifcu {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 unsafe {
                     f.debug_struct("__c_anonymous_ifc_ifcu")
                         .field("ifcu_buf", &self.ifcu_buf)
@@ -1381,8 +1379,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for __c_anonymous_ifc_ifcu {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_ifc_ifcu {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self.ifcu_buf.hash(state);
                     self.ifcu_req.hash(state);
@@ -2440,20 +2438,19 @@ const_fn! {
 
 f! {
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(_ALIGN(crate::mem::size_of::<cmsghdr>()) as isize)
+        (cmsg as *mut c_uchar).offset(_ALIGN(mem::size_of::<cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        _ALIGN(crate::mem::size_of::<cmsghdr>()) as c_uint + length
+        _ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub fn CMSG_NXTHDR(mhdr: *const crate::msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         if cmsg.is_null() {
             return crate::CMSG_FIRSTHDR(mhdr);
         };
-        let next = cmsg as usize
-            + _ALIGN((*cmsg).cmsg_len as usize)
-            + _ALIGN(crate::mem::size_of::<cmsghdr>());
+        let next =
+            cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize) + _ALIGN(mem::size_of::<cmsghdr>());
         let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next > max {
             0 as *mut cmsghdr
@@ -2463,7 +2460,7 @@ f! {
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (_ALIGN(crate::mem::size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
+        (_ALIGN(mem::size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
     }
 
     // dirfd() is a macro on netbsd to access
@@ -2475,7 +2472,7 @@ f! {
 
     pub fn SOCKCREDSIZE(ngrps: usize) -> usize {
         let ngrps = if ngrps > 0 { ngrps - 1 } else { 0 };
-        crate::mem::size_of::<sockcred>() + crate::mem::size_of::<crate::gid_t>() * ngrps
+        mem::size_of::<sockcred>() + mem::size_of::<crate::gid_t>() * ngrps
     }
 
     pub fn PROT_MPROTECT(x: c_int) -> c_int {

--- a/src/unix/bsd/netbsdlike/netbsd/powerpc.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/powerpc.rs
@@ -1,11 +1,12 @@
-use crate::{c_double, c_int, PT_FIRSTMACH};
+use crate::prelude::*;
+use crate::PT_FIRSTMACH;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type c_char = u8;
 pub type __cpu_simple_lock_nv_t = c_int;
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_double>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_double>() - 1;
 
 pub const PT_STEP: c_int = PT_FIRSTMACH + 0;
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 1;

--- a/src/unix/bsd/netbsdlike/netbsd/riscv64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/riscv64.rs
@@ -1,6 +1,6 @@
 use PT_FIRSTMACH;
 
-use crate::{c_double, c_int};
+use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
@@ -26,7 +26,7 @@ s_no_extra_traits! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
 
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 0;
 pub const PT_SETREGS: c_int = PT_FIRSTMACH + 1;

--- a/src/unix/bsd/netbsdlike/netbsd/sparc64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/sparc64.rs
@@ -1,4 +1,4 @@
-use crate::c_uchar;
+use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/unix/bsd/netbsdlike/netbsd/x86.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/x86.rs
@@ -1,8 +1,8 @@
-use crate::{c_int, c_uchar};
+use crate::prelude::*;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type c_char = i8;
 pub type __cpu_simple_lock_nv_t = c_uchar;
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_int>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_int>() - 1;

--- a/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_uchar, c_uint, PT_FIRSTMACH};
+use crate::prelude::*;
+use crate::PT_FIRSTMACH;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
@@ -22,7 +23,7 @@ s! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
 
 pub const PT_STEP: c_int = PT_FIRSTMACH + 0;
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 1;

--- a/src/unix/bsd/netbsdlike/openbsd/aarch64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/aarch64.rs
@@ -1,4 +1,4 @@
-use crate::c_int;
+use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
@@ -18,6 +18,6 @@ s! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
 
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/arm.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/arm.rs
@@ -1,9 +1,9 @@
-use crate::c_double;
+use crate::prelude::*;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type c_char = u8;
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_double>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_double>() - 1;
 
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1,7 +1,6 @@
+use crate::prelude::*;
 use crate::unix::bsd::O_SYNC;
-use crate::{
-    c_int, c_longlong, c_short, c_uchar, c_uint, c_ushort, c_void, cmsghdr, off_t, size_t,
-};
+use crate::{cmsghdr, off_t};
 
 pub type clock_t = i64;
 pub type suseconds_t = c_long;
@@ -773,8 +772,8 @@ cfg_if! {
 
         impl Eq for dirent {}
 
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_fileno", &self.d_fileno)
                     .field("d_off", &self.d_off)
@@ -786,8 +785,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for dirent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_fileno.hash(state);
                 self.d_off.hash(state);
                 self.d_reclen.hash(state);
@@ -805,8 +804,8 @@ cfg_if! {
 
         impl Eq for sockaddr_storage {}
 
-        impl crate::fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_storage {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_storage")
                     .field("ss_len", &self.ss_len)
                     .field("ss_family", &self.ss_family)
@@ -814,8 +813,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for sockaddr_storage {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_storage {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_len.hash(state);
                 self.ss_family.hash(state);
             }
@@ -832,8 +831,8 @@ cfg_if! {
 
         impl Eq for siginfo_t {}
 
-        impl crate::fmt::Debug for siginfo_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for siginfo_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("siginfo_t")
                     .field("si_signo", &self.si_signo)
                     .field("si_code", &self.si_code)
@@ -843,8 +842,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for siginfo_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for siginfo_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.si_signo.hash(state);
                 self.si_code.hash(state);
                 self.si_errno.hash(state);
@@ -870,8 +869,8 @@ cfg_if! {
 
         impl Eq for lastlog {}
 
-        impl crate::fmt::Debug for lastlog {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for lastlog {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("lastlog")
                     .field("ll_time", &self.ll_time)
                     // FIXME: .field("ll_line", &self.ll_line)
@@ -880,8 +879,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for lastlog {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for lastlog {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ll_time.hash(state);
                 self.ll_line.hash(state);
                 self.ll_host.hash(state);
@@ -911,8 +910,8 @@ cfg_if! {
 
         impl Eq for utmp {}
 
-        impl crate::fmt::Debug for utmp {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utmp {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utmp")
                     // FIXME: .field("ut_line", &self.ut_line)
                     // FIXME: .field("ut_name", &self.ut_name)
@@ -922,8 +921,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for utmp {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utmp {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_line.hash(state);
                 self.ut_name.hash(state);
                 self.ut_host.hash(state);
@@ -944,16 +943,16 @@ cfg_if! {
 
         impl Eq for mount_info {}
 
-        impl crate::fmt::Debug for mount_info {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mount_info {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mount_info")
                     // FIXME: .field("align", &self.align)
                     .finish()
             }
         }
 
-        impl crate::hash::Hash for mount_info {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mount_info {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe { self.align.hash(state) };
             }
         }
@@ -976,8 +975,8 @@ cfg_if! {
 
         impl Eq for __c_anonymous_ifr_ifru {}
 
-        impl crate::fmt::Debug for __c_anonymous_ifr_ifru {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_ifr_ifru {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("__c_anonymous_ifr_ifru")
                     .field("ifru_addr", unsafe { &self.ifru_addr })
                     .field("ifru_dstaddr", unsafe { &self.ifru_dstaddr })
@@ -992,8 +991,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for __c_anonymous_ifr_ifru {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_ifr_ifru {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self.ifru_addr.hash(state);
                     self.ifru_dstaddr.hash(state);
@@ -1053,8 +1052,8 @@ cfg_if! {
 
         impl Eq for statfs {}
 
-        impl crate::fmt::Debug for statfs {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for statfs {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("statfs")
                     .field("f_flags", &self.f_flags)
                     .field("f_bsize", &self.f_bsize)
@@ -1082,8 +1081,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for statfs {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for statfs {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_flags.hash(state);
                 self.f_bsize.hash(state);
                 self.f_iosize.hash(state);
@@ -1724,7 +1723,7 @@ pub const NTFS_MFLAG_ALLNAMES: c_int = 0x2;
 pub const TMPFS_ARGS_VERSION: c_int = 1;
 
 const SI_MAXSZ: size_t = 128;
-const SI_PAD: size_t = (SI_MAXSZ / crate::mem::size_of::<c_int>()) - 3;
+const SI_PAD: size_t = (SI_MAXSZ / mem::size_of::<c_int>()) - 3;
 
 pub const MAP_STACK: c_int = 0x4000;
 pub const MAP_CONCEAL: c_int = 0x8000;
@@ -1950,20 +1949,19 @@ const_fn! {
 
 f! {
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(_ALIGN(crate::mem::size_of::<cmsghdr>()) as isize)
+        (cmsg as *mut c_uchar).offset(_ALIGN(mem::size_of::<cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        _ALIGN(crate::mem::size_of::<cmsghdr>()) as c_uint + length
+        _ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub fn CMSG_NXTHDR(mhdr: *const crate::msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         if cmsg.is_null() {
             return crate::CMSG_FIRSTHDR(mhdr);
         };
-        let next = cmsg as usize
-            + _ALIGN((*cmsg).cmsg_len as usize)
-            + _ALIGN(crate::mem::size_of::<cmsghdr>());
+        let next =
+            cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize) + _ALIGN(mem::size_of::<cmsghdr>());
         let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next > max {
             0 as *mut cmsghdr
@@ -1973,7 +1971,7 @@ f! {
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (_ALIGN(crate::mem::size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
+        (_ALIGN(mem::size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
     }
 
     pub fn major(dev: crate::dev_t) -> c_uint {

--- a/src/unix/bsd/netbsdlike/openbsd/powerpc.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/powerpc.rs
@@ -1,9 +1,9 @@
-use crate::c_double;
+use crate::prelude::*;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type c_char = u8;
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_double>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_double>() - 1;
 
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/powerpc64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/powerpc64.rs
@@ -1,7 +1,9 @@
+use crate::prelude::*;
+
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type c_char = u8;
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
 
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/riscv64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/riscv64.rs
@@ -1,4 +1,4 @@
-use crate::c_int;
+use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
@@ -23,6 +23,6 @@ s! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
 
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/x86.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/x86.rs
@@ -1,9 +1,9 @@
-use crate::c_int;
+use crate::prelude::*;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type c_char = i8;
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_int>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_int>() - 1;
 
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/x86_64.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, PT_FIRSTMACH};
+use crate::prelude::*;
+use crate::PT_FIRSTMACH;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
@@ -83,8 +84,8 @@ cfg_if! {
             }
         }
         impl Eq for fxsave64 {}
-        impl crate::fmt::Debug for fxsave64 {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for fxsave64 {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("fxsave64")
                     .field("fx_fcw", &{ self.fx_fcw })
                     .field("fx_fsw", &{ self.fx_fsw })
@@ -99,8 +100,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for fxsave64 {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for fxsave64 {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.fx_fcw }.hash(state);
                 { self.fx_fsw }.hash(state);
                 { self.fx_ftw }.hash(state);
@@ -116,7 +117,7 @@ cfg_if! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = crate::mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
 
 pub const _MAX_PAGE_SHIFT: u32 = 12;
 

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -1,6 +1,4 @@
-use crate::{
-    c_double, c_int, c_short, c_uchar, c_uint, c_ushort, c_void, intptr_t, size_t, ssize_t,
-};
+use crate::prelude::*;
 
 pub type rlim_t = crate::uintptr_t;
 pub type sa_family_t = u8;
@@ -521,8 +519,8 @@ cfg_if! {
 
         impl Eq for utmpx {}
 
-        impl crate::fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utmpx {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utmpx")
                     .field("ut_type", &self.ut_type)
                     .field("ut_tv", &self.ut_tv)
@@ -536,8 +534,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for utmpx {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utmpx {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_type.hash(state);
                 self.ut_tv.hash(state);
                 self.ut_id.hash(state);
@@ -560,8 +558,8 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_un {}
-        impl crate::fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_un {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_un")
                     .field("sun_len", &self.sun_len)
                     .field("sun_family", &self.sun_family)
@@ -569,8 +567,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sockaddr_un {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_un {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sun_len.hash(state);
                 self.sun_family.hash(state);
                 self.sun_path.hash(state);
@@ -595,8 +593,8 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_storage {}
-        impl crate::fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_storage {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_storage")
                     .field("ss_len", &self.ss_len)
                     .field("ss_family", &self.ss_family)
@@ -606,8 +604,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sockaddr_storage {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_storage {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_len.hash(state);
                 self.ss_family.hash(state);
                 self.__ss_pad1.hash(state);
@@ -631,8 +629,8 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_dev", &self.d_dev)
                     .field("d_pdev", &self.d_pdev)
@@ -643,8 +641,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for dirent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_dev.hash(state);
                 self.d_pdev.hash(state);
                 self.d_ino.hash(state);
@@ -663,8 +661,8 @@ cfg_if! {
             }
         }
         impl Eq for sigevent {}
-        impl crate::fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sigevent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sigevent")
                     .field("sigev_notify", &self.sigev_notify)
                     .field("sigev_signo", &self.sigev_signo)
@@ -673,8 +671,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sigevent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sigevent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sigev_notify.hash(state);
                 self.sigev_signo.hash(state);
                 self.sigev_value.hash(state);
@@ -1564,13 +1562,13 @@ pub const POSIX_SPAWN_SETSID: c_short = 0x40;
 
 const_fn! {
     {const} fn CMSG_ALIGN(len: usize) -> usize {
-        len + crate::mem::size_of::<usize>() - 1 & !(crate::mem::size_of::<usize>() - 1)
+        len + mem::size_of::<usize>() - 1 & !(mem::size_of::<usize>() - 1)
     }
 }
 
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= crate::mem::size_of::<cmsghdr>() {
+        if (*mhdr).msg_controllen as usize >= mem::size_of::<cmsghdr>() {
             (*mhdr).msg_control as *mut cmsghdr
         } else {
             0 as *mut cmsghdr
@@ -1578,15 +1576,15 @@ f! {
     }
 
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(CMSG_ALIGN(crate::mem::size_of::<cmsghdr>()) as isize)
+        (cmsg as *mut c_uchar).offset(CMSG_ALIGN(mem::size_of::<cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(crate::mem::size_of::<cmsghdr>())) as c_uint
+        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(mem::size_of::<cmsghdr>())) as c_uint
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        CMSG_ALIGN(crate::mem::size_of::<cmsghdr>()) as c_uint + length
+        CMSG_ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
@@ -1595,7 +1593,7 @@ f! {
         };
         let next = cmsg as usize
             + CMSG_ALIGN((*cmsg).cmsg_len as usize)
-            + CMSG_ALIGN(crate::mem::size_of::<cmsghdr>());
+            + CMSG_ALIGN(mem::size_of::<cmsghdr>());
         let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next > max {
             0 as *mut cmsghdr
@@ -1606,20 +1604,20 @@ f! {
 
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
         return;
     }

--- a/src/unix/haiku/native.rs
+++ b/src/unix/haiku/native.rs
@@ -1,4 +1,5 @@
-use crate::{c_char, c_double, c_int, c_uint, c_ulong, c_void, off_t, size_t, ssize_t};
+use crate::off_t;
+use crate::prelude::*;
 
 // This module contains bindings to the native Haiku API. The Haiku API
 // originates from BeOS, and it was the original way to perform low level
@@ -500,8 +501,8 @@ cfg_if! {
             }
         }
         impl Eq for cpuid_info {}
-        impl crate::fmt::Debug for cpuid_info {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for cpuid_info {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 unsafe {
                     f.debug_struct("cpuid_info")
                         .field("eax_0", &self.eax_0)
@@ -525,8 +526,8 @@ cfg_if! {
             }
         }
         impl Eq for __c_anonymous_cpu_topology_info_data {}
-        impl crate::fmt::Debug for __c_anonymous_cpu_topology_info_data {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_cpu_topology_info_data {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 unsafe {
                     f.debug_struct("__c_anonymous_cpu_topology_info_data")
                         .field("root", &self.root)
@@ -544,8 +545,8 @@ cfg_if! {
         }
 
         impl Eq for cpu_topology_node_info {}
-        impl crate::fmt::Debug for cpu_topology_node_info {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for cpu_topology_node_info {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("cpu_topology_node_info")
                     .field("id", &self.id)
                     .field("type", &self.type_)

--- a/src/unix/haiku/x86_64.rs
+++ b/src/unix/haiku/x86_64.rs
@@ -1,4 +1,4 @@
-use crate::{c_uchar, c_uint, c_ulong, c_ushort};
+use crate::prelude::*;
 
 s_no_extra_traits! {
     pub struct fpu_state {
@@ -83,8 +83,8 @@ cfg_if! {
             }
         }
         impl Eq for fpu_state {}
-        impl crate::fmt::Debug for fpu_state {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for fpu_state {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("fpu_state")
                     .field("control", &self.control)
                     .field("status", &self.status)
@@ -100,8 +100,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for fpu_state {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for fpu_state {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.control.hash(state);
                 self.status.hash(state);
                 self.tag.hash(state);
@@ -128,8 +128,8 @@ cfg_if! {
             }
         }
         impl Eq for xstate_hdr {}
-        impl crate::fmt::Debug for xstate_hdr {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for xstate_hdr {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("xstate_hdr")
                     .field("bv", &self.bv)
                     .field("xcomp_bv", &self.xcomp_bv)
@@ -137,8 +137,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for xstate_hdr {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for xstate_hdr {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.bv.hash(state);
                 self.xcomp_bv.hash(state);
                 self._reserved.hash(state);
@@ -157,8 +157,8 @@ cfg_if! {
             }
         }
         impl Eq for savefpu {}
-        impl crate::fmt::Debug for savefpu {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for savefpu {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("savefpu")
                     .field("fp_fxsave", &self.fp_fxsave)
                     .field("fp_xstate", &self.fp_xstate)
@@ -166,8 +166,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for savefpu {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for savefpu {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.fp_fxsave.hash(state);
                 self.fp_xstate.hash(state);
                 self._fp_ymm.hash(state);
@@ -198,8 +198,8 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl crate::fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mcontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mcontext_t")
                     .field("rax", &self.rax)
                     .field("rbx", &self.rbx)
@@ -223,8 +223,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for mcontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mcontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.rax.hash(state);
                 self.rbx.hash(state);
                 self.rcx.hash(state);
@@ -256,8 +256,8 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl crate::fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ucontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ucontext_t")
                     .field("uc_link", &self.uc_link)
                     .field("uc_sigmask", &self.uc_sigmask)
@@ -266,8 +266,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for ucontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ucontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_link.hash(state);
                 self.uc_sigmask.hash(state);
                 self.uc_stack.hash(state);

--- a/src/unix/hurd/b32.rs
+++ b/src/unix/hurd/b32.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_longlong, c_uchar, c_uint, c_ulonglong, c_ushort};
+use crate::prelude::*;
 
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/unix/hurd/b64.rs
+++ b/src/unix/hurd/b64.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_uchar, c_uint};
+use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -1,9 +1,7 @@
 #![allow(dead_code)]
 
-use crate::{
-    c_double, c_int, c_schar, c_short, c_uchar, c_uint, c_ulonglong, c_ushort, c_void, intptr_t,
-    size_t, ssize_t,
-};
+use crate::c_schar;
+use crate::prelude::*;
 
 // types
 pub type c_char = i8;
@@ -1088,8 +1086,8 @@ cfg_if! {
 
         impl Eq for utmpx {}
 
-        impl crate::fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utmpx {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utmpx")
                     .field("ut_type", &self.ut_type)
                     .field("ut_pid", &self.ut_pid)
@@ -1106,8 +1104,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for utmpx {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utmpx {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_type.hash(state);
                 self.ut_pid.hash(state);
                 self.ut_line.hash(state);
@@ -3438,14 +3436,14 @@ const _UTSNAME_LENGTH: usize = 1024;
 
 const_fn! {
     {const} fn CMSG_ALIGN(len: usize) -> usize {
-        len + crate::mem::size_of::<usize>() - 1 & !(crate::mem::size_of::<usize>() - 1)
+        len + mem::size_of::<usize>() - 1 & !(mem::size_of::<usize>() - 1)
     }
 }
 
 // functions
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= crate::mem::size_of::<cmsghdr>() {
+        if (*mhdr).msg_controllen as usize >= mem::size_of::<cmsghdr>() {
             (*mhdr).msg_control as *mut cmsghdr
         } else {
             0 as *mut cmsghdr
@@ -3457,15 +3455,15 @@ f! {
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(crate::mem::size_of::<cmsghdr>())) as c_uint
+        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(mem::size_of::<cmsghdr>())) as c_uint
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        CMSG_ALIGN(crate::mem::size_of::<cmsghdr>()) as c_uint + length
+        CMSG_ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        if ((*cmsg).cmsg_len as usize) < crate::mem::size_of::<cmsghdr>() {
+        if ((*cmsg).cmsg_len as usize) < mem::size_of::<cmsghdr>() {
             return 0 as *mut cmsghdr;
         };
         let next = (cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr;
@@ -3480,8 +3478,8 @@ f! {
     }
 
     pub fn CPU_ALLOC_SIZE(count: c_int) -> size_t {
-        let _dummy: cpu_set_t = crate::mem::zeroed();
-        let size_in_bits = 8 * crate::mem::size_of_val(&_dummy.bits[0]);
+        let _dummy: cpu_set_t = mem::zeroed();
+        let size_in_bits = 8 * mem::size_of_val(&_dummy.bits[0]);
         ((count as size_t + size_in_bits - 1) / 8) as size_t
     }
 
@@ -3492,28 +3490,28 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * crate::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] |= 1 << offset;
         ()
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * crate::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] &= !(1 << offset);
         ()
     }
 
     pub fn CPU_ISSET(cpu: usize, cpuset: &cpu_set_t) -> bool {
-        let size_in_bits = 8 * crate::mem::size_of_val(&cpuset.bits[0]);
+        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]);
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         0 != (cpuset.bits[idx] & (1 << offset))
     }
 
     pub fn CPU_COUNT_S(size: usize, cpuset: &cpu_set_t) -> c_int {
         let mut s: u32 = 0;
-        let size_of_mask = crate::mem::size_of_val(&cpuset.bits[0]);
+        let size_of_mask = mem::size_of_val(&cpuset.bits[0]);
         for i in cpuset.bits[..(size / size_of_mask)].iter() {
             s += i.count_ones();
         }
@@ -3521,7 +3519,7 @@ f! {
     }
 
     pub fn CPU_COUNT(cpuset: &cpu_set_t) -> c_int {
-        CPU_COUNT_S(crate::mem::size_of::<cpu_set_t>(), cpuset)
+        CPU_COUNT_S(mem::size_of::<cpu_set_t>(), cpuset)
     }
 
     pub fn CPU_EQUAL(set1: &cpu_set_t, set2: &cpu_set_t) -> bool {
@@ -3546,20 +3544,20 @@ f! {
 
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
         return;
     }

--- a/src/unix/linux_like/android/b32/arm.rs
+++ b/src/unix/linux_like/android/b32/arm.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_long, c_longlong, c_ulong};
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type wchar_t = u32;
@@ -66,16 +66,16 @@ cfg_if! {
             }
         }
         impl Eq for __c_anonymous_uc_sigmask_with_padding {}
-        impl crate::fmt::Debug for __c_anonymous_uc_sigmask_with_padding {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_uc_sigmask_with_padding {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("uc_sigmask_with_padding")
                     .field("uc_sigmask_with_padding", &self.uc_sigmask)
                     // Ignore padding
                     .finish()
             }
         }
-        impl crate::hash::Hash for __c_anonymous_uc_sigmask_with_padding {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_uc_sigmask_with_padding {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_sigmask.hash(state)
                 // Ignore padding
             }
@@ -87,15 +87,15 @@ cfg_if! {
             }
         }
         impl Eq for __c_anonymous_uc_sigmask {}
-        impl crate::fmt::Debug for __c_anonymous_uc_sigmask {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_uc_sigmask {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("uc_sigmask")
                     .field("uc_sigmask", unsafe { &self.uc_sigmask })
                     .finish()
             }
         }
-        impl crate::hash::Hash for __c_anonymous_uc_sigmask {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_uc_sigmask {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe { self.uc_sigmask.hash(state) }
             }
         }
@@ -112,8 +112,8 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl crate::fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ucontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ucontext_t")
                     .field("uc_flags", &self.uc_flags)
                     .field("uc_link", &self.uc_link)
@@ -128,8 +128,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for ucontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ucontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_flags.hash(state);
                 self.uc_link.hash(state);
                 self.uc_stack.hash(state);

--- a/src/unix/linux_like/android/b32/mod.rs
+++ b/src/unix/linux_like/android/b32/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_longlong, c_uchar, c_uint, c_ulonglong, c_ushort, c_void, size_t};
+use crate::prelude::*;
 
 // The following definitions are correct for arm and i686,
 // but may be wrong for mips
@@ -185,8 +185,8 @@ s_no_extra_traits! {
 
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
-        impl crate::fmt::Debug for sigset64_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sigset64_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sigset64_t")
                     .field("__bits", &self.__bits)
                     .finish()

--- a/src/unix/linux_like/android/b32/x86/mod.rs
+++ b/src/unix/linux_like/android/b32/x86/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_long, c_ulong};
+use crate::prelude::*;
 
 pub type c_char = i8;
 pub type wchar_t = i32;
@@ -68,16 +68,16 @@ cfg_if! {
             }
         }
         impl Eq for __c_anonymous_uc_sigmask_with_padding {}
-        impl crate::fmt::Debug for __c_anonymous_uc_sigmask_with_padding {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_uc_sigmask_with_padding {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("uc_sigmask_with_padding")
                     .field("uc_sigmask_with_padding", &self.uc_sigmask)
                     // Ignore padding
                     .finish()
             }
         }
-        impl crate::hash::Hash for __c_anonymous_uc_sigmask_with_padding {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_uc_sigmask_with_padding {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_sigmask.hash(state)
                 // Ignore padding
             }
@@ -89,15 +89,15 @@ cfg_if! {
             }
         }
         impl Eq for __c_anonymous_uc_sigmask {}
-        impl crate::fmt::Debug for __c_anonymous_uc_sigmask {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_uc_sigmask {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("uc_sigmask")
                     .field("uc_sigmask", unsafe { &self.uc_sigmask })
                     .finish()
             }
         }
-        impl crate::hash::Hash for __c_anonymous_uc_sigmask {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_uc_sigmask {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe { self.uc_sigmask.hash(state) }
             }
         }
@@ -113,8 +113,8 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl crate::fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ucontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ucontext_t")
                     .field("uc_flags", &self.uc_flags)
                     .field("uc_link", &self.uc_link)
@@ -128,8 +128,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for ucontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ucontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_flags.hash(state);
                 self.uc_link.hash(state);
                 self.uc_stack.hash(state);

--- a/src/unix/linux_like/android/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/android/b64/aarch64/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_longlong, c_uint, c_ulong, c_ulonglong, off64_t, size_t};
+use crate::off64_t;
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type wchar_t = u32;

--- a/src/unix/linux_like/android/b64/mod.rs
+++ b/src/unix/linux_like/android/b64/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_uint, c_ulonglong, c_ushort, c_void, size_t};
+use crate::prelude::*;
 
 // The following definitions are correct for aarch64 and x86_64,
 // but may be wrong for mips64
@@ -157,8 +157,8 @@ cfg_if! {
 
         impl Eq for pthread_mutex_t {}
 
-        impl crate::fmt::Debug for pthread_mutex_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_mutex_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_mutex_t")
                     .field("value", &self.value)
                     // FIXME: .field("__reserved", &self.__reserved)
@@ -166,8 +166,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for pthread_mutex_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_mutex_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.value.hash(state);
                 self.__reserved.hash(state);
             }
@@ -186,8 +186,8 @@ cfg_if! {
 
         impl Eq for pthread_cond_t {}
 
-        impl crate::fmt::Debug for pthread_cond_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_cond_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_cond_t")
                     .field("value", &self.value)
                     // FIXME: .field("__reserved", &self.__reserved)
@@ -195,8 +195,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for pthread_cond_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_cond_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.value.hash(state);
                 self.__reserved.hash(state);
             }
@@ -219,8 +219,8 @@ cfg_if! {
 
         impl Eq for pthread_rwlock_t {}
 
-        impl crate::fmt::Debug for pthread_rwlock_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_rwlock_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_rwlock_t")
                     .field("numLocks", &self.numLocks)
                     .field("writerThreadId", &self.writerThreadId)
@@ -232,8 +232,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for pthread_rwlock_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_rwlock_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.numLocks.hash(state);
                 self.writerThreadId.hash(state);
                 self.pendingReaders.hash(state);
@@ -243,8 +243,8 @@ cfg_if! {
             }
         }
 
-        impl crate::fmt::Debug for sigset64_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sigset64_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sigset64_t")
                     .field("__bits", &self.__bits)
                     .finish()

--- a/src/unix/linux_like/android/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/android/b64/riscv64/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_longlong, c_uint, c_ulong, c_ulonglong, off64_t, size_t};
+use crate::off64_t;
+use crate::prelude::*;
 
 pub type c_char = i8;
 pub type wchar_t = u32;

--- a/src/unix/linux_like/android/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/android/b64/x86_64/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_longlong, c_uint, c_ulong, c_ulonglong, c_ushort, off64_t, size_t};
+use crate::off64_t;
+use crate::prelude::*;
 
 pub type c_char = i8;
 pub type wchar_t = i32;
@@ -127,15 +128,15 @@ cfg_if! {
             }
         }
         impl Eq for __c_anonymous_uc_sigmask {}
-        impl crate::fmt::Debug for __c_anonymous_uc_sigmask {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_uc_sigmask {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("uc_sigmask")
                     .field("uc_sigmask", unsafe { &self.uc_sigmask })
                     .finish()
             }
         }
-        impl crate::hash::Hash for __c_anonymous_uc_sigmask {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_uc_sigmask {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe { self.uc_sigmask.hash(state) }
             }
         }
@@ -202,8 +203,8 @@ cfg_if! {
             }
         }
         impl Eq for _libc_fpxreg {}
-        impl crate::fmt::Debug for _libc_fpxreg {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for _libc_fpxreg {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("_libc_fpxreg")
                     .field("significand", &self.significand)
                     .field("exponent", &self.exponent)
@@ -211,8 +212,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for _libc_fpxreg {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for _libc_fpxreg {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.significand.hash(state);
                 self.exponent.hash(state);
                 // Ignore padding field
@@ -235,8 +236,8 @@ cfg_if! {
             }
         }
         impl Eq for _libc_fpstate {}
-        impl crate::fmt::Debug for _libc_fpstate {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for _libc_fpstate {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("_libc_fpstate")
                     .field("cwd", &self.cwd)
                     .field("swd", &self.swd)
@@ -252,8 +253,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for _libc_fpstate {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for _libc_fpstate {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cwd.hash(state);
                 self.swd.hash(state);
                 self.ftw.hash(state);
@@ -275,8 +276,8 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl crate::fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mcontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mcontext_t")
                     .field("gregs", &self.gregs)
                     .field("fpregs", &self.fpregs)
@@ -284,8 +285,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for mcontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mcontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.gregs.hash(state);
                 self.fpregs.hash(state);
                 // Ignore padding field
@@ -303,8 +304,8 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl crate::fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ucontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ucontext_t")
                     .field("uc_flags", &self.uc_flags)
                     .field("uc_link", &self.uc_link)
@@ -315,8 +316,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for ucontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ucontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_flags.hash(state);
                 self.uc_link.hash(state);
                 self.uc_stack.hash(state);
@@ -348,8 +349,8 @@ cfg_if! {
 
         impl Eq for user_fpregs_struct {}
 
-        impl crate::fmt::Debug for user_fpregs_struct {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for user_fpregs_struct {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("user_fpregs_struct")
                     .field("cwd", &self.cwd)
                     .field("swd", &self.swd)
@@ -366,8 +367,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for user_fpregs_struct {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for user_fpregs_struct {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cwd.hash(state);
                 self.swd.hash(state);
                 self.ftw.hash(state);

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -1,8 +1,6 @@
 //! Android-specific definitions for linux-like values
 
-use crate::{
-    c_int, c_longlong, c_short, c_uchar, c_uint, c_ulonglong, c_ushort, c_void, size_t, ssize_t,
-};
+use crate::prelude::*;
 
 pub type clock_t = c_long;
 pub type time_t = c_long;
@@ -652,8 +650,8 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_nl {}
-        impl crate::fmt::Debug for sockaddr_nl {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_nl {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_nl")
                     .field("nl_family", &self.nl_family)
                     .field("nl_pid", &self.nl_pid)
@@ -661,8 +659,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sockaddr_nl {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_nl {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.nl_family.hash(state);
                 self.nl_pid.hash(state);
                 self.nl_groups.hash(state);
@@ -685,8 +683,8 @@ cfg_if! {
 
         impl Eq for dirent {}
 
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_ino", &self.d_ino)
                     .field("d_off", &self.d_off)
@@ -697,8 +695,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for dirent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
                 self.d_off.hash(state);
                 self.d_reclen.hash(state);
@@ -723,8 +721,8 @@ cfg_if! {
 
         impl Eq for dirent64 {}
 
-        impl crate::fmt::Debug for dirent64 {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent64 {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent64")
                     .field("d_ino", &self.d_ino)
                     .field("d_off", &self.d_off)
@@ -735,8 +733,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for dirent64 {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent64 {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
                 self.d_off.hash(state);
                 self.d_reclen.hash(state);
@@ -757,8 +755,8 @@ cfg_if! {
 
         impl Eq for siginfo_t {}
 
-        impl crate::fmt::Debug for siginfo_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for siginfo_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("siginfo_t")
                     .field("si_signo", &self.si_signo)
                     .field("si_errno", &self.si_errno)
@@ -769,8 +767,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for siginfo_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for siginfo_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.si_signo.hash(state);
                 self.si_errno.hash(state);
                 self.si_code.hash(state);
@@ -797,8 +795,8 @@ cfg_if! {
 
         impl Eq for lastlog {}
 
-        impl crate::fmt::Debug for lastlog {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for lastlog {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("lastlog")
                     .field("ll_time", &self.ll_time)
                     .field("ll_line", &self.ll_line)
@@ -807,8 +805,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for lastlog {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for lastlog {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ll_time.hash(state);
                 self.ll_line.hash(state);
                 self.ll_host.hash(state);
@@ -845,8 +843,8 @@ cfg_if! {
 
         impl Eq for utmp {}
 
-        impl crate::fmt::Debug for utmp {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utmp {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utmp")
                     .field("ut_type", &self.ut_type)
                     .field("ut_pid", &self.ut_pid)
@@ -863,8 +861,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for utmp {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utmp {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_type.hash(state);
                 self.ut_pid.hash(state);
                 self.ut_line.hash(state);
@@ -899,8 +897,8 @@ cfg_if! {
 
         impl Eq for sockaddr_alg {}
 
-        impl crate::fmt::Debug for sockaddr_alg {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_alg {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_alg")
                     .field("salg_family", &self.salg_family)
                     .field("salg_type", &self.salg_type)
@@ -911,8 +909,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for sockaddr_alg {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_alg {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.salg_family.hash(state);
                 self.salg_type.hash(state);
                 self.salg_feat.hash(state);
@@ -930,8 +928,8 @@ cfg_if! {
         }
         impl Eq for uinput_setup {}
 
-        impl crate::fmt::Debug for uinput_setup {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for uinput_setup {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("uinput_setup")
                     .field("id", &self.id)
                     .field("name", &&self.name[..])
@@ -940,8 +938,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for uinput_setup {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for uinput_setup {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.id.hash(state);
                 self.name.hash(state);
                 self.ff_effects_max.hash(state);
@@ -961,8 +959,8 @@ cfg_if! {
         }
         impl Eq for uinput_user_dev {}
 
-        impl crate::fmt::Debug for uinput_user_dev {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for uinput_user_dev {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("uinput_setup")
                     .field("name", &&self.name[..])
                     .field("id", &self.id)
@@ -975,8 +973,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for uinput_user_dev {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for uinput_user_dev {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.name.hash(state);
                 self.id.hash(state);
                 self.ff_effects_max.hash(state);
@@ -987,8 +985,8 @@ cfg_if! {
             }
         }
 
-        impl crate::fmt::Debug for __c_anonymous_ifr_ifru {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_ifr_ifru {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ifr_ifru")
                     .field("ifru_addr", unsafe { &self.ifru_addr })
                     .field("ifru_dstaddr", unsafe { &self.ifru_dstaddr })
@@ -1006,8 +1004,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::fmt::Debug for ifreq {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ifreq {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ifreq")
                     .field("ifr_name", &self.ifr_name)
                     .field("ifr_ifru", &self.ifr_ifru)
@@ -1015,16 +1013,16 @@ cfg_if! {
             }
         }
 
-        impl crate::fmt::Debug for __c_anonymous_ifc_ifcu {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_ifc_ifcu {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ifr_ifru")
                     .field("ifcu_buf", unsafe { &self.ifcu_buf })
                     .field("ifcu_req", unsafe { &self.ifcu_req })
                     .finish()
             }
         }
-        impl crate::fmt::Debug for ifconf {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ifconf {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ifconf")
                     .field("ifc_len", &self.ifc_len)
                     .field("ifc_ifcu", &self.ifc_ifcu)
@@ -1040,8 +1038,8 @@ cfg_if! {
             }
         }
         impl Eq for prop_info {}
-        impl crate::fmt::Debug for prop_info {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for prop_info {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("prop_info")
                     .field("__name", &self.__name)
                     .field("__serial", &self.__serial)
@@ -3578,8 +3576,8 @@ f! {
     }
 
     pub fn CPU_ALLOC_SIZE(count: c_int) -> size_t {
-        let _dummy: cpu_set_t = crate::mem::zeroed();
-        let size_in_bits = 8 * crate::mem::size_of_val(&_dummy.__bits[0]);
+        let _dummy: cpu_set_t = mem::zeroed();
+        let size_in_bits = 8 * mem::size_of_val(&_dummy.__bits[0]);
         ((count as size_t + size_in_bits - 1) / 8) as size_t
     }
 
@@ -3590,28 +3588,28 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * crate::mem::size_of_val(&cpuset.__bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * mem::size_of_val(&cpuset.__bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.__bits[idx] |= 1 << offset;
         ()
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * crate::mem::size_of_val(&cpuset.__bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * mem::size_of_val(&cpuset.__bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.__bits[idx] &= !(1 << offset);
         ()
     }
 
     pub fn CPU_ISSET(cpu: usize, cpuset: &cpu_set_t) -> bool {
-        let size_in_bits = 8 * crate::mem::size_of_val(&cpuset.__bits[0]);
+        let size_in_bits = 8 * mem::size_of_val(&cpuset.__bits[0]);
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         0 != (cpuset.__bits[idx] & (1 << offset))
     }
 
     pub fn CPU_COUNT_S(size: usize, cpuset: &cpu_set_t) -> c_int {
         let mut s: u32 = 0;
-        let size_of_mask = crate::mem::size_of_val(&cpuset.__bits[0]);
+        let size_of_mask = mem::size_of_val(&cpuset.__bits[0]);
         for i in cpuset.__bits[..(size / size_of_mask)].iter() {
             s += i.count_ones();
         }
@@ -3619,7 +3617,7 @@ f! {
     }
 
     pub fn CPU_COUNT(cpuset: &cpu_set_t) -> c_int {
-        CPU_COUNT_S(crate::mem::size_of::<cpu_set_t>(), cpuset)
+        CPU_COUNT_S(mem::size_of::<cpu_set_t>(), cpuset)
     }
 
     pub fn CPU_EQUAL(set1: &cpu_set_t, set2: &cpu_set_t) -> bool {

--- a/src/unix/linux_like/emscripten/lfs64.rs
+++ b/src/unix/linux_like/emscripten/lfs64.rs
@@ -1,4 +1,5 @@
-use crate::{c_char, c_int, c_void, off64_t, size_t, ssize_t};
+use crate::off64_t;
+use crate::prelude::*;
 
 // In-sync with ../linux/musl/lfs64.rs except for fallocate64, prlimit64 and sendfile64
 

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_double, c_int, c_short, c_uchar, c_uint, c_ushort, c_void, size_t, ssize_t};
+use crate::prelude::*;
 
 pub type c_char = i8;
 pub type wchar_t = i32;
@@ -406,8 +406,8 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_ino", &self.d_ino)
                     .field("d_off", &self.d_off)
@@ -417,8 +417,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for dirent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
                 self.d_off.hash(state);
                 self.d_reclen.hash(state);
@@ -450,8 +450,8 @@ cfg_if! {
             }
         }
         impl Eq for sysinfo {}
-        impl crate::fmt::Debug for sysinfo {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sysinfo {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sysinfo")
                     .field("uptime", &self.uptime)
                     .field("loads", &self.loads)
@@ -470,8 +470,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sysinfo {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sysinfo {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uptime.hash(state);
                 self.loads.hash(state);
                 self.totalram.hash(state);
@@ -498,8 +498,8 @@ cfg_if! {
             }
         }
         impl Eq for mq_attr {}
-        impl crate::fmt::Debug for mq_attr {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mq_attr {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mq_attr")
                     .field("mq_flags", &self.mq_flags)
                     .field("mq_maxmsg", &self.mq_maxmsg)
@@ -508,8 +508,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for mq_attr {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mq_attr {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mq_flags.hash(state);
                 self.mq_maxmsg.hash(state);
                 self.mq_msgsize.hash(state);
@@ -523,15 +523,15 @@ cfg_if! {
             }
         }
         impl Eq for pthread_cond_t {}
-        impl crate::fmt::Debug for pthread_cond_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_cond_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_cond_t")
                     // FIXME: .field("size", &self.size)
                     .finish()
             }
         }
-        impl crate::hash::Hash for pthread_cond_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_cond_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.size.hash(state);
             }
         }
@@ -1414,7 +1414,7 @@ pub const SOMAXCONN: c_int = 128;
 
 f! {
     pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        if ((*cmsg).cmsg_len as usize) < crate::mem::size_of::<cmsghdr>() {
+        if ((*cmsg).cmsg_len as usize) < mem::size_of::<cmsghdr>() {
             return 0 as *mut cmsghdr;
         };
         let next = (cmsg as usize + super::CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr;
@@ -1433,21 +1433,21 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * crate::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] |= 1 << offset;
         ()
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * crate::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] &= !(1 << offset);
         ()
     }
 
     pub fn CPU_ISSET(cpu: usize, cpuset: &cpu_set_t) -> bool {
-        let size_in_bits = 8 * crate::mem::size_of_val(&cpuset.bits[0]);
+        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]);
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         0 != (cpuset.bits[idx] & (1 << offset))
     }

--- a/src/unix/linux_like/linux/arch/generic/mod.rs
+++ b/src/unix/linux_like/linux/arch/generic/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, Ioctl};
+use crate::prelude::*;
+use crate::Ioctl;
 
 s! {
     pub struct termios2 {
@@ -126,8 +127,8 @@ cfg_if! {
         target_arch = "csky",
         target_arch = "loongarch64"
     ))] {
-        pub const FICLONE: crate::c_ulong = 0x40049409;
-        pub const FICLONERANGE: crate::c_ulong = 0x4020940D;
+        pub const FICLONE: c_ulong = 0x40049409;
+        pub const FICLONERANGE: c_ulong = 0x4020940D;
     }
 }
 

--- a/src/unix/linux_like/linux/arch/mips/mod.rs
+++ b/src/unix/linux_like/linux/arch/mips/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_ulong, Ioctl};
+use crate::prelude::*;
+use crate::Ioctl;
 
 s! {
     pub struct termios2 {

--- a/src/unix/linux_like/linux/arch/powerpc/mod.rs
+++ b/src/unix/linux_like/linux/arch/powerpc/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_ulong, Ioctl};
+use crate::prelude::*;
+use crate::Ioctl;
 
 // arch/powerpc/include/uapi/asm/socket.h
 

--- a/src/unix/linux_like/linux/arch/sparc/mod.rs
+++ b/src/unix/linux_like/linux/arch/sparc/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, Ioctl};
+use crate::prelude::*;
+use crate::Ioctl;
 
 s! {
     pub struct termios2 {

--- a/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_short, c_uint, c_ulong, c_ushort, c_void, off64_t, off_t, size_t};
+use crate::prelude::*;
+use crate::{off64_t, off_t};
 
 pub type c_char = u8;
 pub type wchar_t = u32;
@@ -242,8 +243,8 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl crate::fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ucontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ucontext_t")
                     .field("uc_flags", &self.uc_link)
                     .field("uc_link", &self.uc_link)
@@ -253,8 +254,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for ucontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ucontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_flags.hash(state);
                 self.uc_link.hash(state);
                 self.uc_stack.hash(state);

--- a/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_short, c_uint, c_ulong, c_ushort, c_void, off64_t, off_t, size_t};
+use crate::prelude::*;
+use crate::{off64_t, off_t};
 
 pub type c_char = u8;
 pub type wchar_t = u32;

--- a/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_short, c_uint, c_ulong, c_ushort, c_void, off64_t, off_t, size_t};
+use crate::prelude::*;
+use crate::{off64_t, off_t};
 
 pub type c_char = i8;
 pub type wchar_t = i32;

--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_short, c_uint, c_ulong, c_ushort, c_void, off64_t, off_t, size_t};
+use crate::prelude::*;
+use crate::{off64_t, off_t};
 
 pub type c_char = i8;
 pub type wchar_t = i32;

--- a/src/unix/linux_like/linux/gnu/b32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mod.rs
@@ -1,6 +1,7 @@
 //! 32-bit specific definitions for linux-like values
 
-use crate::{c_int, c_longlong, c_uint, c_ulonglong, c_ushort, c_void, pthread_mutex_t, size_t};
+use crate::prelude::*;
+use crate::pthread_mutex_t;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
@@ -49,7 +50,7 @@ s! {
         pub st_dev: c_ulong,
 
         #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        __pad1: crate::c_short,
+        __pad1: c_short,
         #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
         st_pad1: [c_long; 3],
         pub st_ino: crate::ino_t,
@@ -62,7 +63,7 @@ s! {
         #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
         pub st_rdev: c_ulong,
         #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        __pad2: crate::c_short,
+        __pad2: c_short,
         #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
         st_pad2: [c_long; 2],
         pub st_size: off_t,

--- a/src/unix/linux_like/linux/gnu/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/gnu/b32/powerpc.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_short, c_uint, c_ulong, c_ushort, c_void, off64_t, off_t, size_t};
+use crate::prelude::*;
+use crate::{off64_t, off_t};
 
 pub type c_char = u8;
 pub type wchar_t = i32;

--- a/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
@@ -1,8 +1,7 @@
 //! RISC-V-specific definitions for 32-bit linux-like values
 
-use crate::{
-    c_int, c_long, c_short, c_uint, c_ulong, c_ulonglong, c_ushort, c_void, off64_t, off_t, size_t,
-};
+use crate::prelude::*;
+use crate::{off64_t, off_t};
 
 pub type c_char = u8;
 pub type wchar_t = c_int;

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -1,8 +1,7 @@
 //! SPARC-specific definitions for 32-bit linux-like values
 
-use crate::{
-    c_int, c_long, c_short, c_uint, c_ulong, c_ulonglong, c_ushort, c_void, off64_t, off_t, size_t,
-};
+use crate::prelude::*;
+use crate::{off64_t, off_t};
 
 pub type c_char = i8;
 pub type wchar_t = i32;

--- a/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_short, c_uint, c_ulong, c_ushort, c_void, off64_t, off_t, size_t};
+use crate::prelude::*;
+use crate::{off64_t, off_t};
 
 pub type c_char = i8;
 pub type wchar_t = i32;
@@ -296,8 +297,8 @@ cfg_if! {
 
         impl Eq for user_fpxregs_struct {}
 
-        impl crate::fmt::Debug for user_fpxregs_struct {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for user_fpxregs_struct {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("user_fpxregs_struct")
                     .field("cwd", &self.cwd)
                     .field("swd", &self.swd)
@@ -316,8 +317,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for user_fpxregs_struct {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for user_fpxregs_struct {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cwd.hash(state);
                 self.swd.hash(state);
                 self.twd.hash(state);
@@ -347,8 +348,8 @@ cfg_if! {
 
         impl Eq for ucontext_t {}
 
-        impl crate::fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ucontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ucontext_t")
                     .field("uc_flags", &self.uc_flags)
                     .field("uc_link", &self.uc_link)
@@ -360,8 +361,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for ucontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ucontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_flags.hash(state);
                 self.uc_link.hash(state);
                 self.uc_stack.hash(state);

--- a/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
@@ -1,8 +1,7 @@
 //! AArch64-specific definitions for 64-bit linux-like values
 
-use crate::{
-    c_int, c_longlong, c_short, c_uint, c_ulonglong, c_ushort, c_void, off64_t, off_t, size_t,
-};
+use crate::prelude::*;
+use crate::{off64_t, off_t};
 
 pub type c_char = u8;
 pub type wchar_t = u32;

--- a/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
@@ -1,7 +1,5 @@
-use crate::{
-    c_int, c_longlong, c_short, c_uint, c_ulonglong, c_ushort, c_void, off64_t, off_t,
-    pthread_mutex_t, size_t,
-};
+use crate::prelude::*;
+use crate::{off64_t, off_t, pthread_mutex_t};
 
 pub type c_char = i8;
 pub type c_long = i64;

--- a/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_short, c_uint, c_ushort, c_void, off64_t, off_t, pthread_mutex_t, size_t};
+use crate::prelude::*;
+use crate::{off64_t, off_t, pthread_mutex_t};
 
 pub type blksize_t = i64;
 pub type c_char = i8;

--- a/src/unix/linux_like/linux/gnu/b64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mod.rs
@@ -1,6 +1,6 @@
 //! 64-bit specific definitions for linux-like values
 
-use crate::{c_int, c_uint, c_ushort};
+use crate::prelude::*;
 
 pub type ino_t = u64;
 pub type off_t = i64;
@@ -12,7 +12,7 @@ pub type fsblkcnt_t = u64;
 pub type fsfilcnt_t = u64;
 pub type rlim_t = u64;
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
-pub type __syscall_ulong_t = crate::c_ulonglong;
+pub type __syscall_ulong_t = c_ulonglong;
 #[cfg(not(all(target_arch = "x86_64", target_pointer_width = "32")))]
 pub type __syscall_ulong_t = c_ulong;
 

--- a/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
@@ -1,6 +1,7 @@
 //! PowerPC64-specific definitions for 64-bit linux-like values
 
-use crate::{c_int, c_short, c_uint, c_void, off64_t, off_t, pthread_mutex_t, size_t};
+use crate::prelude::*;
+use crate::{off64_t, off_t, pthread_mutex_t};
 
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
@@ -1,8 +1,7 @@
 //! RISC-V-specific definitions for 64-bit linux-like values
 
-use crate::{
-    c_int, c_longlong, c_short, c_uint, c_ulonglong, c_ushort, c_void, off64_t, off_t, size_t,
-};
+use crate::prelude::*;
+use crate::{off64_t, off_t};
 
 pub type c_char = u8;
 pub type c_long = i64;

--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -1,8 +1,7 @@
 //! s390x
 
-use crate::{
-    c_double, c_int, c_short, c_uint, c_ushort, c_void, off64_t, off_t, pthread_mutex_t, size_t,
-};
+use crate::prelude::*;
+use crate::{off64_t, off_t, pthread_mutex_t};
 
 pub type blksize_t = i64;
 pub type c_char = u8;
@@ -231,15 +230,15 @@ cfg_if! {
 
         impl Eq for fpreg_t {}
 
-        impl crate::fmt::Debug for fpreg_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for fpreg_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("fpreg_t").field("d", &self.d).finish()
             }
         }
 
-        impl crate::hash::Hash for fpreg_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
-                let d: u64 = unsafe { crate::mem::transmute(self.d) };
+        impl hash::Hash for fpreg_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
+                let d: u64 = unsafe { mem::transmute(self.d) };
                 d.hash(state);
             }
         }

--- a/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
@@ -1,9 +1,7 @@
 //! SPARC64-specific definitions for 64-bit linux-like values
 
-use crate::{
-    c_int, c_longlong, c_short, c_uint, c_ulonglong, c_ushort, c_void, off64_t, off_t,
-    pthread_mutex_t, size_t,
-};
+use crate::prelude::*;
+use crate::{off64_t, off_t, pthread_mutex_t};
 
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -1,8 +1,7 @@
 //! x86_64-specific definitions for 64-bit linux-like values
 
-use crate::{
-    c_int, c_longlong, c_short, c_uint, c_ulonglong, c_ushort, c_void, off64_t, off_t, size_t,
-};
+use crate::prelude::*;
+use crate::{off64_t, off_t};
 
 pub type c_char = i8;
 pub type wchar_t = i32;
@@ -348,8 +347,8 @@ cfg_if! {
 
         impl Eq for user_fpregs_struct {}
 
-        impl crate::fmt::Debug for user_fpregs_struct {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for user_fpregs_struct {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("user_fpregs_struct")
                     .field("cwd", &self.cwd)
                     .field("ftw", &self.ftw)
@@ -365,8 +364,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for user_fpregs_struct {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for user_fpregs_struct {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cwd.hash(state);
                 self.ftw.hash(state);
                 self.fop.hash(state);
@@ -393,8 +392,8 @@ cfg_if! {
 
         impl Eq for ucontext_t {}
 
-        impl crate::fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ucontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ucontext_t")
                     .field("uc_flags", &self.uc_flags)
                     .field("uc_link", &self.uc_link)
@@ -406,8 +405,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for ucontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ucontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_flags.hash(state);
                 self.uc_link.hash(state);
                 self.uc_stack.hash(state);

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/not_x32.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/not_x32.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_void, pthread_mutex_t, size_t};
+use crate::prelude::*;
+use crate::pthread_mutex_t;
 
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/x32.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/x32.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, pthread_mutex_t};
+use crate::prelude::*;
+use crate::pthread_mutex_t;
 
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1,6 +1,5 @@
-use crate::{
-    c_int, c_short, c_uchar, c_uint, c_ulonglong, c_ushort, c_void, off64_t, size_t, ssize_t,
-};
+use crate::off64_t;
+use crate::prelude::*;
 
 pub type pthread_t = c_ulong;
 pub type __priority_which_t = c_uint;
@@ -658,8 +657,8 @@ cfg_if! {
 
         impl Eq for utmpx {}
 
-        impl crate::fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utmpx {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utmpx")
                     .field("ut_type", &self.ut_type)
                     .field("ut_pid", &self.ut_pid)
@@ -676,8 +675,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for utmpx {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utmpx {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_type.hash(state);
                 self.ut_pid.hash(state);
                 self.ut_line.hash(state);
@@ -704,8 +703,8 @@ cfg_if! {
 
         impl Eq for __c_anonymous_ptrace_syscall_info_data {}
 
-        impl crate::fmt::Debug for __c_anonymous_ptrace_syscall_info_data {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_ptrace_syscall_info_data {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 unsafe {
                     f.debug_struct("__c_anonymous_ptrace_syscall_info_data")
                         .field("entry", &self.entry)
@@ -716,8 +715,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for __c_anonymous_ptrace_syscall_info_data {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for __c_anonymous_ptrace_syscall_info_data {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self.entry.hash(state);
                     self.exit.hash(state);

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -2,9 +2,7 @@
 
 use core::mem::size_of;
 
-use crate::{
-    c_double, c_int, c_longlong, c_short, c_uchar, c_uint, c_ushort, c_void, size_t, ssize_t,
-};
+use crate::prelude::*;
 
 pub type useconds_t = u32;
 pub type dev_t = u64;
@@ -477,9 +475,9 @@ s! {
         // will probably need including here. tsidea, skrap
         // QNX (NTO) platform does not define these fields
         #[cfg(not(any(target_env = "uclibc", target_os = "nto")))]
-        pub dlpi_adds: crate::c_ulonglong,
+        pub dlpi_adds: c_ulonglong,
         #[cfg(not(any(target_env = "uclibc", target_os = "nto")))]
-        pub dlpi_subs: crate::c_ulonglong,
+        pub dlpi_subs: c_ulonglong,
         #[cfg(not(any(target_env = "uclibc", target_os = "nto")))]
         pub dlpi_tls_modid: size_t,
         #[cfg(not(any(target_env = "uclibc", target_os = "nto")))]
@@ -1710,8 +1708,8 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_nl {}
-        impl crate::fmt::Debug for sockaddr_nl {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_nl {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_nl")
                     .field("nl_family", &self.nl_family)
                     .field("nl_pid", &self.nl_pid)
@@ -1719,8 +1717,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sockaddr_nl {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_nl {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.nl_family.hash(state);
                 self.nl_pid.hash(state);
                 self.nl_groups.hash(state);
@@ -1743,8 +1741,8 @@ cfg_if! {
 
         impl Eq for dirent {}
 
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_ino", &self.d_ino)
                     .field("d_off", &self.d_off)
@@ -1755,8 +1753,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for dirent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
                 self.d_off.hash(state);
                 self.d_reclen.hash(state);
@@ -1781,8 +1779,8 @@ cfg_if! {
 
         impl Eq for dirent64 {}
 
-        impl crate::fmt::Debug for dirent64 {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent64 {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent64")
                     .field("d_ino", &self.d_ino)
                     .field("d_off", &self.d_off)
@@ -1793,8 +1791,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for dirent64 {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent64 {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
                 self.d_off.hash(state);
                 self.d_reclen.hash(state);
@@ -1811,16 +1809,16 @@ cfg_if! {
 
         impl Eq for pthread_cond_t {}
 
-        impl crate::fmt::Debug for pthread_cond_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_cond_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_cond_t")
                     // FIXME: .field("size", &self.size)
                     .finish()
             }
         }
 
-        impl crate::hash::Hash for pthread_cond_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_cond_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.size.hash(state);
             }
         }
@@ -1833,16 +1831,16 @@ cfg_if! {
 
         impl Eq for pthread_mutex_t {}
 
-        impl crate::fmt::Debug for pthread_mutex_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_mutex_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_mutex_t")
                     // FIXME: .field("size", &self.size)
                     .finish()
             }
         }
 
-        impl crate::hash::Hash for pthread_mutex_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_mutex_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.size.hash(state);
             }
         }
@@ -1855,16 +1853,16 @@ cfg_if! {
 
         impl Eq for pthread_rwlock_t {}
 
-        impl crate::fmt::Debug for pthread_rwlock_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_rwlock_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_rwlock_t")
                     // FIXME: .field("size", &self.size)
                     .finish()
             }
         }
 
-        impl crate::hash::Hash for pthread_rwlock_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_rwlock_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.size.hash(state);
             }
         }
@@ -1877,16 +1875,16 @@ cfg_if! {
 
         impl Eq for pthread_barrier_t {}
 
-        impl crate::fmt::Debug for pthread_barrier_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_barrier_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_barrier_t")
                     .field("size", &self.size)
                     .finish()
             }
         }
 
-        impl crate::hash::Hash for pthread_barrier_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pthread_barrier_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.size.hash(state);
             }
         }
@@ -1911,8 +1909,8 @@ cfg_if! {
 
         impl Eq for sockaddr_alg {}
 
-        impl crate::fmt::Debug for sockaddr_alg {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_alg {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_alg")
                     .field("salg_family", &self.salg_family)
                     .field("salg_type", &self.salg_type)
@@ -1923,8 +1921,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for sockaddr_alg {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_alg {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.salg_family.hash(state);
                 self.salg_type.hash(state);
                 self.salg_feat.hash(state);
@@ -1942,8 +1940,8 @@ cfg_if! {
         }
         impl Eq for uinput_setup {}
 
-        impl crate::fmt::Debug for uinput_setup {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for uinput_setup {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("uinput_setup")
                     .field("id", &self.id)
                     .field("name", &&self.name[..])
@@ -1952,8 +1950,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for uinput_setup {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for uinput_setup {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.id.hash(state);
                 self.name.hash(state);
                 self.ff_effects_max.hash(state);
@@ -1973,8 +1971,8 @@ cfg_if! {
         }
         impl Eq for uinput_user_dev {}
 
-        impl crate::fmt::Debug for uinput_user_dev {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for uinput_user_dev {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("uinput_setup")
                     .field("name", &&self.name[..])
                     .field("id", &self.id)
@@ -1987,8 +1985,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for uinput_user_dev {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for uinput_user_dev {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.name.hash(state);
                 self.id.hash(state);
                 self.ff_effects_max.hash(state);
@@ -2008,8 +2006,8 @@ cfg_if! {
             }
         }
         impl Eq for mq_attr {}
-        impl crate::fmt::Debug for mq_attr {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mq_attr {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mq_attr")
                     .field("mq_flags", &self.mq_flags)
                     .field("mq_maxmsg", &self.mq_maxmsg)
@@ -2018,16 +2016,16 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for mq_attr {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mq_attr {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mq_flags.hash(state);
                 self.mq_maxmsg.hash(state);
                 self.mq_msgsize.hash(state);
                 self.mq_curmsgs.hash(state);
             }
         }
-        impl crate::fmt::Debug for __c_anonymous_ifr_ifru {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_ifr_ifru {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ifr_ifru")
                     .field("ifru_addr", unsafe { &self.ifru_addr })
                     .field("ifru_dstaddr", unsafe { &self.ifru_dstaddr })
@@ -2045,8 +2043,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::fmt::Debug for ifreq {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ifreq {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ifreq")
                     .field("ifr_name", &self.ifr_name)
                     .field("ifr_ifru", &self.ifr_ifru)
@@ -2054,24 +2052,24 @@ cfg_if! {
             }
         }
 
-        impl crate::fmt::Debug for __c_anonymous_ifc_ifcu {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_ifc_ifcu {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ifr_ifru")
                     .field("ifcu_buf", unsafe { &self.ifcu_buf })
                     .field("ifcu_req", unsafe { &self.ifcu_req })
                     .finish()
             }
         }
-        impl crate::fmt::Debug for ifconf {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ifconf {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ifconf")
                     .field("ifc_len", &self.ifc_len)
                     .field("ifc_ifcu", &self.ifc_ifcu)
                     .finish()
             }
         }
-        impl crate::fmt::Debug for hwtstamp_config {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for hwtstamp_config {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("hwtstamp_config")
                     .field("flags", &self.flags)
                     .field("tx_type", &self.tx_type)
@@ -2087,16 +2085,16 @@ cfg_if! {
             }
         }
         impl Eq for hwtstamp_config {}
-        impl crate::hash::Hash for hwtstamp_config {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for hwtstamp_config {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.flags.hash(state);
                 self.tx_type.hash(state);
                 self.rx_filter.hash(state);
             }
         }
 
-        impl crate::fmt::Debug for sched_attr {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sched_attr {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sched_attr")
                     .field("size", &self.size)
                     .field("sched_policy", &self.sched_policy)
@@ -2122,8 +2120,8 @@ cfg_if! {
             }
         }
         impl Eq for sched_attr {}
-        impl crate::hash::Hash for sched_attr {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sched_attr {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.size.hash(state);
                 self.sched_policy.hash(state);
                 self.sched_flags.hash(state);
@@ -2135,8 +2133,8 @@ cfg_if! {
             }
         }
 
-        impl crate::fmt::Debug for iwreq_data {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for iwreq_data {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("iwreq_data")
                     .field("name", unsafe { &self.name })
                     .field("essid", unsafe { &self.essid })
@@ -2160,8 +2158,8 @@ cfg_if! {
             }
         }
 
-        impl crate::fmt::Debug for iw_event {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for iw_event {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("iw_event")
                     .field("len", &self.len)
                     .field("cmd", &self.cmd)
@@ -2170,16 +2168,16 @@ cfg_if! {
             }
         }
 
-        impl crate::fmt::Debug for __c_anonymous_iwreq {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_iwreq {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("__c_anonymous_iwreq")
                     .field("ifrn_name", unsafe { &self.ifrn_name })
                     .finish()
             }
         }
 
-        impl crate::fmt::Debug for iwreq {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for iwreq {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("iwreq")
                     .field("ifr_ifrn", &self.ifr_ifrn)
                     .field("u", &self.u)
@@ -5798,8 +5796,8 @@ f! {
     }
 
     pub fn CPU_ALLOC_SIZE(count: c_int) -> size_t {
-        let _dummy: cpu_set_t = crate::mem::zeroed();
-        let size_in_bits = 8 * crate::mem::size_of_val(&_dummy.bits[0]);
+        let _dummy: cpu_set_t = mem::zeroed();
+        let size_in_bits = 8 * mem::size_of_val(&_dummy.bits[0]);
         ((count as size_t + size_in_bits - 1) / 8) as size_t
     }
 
@@ -5810,28 +5808,28 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * crate::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] |= 1 << offset;
         ()
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * crate::mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] &= !(1 << offset);
         ()
     }
 
     pub fn CPU_ISSET(cpu: usize, cpuset: &cpu_set_t) -> bool {
-        let size_in_bits = 8 * crate::mem::size_of_val(&cpuset.bits[0]);
+        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]);
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         0 != (cpuset.bits[idx] & (1 << offset))
     }
 
     pub fn CPU_COUNT_S(size: usize, cpuset: &cpu_set_t) -> c_int {
         let mut s: u32 = 0;
-        let size_of_mask = crate::mem::size_of_val(&cpuset.bits[0]);
+        let size_of_mask = mem::size_of_val(&cpuset.bits[0]);
         for i in cpuset.bits[..(size / size_of_mask)].iter() {
             s += i.count_ones();
         }

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_short, c_uint, c_ulong, c_ulonglong, c_void, off_t, size_t, ssize_t};
+use crate::off_t;
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type wchar_t = u32;
@@ -154,8 +155,8 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl crate::fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ucontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ucontext_t")
                     .field("uc_flags", &self.uc_link)
                     .field("uc_link", &self.uc_link)
@@ -165,8 +166,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for ucontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ucontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_flags.hash(state);
                 self.uc_link.hash(state);
                 self.uc_stack.hash(state);

--- a/src/unix/linux_like/linux/musl/b32/hexagon.rs
+++ b/src/unix/linux_like/linux/musl/b32/hexagon.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_long, c_longlong, c_uint, c_ulong, c_ulonglong, c_ushort, c_void, size_t};
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type wchar_t = u32;

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_short, c_ulong, c_void, off_t, size_t};
+use crate::off_t;
+use crate::prelude::*;
 
 pub type c_char = i8;
 pub type wchar_t = c_int;

--- a/src/unix/linux_like/linux/musl/b32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_longlong, c_ulonglong, c_void};
+use crate::prelude::*;
 
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_longlong, c_short, c_uint, c_ulong, c_void, off_t, size_t, ssize_t};
+use crate::off_t;
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type wchar_t = i32;

--- a/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
@@ -1,6 +1,7 @@
 //! RISC-V-specific definitions for 32-bit linux-like values
 
-use crate::{c_int, c_long, c_short, c_ulong, c_ushort, c_void, off64_t, off_t, size_t};
+use crate::prelude::*;
+use crate::{off64_t, off_t};
 
 pub type c_char = u8;
 pub type wchar_t = c_int;

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_short, c_uint, c_ulong, c_ushort, c_void, off_t, size_t, ssize_t};
+use crate::off_t;
+use crate::prelude::*;
 
 pub type c_char = i8;
 pub type wchar_t = i32;
@@ -159,8 +160,8 @@ cfg_if! {
 
         impl Eq for user_fpxregs_struct {}
 
-        impl crate::fmt::Debug for user_fpxregs_struct {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for user_fpxregs_struct {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("user_fpxregs_struct")
                     .field("cwd", &self.cwd)
                     .field("swd", &self.swd)
@@ -179,8 +180,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for user_fpxregs_struct {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for user_fpxregs_struct {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cwd.hash(state);
                 self.swd.hash(state);
                 self.twd.hash(state);
@@ -214,8 +215,8 @@ cfg_if! {
 
         impl Eq for ucontext_t {}
 
-        impl crate::fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ucontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ucontext_t")
                     .field("uc_flags", &self.uc_flags)
                     .field("uc_link", &self.uc_link)
@@ -227,8 +228,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for ucontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ucontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_flags.hash(state);
                 self.uc_link.hash(state);
                 self.uc_stack.hash(state);

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -1,6 +1,5 @@
-use crate::{
-    c_int, c_long, c_longlong, c_short, c_uint, c_ulong, c_ulonglong, c_ushort, off_t, size_t,
-};
+use crate::off_t;
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type __u64 = c_ulonglong;

--- a/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
@@ -1,9 +1,7 @@
 //! LoongArch-specific definitions for 64-bit linux-like values
 
-use crate::{
-    c_int, c_long, c_longlong, c_short, c_uint, c_ulong, c_ulonglong, c_ushort, off64_t, off_t,
-    size_t,
-};
+use crate::prelude::*;
+use crate::{off64_t, off_t};
 
 pub type c_char = i8;
 pub type wchar_t = c_int;

--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_short, c_uint, c_ulong, off_t, size_t};
+use crate::off_t;
+use crate::prelude::*;
 
 pub type c_char = i8;
 pub type wchar_t = i32;

--- a/src/unix/linux_like/linux/musl/b64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_uint, c_void, size_t, ssize_t};
+use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_long, c_short, c_ulong, off_t, size_t};
+use crate::off_t;
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type wchar_t = i32;

--- a/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
@@ -1,9 +1,7 @@
 //! RISC-V-specific definitions for 64-bit linux-like values
 
-use crate::{
-    c_int, c_long, c_longlong, c_short, c_uint, c_ulong, c_ulonglong, c_ushort, off64_t, off_t,
-    size_t,
-};
+use crate::prelude::*;
+use crate::{off64_t, off_t};
 
 pub type c_char = u8;
 pub type wchar_t = c_int;

--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -1,4 +1,5 @@
-use crate::{c_double, c_int, c_long, c_short, off_t, size_t};
+use crate::off_t;
+use crate::prelude::*;
 
 pub type blksize_t = i64;
 pub type c_char = u8;
@@ -80,15 +81,15 @@ cfg_if! {
 
         impl Eq for fpreg_t {}
 
-        impl crate::fmt::Debug for fpreg_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for fpreg_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("fpreg_t").field("d", &self.d).finish()
             }
         }
 
-        impl crate::hash::Hash for fpreg_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
-                let d: u64 = unsafe { crate::mem::transmute(self.d) };
+        impl hash::Hash for fpreg_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
+                let d: u64 = unsafe { mem::transmute(self.d) };
                 d.hash(state);
             }
         }

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -1,6 +1,5 @@
-use crate::{
-    c_int, c_long, c_longlong, c_short, c_uint, c_ulong, c_ulonglong, c_ushort, off_t, size_t,
-};
+use crate::off_t;
+use crate::prelude::*;
 
 pub type c_char = i8;
 pub type wchar_t = i32;
@@ -196,8 +195,8 @@ cfg_if! {
 
         impl Eq for user_fpregs_struct {}
 
-        impl crate::fmt::Debug for user_fpregs_struct {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for user_fpregs_struct {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("user_fpregs_struct")
                     .field("cwd", &self.cwd)
                     .field("ftw", &self.ftw)
@@ -213,8 +212,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for user_fpregs_struct {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for user_fpregs_struct {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cwd.hash(state);
                 self.ftw.hash(state);
                 self.fop.hash(state);
@@ -245,8 +244,8 @@ cfg_if! {
 
         impl Eq for ucontext_t {}
 
-        impl crate::fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ucontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ucontext_t")
                     .field("uc_flags", &self.uc_flags)
                     .field("uc_link", &self.uc_link)
@@ -258,8 +257,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for ucontext_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for ucontext_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_flags.hash(state);
                 self.uc_link.hash(state);
                 self.uc_stack.hash(state);

--- a/src/unix/linux_like/linux/musl/lfs64.rs
+++ b/src/unix/linux_like/linux/musl/lfs64.rs
@@ -1,4 +1,5 @@
-use crate::{c_char, c_int, c_void, off64_t, size_t, ssize_t};
+use crate::off64_t;
+use crate::prelude::*;
 
 #[inline]
 pub unsafe extern "C" fn creat64(path: *const c_char, mode: crate::mode_t) -> c_int {

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -1,6 +1,5 @@
-use crate::{
-    c_int, c_short, c_uchar, c_uint, c_ulonglong, c_ushort, c_void, off64_t, size_t, ssize_t,
-};
+use crate::off64_t;
+use crate::prelude::*;
 
 pub type pthread_t = *mut c_void;
 pub type clock_t = c_long;
@@ -595,8 +594,8 @@ cfg_if! {
 
         impl Eq for sysinfo {}
 
-        impl crate::fmt::Debug for sysinfo {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sysinfo {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sysinfo")
                     .field("uptime", &self.uptime)
                     .field("loads", &self.loads)
@@ -616,8 +615,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for sysinfo {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sysinfo {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uptime.hash(state);
                 self.loads.hash(state);
                 self.totalram.hash(state);
@@ -659,8 +658,8 @@ cfg_if! {
 
         impl Eq for utmpx {}
 
-        impl crate::fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utmpx {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utmpx")
                     .field("ut_type", &self.ut_type)
                     //.field("__ut_pad1", &self.__ut_pad1)
@@ -679,8 +678,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for utmpx {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utmpx {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_type.hash(state);
                 //self.__ut_pad1.hash(state);
                 self.ut_pid.hash(state);

--- a/src/unix/linux_like/linux/uclibc/arm/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/arm/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_longlong, c_short, c_uint, c_ulonglong, c_ushort, c_void, off64_t, size_t};
+use crate::off64_t;
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type wchar_t = c_uint;

--- a/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_longlong, c_short, c_uint, c_ulonglong, c_ushort, c_void, off64_t, size_t};
+use crate::off64_t;
+use crate::prelude::*;
 
 pub type c_char = i8;
 pub type c_long = i32;

--- a/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_uint, c_ushort, c_void, off64_t, size_t};
+use crate::off64_t;
+use crate::prelude::*;
 
 pub type blkcnt_t = i64;
 pub type blksize_t = i64;

--- a/src/unix/linux_like/linux/uclibc/mips/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_short, c_uint, size_t};
+use crate::prelude::*;
 
 pub type pthread_t = c_ulong;
 

--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_short, c_uchar, c_uint, c_ushort, c_void, off64_t, size_t, ssize_t};
+use crate::off64_t;
+use crate::prelude::*;
 
 pub type shmatt_t = c_ulong;
 pub type msgqnum_t = c_ulong;

--- a/src/unix/linux_like/linux/uclibc/x86_64/l4re.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/l4re.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_uint, c_ulong, c_void, size_t};
+use crate::prelude::*;
 
 /// L4Re specifics
 /// This module contains definitions required by various L4Re libc backends.

--- a/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
@@ -1,6 +1,7 @@
 //! Definitions for uclibc on 64bit systems
 
-use crate::{c_int, c_uint, c_ushort, c_void, off64_t, size_t};
+use crate::off64_t;
+use crate::prelude::*;
 
 pub type blkcnt_t = i64;
 pub type blksize_t = i64;

--- a/src/unix/linux_like/linux/uclibc/x86_64/other.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/other.rs
@@ -1,4 +1,4 @@
-use crate::c_ulong;
+use crate::prelude::*;
 
 // Thestyle checker discourages the use of #[cfg], so this has to go into a
 // separate module

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_short, c_uchar, c_uint, c_ushort, c_void, intptr_t, size_t, ssize_t};
+use crate::prelude::*;
 
 pub type sa_family_t = u16;
 pub type speed_t = c_uint;
@@ -315,8 +315,8 @@ cfg_if! {
             }
         }
         impl Eq for epoll_event {}
-        impl crate::fmt::Debug for epoll_event {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for epoll_event {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let events = self.events;
                 let u64 = self.u64;
                 f.debug_struct("epoll_event")
@@ -325,8 +325,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for epoll_event {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for epoll_event {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let events = self.events;
                 let u64 = self.u64;
                 events.hash(state);
@@ -345,16 +345,16 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_un {}
-        impl crate::fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_un {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_un")
                     .field("sun_family", &self.sun_family)
                     // FIXME: .field("sun_path", &self.sun_path)
                     .finish()
             }
         }
-        impl crate::hash::Hash for sockaddr_un {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_un {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sun_family.hash(state);
                 self.sun_path.hash(state);
             }
@@ -373,8 +373,8 @@ cfg_if! {
 
         impl Eq for sockaddr_storage {}
 
-        impl crate::fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_storage {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_storage")
                     .field("ss_family", &self.ss_family)
                     .field("__ss_align", &self.__ss_align)
@@ -383,8 +383,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for sockaddr_storage {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_storage {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_family.hash(state);
                 self.__ss_pad2.hash(state);
             }
@@ -426,8 +426,8 @@ cfg_if! {
 
         impl Eq for utsname {}
 
-        impl crate::fmt::Debug for utsname {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utsname {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utsname")
                     // FIXME: .field("sysname", &self.sysname)
                     // FIXME: .field("nodename", &self.nodename)
@@ -439,8 +439,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for utsname {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utsname {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sysname.hash(state);
                 self.nodename.hash(state);
                 self.release.hash(state);
@@ -450,8 +450,8 @@ cfg_if! {
             }
         }
 
-        impl crate::fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sigevent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sigevent")
                     .field("sigev_value", &self.sigev_value)
                     .field("sigev_signo", &self.sigev_signo)
@@ -595,7 +595,7 @@ pub const XATTR_REPLACE: c_int = 0x2;
 
 cfg_if! {
     if #[cfg(target_os = "android")] {
-        pub const RLIM64_INFINITY: crate::c_ulonglong = !0;
+        pub const RLIM64_INFINITY: c_ulonglong = !0;
     } else {
         pub const RLIM64_INFINITY: crate::rlim64_t = !0;
     }
@@ -1608,13 +1608,13 @@ cfg_if! {
 
 const_fn! {
     {const} fn CMSG_ALIGN(len: usize) -> usize {
-        len + crate::mem::size_of::<usize>() - 1 & !(crate::mem::size_of::<usize>() - 1)
+        len + mem::size_of::<usize>() - 1 & !(mem::size_of::<usize>() - 1)
     }
 }
 
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= crate::mem::size_of::<cmsghdr>() {
+        if (*mhdr).msg_controllen as usize >= mem::size_of::<cmsghdr>() {
             (*mhdr).msg_control as *mut cmsghdr
         } else {
             0 as *mut cmsghdr
@@ -1626,29 +1626,29 @@ f! {
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(crate::mem::size_of::<cmsghdr>())) as c_uint
+        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(mem::size_of::<cmsghdr>())) as c_uint
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        CMSG_ALIGN(crate::mem::size_of::<cmsghdr>()) as c_uint + length
+        CMSG_ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
         return;
     }

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -3,7 +3,7 @@
 //! More functions and definitions can be found in the more specific modules
 //! according to the platform in question.
 
-use crate::c_void;
+use crate::prelude::*;
 
 pub type c_schar = i8;
 pub type c_uchar = u8;

--- a/src/unix/newlib/aarch64/mod.rs
+++ b/src/unix/newlib/aarch64/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_short};
+use crate::prelude::*;
 
 pub type clock_t = c_long;
 pub type c_char = u8;

--- a/src/unix/newlib/arm/mod.rs
+++ b/src/unix/newlib/arm/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_short};
+use crate::prelude::*;
 
 pub type clock_t = c_long;
 pub type c_char = u8;

--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_short, c_uint, c_void, size_t, ssize_t};
+use crate::prelude::*;
 
 pub type clock_t = c_ulong;
 pub type c_char = i8;

--- a/src/unix/newlib/generic.rs
+++ b/src/unix/newlib/generic.rs
@@ -1,11 +1,12 @@
 //! Common types used by most newlib platforms
 
-use crate::{c_char, c_long, c_uchar, off_t};
+use crate::off_t;
+use crate::prelude::*;
 
 s! {
     pub struct sigset_t {
         #[cfg(target_os = "horizon")]
-        __val: [crate::c_ulong; 16],
+        __val: [c_ulong; 16],
         #[cfg(not(target_os = "horizon"))]
         __val: u32,
     }

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -1,8 +1,7 @@
 //! ARMv6K Nintendo 3DS C Newlib definitions
 
-use crate::{
-    c_int, c_longlong, c_short, c_uchar, c_uint, c_ushort, c_void, off_t, size_t, ssize_t,
-};
+use crate::off_t;
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type c_long = i32;

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_longlong, c_uint, c_ushort, c_void, size_t};
+use crate::prelude::*;
 
 pub type blkcnt_t = i32;
 pub type blksize_t = i32;
@@ -7,11 +7,11 @@ pub type clockid_t = c_ulong;
 
 cfg_if! {
     if #[cfg(any(target_os = "espidf"))] {
-        pub type dev_t = crate::c_short;
+        pub type dev_t = c_short;
         pub type ino_t = c_ushort;
         pub type off_t = c_long;
     } else if #[cfg(any(target_os = "vita"))] {
-        pub type dev_t = crate::c_short;
+        pub type dev_t = c_short;
         pub type ino_t = c_ushort;
         pub type off_t = c_int;
     } else {
@@ -253,7 +253,7 @@ s! {
         #[cfg(target_os = "espidf")]
         pub is_initialized: i32,
         #[cfg(target_os = "espidf")]
-        pub stackaddr: *mut crate::c_void,
+        pub stackaddr: *mut c_void,
         #[cfg(target_os = "espidf")]
         pub stacksize: i32,
         #[cfg(target_os = "espidf")]
@@ -836,20 +836,20 @@ pub const PRIO_USER: c_int = 2;
 
 f! {
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
-        let bits = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] &= !(1 << (fd % bits));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
-        let bits = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
-        let bits = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] |= 1 << (fd % bits);
         return;

--- a/src/unix/newlib/powerpc/mod.rs
+++ b/src/unix/newlib/powerpc/mod.rs
@@ -1,4 +1,4 @@
-use crate::c_int;
+use crate::prelude::*;
 
 pub type clock_t = c_ulong;
 pub type c_char = u8;

--- a/src/unix/newlib/rtems/mod.rs
+++ b/src/unix/newlib/rtems/mod.rs
@@ -1,5 +1,6 @@
 // defined in architecture specific module
-use crate::{c_char, c_int, c_long, c_ulong, c_void, size_t, ssize_t};
+
+use crate::prelude::*;
 
 s! {
     pub struct sockaddr_un {

--- a/src/unix/newlib/vita/mod.rs
+++ b/src/unix/newlib/vita/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_int, c_short, c_void, off_t, size_t, ssize_t};
+use crate::off_t;
+use crate::prelude::*;
 
 pub type clock_t = c_long;
 

--- a/src/unix/nto/aarch64.rs
+++ b/src/unix/nto/aarch64.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_void, size_t};
+use crate::prelude::*;
 
 pub type c_char = u8;
 pub type wchar_t = u32;

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_short, c_uchar, c_uint, c_ushort, c_void, size_t, ssize_t};
+use crate::prelude::*;
 
 pub type clock_t = u32;
 
@@ -770,8 +770,8 @@ cfg_if! {
             }
         }
         impl Eq for sigevent {}
-        impl crate::fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sigevent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sigevent")
                     .field("sigev_notify", &self.sigev_notify)
                     .field("sigev_signo", &self.sigev_signo)
@@ -780,8 +780,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sigevent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sigevent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sigev_notify.hash(state);
                 self.sigev_signo.hash(state);
                 self.sigev_value.hash(state);
@@ -801,8 +801,8 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_un {}
-        impl crate::fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_un {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_un")
                     .field("sun_len", &self.sun_len)
                     .field("sun_family", &self.sun_family)
@@ -811,8 +811,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for sockaddr_un {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_un {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sun_len.hash(state);
                 self.sun_family.hash(state);
                 self.sun_path.hash(state);
@@ -826,22 +826,22 @@ cfg_if! {
             }
         }
         impl Eq for sigset_t {}
-        impl crate::fmt::Debug for sigset_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sigset_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sigset_t")
                     .field("__val", &self.__val)
                     .finish()
             }
         }
-        impl crate::hash::Hash for sigset_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sigset_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__val.hash(state);
             }
         }
 
         // msg
-        impl crate::fmt::Debug for msg {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for msg {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("msg")
                     .field("msg_next", &self.msg_next)
                     .field("msg_type", &self.msg_type)
@@ -852,8 +852,8 @@ cfg_if! {
         }
 
         // msqid_ds
-        impl crate::fmt::Debug for msqid_ds {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for msqid_ds {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("msqid_ds")
                     .field("msg_perm", &self.msg_perm)
                     .field("msg_first", &self.msg_first)
@@ -870,8 +870,8 @@ cfg_if! {
         }
 
         // sockaddr_dl
-        impl crate::fmt::Debug for sockaddr_dl {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_dl {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_dl")
                     .field("sdl_len", &self.sdl_len)
                     .field("sdl_family", &self.sdl_family)
@@ -901,8 +901,8 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_dl {}
-        impl crate::hash::Hash for sockaddr_dl {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_dl {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sdl_len.hash(state);
                 self.sdl_family.hash(state);
                 self.sdl_index.hash(state);
@@ -915,8 +915,8 @@ cfg_if! {
         }
 
         // sync_t
-        impl crate::fmt::Debug for sync_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sync_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sync_t")
                     .field("__owner", &self.__owner)
                     .field("__u", &self.__u)
@@ -925,8 +925,8 @@ cfg_if! {
         }
 
         // pthread_barrier_t
-        impl crate::fmt::Debug for pthread_barrier_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_barrier_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_barrier_t")
                     .field("__pad", &self.__pad)
                     .finish()
@@ -934,8 +934,8 @@ cfg_if! {
         }
 
         // pthread_rwlock_t
-        impl crate::fmt::Debug for pthread_rwlock_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pthread_rwlock_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("pthread_rwlock_t")
                     .field("__active", &self.__active)
                     .field("__blockedwriters", &self.__blockedwriters)
@@ -951,8 +951,8 @@ cfg_if! {
         }
 
         // syspage_entry
-        impl crate::fmt::Debug for syspage_entry {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for syspage_entry {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("syspage_entry")
                     .field("size", &self.size)
                     .field("total_size", &self.total_size)
@@ -1012,8 +1012,8 @@ cfg_if! {
 
         impl Eq for utsname {}
 
-        impl crate::fmt::Debug for utsname {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utsname {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utsname")
                     // FIXME: .field("sysname", &self.sysname)
                     // FIXME: .field("nodename", &self.nodename)
@@ -1024,8 +1024,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for utsname {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utsname {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sysname.hash(state);
                 self.nodename.hash(state);
                 self.release.hash(state);
@@ -1048,8 +1048,8 @@ cfg_if! {
 
         impl Eq for mq_attr {}
 
-        impl crate::fmt::Debug for mq_attr {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mq_attr {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mq_attr")
                     .field("mq_maxmsg", &self.mq_maxmsg)
                     .field("mq_msgsize", &self.mq_msgsize)
@@ -1061,8 +1061,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for mq_attr {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for mq_attr {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mq_maxmsg.hash(state);
                 self.mq_msgsize.hash(state);
                 self.mq_flags.hash(state);
@@ -1088,8 +1088,8 @@ cfg_if! {
 
         impl Eq for sockaddr_storage {}
 
-        impl crate::fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_storage {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_storage")
                     .field("ss_len", &self.ss_len)
                     .field("ss_family", &self.ss_family)
@@ -1100,8 +1100,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for sockaddr_storage {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_storage {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_len.hash(state);
                 self.ss_family.hash(state);
                 self.__ss_pad1.hash(state);
@@ -1125,8 +1125,8 @@ cfg_if! {
 
         impl Eq for dirent {}
 
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_ino", &self.d_ino)
                     .field("d_offset", &self.d_offset)
@@ -1137,8 +1137,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for dirent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
                 self.d_offset.hash(state);
                 self.d_reclen.hash(state);
@@ -2378,7 +2378,7 @@ pub const BIOCSRTIMEOUT: c_int = -2146418067;
 pub const BIOCSSEESENT: c_int = -2147204487;
 pub const BIOCVERSION: c_int = 1074020977;
 
-pub const BPF_ALIGNMENT: usize = crate::mem::size_of::<c_long>();
+pub const BPF_ALIGNMENT: usize = mem::size_of::<c_long>();
 pub const CHAR_BIT: usize = 8;
 pub const CODESET: crate::nl_item = 1;
 pub const CRNCYSTR: crate::nl_item = 55;
@@ -2579,7 +2579,7 @@ pub const SO_SETFIB: c_int = 0x100a;
 pub const SO_TXPRIO: c_int = 0x100b;
 pub const SO_USELOOPBACK: c_int = 0x0040;
 pub const SO_VLANPRIO: c_int = 0x100c;
-pub const _SS_ALIGNSIZE: usize = crate::mem::size_of::<i64>();
+pub const _SS_ALIGNSIZE: usize = mem::size_of::<i64>();
 pub const _SS_MAXSIZE: usize = 128;
 pub const _SS_PAD1SIZE: usize = _SS_ALIGNSIZE - 2;
 pub const _SS_PAD2SIZE: usize = _SS_MAXSIZE - 2 - _SS_PAD1SIZE - _SS_ALIGNSIZE;
@@ -2709,7 +2709,7 @@ pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
 
 const_fn! {
     {const} fn _CMSG_ALIGN(len: usize) -> usize {
-        len + crate::mem::size_of::<usize>() - 1 & !(crate::mem::size_of::<usize>() - 1)
+        len + mem::size_of::<usize>() - 1 & !(mem::size_of::<usize>() - 1)
     }
 
     {const} fn _ALIGN(p: usize, b: usize) -> usize {
@@ -2719,7 +2719,7 @@ const_fn! {
 
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= crate::mem::size_of::<cmsghdr>() {
+        if (*mhdr).msg_controllen as usize >= mem::size_of::<cmsghdr>() {
             (*mhdr).msg_control as *mut cmsghdr
         } else {
             0 as *mut cmsghdr
@@ -2728,7 +2728,7 @@ f! {
 
     pub fn CMSG_NXTHDR(mhdr: *const crate::msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         let msg = _CMSG_ALIGN((*cmsg).cmsg_len as usize);
-        let next = cmsg as usize + msg + _CMSG_ALIGN(crate::mem::size_of::<cmsghdr>());
+        let next = cmsg as usize + msg + _CMSG_ALIGN(mem::size_of::<cmsghdr>());
         if next > (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize {
             0 as *mut cmsghdr
         } else {
@@ -2737,33 +2737,33 @@ f! {
     }
 
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(_CMSG_ALIGN(crate::mem::size_of::<cmsghdr>()) as isize)
+        (cmsg as *mut c_uchar).offset(_CMSG_ALIGN(mem::size_of::<cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        _CMSG_ALIGN(crate::mem::size_of::<cmsghdr>()) as c_uint + length
+        _CMSG_ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (_CMSG_ALIGN(crate::mem::size_of::<cmsghdr>()) + _CMSG_ALIGN(length as usize)) as c_uint
+        (_CMSG_ALIGN(mem::size_of::<cmsghdr>()) + _CMSG_ALIGN(length as usize)) as c_uint
     }
 
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
         return;
     }
@@ -2782,7 +2782,7 @@ f! {
     }
 
     pub fn _DEXTRA_VALID(_x: *const crate::dirent_extra, _d: *const dirent) -> bool {
-        let sz = _x as usize - _d as usize + crate::mem::size_of::<crate::dirent_extra>();
+        let sz = _x as usize - _d as usize + mem::size_of::<crate::dirent_extra>();
         let rsz = (*_d).d_reclen as usize;
 
         if sz > rsz || sz + (*_x).d_datalen as usize > rsz {
@@ -2794,14 +2794,14 @@ f! {
 
     pub fn _DEXTRA_NEXT(_x: *const crate::dirent_extra) -> *mut crate::dirent_extra {
         _ALIGN(
-            _x as usize + crate::mem::size_of::<crate::dirent_extra>() + (*_x).d_datalen as usize,
+            _x as usize + mem::size_of::<crate::dirent_extra>() + (*_x).d_datalen as usize,
             8,
         ) as *mut crate::dirent_extra
     }
 
     pub fn SOCKCREDSIZE(ngrps: usize) -> usize {
         let ngrps = if ngrps > 0 { ngrps - 1 } else { 0 };
-        crate::mem::size_of::<sockcred>() + crate::mem::size_of::<crate::gid_t>() * ngrps
+        mem::size_of::<sockcred>() + mem::size_of::<crate::gid_t>() * ngrps
     }
 
     pub fn major(dev: crate::dev_t) -> c_uint {

--- a/src/unix/nto/neutrino.rs
+++ b/src/unix/nto/neutrino.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_long, c_uint, c_void, size_t};
+use crate::prelude::*;
 
 pub type nto_job_t = crate::sync_t;
 

--- a/src/unix/nto/x86_64.rs
+++ b/src/unix/nto/x86_64.rs
@@ -1,4 +1,4 @@
-use crate::{c_int, c_void, size_t};
+use crate::prelude::*;
 
 pub type c_char = i8;
 pub type wchar_t = u32;
@@ -101,8 +101,8 @@ cfg_if! {
             }
         }
 
-        impl crate::fmt::Debug for x86_64_fpu_registers {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for x86_64_fpu_registers {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 unsafe {
                     f.debug_struct("x86_64_fpu_registers")
                         .field("fsave_area", &self.fsave_area)
@@ -113,8 +113,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for x86_64_fpu_registers {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for x86_64_fpu_registers {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self.fsave_area.hash(state);
                     self.fxsave_area.hash(state);

--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -1,4 +1,5 @@
-use crate::{c_void, in6_addr, in_addr_t, timespec, DIR};
+use crate::prelude::*;
+use crate::{in6_addr, in_addr_t, timespec, DIR};
 
 pub type nlink_t = u16;
 pub type ino_t = u16;

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -1,6 +1,4 @@
-use crate::{
-    c_int, c_longlong, c_short, c_uchar, c_uint, c_ulonglong, c_ushort, c_void, size_t, ssize_t,
-};
+use crate::prelude::*;
 
 pub type c_char = i8;
 pub type wchar_t = i32;
@@ -84,8 +82,7 @@ s_no_extra_traits! {
 
     pub struct sockaddr_storage {
         pub ss_family: crate::sa_family_t,
-        __ss_padding:
-            [u8; 128 - crate::mem::size_of::<sa_family_t>() - crate::mem::size_of::<c_ulong>()],
+        __ss_padding: [u8; 128 - mem::size_of::<sa_family_t>() - mem::size_of::<c_ulong>()],
         __ss_align: c_ulong,
     }
 }
@@ -1020,20 +1017,20 @@ pub const PRIO_USER: c_int = 2;
 f! {
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
         return;
     }
@@ -1280,8 +1277,8 @@ cfg_if! {
 
         impl Eq for dirent {}
 
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_ino", &self.d_ino)
                     .field("d_off", &self.d_off)
@@ -1292,8 +1289,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for dirent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for dirent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
                 self.d_off.hash(state);
                 self.d_reclen.hash(state);
@@ -1315,8 +1312,8 @@ cfg_if! {
 
         impl Eq for sockaddr_un {}
 
-        impl crate::fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_un {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_un")
                     .field("sun_family", &self.sun_family)
                     // FIXME: .field("sun_path", &self.sun_path)
@@ -1324,8 +1321,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for sockaddr_un {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_un {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sun_family.hash(state);
                 self.sun_path.hash(state);
             }
@@ -1345,8 +1342,8 @@ cfg_if! {
 
         impl Eq for sockaddr_storage {}
 
-        impl crate::fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_storage {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_storage")
                     .field("ss_family", &self.ss_family)
                     .field("__ss_align", &self.__ss_align)
@@ -1355,8 +1352,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for sockaddr_storage {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_storage {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_family.hash(state);
                 self.__ss_padding.hash(state);
                 self.__ss_align.hash(state);
@@ -1399,8 +1396,8 @@ cfg_if! {
 
         impl Eq for utsname {}
 
-        impl crate::fmt::Debug for utsname {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utsname {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utsname")
                     // FIXME: .field("sysname", &self.sysname)
                     // FIXME: .field("nodename", &self.nodename)
@@ -1412,8 +1409,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for utsname {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utsname {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sysname.hash(state);
                 self.nodename.hash(state);
                 self.release.hash(state);

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -1,6 +1,6 @@
+use crate::prelude::*;
 use crate::{
-    c_char, c_double, c_int, c_short, c_uint, c_ulong, c_ushort, c_void, exit_status, off_t,
-    size_t, ssize_t, NET_MAC_AWARE, NET_MAC_AWARE_INHERIT, PRIV_AWARE_RESET, PRIV_DEBUG,
+    exit_status, off_t, NET_MAC_AWARE, NET_MAC_AWARE_INHERIT, PRIV_AWARE_RESET, PRIV_DEBUG,
     PRIV_PFEXEC, PRIV_XPOLICY,
 };
 
@@ -89,8 +89,8 @@ cfg_if! {
 
         impl Eq for utmpx {}
 
-        impl crate::fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utmpx {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utmpx")
                     .field("ut_user", &self.ut_user)
                     .field("ut_id", &self.ut_id)
@@ -107,8 +107,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for utmpx {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utmpx {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_user.hash(state);
                 self.ut_type.hash(state);
                 self.ut_pid.hash(state);
@@ -129,8 +129,8 @@ cfg_if! {
             }
         }
         impl Eq for epoll_event {}
-        impl crate::fmt::Debug for epoll_event {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for epoll_event {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let events = self.events;
                 let u64 = self.u64;
                 f.debug_struct("epoll_event")
@@ -139,8 +139,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for epoll_event {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for epoll_event {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let events = self.events;
                 let u64 = self.u64;
                 events.hash(state);

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1,8 +1,6 @@
 use core::mem::size_of;
 
-use crate::{
-    c_double, c_int, c_longlong, c_short, c_uchar, c_uint, c_ushort, c_void, size_t, ssize_t,
-};
+use crate::prelude::*;
 
 pub type c_char = i8;
 pub type c_long = i64;
@@ -587,16 +585,16 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_un {}
-        impl crate::fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_un {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_un")
                     .field("sun_family", &self.sun_family)
                     // FIXME: .field("sun_path", &self.sun_path)
                     .finish()
             }
         }
-        impl crate::hash::Hash for sockaddr_un {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_un {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sun_family.hash(state);
                 self.sun_path.hash(state);
             }
@@ -631,8 +629,8 @@ cfg_if! {
             }
         }
         impl Eq for utsname {}
-        impl crate::fmt::Debug for utsname {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utsname {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utsname")
                     // FIXME: .field("sysname", &self.sysname)
                     // FIXME: .field("nodename", &self.nodename)
@@ -642,8 +640,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for utsname {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utsname {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sysname.hash(state);
                 self.nodename.hash(state);
                 self.release.hash(state);
@@ -661,15 +659,15 @@ cfg_if! {
             }
         }
         impl Eq for fd_set {}
-        impl crate::fmt::Debug for fd_set {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for fd_set {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("fd_set")
                     // FIXME: .field("fds_bits", &self.fds_bits)
                     .finish()
             }
         }
-        impl crate::hash::Hash for fd_set {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for fd_set {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.fds_bits.hash(state);
             }
         }
@@ -687,8 +685,8 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_storage {}
-        impl crate::fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_storage {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_storage")
                     .field("ss_family", &self.ss_family)
                     .field("__ss_pad1", &self.__ss_pad1)
@@ -697,8 +695,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sockaddr_storage {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_storage {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_family.hash(state);
                 self.__ss_pad1.hash(state);
                 self.__ss_align.hash(state);
@@ -756,8 +754,8 @@ cfg_if! {
             }
         }
         impl Eq for siginfo_t {}
-        impl crate::fmt::Debug for siginfo_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for siginfo_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("siginfo_t")
                     .field("si_signo", &self.si_signo)
                     .field("si_code", &self.si_code)
@@ -766,8 +764,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for siginfo_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for siginfo_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.si_signo.hash(state);
                 self.si_code.hash(state);
                 self.si_errno.hash(state);
@@ -796,8 +794,8 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_dl {}
-        impl crate::fmt::Debug for sockaddr_dl {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_dl {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_dl")
                     .field("sdl_family", &self.sdl_family)
                     .field("sdl_index", &self.sdl_index)
@@ -809,8 +807,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sockaddr_dl {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sockaddr_dl {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sdl_family.hash(state);
                 self.sdl_index.hash(state);
                 self.sdl_type.hash(state);
@@ -831,8 +829,8 @@ cfg_if! {
             }
         }
         impl Eq for sigevent {}
-        impl crate::fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sigevent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sigevent")
                     .field("sigev_notify", &self.sigev_notify)
                     .field("sigev_signo", &self.sigev_signo)
@@ -842,8 +840,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::hash::Hash for sigevent {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sigevent {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sigev_notify.hash(state);
                 self.sigev_signo.hash(state);
                 self.sigev_value.hash(state);
@@ -861,8 +859,8 @@ cfg_if! {
             }
         }
         impl Eq for pad128_t {}
-        impl crate::fmt::Debug for pad128_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for pad128_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 unsafe {
                     f.debug_struct("pad128_t")
                         // FIXME: .field("_q", &{self._q})
@@ -871,8 +869,8 @@ cfg_if! {
                 }
             }
         }
-        impl crate::hash::Hash for pad128_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for pad128_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     // FIXME: state.write_i64(self._q as i64);
                     self._l.hash(state);
@@ -888,8 +886,8 @@ cfg_if! {
             }
         }
         impl Eq for upad128_t {}
-        impl crate::fmt::Debug for upad128_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for upad128_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 unsafe {
                     f.debug_struct("upad128_t")
                         // FIXME: .field("_q", &{self._q})
@@ -898,8 +896,8 @@ cfg_if! {
                 }
             }
         }
-        impl crate::hash::Hash for upad128_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for upad128_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     // FIXME: state.write_i64(self._q as i64);
                     self._l.hash(state);
@@ -2487,7 +2485,7 @@ f! {
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        _CMSG_DATA_ALIGN(crate::mem::size_of::<cmsghdr>()) as c_uint + length
+        _CMSG_DATA_ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub fn CMSG_FIRSTHDR(mhdr: *const crate::msghdr) -> *mut cmsghdr {
@@ -2517,20 +2515,20 @@ f! {
     }
 
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
-        let bits = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] &= !(1 << (fd % bits));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
-        let bits = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
-        let bits = crate::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] |= 1 << (fd % bits);
         return;

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -1,7 +1,7 @@
+use crate::prelude::*;
 use crate::{
-    c_char, c_int, c_short, c_uint, c_ulong, c_ulonglong, c_ushort, c_void, exit_status, off_t,
-    size_t, NET_MAC_AWARE, NET_MAC_AWARE_INHERIT, PRIV_AWARE_RESET, PRIV_DEBUG, PRIV_PFEXEC,
-    PRIV_XPOLICY,
+    exit_status, off_t, NET_MAC_AWARE, NET_MAC_AWARE_INHERIT, PRIV_AWARE_RESET, PRIV_DEBUG,
+    PRIV_PFEXEC, PRIV_XPOLICY,
 };
 
 pub type door_attr_t = c_uint;
@@ -126,8 +126,8 @@ cfg_if! {
 
         impl Eq for utmpx {}
 
-        impl crate::fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for utmpx {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("utmpx")
                     .field("ut_user", &self.ut_user)
                     .field("ut_id", &self.ut_id)
@@ -144,8 +144,8 @@ cfg_if! {
             }
         }
 
-        impl crate::hash::Hash for utmpx {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for utmpx {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_user.hash(state);
                 self.ut_type.hash(state);
                 self.ut_pid.hash(state);

--- a/src/unix/solarish/x86.rs
+++ b/src/unix/solarish/x86.rs
@@ -1,4 +1,4 @@
-use crate::{c_char, c_long, c_ulong, c_ulonglong, c_ushort};
+use crate::prelude::*;
 
 pub type Elf32_Addr = c_ulong;
 pub type Elf32_Half = c_ushort;

--- a/src/unix/solarish/x86_64.rs
+++ b/src/unix/solarish/x86_64.rs
@@ -1,4 +1,4 @@
-use crate::{c_char, c_int, c_long, c_uint, c_ulong, c_ulonglong, c_ushort, c_void};
+use crate::prelude::*;
 
 cfg_if! {
     if #[cfg(target_os = "solaris")] {
@@ -110,8 +110,8 @@ cfg_if! {
             }
         }
         impl Eq for __c_anonymous_fp_reg_set {}
-        impl crate::fmt::Debug for __c_anonymous_fp_reg_set {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for __c_anonymous_fp_reg_set {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 unsafe {
                     f.debug_struct("__c_anonymous_fp_reg_set")
                         .field("fpchip_state", &{ self.fpchip_state })
@@ -126,8 +126,8 @@ cfg_if! {
             }
         }
         impl Eq for fpregset_t {}
-        impl crate::fmt::Debug for fpregset_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for fpregset_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("fpregset_t")
                     .field("fp_reg_set", &self.fp_reg_set)
                     .finish()
@@ -139,8 +139,8 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl crate::fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for mcontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("mcontext_t")
                     .field("gregs", &self.gregs)
                     .field("fpregs", &self.fpregs)
@@ -158,8 +158,8 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl crate::fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for ucontext_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("ucontext_t")
                     .field("uc_flags", &self.uc_flags)
                     .field("uc_link", &self.uc_link)

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -3,7 +3,7 @@
 use core::mem::size_of;
 use core::ptr::null_mut;
 
-use crate::c_void;
+use crate::prelude::*;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum DIR {}
@@ -471,8 +471,8 @@ s_no_extra_traits! {
 
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
-        impl crate::fmt::Debug for dirent {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for dirent {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("dirent")
                     .field("d_ino", &self.d_ino)
                     .field("d_name", &&self.d_name[..])
@@ -480,8 +480,8 @@ cfg_if! {
             }
         }
 
-        impl crate::fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_un {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_un")
                     .field("sun_len", &self.sun_len)
                     .field("sun_family", &self.sun_family)
@@ -490,8 +490,8 @@ cfg_if! {
             }
         }
 
-        impl crate::fmt::Debug for RTP_DESC {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for RTP_DESC {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("RTP_DESC")
                     .field("status", &self.status)
                     .field("options", &self.options)
@@ -505,8 +505,8 @@ cfg_if! {
                     .finish()
             }
         }
-        impl crate::fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sockaddr_storage {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sockaddr_storage")
                     .field("ss_len", &self.ss_len)
                     .field("ss_family", &self.ss_family)
@@ -533,8 +533,8 @@ cfg_if! {
             }
         }
         impl Eq for sa_u_t {}
-        impl crate::fmt::Debug for sa_u_t {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sa_u_t {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 unsafe {
                     let h = match self.sa_handler {
                         Some(handler) => handler as usize,
@@ -545,8 +545,8 @@ cfg_if! {
                 }
             }
         }
-        impl crate::hash::Hash for sa_u_t {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sa_u_t {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     let h = match self.sa_handler {
                         Some(handler) => handler as usize,
@@ -563,15 +563,15 @@ cfg_if! {
             }
         }
         impl Eq for sigval {}
-        impl crate::fmt::Debug for sigval {
-            fn fmt(&self, f: &mut crate::fmt::Formatter) -> crate::fmt::Result {
+        impl fmt::Debug for sigval {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_struct("sigval")
                     .field("sival_ptr", unsafe { &(self.sival_ptr as usize) })
                     .finish()
             }
         }
-        impl crate::hash::Hash for sigval {
-            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+        impl hash::Hash for sigval {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe { (self.sival_ptr as usize).hash(state) };
             }
         }
@@ -1106,13 +1106,13 @@ impl Clone for fpos_t {
 
 f! {
     pub {const} fn CMSG_ALIGN(len: usize) -> usize {
-        len + crate::mem::size_of::<usize>() - 1 & !(crate::mem::size_of::<usize>() - 1)
+        len + mem::size_of::<usize>() - 1 & !(mem::size_of::<usize>() - 1)
     }
 
     pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         let next = cmsg as usize
             + CMSG_ALIGN((*cmsg).cmsg_len as usize)
-            + CMSG_ALIGN(crate::mem::size_of::<cmsghdr>());
+            + CMSG_ALIGN(mem::size_of::<cmsghdr>());
         let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next <= max {
             (cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr
@@ -1130,15 +1130,15 @@ f! {
     }
 
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(CMSG_ALIGN(crate::mem::size_of::<cmsghdr>()) as isize)
+        (cmsg as *mut c_uchar).offset(CMSG_ALIGN(mem::size_of::<cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(crate::mem::size_of::<cmsghdr>())) as c_uint
+        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(mem::size_of::<cmsghdr>())) as c_uint
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        CMSG_ALIGN(crate::mem::size_of::<cmsghdr>()) as c_uint + length
+        CMSG_ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
     }
 }
 

--- a/src/wasi/mod.rs
+++ b/src/wasi/mod.rs
@@ -5,8 +5,7 @@
 
 use core::iter::Iterator;
 
-use super::{Send, Sync};
-use crate::c_void;
+use crate::prelude::*;
 
 pub type c_char = i8;
 pub type c_uchar = u8;

--- a/src/wasi/p2.rs
+++ b/src/wasi/p2.rs
@@ -1,4 +1,4 @@
-use crate::{c_char, c_int, c_uchar, c_uint, c_ushort, c_void, size_t, ssize_t};
+use crate::prelude::*;
 
 pub type sa_family_t = c_ushort;
 pub type in_port_t = c_ushort;

--- a/src/windows/gnu/mod.rs
+++ b/src/windows/gnu/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_char, c_int, c_uint, size_t};
+use crate::prelude::*;
 
 cfg_if! {
     if #[cfg(target_pointer_width = "64")] {

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1,6 +1,6 @@
 //! Windows CRT definitions
 
-use crate::c_void;
+use crate::prelude::*;
 
 pub type c_schar = i8;
 pub type c_uchar = u8;

--- a/src/windows/msvc/mod.rs
+++ b/src/windows/msvc/mod.rs
@@ -1,4 +1,4 @@
-use crate::{c_char, c_int, c_uint, c_void, size_t};
+use crate::prelude::*;
 
 pub const L_tmpnam: c_uint = 260;
 pub const TMP_MAX: c_uint = 0x7fff_ffff;


### PR DESCRIPTION
When building with `rustc-dep-of-std`, we don't get the core types imported by default (`Clone`, `Copy`, `Option`). In order to avoid needing to import these individually, introduce a prelude that includes them.

This also includes the C numeric types that are frequently used.