### PR TITLE
Re-export c_char_def as c_char instead of defining c_char per target

### DIFF
--- a/src/fuchsia/aarch64.rs
+++ b/src/fuchsia/aarch64.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type __u64 = c_ulonglong;
 pub type wchar_t = u32;
 pub type nlink_t = c_ulong;

--- a/src/fuchsia/riscv64.rs
+++ b/src/fuchsia/riscv64.rs
@@ -1,8 +1,8 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off_t;
 use crate::prelude::*;
 
 // From psABI Calling Convention for RV64
-pub type c_char = u8;
 pub type __u64 = c_ulonglong;
 pub type wchar_t = i32;
 

--- a/src/fuchsia/x86_64.rs
+++ b/src/fuchsia/x86_64.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type nlink_t = u64;
 pub type blksize_t = c_long;

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -1,14 +1,7 @@
 //! Hermit C type definitions
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
-
-cfg_if! {
-    if #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))] {
-        pub type c_char = u8;
-    } else {
-        pub type c_char = i8;
-    }
-}
 
 pub type c_schar = i8;
 pub type c_uchar = u8;

--- a/src/sgx.rs
+++ b/src/sgx.rs
@@ -1,5 +1,7 @@
 //! SGX C types definition
 
+pub use crate::arch::c_char_def as c_char;
+
 pub type c_schar = i8;
 pub type c_uchar = u8;
 pub type c_short = i16;
@@ -19,7 +21,6 @@ pub type intptr_t = isize;
 pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
-pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 

--- a/src/solid/aarch64.rs
+++ b/src/solid/aarch64.rs
@@ -1,4 +1,3 @@
-pub type c_char = i8;
 pub type wchar_t = u32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/solid/arm.rs
+++ b/src/solid/arm.rs
@@ -1,4 +1,3 @@
-pub type c_char = i8;
 pub type wchar_t = u32;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/solid/mod.rs
+++ b/src/solid/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! [SOLID]: https://solid.kmckk.com/
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type c_schar = i8;

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -1,5 +1,7 @@
 //! Switch C type definitions
 
+pub use crate::arch::c_char_def as c_char;
+
 pub type c_schar = i8;
 pub type c_uchar = u8;
 pub type c_short = i16;
@@ -20,7 +22,6 @@ pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
 pub type off_t = i64;
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type wchar_t = u32;

--- a/src/teeos/mod.rs
+++ b/src/teeos/mod.rs
@@ -5,6 +5,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type c_schar = i8;
@@ -44,9 +45,6 @@ pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
 pub type pid_t = c_int;
-
-// aarch64 specific
-pub type c_char = u8;
 
 pub type wchar_t = u32;
 

--- a/src/trusty.rs
+++ b/src/trusty.rs
@@ -1,17 +1,11 @@
 use crate::prelude::*;
 
+pub use crate::arch::c_char_def as c_char;
+
 pub type size_t = usize;
 pub type ssize_t = isize;
 
 pub type off_t = i64;
-
-cfg_if! {
-    if #[cfg(any(target_arch = "aarch64", target_arch = "arm"))] {
-        pub type c_char = u8;
-    } else if #[cfg(target_arch = "x86_64")] {
-        pub type c_char = i8;
-    }
-}
 
 pub type c_schar = i8;
 pub type c_uchar = u8;

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -1,6 +1,6 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type caddr_t = *mut c_char;
 pub type clockid_t = c_longlong;
 pub type blkcnt_t = c_long;

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -2,10 +2,10 @@
 //!
 //! This covers *-apple-* triples currently
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{cmsghdr, off_t};
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type clock_t = c_ulong;
 pub type time_t = c_long;

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1,8 +1,8 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{cmsghdr, off_t};
 
 pub type dev_t = u32;
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type clock_t = u64;
 pub type ino_t = u64;

--- a/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
@@ -1,6 +1,6 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type clock_t = i32;

--- a/src/unix/bsd/freebsdlike/freebsd/arm.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/arm.rs
@@ -1,6 +1,6 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type clock_t = u32;

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
@@ -1,6 +1,6 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type clock_t = u32;

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
@@ -1,6 +1,6 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type clock_t = u32;

