### PR TITLE
Add a `.git-blame-ignore-revs` entry for adding the prelude

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,5 +1,6 @@
 # Format macro bodies
 a0c7f8017b964a2de8bc3aabebdabd4a8f2c0905
 
-# Automated changes to upgrade to the 2021 edition
+# Automated changes related to the 2021 edition upgrade
 20f6aa4c8135ba5e2c079ff21b20f0a1be87e1c4
+f8a018a8e3efaf8cc4fbad84974255b0fa899fc2


### PR DESCRIPTION
Ignore f8a018a8e3 ("Make use of the crate's prelude...") since this was an automated refactoring.