### PR TITLE
Skip `c_char_def` on OpenBSD

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -603,6 +603,11 @@ fn test_openbsd(target: &str) {
         }
     });
 
+    cfg.skip_type(move |ty| {
+        // `c_char_def` is always public but not always reexported.
+        ty == "c_char_def"
+    });
+
     cfg.type_name(move |ty, is_struct, is_union| {
         match ty {
             // Just pass all these through, no need for a "struct" prefix


### PR DESCRIPTION
Fixes https://github.com/rust-lang/libc/issues/4209