### PR TITLE
Fix c_char on various targets

### DIFF
--- a/src/solid/aarch64.rs
+++ b/src/solid/aarch64.rs
@@ -1,4 +1,4 @@
-pub type c_char = i8;
+pub type c_char = u8;
 pub type wchar_t = u32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/solid/arm.rs
+++ b/src/solid/arm.rs
@@ -1,4 +1,4 @@
-pub type c_char = i8;
+pub type c_char = u8;
 pub type wchar_t = u32;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/unix/linux_like/android/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/android/b64/riscv64/mod.rs
@@ -1,7 +1,7 @@
 use crate::off64_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
+pub type c_char = u8;
 pub type wchar_t = u32;
 pub type greg_t = i64;
 pub type __u64 = c_ulonglong;

--- a/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
@@ -6,7 +6,7 @@ use crate::prelude::*;
 pub type blkcnt_t = i64;
 pub type blksize_t = i64;
 pub type clock_t = i64;
-pub type c_char = u8;
+pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type fsblkcnt_t = c_ulong;

--- a/src/unix/newlib/vita/mod.rs
+++ b/src/unix/newlib/vita/mod.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 
 pub type clock_t = c_long;
 
-pub type c_char = i8;
+pub type c_char = u8;
 pub type wchar_t = u32;
 
 pub type c_long = i32;

--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -5,7 +5,17 @@ pub type nlink_t = u16;
 pub type ino_t = u16;
 pub type blkcnt_t = u64;
 pub type blksize_t = i16;
-pub type c_char = i8;
+cfg_if! {
+    if #[cfg(any(
+        target_arch = "arm",
+        target_arch = "riscv32",
+        target_arch = "riscv64",
+    ))] {
+        pub type c_char = u8;
+    } else {
+        pub type c_char = i8;
+    }
+}
 pub type c_long = isize;
 pub type c_ulong = usize;
 pub type cc_t = u8;

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -1,6 +1,12 @@
 use crate::prelude::*;
 
-pub type c_char = i8;
+cfg_if! {
+    if #[cfg(target_arch = "aarch64")] {
+        pub type c_char = u8;
+    } else {
+        pub type c_char = i8;
+    }
+}
 pub type wchar_t = i32;
 
 cfg_if! {

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2,7 +2,13 @@ use core::mem::size_of;
 
 use crate::prelude::*;
 
-pub type c_char = i8;
+cfg_if! {
+    if #[cfg(target_arch = "aarch64")] {
+        pub type c_char = u8;
+    } else {
+        pub type c_char = i8;
+    }
+}
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type caddr_t = *mut c_char;

--- a/src/vxworks/riscv32.rs
+++ b/src/vxworks/riscv32.rs
@@ -1,4 +1,4 @@
-pub type c_char = i8;
+pub type c_char = u8;
 pub type wchar_t = i32;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/vxworks/riscv64.rs
+++ b/src/vxworks/riscv64.rs
@@ -1,4 +1,4 @@
-pub type c_char = i8;
+pub type c_char = u8;
 pub type wchar_t = i32;
 pub type c_long = i64;
 pub type c_ulong = u64;


### PR DESCRIPTION

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

This was originally included in the list as a TODO for https://github.com/rust-lang/rust/pull/131319 and should have been done at the same time the c_char definition was updated, just as it was done for https://github.com/rust-lang/rust/pull/122986.

Fixes the following targets:

- aarch64-kmc-solid_asp3
- armv7a-kmc-solid_asp3-eabi
- armv7a-kmc-solid_asp3-eabihf
- riscv64-linux-android
- x86_64-unknown-l4re-uclibc
- armv7-sony-vita-newlibeabihf
- riscv32imac-unknown-nuttx-elf
- riscv32imafc-unknown-nuttx-elf
- riscv32imc-unknown-nuttx-elf
- riscv64gc-unknown-nuttx-elf
- riscv64imac-unknown-nuttx-elf
- thumbv6m-nuttx-eabi
- thumbv7em-nuttx-eabi
- thumbv7em-nuttx-eabihf
- thumbv7m-nuttx-eabi
- thumbv8m.base-nuttx-eabi
- thumbv8m.main-nuttx-eabi
- thumbv8m.main-nuttx-eabihf
- aarch64-unknown-redox
- aarch64-unknown-illumos
- riscv32-wrs-vxworks
- riscv64-wrs-vxworks

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
