### PR TITLE
Add sockaddr_vm definition for Fuchsia

### DIFF
--- a/libc-test/semver/fuchsia.txt
+++ b/libc-test/semver/fuchsia.txt
@@ -1446,6 +1446,7 @@ sigwait
 sigwaitinfo
 sockaddr_ll
 sockaddr_nl
+sockaddr_vm
 splice
 spwd
 srand

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -357,6 +357,14 @@ s! {
         pub sin6_scope_id: u32,
     }
 
+    pub struct sockaddr_vm {
+        pub svm_family: sa_family_t,
+        pub svm_reserved1: c_ushort,
+        pub svm_port: crate::in_port_t,
+        pub svm_cid: c_uint,
+        pub svm_zero: [u8; 4],
+    }
+
     pub struct addrinfo {
         pub ai_flags: c_int,
         pub ai_family: c_int,


### PR DESCRIPTION
# Description

This adds a definition of `struct sockaddr_vm` for Fuchsia

# Sources

`man vsock` documents this type on most platforms. The Fuchsia definition matches
Linux except that we do not (currently) have support for flags.

# Checklist

libc-test does not have support for Fuchsia currently.

