### PR TITLE
v0.2: Backport c_char fixes

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -364,9 +364,6 @@ fn test_apple(target: &str) {
             // FIXME: "'__uint128' undeclared" in C
             "__uint128" => true,
 
-            // `c_char_def` is always public but not always reexported.
-            "c_char_def" => true,
-
             _ => false,
         }
     });
@@ -761,8 +758,6 @@ fn test_windows(target: &str) {
         "ssize_t" if !gnu => true,
         // FIXME: The size and alignment of this type are incorrect
         "time_t" if gnu && i686 => true,
-        // `c_char_def` is always public but not always reexported.
-        "c_char_def" => true,
         _ => false,
     });
 
@@ -980,8 +975,6 @@ fn test_solarish(target: &str) {
 
     cfg.skip_type(move |ty| match ty {
         "sighandler_t" => true,
-        // `c_char_def` is always public but not always reexported.
-        "c_char_def" => true,
         _ => false,
     });
 
@@ -1285,8 +1278,6 @@ fn test_netbsd(target: &str) {
         match ty {
             // FIXME: sighandler_t is crazy across platforms
             "sighandler_t" => true,
-            // `c_char_def` is always public but not always reexported.
-            "c_char_def" => true,
             _ => false,
         }
     });
@@ -1506,8 +1497,6 @@ fn test_dragonflybsd(target: &str) {
         match ty {
             // sighandler_t is crazy across platforms
             "sighandler_t" => true,
-            // `c_char_def` is always public but not always reexported.
-            "c_char_def" => true,
             _ => false,
         }
     });
@@ -1668,8 +1657,6 @@ fn test_wasi(target: &str) {
             s => s.to_string(),
         }
     });
-
-    cfg.skip_type(|ty| ty == "c_char_def");
 
     // These have a different and internal type in header files and are only
     // used here to generate a pointer to them in bindings so skip these tests.
@@ -1918,9 +1905,6 @@ fn test_android(target: &str) {
 
             // FIXME: "'__uint128' undeclared" in C
             "__uint128" => true,
-
-            // `c_char_def` is always public but not always reexported.
-            "c_char_def" => true,
 
             _ => false,
         }
@@ -2684,9 +2668,6 @@ fn test_freebsd(target: &str) {
             // `eventfd(2)` and things come with it are added in FreeBSD 13
             "eventfd_t" if Some(13) > freebsd_ver => true,
 
-            // `c_char_def` is always public but not always reexported.
-            "c_char_def" => true,
-
             _ => false,
         }
     });
@@ -3007,9 +2988,6 @@ fn test_emscripten(target: &str) {
             // https://github.com/emscripten-core/emscripten/issues/5033
             ty if ty.starts_with("epoll") => true,
 
-            // `c_char_def` is always public but not always reexported.
-            "c_char_def" => true,
-
             // LFS64 types have been removed in Emscripten 3.1.44
             // https://github.com/emscripten-core/emscripten/pull/19812
             t => t.ends_with("64") || t.ends_with("64_t"),
@@ -3281,9 +3259,6 @@ fn test_neutrino(target: &str) {
             // Does not exist in Neutrino
             "locale_t" => true,
 
-            // `c_char_def` is always public but not always reexported.
-            "c_char_def" => true,
-
             _ => false,
         }
     });
