### PR TITLE
 ci: Add caching 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,8 +43,20 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Rust toolchain
         run: ./ci/install-rust.sh
+
+      # FIXME(ci): These `du` statements are temporary for debugging cache
+      - name: Target size before restoring cache
+        run: du -sh target | sort -k 2 || true
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.os }}-${{ matrix.toolchain }}
+      - name: Target size after restoring cache
+        run: du -sh target | sort -k 2 || true
+
       - name: Execute build.sh
         run: ./ci/verify-build.sh
+      - name: Target size after job completion
+        run: du -sh target | sort -k 2
 
   test_tier1:
     name: Test tier1
@@ -81,6 +93,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Rust toolchain
         run: ./ci/install-rust.sh
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
       - name: Run natively
         if: "!matrix.docker"
         run: ./ci/run.sh ${{ matrix.target }}
@@ -132,6 +147,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Rust toolchain
         run: ./ci/install-rust.sh
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
       - name: Execute run-docker.sh
         run: ./ci/run-docker.sh ${{ matrix.target }}
 


### PR DESCRIPTION
We have a handful of jobs that could benefit from reusing the target directory. Make use of Swatinem/rust-cache to do so.

Something still isn't quite right since the largest job only seems to be restoring a portion of the cache, but this still shows an improvement for most jobs.