### PR TITLE
Update ESP-IDF `c_char` type

### DIFF
--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 pub type clock_t = c_ulong;
-pub type c_char = i8;
+pub type c_char = u8;
 pub type wchar_t = u32;
 
 pub type c_long = i32;


### PR DESCRIPTION
# Description

Updates the `c_chart` type for ESP-IDF after https://github.com/rust-lang/rust/pull/132975

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
  - Still not tested, hence the PR is still in draft
