### PR TITLE
Make `makedev`, `major`, `minor` const

### DIFF
--- a/libc-test/src/makedev.c
+++ b/libc-test/src/makedev.c
@@ -3,11 +3,19 @@
 #include <sys/sysmacros.h>
 #endif
 
-// Since makedev is a macro instead of a function, it isn't available to FFI.
-// libc must reimplement it, which is error-prone.  This file provides FFI
-// access to the actual macro so it can be tested against the Rust
-// reimplementation.
+// Since makedev, major, minor are macros instead of functions, they aren't
+// available to FFI. libc must reimplement them, which is error-prone. This
+// file provides FFI access to the actual macros so they can be tested against
+// the Rust reimplementation.
 
 dev_t makedev_ffi(unsigned major, unsigned minor) {
 	return makedev(major, minor);
+}
+
+unsigned int major_ffi(dev_t dev) {
+    return major(dev);
+}
+
+unsigned int minor_ffi(dev_t dev) {
+    return minor(dev);
 }

--- a/libc-test/test/makedev.rs
+++ b/libc-test/test/makedev.rs
@@ -1,5 +1,49 @@
-//! Compare libc's makdev function against the actual C macros, for various
+//! Compare libc's makedev, major, minor functions against the actual C macros, for various
 //! inputs.
+
+#[cfg(any(target_os = "solaris", target_os = "illumos"))]
+mod ret {
+    pub type MajorRetType = libc::major_t;
+    pub type MinorRetType = libc::minor_t;
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "l4re",
+    target_os = "emscripten",
+    target_os = "fuchsia",
+    target_os = "aix",
+    target_os = "nto",
+    target_os = "hurd",
+    target_os = "openbsd",
+))]
+mod ret {
+    pub type MajorRetType = libc::c_uint;
+    pub type MinorRetType = libc::c_uint;
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "netbsd",
+    target_os = "freebsd",
+))]
+mod ret {
+    pub type MajorRetType = libc::c_int;
+    pub type MinorRetType = libc::c_int;
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos",
+    target_os = "visionos"
+))]
+mod ret {
+    pub type MajorRetType = i32;
+    pub type MinorRetType = i32;
+}
 
 #[cfg(any(
     target_os = "android",
@@ -14,13 +58,21 @@
 mod t {
     use libc::{self, c_uint, dev_t};
 
+    use super::ret::*;
+
     extern "C" {
         pub fn makedev_ffi(major: c_uint, minor: c_uint) -> dev_t;
+        pub fn major_ffi(dev: dev_t) -> c_uint;
+        pub fn minor_ffi(dev: dev_t) -> c_uint;
     }
 
     fn compare(major: c_uint, minor: c_uint) {
-        let expected = unsafe { makedev_ffi(major, minor) };
-        assert_eq!(libc::makedev(major, minor), expected);
+        let dev = unsafe { makedev_ffi(major, minor) };
+        assert_eq!(libc::makedev(major, minor), dev);
+        let major = unsafe { major_ffi(dev) };
+        assert_eq!(libc::major(dev), major as MajorRetType);
+        let minor = unsafe { minor_ffi(dev) };
+        assert_eq!(libc::minor(dev), minor as MinorRetType);
     }
 
     // Every OS should be able to handle 8 bit major and minor numbers

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -3423,20 +3423,6 @@ f! {
         set1.bits == set2.bits
     }
 
-    pub fn major(dev: crate::dev_t) -> c_uint {
-        let mut major = 0;
-        major |= (dev & 0x00000000000fff00) >> 8;
-        major |= (dev & 0xfffff00000000000) >> 32;
-        major as c_uint
-    }
-
-    pub fn minor(dev: crate::dev_t) -> c_uint {
-        let mut minor = 0;
-        minor |= (dev & 0x00000000000000ff) >> 0;
-        minor |= (dev & 0x00000ffffff00000) >> 12;
-        minor as c_uint
-    }
-
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
         cmsg.offset(1) as *mut c_uchar
     }
@@ -3518,6 +3504,20 @@ safe_f! {
         dev |= (minor & 0x000000ff) << 0;
         dev |= (minor & 0xffffff00) << 12;
         dev
+    }
+
+    pub {const} fn major(dev: crate::dev_t) -> c_uint {
+        let mut major = 0;
+        major |= (dev & 0x00000000000fff00) >> 8;
+        major |= (dev & 0xfffff00000000000) >> 32;
+        major as c_uint
+    }
+
+    pub {const} fn minor(dev: crate::dev_t) -> c_uint {
+        let mut minor = 0;
+        minor |= (dev & 0x00000000000000ff) >> 0;
+        minor |= (dev & 0x00000ffffff00000) >> 12;
+        minor as c_uint
     }
 }
 

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -2545,25 +2545,6 @@ f! {
         let fd = fd as usize;
         return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0;
     }
