### PR TITLE
Replace arch-conditional c_char with a reexport

### DIFF
--- a/ci/style.rs
+++ b/ci/style.rs
@@ -28,10 +28,9 @@
 //! * alignment
 //! * leading colons on paths
 
-use std::env;
-use std::fs;
 use std::io::prelude::*;
 use std::path::Path;
+use std::{env, fs};
 
 macro_rules! t {
     ($e:expr) => {
@@ -130,7 +129,7 @@ fn check_style(file: &str, path: &Path, err: &mut Errors) {
         let line = if is_pub { &line[4..] } else { line };
 
         let line_state = if line.starts_with("use ") {
-            if line.contains("c_void") {
+            if line.contains("c_void") || line.contains("c_char") {
                 continue;
             }
             if is_pub {

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -1,14 +1,7 @@
 //! Hermit C type definitions
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
-
-cfg_if! {
-    if #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))] {
-        pub type c_char = u8;
-    } else {
-        pub type c_char = i8;
-    }
-}
 
 pub type c_schar = i8;
 pub type c_uchar = u8;

--- a/src/trusty.rs
+++ b/src/trusty.rs
@@ -1,17 +1,9 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
-
 pub type size_t = usize;
 pub type ssize_t = isize;
 
 pub type off_t = i64;
-
-cfg_if! {
-    if #[cfg(any(target_arch = "aarch64", target_arch = "arm"))] {
-        pub type c_char = u8;
-    } else if #[cfg(target_arch = "x86_64")] {
-        pub type c_char = i8;
-    }
-}
 
 pub type c_schar = i8;
 pub type c_uchar = u8;

--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -1,3 +1,4 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 use crate::{in6_addr, in_addr_t, timespec, DIR};
 
@@ -5,17 +6,6 @@ pub type nlink_t = u16;
 pub type ino_t = u16;
 pub type blkcnt_t = u64;
 pub type blksize_t = i16;
-cfg_if! {
-    if #[cfg(any(
-        target_arch = "arm",
-        target_arch = "riscv32",
-        target_arch = "riscv64",
-    ))] {
-        pub type c_char = u8;
-    } else {
-        pub type c_char = i8;
-    }
-}
 pub type c_long = isize;
 pub type c_ulong = usize;
 pub type cc_t = u8;

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -1,12 +1,6 @@
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-cfg_if! {
-    if #[cfg(target_arch = "aarch64")] {
-        pub type c_char = u8;
-    } else {
-        pub type c_char = i8;
-    }
-}
 pub type wchar_t = i32;
 
 cfg_if! {

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1,14 +1,8 @@
 use core::mem::size_of;
 
+pub use crate::arch::c_char_def as c_char;
 use crate::prelude::*;
 
-cfg_if! {
-    if #[cfg(target_arch = "aarch64")] {
-        pub type c_char = u8;
-    } else {
-        pub type c_char = i8;
-    }
-}
 pub type c_long = i64;
 pub type c_ulong = u64;
 pub type caddr_t = *mut c_char;


### PR DESCRIPTION
For any platforms that have `c_char` within a `cfg_if` block, ensure they match the top-level `arch` definitions and reexport that to clean up code.