### PR TITLE
[0.2] Skip `c_char_def` on OpenBSD

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -647,6 +647,11 @@ fn test_openbsd(target: &str) {
         }
     });
 
+    cfg.skip_type(move |ty| {
+        // `c_char_def` is always public but not always reexported.
+        ty == "c_char_def"
+    });
+
     cfg.type_name(move |ty, is_struct, is_union| {
         match ty {
             // Just pass all these through, no need for a "struct" prefix


### PR DESCRIPTION
Fixes https://github.com/rust-lang/libc/issues/4209

(backport <https://github.com/rust-lang/libc/pull/4210>)
(cherry picked from commit 9ff340933538e23fdf6cc1ecefc810c664bd0ebe)