### PR TITLE
[0.2] Deprecate FreeBSD's CAP_UNUSED* and CAP_ALL* constants

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2618,6 +2618,11 @@ fn test_freebsd(target: &str) {
             // Added in FreeBSD 14.0
             "TCP_FUNCTION_ALIAS" if Some(14) > freebsd_ver => true,
 
+            // These constants may change or disappear in future OS releases, and they probably
+            // have no legitimate use in applications anyway.
+            "CAP_UNUSED0_44" | "CAP_UNUSED0_57" | "CAP_UNUSED1_22" | "CAP_UNUSED1_57" |
+                "CAP_ALL0" | "CAP_ALL1" => true,
+
             _ => false,
         }
     });

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -2708,8 +2708,11 @@ pub const CAP_SOCK_SERVER: u64 = CAP_ACCEPT
     | CAP_SEND
     | CAP_SETSOCKOPT
     | CAP_SHUTDOWN;
+#[deprecated(since = "0.2.165", note = "Not stable across OS versions")]
 pub const CAP_ALL0: u64 = cap_right!(0, 0x000007FFFFFFFFFFu64);
+#[deprecated(since = "0.2.165", note = "Not stable across OS versions")]
 pub const CAP_UNUSED0_44: u64 = cap_right!(0, 0x0000080000000000u64);
+#[deprecated(since = "0.2.165", note = "Not stable across OS versions")]
 pub const CAP_UNUSED0_57: u64 = cap_right!(0, 0x0100000000000000u64);
 pub const CAP_MAC_GET: u64 = cap_right!(1, 0x0000000000000001u64);
 pub const CAP_MAC_SET: u64 = cap_right!(1, 0x0000000000000002u64);
@@ -2733,8 +2736,11 @@ pub const CAP_ACL_GET: u64 = cap_right!(1, 0x0000000000040000u64);
 pub const CAP_ACL_SET: u64 = cap_right!(1, 0x0000000000080000u64);
 pub const CAP_KQUEUE_CHANGE: u64 = cap_right!(1, 0x0000000000100000u64);
 pub const CAP_KQUEUE: u64 = CAP_KQUEUE_EVENT | CAP_KQUEUE_CHANGE;
+#[deprecated(since = "0.2.165", note = "Not stable across OS versions")]
 pub const CAP_ALL1: u64 = cap_right!(1, 0x00000000001FFFFFu64);
+#[deprecated(since = "0.2.165", note = "Not stable across OS versions")]
 pub const CAP_UNUSED1_22: u64 = cap_right!(1, 0x0000000000200000u64);
+#[deprecated(since = "0.2.165", note = "Not stable across OS versions")]
 pub const CAP_UNUSED1_57: u64 = cap_right!(1, 0x0100000000000000u64);
 pub const CAP_FCNTL_GETFL: u32 = 1 << 3;
 pub const CAP_FCNTL_SETFL: u32 = 1 << 4;


### PR DESCRIPTION
They aren't stable across OS versions, and they don't have any legitimate use in applications.

# Description

Deprecate constants that are unstable and not useful to our consumers

# Sources

This commit, for example, changed some of these constants in FreeBSD 15.

https://github.com/freebsd/freebsd-src/commit/b165e9e3ea4e327fc421d81c2a89242bd8720780

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
