### PR TITLE
Allow `unpredictable_function_pointer_comparisons` in another place

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -864,6 +864,8 @@ cfg_if! {
                 self.mc_fpregs.hash(state);
             }
         }
+        // FIXME(msrv): suggested method was added in 1.85
+        #[allow(unpredictable_function_pointer_comparisons)]
         impl PartialEq for ucontext_t {
             fn eq(&self, other: &ucontext_t) -> bool {
                 self.uc_sigmask == other.uc_sigmask


### PR DESCRIPTION
Nightly must have just recently updated how this gets checked, we are getting new errors in CI. Allow the lint in another place.