@@ -3450,8 +3425,6 @@ fn test_vxworks(target: &str) {
     // FIXME
     cfg.skip_type(move |ty| match ty {
         "stat64" | "sighandler_t" | "off64_t" => true,
-        // `c_char_def` is always public but not always reexported.
-        "c_char_def" => true,
         _ => false,
     });
 
@@ -3799,9 +3772,6 @@ fn test_linux(target: &str) {
             // FIXME: "'__uint128' undeclared" in C
             "__uint128" => true,
 
-            // `c_char_def` is always public but not always reexported.
-            "c_char_def" => true,
-
             t => {
                 if musl {
                     // LFS64 types have been removed in musl 1.2.4+
@@ -4031,7 +4001,7 @@ fn test_linux(target: &str) {
             }
             // FIXME: Requires >= 5.4 kernel headers
             if name == "PTP_CLOCK_GETCAPS2"
-                || name == "PTP_ENABLE_PPS2" 
+                || name == "PTP_ENABLE_PPS2"
                 || name == "PTP_EXTTS_REQUEST2"
                 || name == "PTP_PEROUT_REQUEST2"
                 || name == "PTP_PIN_GETFUNC2"
@@ -4754,8 +4724,6 @@ fn test_linux_like_apis(target: &str) {
             })
             .skip_type(move |ty| match ty {
                 "Elf64_Phdr" | "Elf32_Phdr" => false,
-                // `c_char_def` is always public but not always reexported.
-                "c_char_def" => true,
                 _ => true,
             });
         cfg.generate(src_hotfix_dir().join("lib.rs"), "linux_elf.rs");
@@ -4991,8 +4959,6 @@ fn test_haiku(target: &str) {
             "pthread_condattr_t" => true,
             "pthread_mutexattr_t" => true,
             "pthread_rwlockattr_t" => true,
-            // `c_char_def` is always public but not always reexported.
-            "c_char_def" => true,
             _ => false,
         }
     });

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -364,6 +364,9 @@ fn test_apple(target: &str) {
             // FIXME: "'__uint128' undeclared" in C
             "__uint128" => true,
 
+            // `c_char_def` is always public but not always reexported.
+            "c_char_def" => true,
+
             _ => false,
         }
     });
@@ -758,6 +761,8 @@ fn test_windows(target: &str) {
         "ssize_t" if !gnu => true,
         // FIXME: The size and alignment of this type are incorrect
         "time_t" if gnu && i686 => true,
+        // `c_char_def` is always public but not always reexported.
+        "c_char_def" => true,
         _ => false,
     });
 
@@ -975,6 +980,8 @@ fn test_solarish(target: &str) {
 
     cfg.skip_type(move |ty| match ty {
         "sighandler_t" => true,
+        // `c_char_def` is always public but not always reexported.
+        "c_char_def" => true,
         _ => false,
     });
 
@@ -1278,6 +1285,8 @@ fn test_netbsd(target: &str) {
         match ty {
             // FIXME: sighandler_t is crazy across platforms
             "sighandler_t" => true,
+            // `c_char_def` is always public but not always reexported.
+            "c_char_def" => true,
             _ => false,
         }
     });
@@ -1497,7 +1506,8 @@ fn test_dragonflybsd(target: &str) {
         match ty {
             // sighandler_t is crazy across platforms
             "sighandler_t" => true,
-
+            // `c_char_def` is always public but not always reexported.
+            "c_char_def" => true,
             _ => false,
         }
     });
@@ -1658,6 +1668,8 @@ fn test_wasi(target: &str) {
             s => s.to_string(),
         }
     });
+
+    cfg.skip_type(|ty| ty == "c_char_def");
 
     // These have a different and internal type in header files and are only
     // used here to generate a pointer to them in bindings so skip these tests.
@@ -1906,6 +1918,9 @@ fn test_android(target: &str) {
 
             // FIXME: "'__uint128' undeclared" in C
             "__uint128" => true,
+
+            // `c_char_def` is always public but not always reexported.
+            "c_char_def" => true,
 
             _ => false,
         }
@@ -2669,6 +2684,9 @@ fn test_freebsd(target: &str) {
             // `eventfd(2)` and things come with it are added in FreeBSD 13
             "eventfd_t" if Some(13) > freebsd_ver => true,
 
+            // `c_char_def` is always public but not always reexported.
+            "c_char_def" => true,
+
             _ => false,
         }
     });
@@ -2989,6 +3007,9 @@ fn test_emscripten(target: &str) {
             // https://github.com/emscripten-core/emscripten/issues/5033
             ty if ty.starts_with("epoll") => true,
 
+            // `c_char_def` is always public but not always reexported.
+            "c_char_def" => true,
+
             // LFS64 types have been removed in Emscripten 3.1.44
             // https://github.com/emscripten-core/emscripten/pull/19812
             t => t.ends_with("64") || t.ends_with("64_t"),
@@ -3260,6 +3281,9 @@ fn test_neutrino(target: &str) {
             // Does not exist in Neutrino
             "locale_t" => true,
 
+            // `c_char_def` is always public but not always reexported.
+            "c_char_def" => true,
+
             _ => false,
         }
     });
