### PR TITLE
Allow the `unpredictable_function_pointer_comparisons` where needed

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -1340,6 +1340,8 @@ cfg_if! {
             }
         }
 
+        // FIXME(msrv): suggested method was added in 1.85
+        #[allow(unpredictable_function_pointer_comparisons)]
         impl PartialEq for sigevent {
             fn eq(&self, other: &sigevent) -> bool {
                 self.sigev_value == other.sigev_value

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -238,6 +238,8 @@ cfg_if! {
             }
         }
 
+        // FIXME(msrv): suggested method was added in 1.85
+        #[allow(unpredictable_function_pointer_comparisons)]
         impl PartialEq for __c_anonymous_elf64_auxv_union {
             fn eq(&self, other: &__c_anonymous_elf64_auxv_union) -> bool {
                 unsafe {


### PR DESCRIPTION
This lint was recently added so this change is needed to fix CI. The suggested alternative is to use `ptr::fn_addr_eq` which isn't available until 1.85, so allow the lint here.

This is in a `PartialEq` for a union so hopefully this code should go away in 1.0 anyway.