-
-    pub fn major(dev: crate::dev_t) -> c_uint {
-        let x = dev >> 16;
-        x as c_uint
-    }
-
-    pub fn minor(dev: crate::dev_t) -> c_uint {
-        let y = dev & 0xFFFF;
-        y as c_uint
-    }
-
-    pub fn makedev(major: c_uint, minor: c_uint) -> crate::dev_t {
-        let major = major as crate::dev_t;
-        let minor = minor as crate::dev_t;
-        let mut dev = 0;
-        dev |= major << 16;
-        dev |= minor;
-        dev
-    }
 }
 
 safe_f! {
@@ -2610,6 +2591,25 @@ safe_f! {
     // AIX doesn't have native WCOREDUMP.
     pub {const} fn WCOREDUMP(_status: c_int) -> bool {
         false
+    }
+
+    pub {const} fn major(dev: crate::dev_t) -> c_uint {
+        let x = dev >> 16;
+        x as c_uint
+    }
+
+    pub {const} fn minor(dev: crate::dev_t) -> c_uint {
+        let y = dev & 0xFFFF;
+        y as c_uint
+    }
+
+    pub {const} fn makedev(major: c_uint, minor: c_uint) -> crate::dev_t {
+        let major = major as crate::dev_t;
+        let minor = minor as crate::dev_t;
+        let mut dev = 0;
+        dev |= major << 16;
+        dev |= minor;
+        dev
     }
 }
 

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -5543,18 +5543,6 @@ f! {
     pub {const} fn VM_MAKE_TAG(id: u8) -> u32 {
         (id as u32) << 24u32
     }
-
-    pub fn major(dev: dev_t) -> i32 {
-        (dev >> 24) & 0xff
-    }
-
-    pub fn minor(dev: dev_t) -> i32 {
-        dev & 0xffffff
-    }
-
-    pub fn makedev(major: i32, minor: i32) -> dev_t {
-        (major << 24) | minor
-    }
 }
 
 safe_f! {
@@ -5576,6 +5564,18 @@ safe_f! {
 
     pub {const} fn WIFSTOPPED(status: c_int) -> bool {
         _WSTATUS(status) == _WSTOPPED && WSTOPSIG(status) != 0x13
+    }
+
+    pub {const} fn makedev(major: i32, minor: i32) -> dev_t {
+        (major << 24) | minor
+    }
+
+    pub {const} fn major(dev: dev_t) -> i32 {
+        (dev >> 24) & 0xff
+    }
+
+    pub {const} fn minor(dev: dev_t) -> i32 {
+        dev & 0xffffff
     }
 }
 

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1590,14 +1590,6 @@ f! {
         let (idx, offset) = ((cpu >> 6) & 3, cpu & 63);
         0 != cpuset.ary[idx] & (1 << offset)
     }
-
-    pub fn major(dev: crate::dev_t) -> c_int {
-        ((dev >> 8) & 0xff) as c_int
-    }
-
-    pub fn minor(dev: crate::dev_t) -> c_int {
-        (dev & 0xffff00ff) as c_int
-    }
 }
 
 safe_f! {
@@ -1612,6 +1604,14 @@ safe_f! {
         dev |= major << 8;
         dev |= minor;
         dev
+    }
+
+    pub {const} fn major(dev: crate::dev_t) -> c_int {
+        ((dev >> 8) & 0xff) as c_int
+    }
+
+    pub {const} fn minor(dev: crate::dev_t) -> c_int {
+        (dev & 0xffff00ff) as c_int
     }
 }
 

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
@@ -441,14 +441,12 @@ safe_f! {
         let minor = minor as crate::dev_t;
         (major << 8) | minor
     }
-}
 