@@ -3426,6 +3450,8 @@ fn test_vxworks(target: &str) {
     // FIXME
     cfg.skip_type(move |ty| match ty {
         "stat64" | "sighandler_t" | "off64_t" => true,
+        // `c_char_def` is always public but not always reexported.
+        "c_char_def" => true,
         _ => false,
     });
 
@@ -3772,6 +3798,9 @@ fn test_linux(target: &str) {
 
             // FIXME: "'__uint128' undeclared" in C
             "__uint128" => true,
+
+            // `c_char_def` is always public but not always reexported.
+            "c_char_def" => true,
 
             t => {
                 if musl {
@@ -4725,6 +4754,8 @@ fn test_linux_like_apis(target: &str) {
             })
             .skip_type(move |ty| match ty {
                 "Elf64_Phdr" | "Elf32_Phdr" => false,
+                // `c_char_def` is always public but not always reexported.
+                "c_char_def" => true,
                 _ => true,
             });
         cfg.generate(src_hotfix_dir().join("lib.rs"), "linux_elf.rs");
@@ -4960,6 +4991,8 @@ fn test_haiku(target: &str) {
             "pthread_condattr_t" => true,
             "pthread_mutexattr_t" => true,
             "pthread_rwlockattr_t" => true,
+            // `c_char_def` is always public but not always reexported.
+            "c_char_def" => true,
             _ => false,
         }
     });

--- a/src/fuchsia/aarch64.rs
+++ b/src/fuchsia/aarch64.rs
@@ -1,7 +1,6 @@
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type __u64 = c_ulonglong;
 pub type wchar_t = u32;
 pub type nlink_t = c_ulong;

--- a/src/fuchsia/riscv64.rs
+++ b/src/fuchsia/riscv64.rs
@@ -2,7 +2,6 @@ use crate::off_t;
 use crate::prelude::*;
 
 // From psABI Calling Convention for RV64
-pub type c_char = u8;
 pub type __u64 = c_ulonglong;
 pub type wchar_t = i32;
 

--- a/src/fuchsia/x86_64.rs
+++ b/src/fuchsia/x86_64.rs
@@ -1,7 +1,6 @@
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type nlink_t = u64;
 pub type blksize_t = c_long;

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -2,14 +2,6 @@
 
 use crate::prelude::*;
 
-cfg_if! {
-    if #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))] {
-        pub type c_char = u8;
-    } else {
-        pub type c_char = i8;
-    }
-}
-
 pub type c_schar = i8;
 pub type c_uchar = u8;
 pub type c_short = i16;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,44 @@ cfg_if! {
 
 pub use core::ffi::c_void;
 
+/// Type definitions that are coupled tighter to architecture than OS.
+mod arch {
+    cfg_if! {
+        // This configuration comes from `rust-lang/rust` in `library/core/src/ffi/mod.rs`.
+        if #[cfg(all(
+            not(windows),
+            // FIXME(ctest): just use `target_vendor` = "apple"` once `ctest` supports it
+            not(any(
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "tvos",
+                target_os = "watchos",
+                target_os = "visionos",
+            )),
+            any(
+                target_arch = "aarch64",
+                target_arch = "arm",
+                target_arch = "csky",
+                target_arch = "hexagon",
+                target_arch = "msp430",
+                target_arch = "powerpc",
+                target_arch = "powerpc64",
+                target_arch = "riscv64",
+                target_arch = "riscv32",
+                target_arch = "s390x",
+                target_arch = "xtensa",
+            )
+        ))] {
+            // To be reexported as `c_char`
+            // FIXME(ctest): just name these `c_char` once `ctest` learns that these don't get
+            // exported.
+            pub type c_char_def = u8;
+        } else {
+            pub type c_char_def = i8;
+        }
+    }
+}
+
 cfg_if! {
     if #[cfg(windows)] {
         mod fixed_width_ints;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,41 +41,35 @@ cfg_if! {
 
 pub use core::ffi::c_void;
 
-/// Type definitions that are coupled tighter to architecture than OS.
-mod arch {
-    cfg_if! {
-        // This configuration comes from `rust-lang/rust` in `library/core/src/ffi/mod.rs`.
-        if #[cfg(all(
-            not(windows),
-            // FIXME(ctest): just use `target_vendor` = "apple"` once `ctest` supports it
-            not(any(
-                target_os = "macos",
-                target_os = "ios",
-                target_os = "tvos",
-                target_os = "watchos",
-                target_os = "visionos",
-            )),
-            any(
-                target_arch = "aarch64",
-                target_arch = "arm",
-                target_arch = "csky",
-                target_arch = "hexagon",
-                target_arch = "msp430",
-                target_arch = "powerpc",
-                target_arch = "powerpc64",
-                target_arch = "riscv64",
-                target_arch = "riscv32",
-                target_arch = "s390x",
-                target_arch = "xtensa",
-            )
-        ))] {
-            // To be reexported as `c_char`
-            // FIXME(ctest): just name these `c_char` once `ctest` learns that these don't get
-            // exported.
-            pub type c_char_def = u8;
-        } else {
-            pub type c_char_def = i8;
-        }
+cfg_if! {
+    // This configuration comes from `rust-lang/rust` in `library/core/src/ffi/mod.rs`.
+    if #[cfg(all(
+        not(windows),
+        // FIXME(ctest): just use `target_vendor` = "apple"` once `ctest` supports it
+        not(any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "visionos",
+        )),
+        any(
+            target_arch = "aarch64",
+            target_arch = "arm",
+            target_arch = "csky",
+            target_arch = "hexagon",
+            target_arch = "msp430",
+            target_arch = "powerpc",
+            target_arch = "powerpc64",
+            target_arch = "riscv64",
+            target_arch = "riscv32",
+            target_arch = "s390x",
+            target_arch = "xtensa",
+        )
+    ))] {
+        pub type c_char = u8;
+    } else {
+        pub type c_char = i8;
     }
 }
 

