### PR TITLE
Allow `unpredictable_function_pointer_comparisons` in another place

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -865,6 +865,8 @@ cfg_if! {
                 self.mc_fpregs.hash(state);
             }
         }
+        // FIXME(msrv): suggested method was added in 1.85
+        #[allow(unpredictable_function_pointer_comparisons)]
         impl PartialEq for ucontext_t {
             fn eq(&self, other: &ucontext_t) -> bool {
                 self.uc_sigmask == other.uc_sigmask


### PR DESCRIPTION
Nightly must have just recently updated how this gets checked, we are getting new errors in CI. Allow the lint in another place.

(backport <https://github.com/rust-lang/libc/pull/4217>)
(cherry picked from commit 1de1c0afc15d033923fbd8e0037cf2dfc2b6baf7)