### PR TITLE
Update Arm `c_char` to `u8` for Solid

### DIFF
--- a/src/solid/aarch64.rs
+++ b/src/solid/aarch64.rs
@@ -1,4 +1,4 @@
-pub type c_char = i8;
+pub type c_char = u8;
 pub type wchar_t = u32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/solid/arm.rs
+++ b/src/solid/arm.rs
@@ -1,4 +1,4 @@
-pub type c_char = i8;
+pub type c_char = u8;
 pub type wchar_t = u32;
 pub type c_long = i32;
 pub type c_ulong = u32;


### PR DESCRIPTION
In [1], `core::ffi::c_char` was changed from `i8` to `u8` for Solid Arm targets. Make the corresponding change to `libc` here.

Link: https://github.com/rust-lang/rust/pull/132975 [1]