--- a/src/psp.rs
+++ b/src/psp.rs
@@ -25,7 +25,6 @@ pub type intptr_t = isize;
 pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 

--- a/src/sgx.rs
+++ b/src/sgx.rs
@@ -19,7 +19,6 @@ pub type intptr_t = isize;
 pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
-pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 

--- a/src/solid/aarch64.rs
+++ b/src/solid/aarch64.rs
@@ -1,4 +1,3 @@
-pub type c_char = i8;
 pub type wchar_t = u32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/solid/arm.rs
+++ b/src/solid/arm.rs
@@ -1,4 +1,3 @@
-pub type c_char = i8;
 pub type wchar_t = u32;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -20,7 +20,6 @@ pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
 pub type off_t = i64;
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type wchar_t = u32;

--- a/src/teeos/mod.rs
+++ b/src/teeos/mod.rs
@@ -5,9 +5,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-// only supported on Rust > 1.59, so we can directly reexport c_void from core.
-pub use core::ffi::c_void;
-
 use crate::prelude::*;
 
 pub type c_schar = i8;

--- a/src/teeos/mod.rs
+++ b/src/teeos/mod.rs
@@ -45,9 +45,6 @@ pub type ssize_t = isize;
 
 pub type pid_t = c_int;
 
-// aarch64 specific
-pub type c_char = u8;
-
 pub type wchar_t = u32;
 
 pub type c_long = i64;

--- a/src/trusty.rs
+++ b/src/trusty.rs
@@ -5,14 +5,6 @@ pub type ssize_t = isize;
 
 pub type off_t = i64;
 
-cfg_if! {
-    if #[cfg(any(target_arch = "aarch64", target_arch = "arm"))] {
-        pub type c_char = u8;
-    } else if #[cfg(target_arch = "x86_64")] {
-        pub type c_char = i8;
-    }
-}
-
 pub type c_schar = i8;
 pub type c_uchar = u8;
 pub type c_short = i16;

