### PR TITLE
Declare `setdomainname` and `getdomainname` on Android.

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2081,6 +2081,9 @@ fn test_android(target: &str) {
             // Added in API level 26, but some tests use level 24.
             "endgrent" => true,
 
+            // Added in API level 26, but some tests use level 24.
+            "getdomainname" | "setdomainname" => true,
+
             // FIXME: bad function pointers:
             "isalnum" | "isalpha" | "iscntrl" | "isdigit" | "isgraph" | "islower" | "isprint"
             | "ispunct" | "isspace" | "isupper" | "isxdigit" | "isblank" | "tolower"

--- a/libc-test/semver/android.txt
+++ b/libc-test/semver/android.txt
@@ -3324,6 +3324,7 @@ getaddrinfo
 getchar
 getchar_unlocked
 getcwd
+getdomainname
 getegid
 getenv
 geteuid
@@ -3720,6 +3721,7 @@ sendmsg
 sendto
 servent
 setbuf
+setdomainname
 setegid
 setenv
 seteuid

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -4084,9 +4084,6 @@ extern "C" {
         newpath: *const c_char,
         flags: c_uint,
     ) -> c_int;
-
-    pub fn getdomainname(name: *mut c_char, len: size_t) -> c_int;
-    pub fn setdomainname(name: *const c_char, len: size_t) -> c_int;
 }
 
 cfg_if! {

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -4084,6 +4084,9 @@ extern "C" {
         newpath: *const c_char,
         flags: c_uint,
     ) -> c_int;
+
+    pub fn getdomainname(name: *mut c_char, len: size_t) -> c_int;
+    pub fn setdomainname(name: *const c_char, len: size_t) -> c_int;
 }
 
 cfg_if! {

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1576,8 +1576,6 @@ extern "C" {
     pub fn mkstemps(template: *mut c_char, suffixlen: c_int) -> c_int;
     pub fn nl_langinfo(item: crate::nl_item) -> *mut c_char;
 
-    pub fn getdomainname(name: *mut c_char, len: size_t) -> c_int;
-    pub fn setdomainname(name: *const c_char, len: size_t) -> c_int;
     pub fn sendmmsg(
         sockfd: c_int,
         msgvec: *mut crate::mmsghdr,

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -6429,8 +6429,6 @@ extern "C" {
 
     pub fn nl_langinfo(item: crate::nl_item) -> *mut c_char;
 
-    pub fn getdomainname(name: *mut c_char, len: size_t) -> c_int;
-    pub fn setdomainname(name: *const c_char, len: size_t) -> c_int;
     pub fn vhangup() -> c_int;
     pub fn sync();
     pub fn syncfs(fd: c_int) -> c_int;

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1863,6 +1863,9 @@ extern "C" {
         locale: crate::locale_t,
     ) -> size_t;
     pub fn strptime(s: *const c_char, format: *const c_char, tm: *mut crate::tm) -> *mut c_char;
+
+    pub fn getdomainname(name: *mut c_char, len: size_t) -> c_int;
+    pub fn setdomainname(name: *const c_char, len: size_t) -> c_int;
 }
 
 // LFS64 extensions


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Declare `setdomainname` and `getdomainname` on Android.

# Sources

Android [supports] `setdomainname` and `getdomainname` in API level 26.

[supports] https://github.com/aosp-google/bionic/blob/28f9101d76b709febe25977f98530d77580387d1/libc/include/unistd.h#L236

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