--- a/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
@@ -1,6 +1,6 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type clock_t = i32;

--- a/src/unix/bsd/freebsdlike/freebsd/x86.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86.rs
@@ -1,6 +1,6 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type clock_t = c_ulong;

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -1,6 +1,6 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type clock_t = i32;

--- a/src/unix/bsd/netbsdlike/netbsd/aarch64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/aarch64.rs
@@ -1,9 +1,9 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::PT_FIRSTMACH;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = u8;
 pub type greg_t = u64;
 pub type __cpu_simple_lock_nv_t = c_uchar;
 

--- a/src/unix/bsd/netbsdlike/netbsd/arm.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/arm.rs
@@ -1,9 +1,9 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::PT_FIRSTMACH;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
-pub type c_char = u8;
 pub type __cpu_simple_lock_nv_t = c_int;
 
 pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_longlong>() - 1;

--- a/src/unix/bsd/netbsdlike/netbsd/mips.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mips.rs
@@ -1,9 +1,9 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::PT_FIRSTMACH;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
-pub type c_char = i8;
 pub type __cpu_simple_lock_nv_t = c_int;
 
 pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_longlong>() - 1;

--- a/src/unix/bsd/netbsdlike/netbsd/powerpc.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/powerpc.rs
@@ -1,9 +1,9 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::PT_FIRSTMACH;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
-pub type c_char = u8;
 pub type __cpu_simple_lock_nv_t = c_int;
 
 pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_double>() - 1;

--- a/src/unix/bsd/netbsdlike/netbsd/riscv64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/riscv64.rs
@@ -1,10 +1,10 @@
 use PT_FIRSTMACH;
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = u8;
 pub type __greg_t = u64;
 pub type __cpu_simple_lock_nv_t = c_int;
 pub type __gregset = [__greg_t; _NGREG];

--- a/src/unix/bsd/netbsdlike/netbsd/sparc64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/sparc64.rs
@@ -1,8 +1,8 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = i8;
 pub type __cpu_simple_lock_nv_t = c_uchar;
 
 // should be pub(crate), but that requires Rust 1.18.0

--- a/src/unix/bsd/netbsdlike/netbsd/x86.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/x86.rs
@@ -1,8 +1,8 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
-pub type c_char = i8;
 pub type __cpu_simple_lock_nv_t = c_uchar;
 
 pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_int>() - 1;

--- a/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
@@ -1,9 +1,9 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::PT_FIRSTMACH;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = i8;
 pub type c___greg_t = u64;
 pub type __cpu_simple_lock_nv_t = c_uchar;
 