--- a/src/trusty.rs
+++ b/src/trusty.rs
@@ -1,4 +1,4 @@
-pub use core::ffi::c_void;
+use crate::prelude::*;
 
 pub type size_t = usize;
 pub type ssize_t = isize;

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type caddr_t = *mut c_char;
 pub type clockid_t = c_longlong;
 pub type blkcnt_t = c_long;

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -5,7 +5,6 @@
 use crate::prelude::*;
 use crate::{cmsghdr, off_t};
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type clock_t = c_ulong;
 pub type time_t = c_long;

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 use crate::{cmsghdr, off_t};
 
 pub type dev_t = u32;
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type clock_t = u64;
 pub type ino_t = u64;

--- a/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type clock_t = i32;

--- a/src/unix/bsd/freebsdlike/freebsd/arm.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/arm.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type clock_t = u32;

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type clock_t = u32;

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type clock_t = u32;

--- a/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type clock_t = i32;

--- a/src/unix/bsd/freebsdlike/freebsd/x86.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type clock_t = c_ulong;

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type clock_t = i32;

--- a/src/unix/bsd/netbsdlike/netbsd/aarch64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/aarch64.rs
@@ -3,7 +3,6 @@ use crate::PT_FIRSTMACH;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = u8;
 pub type greg_t = u64;
 pub type __cpu_simple_lock_nv_t = c_uchar;
 

--- a/src/unix/bsd/netbsdlike/netbsd/arm.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/arm.rs
@@ -3,7 +3,6 @@ use crate::PT_FIRSTMACH;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
-pub type c_char = u8;
 pub type __cpu_simple_lock_nv_t = c_int;
 
 pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_longlong>() - 1;

--- a/src/unix/bsd/netbsdlike/netbsd/mips.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mips.rs
@@ -3,7 +3,6 @@ use crate::PT_FIRSTMACH;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
-pub type c_char = i8;
 pub type __cpu_simple_lock_nv_t = c_int;
 
 pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_longlong>() - 1;

--- a/src/unix/bsd/netbsdlike/netbsd/powerpc.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/powerpc.rs
@@ -3,7 +3,6 @@ use crate::PT_FIRSTMACH;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
-pub type c_char = u8;
 pub type __cpu_simple_lock_nv_t = c_int;
 
 pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_double>() - 1;

--- a/src/unix/bsd/netbsdlike/netbsd/riscv64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/riscv64.rs
@@ -4,7 +4,6 @@ use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = u8;
 pub type __greg_t = u64;
 pub type __cpu_simple_lock_nv_t = c_int;
 pub type __gregset = [__greg_t; _NGREG];

--- a/src/unix/bsd/netbsdlike/netbsd/sparc64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/sparc64.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = i8;
 pub type __cpu_simple_lock_nv_t = c_uchar;
 
 // should be pub(crate), but that requires Rust 1.18.0

--- a/src/unix/bsd/netbsdlike/netbsd/x86.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/x86.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
-pub type c_char = i8;
 pub type __cpu_simple_lock_nv_t = c_uchar;
 
 pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_int>() - 1;

--- a/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
@@ -3,7 +3,6 @@ use crate::PT_FIRSTMACH;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = i8;
 pub type c___greg_t = u64;
 pub type __cpu_simple_lock_nv_t = c_uchar;
 

