### PR TITLE
Apply modulo 256 to BSD WEXITSTATUS

### DIFF
--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -639,7 +639,7 @@ safe_f! {
     }
 
     pub {const} fn WEXITSTATUS(status: c_int) -> c_int {
-        status >> 8
+        (status >> 8) & 0x00ff
     }
 
     pub {const} fn WCOREDUMP(status: c_int) -> bool {


### PR DESCRIPTION
wait(2p)[^1] says

> WEXITSTATUS(status)
>         If WIFEXITED(status) is true, evaluates to the low-order 8 bits
>         of the argument passed to _exit(2) or exit(3) by the child.

meaning WEXITSTATUS(status) is an 8-bit value.  We accidentally return
too many bits. For example WEXITSTATUS(-1) returns -1 instead of 255.

Fix it, matching the C library and our other WEXITSTATUS implementations.

[^1] https://manpage.me/index.cgi?apropos=0&q=wait&sektion=2&manpath=FreeBSD+12-CURRENT+and+Ports&arch=default&format=html

Originally reported at https://github.com/fish-shell/fish-shell/issues/10919