--- a/src/unix/bsd/netbsdlike/openbsd/aarch64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/aarch64.rs
@@ -1,8 +1,8 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = u8;
 pub type ucontext_t = sigcontext;
 
 s! {

--- a/src/unix/bsd/netbsdlike/openbsd/arm.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/arm.rs
@@ -1,8 +1,8 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
-pub type c_char = u8;
 
 pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_double>() - 1;
 

--- a/src/unix/bsd/netbsdlike/openbsd/mips64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mips64.rs
@@ -1,6 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
+
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = i8;
 
 #[doc(hidden)]
 pub const _ALIGNBYTES: usize = 7;

--- a/src/unix/bsd/netbsdlike/openbsd/powerpc.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/powerpc.rs
@@ -1,8 +1,8 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
-pub type c_char = u8;
 
 pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_double>() - 1;
 

--- a/src/unix/bsd/netbsdlike/openbsd/powerpc64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/powerpc64.rs
@@ -1,8 +1,8 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = u8;
 
 pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
 

--- a/src/unix/bsd/netbsdlike/openbsd/riscv64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/riscv64.rs
@@ -1,8 +1,8 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = u8;
 pub type ucontext_t = sigcontext;
 
 s! {

--- a/src/unix/bsd/netbsdlike/openbsd/sparc64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/sparc64.rs
@@ -1,6 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
+
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = i8;
 
 #[doc(hidden)]
 pub const _ALIGNBYTES: usize = 0xf;

--- a/src/unix/bsd/netbsdlike/openbsd/x86.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/x86.rs
@@ -1,8 +1,8 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
-pub type c_char = i8;
 
 pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_int>() - 1;
 

--- a/src/unix/bsd/netbsdlike/openbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/x86_64.rs
@@ -1,9 +1,9 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::PT_FIRSTMACH;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = i8;
 pub type ucontext_t = sigcontext;
 
 s! {

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -1,3 +1,4 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type rlim_t = crate::uintptr_t;
@@ -6,7 +7,6 @@ pub type pthread_key_t = c_int;
 pub type nfds_t = c_ulong;
 pub type tcflag_t = c_uint;
 pub type speed_t = c_uchar;
-pub type c_char = i8;
 pub type clock_t = i32;
 pub type clockid_t = i32;
 pub type suseconds_t = i32;

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -1,11 +1,10 @@
 #![allow(dead_code)]
 
+pub use crate::arch::c_char_def as c_char;
 use crate::c_schar;
 use crate::prelude::*;
 
 // types
-pub type c_char = i8;
-
 pub type __s16_type = c_short;
 pub type __u16_type = c_ushort;
 pub type __s32_type = c_int;

--- a/src/unix/linux_like/android/b32/arm.rs
+++ b/src/unix/linux_like/android/b32/arm.rs
@@ -1,6 +1,6 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type wchar_t = u32;
 pub type greg_t = i32;
 pub type mcontext_t = sigcontext;

--- a/src/unix/linux_like/android/b32/x86/mod.rs
+++ b/src/unix/linux_like/android/b32/x86/mod.rs
@@ -1,6 +1,6 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type greg_t = i32;
 

--- a/src/unix/linux_like/android/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/android/b64/aarch64/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off64_t;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type wchar_t = u32;
 pub type __u64 = c_ulonglong;
 pub type __s64 = c_longlong;

--- a/src/unix/linux_like/android/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/android/b64/riscv64/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off64_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = u32;
 pub type greg_t = i64;
 pub type __u64 = c_ulonglong;

--- a/src/unix/linux_like/android/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/android/b64/x86_64/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off64_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type greg_t = i64;
 pub type __u64 = c_ulonglong;

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1,6 +1,6 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type useconds_t = u32;
 pub type dev_t = u32;

--- a/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = u8;
 pub type wchar_t = u32;
 
 s! {

--- a/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = u8;
 pub type wchar_t = u32;
 
 s! {

--- a/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 
 s! {

--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 
 s! {

--- a/src/unix/linux_like/linux/gnu/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/gnu/b32/powerpc.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = u8;
 pub type wchar_t = i32;
 
 s! {

--- a/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
@@ -1,9 +1,9 @@
 //! RISC-V-specific definitions for 32-bit linux-like values
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = u8;
 pub type wchar_t = c_int;
 
 s! {

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -1,9 +1,9 @@
 //! SPARC-specific definitions for 32-bit linux-like values
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 
 s! {

--- a/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type greg_t = i32;
 

--- a/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
@@ -1,9 +1,9 @@
 //! AArch64-specific definitions for 64-bit linux-like values
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = u8;
 pub type wchar_t = u32;
 pub type nlink_t = u32;
 pub type blksize_t = i32;

--- a/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t, pthread_mutex_t};
 
-pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type wchar_t = i32;

--- a/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
@@ -1,8 +1,8 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t, pthread_mutex_t};
 
 pub type blksize_t = i64;
-pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type nlink_t = u64;

--- a/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
@@ -1,11 +1,11 @@
 //! PowerPC64-specific definitions for 64-bit linux-like values
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t, pthread_mutex_t};
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = u8;
 pub type wchar_t = i32;
 pub type nlink_t = u64;
 pub type blksize_t = i64;

--- a/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
@@ -1,9 +1,9 @@
 //! RISC-V-specific definitions for 64-bit linux-like values
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type wchar_t = c_int;

--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -1,10 +1,10 @@
 //! s390x
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t, pthread_mutex_t};
 
 pub type blksize_t = i64;
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type nlink_t = u64;

--- a/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
@@ -1,11 +1,11 @@
 //! SPARC64-specific definitions for 64-bit linux-like values
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t, pthread_mutex_t};
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type nlink_t = u32;
 pub type blksize_t = i64;

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -1,9 +1,9 @@
 //! x86_64-specific definitions for 64-bit linux-like values
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type nlink_t = u64;
 pub type blksize_t = i64;

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type wchar_t = u32;
 
 s! {

--- a/src/unix/linux_like/linux/musl/b32/hexagon.rs
+++ b/src/unix/linux_like/linux/musl/b32/hexagon.rs
@@ -1,6 +1,6 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type wchar_t = u32;
 pub type stat64 = crate::stat;
 

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = c_int;
 
 s! {

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type wchar_t = i32;
 
 s! {

--- a/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
@@ -1,9 +1,9 @@
 //! RISC-V-specific definitions for 32-bit linux-like values
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = u8;
 pub type wchar_t = c_int;
 
 s! {

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 
 s! {

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type __u64 = c_ulonglong;
 pub type __s64 = c_longlong;
 pub type wchar_t = u32;

--- a/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
@@ -1,9 +1,9 @@
 //! LoongArch-specific definitions for 64-bit linux-like values
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = i8;
 pub type wchar_t = c_int;
 
 pub type nlink_t = c_uint;

--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type __u64 = c_ulong;
 pub type __s64 = c_long;

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type wchar_t = i32;
 pub type __u64 = c_ulong;
 pub type __s64 = c_long;

--- a/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
@@ -1,9 +1,9 @@
 //! RISC-V-specific definitions for 64-bit linux-like values
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = u8;
 pub type wchar_t = c_int;
 
 pub type nlink_t = c_uint;

--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -1,8 +1,8 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off_t;
 use crate::prelude::*;
 
 pub type blksize_t = i64;
-pub type c_char = u8;
 pub type nlink_t = u64;
 pub type wchar_t = i32;
 pub type greg_t = u64;

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type nlink_t = u64;
 pub type blksize_t = c_long;

--- a/src/unix/linux_like/linux/uclibc/arm/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/arm/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off64_t;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type wchar_t = c_uint;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off64_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type clock_t = i32;

--- a/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
@@ -1,9 +1,9 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off64_t;
 use crate::prelude::*;
 
 pub type blkcnt_t = i64;
 pub type blksize_t = i64;
-pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type fsblkcnt_t = c_ulong;

--- a/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
@@ -1,12 +1,12 @@
 //! Definitions for uclibc on 64bit systems
 
+pub use crate::arch::c_char_def as c_char;
 use crate::off64_t;
 use crate::prelude::*;
 
 pub type blkcnt_t = i64;
 pub type blksize_t = i64;
 pub type clock_t = i64;
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type fsblkcnt_t = c_ulong;

--- a/src/unix/newlib/aarch64/mod.rs
+++ b/src/unix/newlib/aarch64/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type clock_t = c_long;
-pub type c_char = u8;
 pub type wchar_t = u32;
 
 pub type c_long = i64;

--- a/src/unix/newlib/arm/mod.rs
+++ b/src/unix/newlib/arm/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type clock_t = c_long;
-pub type c_char = u8;
 pub type wchar_t = u32;
 
 pub type c_long = i32;

--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type clock_t = c_ulong;
-pub type c_char = u8;
 pub type wchar_t = u32;
 
 pub type c_long = i32;

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -1,9 +1,9 @@
 //! ARMv6K Nintendo 3DS C Newlib definitions
 
+pub use crate::arch::c_char_def as c_char;
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type c_long = i32;
 pub type c_ulong = u32;
 

--- a/src/unix/newlib/powerpc/mod.rs
+++ b/src/unix/newlib/powerpc/mod.rs
@@ -1,7 +1,7 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type clock_t = c_ulong;
-pub type c_char = u8;
 pub type wchar_t = c_int;
 
 pub type c_long = i32;

--- a/src/unix/newlib/vita/mod.rs
+++ b/src/unix/newlib/vita/mod.rs
@@ -1,9 +1,9 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::off_t;
 use crate::prelude::*;
 
 pub type clock_t = c_long;
 
-pub type c_char = i8;
 pub type wchar_t = u32;
 
 pub type c_long = i32;

--- a/src/unix/nto/aarch64.rs
+++ b/src/unix/nto/aarch64.rs
@@ -1,6 +1,6 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type wchar_t = u32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/unix/nto/x86_64.rs
+++ b/src/unix/nto/x86_64.rs
@@ -1,6 +1,6 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = u32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -1,3 +1,4 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{in6_addr, in_addr_t, timespec, DIR};
 
@@ -5,7 +6,6 @@ pub type nlink_t = u16;
 pub type ino_t = u16;
 pub type blkcnt_t = u64;
 pub type blksize_t = i16;
-pub type c_char = i8;
 pub type c_long = isize;
 pub type c_ulong = usize;
 pub type cc_t = u8;

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -1,6 +1,6 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 
 cfg_if! {

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1,8 +1,8 @@
 use core::mem::size_of;
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type caddr_t = *mut c_char;

--- a/src/vxworks/aarch64.rs
+++ b/src/vxworks/aarch64.rs
@@ -1,4 +1,5 @@
-pub type c_char = u8;
+pub use crate::arch::c_char_def as c_char;
+
 pub type wchar_t = u32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/vxworks/arm.rs
+++ b/src/vxworks/arm.rs
@@ -1,4 +1,5 @@
-pub type c_char = u8;
+pub use crate::arch::c_char_def as c_char;
+
 pub type wchar_t = u32;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/vxworks/powerpc.rs
+++ b/src/vxworks/powerpc.rs
@@ -1,4 +1,5 @@
-pub type c_char = u8;
+pub use crate::arch::c_char_def as c_char;
+
 pub type wchar_t = u32;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/vxworks/powerpc64.rs
+++ b/src/vxworks/powerpc64.rs
@@ -1,4 +1,5 @@
-pub type c_char = u8;
+pub use crate::arch::c_char_def as c_char;
+
 pub type wchar_t = u32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/vxworks/riscv32.rs
+++ b/src/vxworks/riscv32.rs
@@ -1,4 +1,5 @@
-pub type c_char = i8;
+pub use crate::arch::c_char_def as c_char;
+
 pub type wchar_t = i32;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/vxworks/riscv64.rs
+++ b/src/vxworks/riscv64.rs
@@ -1,4 +1,5 @@
-pub type c_char = i8;
+pub use crate::arch::c_char_def as c_char;
+
 pub type wchar_t = i32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/vxworks/x86.rs
+++ b/src/vxworks/x86.rs
@@ -1,4 +1,5 @@
-pub type c_char = i8;
+pub use crate::arch::c_char_def as c_char;
+
 pub type wchar_t = i32;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/vxworks/x86_64.rs
+++ b/src/vxworks/x86_64.rs
@@ -1,4 +1,5 @@
-pub type c_char = i8;
+pub use crate::arch::c_char_def as c_char;
+
 pub type wchar_t = i32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/wasi/mod.rs
+++ b/src/wasi/mod.rs
@@ -5,9 +5,9 @@
 
 use core::iter::Iterator;
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type c_uchar = u8;
 pub type c_schar = i8;
 pub type c_int = i32;

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1,5 +1,6 @@
 //! Windows CRT definitions
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
 pub type c_schar = i8;
@@ -22,7 +23,6 @@ pub type uintptr_t = usize;
 pub type ssize_t = isize;
 pub type sighandler_t = usize;
 
-pub type c_char = i8;
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type wchar_t = u16;

--- a/src/xous.rs
+++ b/src/xous.rs
@@ -1,5 +1,7 @@
 //! Xous C type definitions
 
+pub use crate::arch::c_char_def as c_char;
+
 pub type c_schar = i8;
 pub type c_uchar = u8;
 pub type c_short = i16;
@@ -20,7 +22,6 @@ pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
 pub type off_t = i64;
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type wchar_t = u32;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

Replaces https://github.com/rust-lang/libc/pull/4199 by doing https://github.com/rust-lang/libc/pull/4199#issuecomment-2548178664.

Closes https://github.com/rust-lang/libc/pull/4199.

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