--- a/src/unix/bsd/netbsdlike/openbsd/aarch64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/aarch64.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = u8;
 pub type ucontext_t = sigcontext;
 
 s! {

--- a/src/unix/bsd/netbsdlike/openbsd/arm.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/arm.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
-pub type c_char = u8;
 
 pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_double>() - 1;
 

--- a/src/unix/bsd/netbsdlike/openbsd/mips64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mips64.rs
@@ -1,6 +1,5 @@
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = i8;
 
 #[doc(hidden)]
 pub const _ALIGNBYTES: usize = 7;

--- a/src/unix/bsd/netbsdlike/openbsd/powerpc.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/powerpc.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
-pub type c_char = u8;
 
 pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_double>() - 1;
 

--- a/src/unix/bsd/netbsdlike/openbsd/powerpc64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/powerpc64.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = u8;
 
 pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
 

--- a/src/unix/bsd/netbsdlike/openbsd/riscv64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/riscv64.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = u8;
 pub type ucontext_t = sigcontext;
 
 s! {

--- a/src/unix/bsd/netbsdlike/openbsd/sparc64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/sparc64.rs
@@ -1,6 +1,5 @@
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = i8;
 
 #[doc(hidden)]
 pub const _ALIGNBYTES: usize = 0xf;

--- a/src/unix/bsd/netbsdlike/openbsd/x86.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/x86.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 
 pub type c_long = i32;
 pub type c_ulong = u32;
-pub type c_char = i8;
 
 pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_int>() - 1;
 

--- a/src/unix/bsd/netbsdlike/openbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/x86_64.rs
@@ -3,7 +3,6 @@ use crate::PT_FIRSTMACH;
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = i8;
 pub type ucontext_t = sigcontext;
 
 s! {

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -6,7 +6,6 @@ pub type pthread_key_t = c_int;
 pub type nfds_t = c_ulong;
 pub type tcflag_t = c_uint;
 pub type speed_t = c_uchar;
-pub type c_char = i8;
 pub type clock_t = i32;
 pub type clockid_t = i32;
 pub type suseconds_t = i32;

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -4,8 +4,6 @@ use crate::c_schar;
 use crate::prelude::*;
 
 // types
-pub type c_char = i8;
-
 pub type __s16_type = c_short;
 pub type __u16_type = c_ushort;
 pub type __s32_type = c_int;

--- a/src/unix/linux_like/android/b32/arm.rs
+++ b/src/unix/linux_like/android/b32/arm.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type wchar_t = u32;
 pub type greg_t = i32;
 pub type mcontext_t = sigcontext;

--- a/src/unix/linux_like/android/b32/x86/mod.rs
+++ b/src/unix/linux_like/android/b32/x86/mod.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type greg_t = i32;
 

--- a/src/unix/linux_like/android/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/android/b64/aarch64/mod.rs
@@ -1,7 +1,6 @@
 use crate::off64_t;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type wchar_t = u32;
 pub type __u64 = c_ulonglong;
 pub type __s64 = c_longlong;

--- a/src/unix/linux_like/android/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/android/b64/riscv64/mod.rs
@@ -1,7 +1,6 @@
 use crate::off64_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = u32;
 pub type greg_t = i64;
 pub type __u64 = c_ulonglong;

--- a/src/unix/linux_like/android/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/android/b64/x86_64/mod.rs
@@ -1,7 +1,6 @@
 use crate::off64_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type greg_t = i64;
 pub type __u64 = c_ulonglong;

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type useconds_t = u32;
 pub type dev_t = u32;

--- a/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = u8;
 pub type wchar_t = u32;
 
 s! {

--- a/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = u8;
 pub type wchar_t = u32;
 
 s! {

--- a/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 
 s! {

--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 
 s! {

--- a/src/unix/linux_like/linux/gnu/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/gnu/b32/powerpc.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = u8;
 pub type wchar_t = i32;
 
 s! {

--- a/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
@@ -3,7 +3,6 @@
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = u8;
 pub type wchar_t = c_int;
 
 s! {

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -3,7 +3,6 @@
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 
 s! {

--- a/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type greg_t = i32;
 

--- a/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
@@ -3,7 +3,6 @@
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = u8;
 pub type wchar_t = u32;
 pub type nlink_t = u32;
 pub type blksize_t = i32;

--- a/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 use crate::{off64_t, off_t, pthread_mutex_t};
 
-pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type wchar_t = i32;

--- a/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 use crate::{off64_t, off_t, pthread_mutex_t};
 
 pub type blksize_t = i64;
-pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type nlink_t = u64;

--- a/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
@@ -5,7 +5,6 @@ use crate::{off64_t, off_t, pthread_mutex_t};
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = u8;
 pub type wchar_t = i32;
 pub type nlink_t = u64;
 pub type blksize_t = i64;

--- a/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
@@ -3,7 +3,6 @@
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type wchar_t = c_int;

--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -4,7 +4,6 @@ use crate::prelude::*;
 use crate::{off64_t, off_t, pthread_mutex_t};
 
 pub type blksize_t = i64;
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type nlink_t = u64;

--- a/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
@@ -5,7 +5,6 @@ use crate::{off64_t, off_t, pthread_mutex_t};
 
 pub type c_long = i64;
 pub type c_ulong = u64;
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type nlink_t = u32;
 pub type blksize_t = i64;

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -3,7 +3,6 @@
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type nlink_t = u64;
 pub type blksize_t = i64;

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -1,7 +1,6 @@
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type wchar_t = u32;
 
 s! {

--- a/src/unix/linux_like/linux/musl/b32/hexagon.rs
+++ b/src/unix/linux_like/linux/musl/b32/hexagon.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type wchar_t = u32;
 pub type stat64 = crate::stat;
 

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -1,7 +1,6 @@
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = c_int;
 
 s! {

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -1,7 +1,6 @@
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type wchar_t = i32;
 
 s! {

--- a/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
@@ -3,7 +3,6 @@
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = u8;
 pub type wchar_t = c_int;
 
 s! {

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -1,7 +1,6 @@
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 
 s! {

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -1,7 +1,6 @@
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type __u64 = c_ulonglong;
 pub type __s64 = c_longlong;
 pub type wchar_t = u32;

--- a/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
@@ -3,7 +3,6 @@
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = i8;
 pub type wchar_t = c_int;
 
 pub type nlink_t = c_uint;

--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -1,7 +1,6 @@
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type __u64 = c_ulong;
 pub type __s64 = c_long;

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -1,7 +1,6 @@
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type wchar_t = i32;
 pub type __u64 = c_ulong;
 pub type __s64 = c_long;

--- a/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
@@ -3,7 +3,6 @@
 use crate::prelude::*;
 use crate::{off64_t, off_t};
 
-pub type c_char = u8;
 pub type wchar_t = c_int;
 
 pub type nlink_t = c_uint;

--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -2,7 +2,6 @@ use crate::off_t;
 use crate::prelude::*;
 
 pub type blksize_t = i64;
-pub type c_char = u8;
 pub type nlink_t = u64;
 pub type wchar_t = i32;
 pub type greg_t = u64;

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -1,7 +1,6 @@
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type nlink_t = u64;
 pub type blksize_t = c_long;

--- a/src/unix/linux_like/linux/uclibc/arm/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/arm/mod.rs
@@ -1,7 +1,6 @@
 use crate::off64_t;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type wchar_t = c_uint;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
@@ -1,7 +1,6 @@
 use crate::off64_t;
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type clock_t = i32;

--- a/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
@@ -3,7 +3,6 @@ use crate::prelude::*;
 
 pub type blkcnt_t = i64;
 pub type blksize_t = i64;
-pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type fsblkcnt_t = c_ulong;

--- a/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
@@ -6,7 +6,6 @@ use crate::prelude::*;
 pub type blkcnt_t = i64;
 pub type blksize_t = i64;
 pub type clock_t = i64;
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type fsblkcnt_t = c_ulong;

--- a/src/unix/newlib/aarch64/mod.rs
+++ b/src/unix/newlib/aarch64/mod.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 
 pub type clock_t = c_long;
-pub type c_char = u8;
 pub type wchar_t = u32;
 
 pub type c_long = i64;

--- a/src/unix/newlib/arm/mod.rs
+++ b/src/unix/newlib/arm/mod.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 
 pub type clock_t = c_long;
-pub type c_char = u8;
 pub type wchar_t = u32;
 
 pub type c_long = i32;

--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 
 pub type clock_t = c_ulong;
-pub type c_char = u8;
 pub type wchar_t = u32;
 
 pub type c_long = i32;

--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 pub type clock_t = c_ulong;
-pub type c_char = i8;
+pub type c_char = u8;
 pub type wchar_t = u32;
 
 pub type c_long = i32;

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -3,7 +3,6 @@
 use crate::off_t;
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type c_long = i32;
 pub type c_ulong = u32;
 

--- a/src/unix/newlib/powerpc/mod.rs
+++ b/src/unix/newlib/powerpc/mod.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 
 pub type clock_t = c_ulong;
-pub type c_char = u8;
 pub type wchar_t = c_int;
 
 pub type c_long = i32;

--- a/src/unix/newlib/vita/mod.rs
+++ b/src/unix/newlib/vita/mod.rs
@@ -3,7 +3,6 @@ use crate::prelude::*;
 
 pub type clock_t = c_long;
 
-pub type c_char = i8;
 pub type wchar_t = u32;
 
 pub type c_long = i32;

--- a/src/unix/nto/aarch64.rs
+++ b/src/unix/nto/aarch64.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 
-pub type c_char = u8;
 pub type wchar_t = u32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/unix/nto/x86_64.rs
+++ b/src/unix/nto/x86_64.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = u32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -5,7 +5,6 @@ pub type nlink_t = u16;
 pub type ino_t = u16;
 pub type blkcnt_t = u64;
 pub type blksize_t = i16;
-pub type c_char = i8;
 pub type c_long = isize;
 pub type c_ulong = usize;
 pub type cc_t = u8;

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type wchar_t = i32;
 
 cfg_if! {

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2,7 +2,6 @@ use core::mem::size_of;
 
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type caddr_t = *mut c_char;

--- a/src/vxworks/aarch64.rs
+++ b/src/vxworks/aarch64.rs
@@ -1,4 +1,3 @@
-pub type c_char = u8;
 pub type wchar_t = u32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/vxworks/arm.rs
+++ b/src/vxworks/arm.rs
@@ -1,4 +1,3 @@
-pub type c_char = u8;
 pub type wchar_t = u32;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/vxworks/powerpc.rs
+++ b/src/vxworks/powerpc.rs
@@ -1,4 +1,3 @@
-pub type c_char = u8;
 pub type wchar_t = u32;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/vxworks/powerpc64.rs
+++ b/src/vxworks/powerpc64.rs
@@ -1,4 +1,3 @@
-pub type c_char = u8;
 pub type wchar_t = u32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/vxworks/riscv32.rs
+++ b/src/vxworks/riscv32.rs
@@ -1,4 +1,3 @@
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/vxworks/riscv64.rs
+++ b/src/vxworks/riscv64.rs
@@ -1,4 +1,3 @@
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/vxworks/x86.rs
+++ b/src/vxworks/x86.rs
@@ -1,4 +1,3 @@
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type c_long = i32;
 pub type c_ulong = u32;

--- a/src/vxworks/x86_64.rs
+++ b/src/vxworks/x86_64.rs
@@ -1,4 +1,3 @@
-pub type c_char = i8;
 pub type wchar_t = i32;
 pub type c_long = i64;
 pub type c_ulong = u64;

--- a/src/wasi/mod.rs
+++ b/src/wasi/mod.rs
@@ -7,7 +7,6 @@ use core::iter::Iterator;
 
 use crate::prelude::*;
 
-pub type c_char = i8;
 pub type c_uchar = u8;
 pub type c_schar = i8;
 pub type c_int = i32;

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -22,7 +22,6 @@ pub type uintptr_t = usize;
 pub type ssize_t = isize;
 pub type sighandler_t = usize;
 
-pub type c_char = i8;
 pub type c_long = i32;
 pub type c_ulong = u32;
 pub type wchar_t = u16;

--- a/src/xous.rs
+++ b/src/xous.rs
@@ -20,7 +20,6 @@ pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
 pub type off_t = i64;
-pub type c_char = u8;
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type wchar_t = u32;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Backports the following to libc-0.2:
- https://github.com/rust-lang/libc/pull/4195
- https://github.com/rust-lang/libc/pull/4198
- https://github.com/rust-lang/libc/pull/4200
- https://github.com/rust-lang/libc/pull/4202

4200 is not actually c_char-related PR, but 4202 depend on import change made in 4200.

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