-f! {
-    pub fn major(dev: crate::dev_t) -> c_int {
+    pub {const} fn major(dev: crate::dev_t) -> c_int {
         ((dev >> 8) & 0xff) as c_int
     }
 
-    pub fn minor(dev: crate::dev_t) -> c_int {
+    pub {const} fn minor(dev: crate::dev_t) -> c_int {
         (dev & 0xffff00ff) as c_int
     }
 }

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -496,14 +496,12 @@ safe_f! {
         dev |= ((minor & 0xffff00ff) as dev_t) << 0;
         dev
     }
-}
 
-f! {
-    pub fn major(dev: crate::dev_t) -> c_int {
+    pub {const} fn major(dev: crate::dev_t) -> c_int {
         (((dev >> 32) & 0xffffff00) | ((dev >> 8) & 0xff)) as c_int
     }
 
-    pub fn minor(dev: crate::dev_t) -> c_int {
+    pub {const} fn minor(dev: crate::dev_t) -> c_int {
         (((dev >> 24) & 0xff00) | (dev & 0xffff00ff)) as c_int
     }
 }

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -518,14 +518,12 @@ safe_f! {
         dev |= ((minor & 0xffff00ff) as dev_t) << 0;
         dev
     }
-}
 
-f! {
-    pub fn major(dev: crate::dev_t) -> c_int {
+    pub {const} fn major(dev: crate::dev_t) -> c_int {
         (((dev >> 32) & 0xffffff00) | ((dev >> 8) & 0xff)) as c_int
     }
 
-    pub fn minor(dev: crate::dev_t) -> c_int {
+    pub {const} fn minor(dev: crate::dev_t) -> c_int {
         (((dev >> 24) & 0xff00) | (dev & 0xffff00ff)) as c_int
     }
 }

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -518,14 +518,12 @@ safe_f! {
         dev |= ((minor & 0xffff00ff) as dev_t) << 0;
         dev
     }
-}
 
-f! {
-    pub fn major(dev: crate::dev_t) -> c_int {
+    pub {const} fn major(dev: crate::dev_t) -> c_int {
         (((dev >> 32) & 0xffffff00) | ((dev >> 8) & 0xff)) as c_int
     }
 
-    pub fn minor(dev: crate::dev_t) -> c_int {
+    pub {const} fn minor(dev: crate::dev_t) -> c_int {
         (((dev >> 24) & 0xff00) | (dev & 0xffff00ff)) as c_int
     }
 }

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
@@ -519,14 +519,12 @@ safe_f! {
         dev |= ((minor & 0xffff00ff) as dev_t) << 0;
         dev
     }
-}
 
-f! {
-    pub fn major(dev: crate::dev_t) -> c_int {
+    pub {const} fn major(dev: crate::dev_t) -> c_int {
         (((dev >> 32) & 0xffffff00) | ((dev >> 8) & 0xff)) as c_int
     }
 
-    pub fn minor(dev: crate::dev_t) -> c_int {
+    pub {const} fn minor(dev: crate::dev_t) -> c_int {
         (((dev >> 24) & 0xff00) | (dev & 0xffff00ff)) as c_int
     }
 }

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2461,17 +2461,6 @@ f! {
     pub fn PROT_MPROTECT_EXTRACT(x: c_int) -> c_int {
         (x >> 3) & 0x7
     }
-
-    pub fn major(dev: crate::dev_t) -> c_int {
-        (((dev as u32) & 0x000fff00) >> 8) as c_int
-    }
-
-    pub fn minor(dev: crate::dev_t) -> c_int {
-        let mut res = 0;
-        res |= ((dev as u32) & 0xfff00000) >> 12;
-        res |= (dev as u32) & 0x000000ff;
-        res as c_int
-    }
 }
 
 safe_f! {
@@ -2499,6 +2488,17 @@ safe_f! {
         dev |= (minor << 12) & 0xfff00000;
         dev |= minor & 0xff;
         dev
+    }
+
+    pub {const} fn major(dev: crate::dev_t) -> c_int {
+        (((dev as u32) & 0x000fff00) >> 8) as c_int
+    }
+
+    pub {const} fn minor(dev: crate::dev_t) -> c_int {
+        let mut res = 0;
+        res |= ((dev as u32) & 0xfff00000) >> 12;
+        res |= (dev as u32) & 0x000000ff;
+        res as c_int
     }
 }
 

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1949,19 +1949,6 @@ f! {
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
         (_ALIGN(mem::size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
     }
-
-    pub fn major(dev: crate::dev_t) -> c_uint {
-        ((dev as c_uint) >> 8) & 0xff
-    }
-
-    pub fn minor(dev: crate::dev_t) -> c_uint {
-        let dev = dev as c_uint;
-        let mut res = 0;
-        res |= (dev) & 0xff;
-        res |= ((dev) & 0xffff0000) >> 8;
-
-        res
-    }
 }
 
 safe_f! {
@@ -1989,6 +1976,18 @@ safe_f! {
         dev |= minor & 0xff;
         dev |= (minor & 0xffff00) << 8;
         dev
+    }
+
+    pub {const} fn major(dev: crate::dev_t) -> c_uint {
+        ((dev as c_uint) >> 8) & 0xff
+    }
+
+    pub {const} fn minor(dev: crate::dev_t) -> c_uint {
+        let dev = dev as c_uint;
+        let mut res = 0;
+        res |= (dev) & 0xff;
+        res |= ((dev) & 0xffff0000) >> 8;
+        res
     }
 }
 

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -3524,14 +3524,6 @@ f! {
         set1.bits == set2.bits
     }
 
-    pub fn major(dev: crate::dev_t) -> c_uint {
-        ((dev >> 8) & 0xff) as c_uint
-    }
-
-    pub fn minor(dev: crate::dev_t) -> c_uint {
-        (dev & 0xffff00ff) as c_uint
-    }
-
     pub fn IPTOS_TOS(tos: u8) -> u8 {
         tos & IPTOS_TOS_MASK
     }
@@ -4562,6 +4554,14 @@ safe_f! {
         dev |= major << 8;
         dev |= minor;
         dev
+    }
+
+    pub {const} fn major(dev: crate::dev_t) -> c_uint {
+        ((dev >> 8) & 0xff) as c_uint
+    }
+
+    pub {const} fn minor(dev: crate::dev_t) -> c_uint {
+        (dev & 0xffff00ff) as c_uint
     }
 
     pub fn SIGRTMAX() -> c_int {

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -3605,12 +3605,6 @@ f! {
         set1.__bits == set2.__bits
     }
 
-    pub fn major(dev: crate::dev_t) -> c_int {
-        ((dev >> 8) & 0xfff) as c_int
-    }
-    pub fn minor(dev: crate::dev_t) -> c_int {
-        ((dev & 0xff) | ((dev >> 12) & 0xfff00)) as c_int
-    }
     pub fn NLA_ALIGN(len: c_int) -> c_int {
         return ((len) + NLA_ALIGNTO - 1) & !(NLA_ALIGNTO - 1);
     }
@@ -3625,6 +3619,14 @@ safe_f! {
         let ma = ma as crate::dev_t;
         let mi = mi as crate::dev_t;
         ((ma & 0xfff) << 8) | (mi & 0xff) | ((mi & 0xfff00) << 12)
+    }
+
+    pub {const} fn major(dev: crate::dev_t) -> c_int {
+        ((dev >> 8) & 0xfff) as c_int
+    }
+
+    pub {const} fn minor(dev: crate::dev_t) -> c_int {
+        ((dev & 0xff) | ((dev >> 12) & 0xfff00)) as c_int
     }
 }
 

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1452,26 +1452,6 @@ f! {
     pub fn CPU_EQUAL(set1: &cpu_set_t, set2: &cpu_set_t) -> bool {
         set1.bits == set2.bits
     }
-
-    pub fn major(dev: crate::dev_t) -> c_uint {
-        // see
-        // https://github.com/emscripten-core/emscripten/blob/
-        // main/system/lib/libc/musl/include/sys/sysmacros.h
-        let mut major = 0;
-        major |= (dev & 0x00000fff) >> 8;
-        major |= (dev & 0xfffff000) >> 31 >> 1;
-        major as c_uint
-    }
-
-    pub fn minor(dev: crate::dev_t) -> c_uint {
-        // see
-        // https://github.com/emscripten-core/emscripten/blob/
-        // main/system/lib/libc/musl/include/sys/sysmacros.h
-        let mut minor = 0;
-        minor |= (dev & 0x000000ff) >> 0;
-        minor |= (dev & 0xffffff00) >> 12;
-        minor as c_uint
-    }
 }
 
 safe_f! {
@@ -1479,11 +1459,31 @@ safe_f! {
         let major = major as crate::dev_t;
         let minor = minor as crate::dev_t;
         let mut dev = 0;
-        dev |= (major & 0x00000fff) << 8;
         dev |= (major & 0xfffff000) << 31 << 1;
-        dev |= (minor & 0x000000ff) << 0;
+        dev |= (major & 0x00000fff) << 8;
         dev |= (minor & 0xffffff00) << 12;
+        dev |= minor & 0x000000ff;
         dev
+    }
+
+    pub {const} fn major(dev: crate::dev_t) -> c_uint {
+        // see
+        // https://github.com/emscripten-core/emscripten/blob/
+        // main/system/lib/libc/musl/include/sys/sysmacros.h
+        let mut major = 0;
+        major |= (dev >> 31 >> 1) & 0xfffff000;
+        major |= (dev >> 8) & 0x00000fff;
+        major as c_uint
+    }
+
+    pub {const} fn minor(dev: crate::dev_t) -> c_uint {
+        // see
+        // https://github.com/emscripten-core/emscripten/blob/
+        // main/system/lib/libc/musl/include/sys/sysmacros.h
+        let mut minor = 0;
+        minor |= (dev >> 12) & 0xffffff00;
+        minor |= dev & 0x000000ff;
+        minor as c_uint
     }
 }
 

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -5966,20 +5966,6 @@ f! {
         ()
     }
 
-    pub fn major(dev: crate::dev_t) -> c_uint {
-        let mut major = 0;
-        major |= (dev & 0x00000000000fff00) >> 8;
-        major |= (dev & 0xfffff00000000000) >> 32;
-        major as c_uint
-    }
-
-    pub fn minor(dev: crate::dev_t) -> c_uint {
-        let mut minor = 0;
-        minor |= (dev & 0x00000000000000ff) >> 0;
-        minor |= (dev & 0x00000ffffff00000) >> 12;
-        minor as c_uint
-    }
-
     pub fn IPTOS_TOS(tos: u8) -> u8 {
         tos & IPTOS_TOS_MASK
     }
@@ -6069,6 +6055,20 @@ safe_f! {
         dev |= (minor & 0x000000ff) << 0;
         dev |= (minor & 0xffffff00) << 12;
         dev
+    }
+
+    pub {const} fn major(dev: crate::dev_t) -> c_uint {
+        let mut major = 0;
+        major |= (dev & 0x00000000000fff00) >> 8;
+        major |= (dev & 0xfffff00000000000) >> 32;
+        major as c_uint
+    }
+
+    pub {const} fn minor(dev: crate::dev_t) -> c_uint {
+        let mut minor = 0;
+        minor |= (dev & 0x00000000000000ff) >> 0;
+        minor |= (dev & 0x00000ffffff00000) >> 12;
+        minor as c_uint
     }
 
     pub {const} fn SCTP_PR_TTL_ENABLED(policy: c_int) -> bool {

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -2803,14 +2803,6 @@ f! {
         let ngrps = if ngrps > 0 { ngrps - 1 } else { 0 };
         mem::size_of::<sockcred>() + mem::size_of::<crate::gid_t>() * ngrps
     }
-
-    pub fn major(dev: crate::dev_t) -> c_uint {
-        ((dev as c_uint) >> 10) & 0x3f
-    }
-
-    pub fn minor(dev: crate::dev_t) -> c_uint {
-        (dev as c_uint) & 0x3ff
-    }
 }
 
 safe_f! {
@@ -2852,6 +2844,14 @@ safe_f! {
 
     pub {const} fn makedev(major: c_uint, minor: c_uint) -> crate::dev_t {
         ((major << 10) | (minor)) as crate::dev_t
+    }
+
+    pub {const} fn major(dev: crate::dev_t) -> c_uint {
+        ((dev as c_uint) >> 10) & 0x3f
+    }
+
+    pub {const} fn minor(dev: crate::dev_t) -> c_uint {
+        (dev as c_uint) & 0x3ff
     }
 }
 


### PR DESCRIPTION
# Description

This PR marks all `makedev`, `major`, `minor` re-implementations (except Solarish) as `const fn` and tests `major` and `minor` against their C counterparts (macros). This PR closely follows the work that was done in this [commit](https://github.com/rust-lang/libc/commit/5e6d9c4a92).

The motivation behind this PR is to make Rust code that uses these three functions consistent across different platforms. To give a concrete example: currently one has to wrap `major` and `minor` in `unsafe` blocks on MacOS, whereas on Linux these blocks are not needed. Unnecessary `unsafe` blocks produce a warning that one silences with `#[allow(unused_unsafe)]`. All of that confuses code reviewers and creates unnecessary noise. `makedev`, `major` and `minor` are macros on most Unixes, there is no need for them to be unsafe.

As far as I understand these changes do not break existing code: changing unsafe functions to const only produce warnings but not compilation errors.

@rustbot label stable-nominated

# Sources

None.

# Checklist

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI