### PR TITLE
Do not re-export c_void in target-specific code

### DIFF
--- a/src/teeos/mod.rs
+++ b/src/teeos/mod.rs
@@ -5,9 +5,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-// only supported on Rust > 1.59, so we can directly reexport c_void from core.
-pub use core::ffi::c_void;
-
 use crate::prelude::*;
 
 pub type c_schar = i8;

--- a/src/trusty.rs
+++ b/src/trusty.rs
@@ -1,4 +1,4 @@
-pub use core::ffi::c_void;
+use crate::prelude::*;
 
 pub type size_t = usize;
 pub type ssize_t = isize;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

It is already re-exported at top-level.

https://github.com/rust-lang/libc/blob/39a6799d350b36e40f1cd30ad09e25460bc1ccb6/src/lib.rs#L39

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
