### PR TITLE
fix: cfg-gate the #![crate_name] and #![crate_type] attributes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! libc - Raw FFI bindings to platforms' system libraries
-#![crate_name = "libc"]
-#![crate_type = "rlib"]
+#![cfg_attr(feature = "rustc-dep-of-std", crate_name = "libc")]
+#![cfg_attr(feature = "rustc-dep-of-std", crate_type = "rlib")]
 #![allow(
     renamed_and_removed_lints, // Keep this order.
     unknown_lints, // Keep this order.


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

I was vendoring `libc` as part of a C codebase that uses the meson build system.
This involved renaming the crate:
```meson
rust3p_libc = library('rust3p_libc', ...)
```

But these attributes clash with meson passing the `--crate-name` argument to `rustc`.
```
rustc -C linker=cc --color=always -C debug-assertions=yes -C overflow-checks=no --crate-type rlib -C opt-level=3 --crate-name rust3p_libc --emit dep-info=rust3p/rust3p_libc.d --emit link=rust3p/librust3p_libc.rlib --out-dir rust3p/librust3p_libc.rlib.p -C metadata=46de84a@@rust3p_libc@sta --edition=2015 --cfg 'feature="std"' ../rust3p/vendor/libc/src/lib.rs
error: `--crate-name` and `#[crate_name]` are required to match, but `rust3p_libc` != `libc`
 --> ../rust3p/vendor/libc/src/lib.rs:2:1
  |
2 | #![crate_name = "libc"]
  | ^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to 1 previous error
```
It looks like this attribute was added to support "rustc-dep-of-std" in #28
Considering the rest of that code is `#[cfg(feature = ...)]` gated, moving this seems like the right the to do.

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
  ```
  ^ I can't run this on `main` locally :S
  ```