### PR TITLE
Haiku bsd

### DIFF
--- a/src/unix/haiku/bsd.rs
+++ b/src/unix/haiku/bsd.rs
@@ -22,6 +22,17 @@ s! {
         pub sl_cur: size_t,
     }
 
+    // sys/event.h
+    pub struct kevent {
+        pub ident: crate::uintptr_t,
+        pub filter: c_short,
+        pub flags: c_ushort,
+        pub fflags: c_uint,
+        pub data: i64,
+        pub udata: *mut c_void,
+        pub ext: [u64; 4],
+    }
+
     // sys/link_elf.h
     pub struct dl_phdr_info {
         pub dlpi_addr: crate::Elf_Addr,
@@ -30,6 +41,25 @@ s! {
         pub dlpi_phnum: crate::Elf_Half,
     }
 }
+
+// sys/event.h
+pub const EVFILT_READ: i16 = -1;
+pub const EVFILT_WRITE: i16 = -2;
+pub const EVFILT_PROC: i16 = -5;
+pub const EV_ADD: u16 = 0x0001;
+pub const EV_DELETE: u16 = 0x0002;
+pub const EV_ONESHOT: u16 = 0x0010;
+pub const EV_CLEAR: u16 = 0x0020;
+pub const EV_EOF: u16 = 0x8000;
+pub const EV_ERROR: u16 = 0x4000;
+pub const NOTE_EXIT: u32 = 0x80000000;
+
+// sys/ioccom.h
+pub const IOC_VOID: c_ulong = 0x20000000;
+pub const IOC_OUT: c_ulong = 0x40000000;
+pub const IOC_IN: c_ulong = 0x80000000;
+pub const IOC_INOUT: c_ulong = IOC_IN | IOC_OUT;
+pub const IOC_DIRMASK: c_ulong = 0xe0000000;
 
 #[link(name = "bsd")]
 extern "C" {
@@ -40,6 +70,13 @@ extern "C" {
     pub fn arc4random() -> u32;
     pub fn arc4random_uniform(upper_bound: u32) -> u32;
     pub fn arc4random_buf(buf: *mut c_void, n: size_t);
+    pub fn mkstemps(template: *mut c_char, suffixlen: c_int) -> c_int;
+    pub fn strtonum(
+        nptr: *const c_char,
+        minval: c_longlong,
+        maxval: c_longlong,
+        errstr: *mut *const c_char,
+    ) -> c_longlong;
 
     // pty.h
     pub fn openpty(
@@ -68,6 +105,17 @@ extern "C" {
     pub fn sl_free(sl: *mut StringList, i: c_int);
     pub fn sl_find(sl: *mut StringList, n: *mut c_char) -> *mut c_char;
 
+    // sys/event.h
+    pub fn kqueue() -> c_int;
+    pub fn kevent(
+        kq: c_int,
+        changelist: *const kevent,
+        nchanges: c_int,
+        eventlist: *mut kevent,
+        nevents: c_int,
+        timeout: *const crate::timespec,
+    ) -> c_int;
+
     // sys/link_elf.h
     pub fn dl_iterate_phdr(
         callback: Option<
@@ -78,4 +126,26 @@ extern "C" {
 
     // sys/time.h
     pub fn lutimes(file: *const c_char, times: *const crate::timeval) -> c_int;
+
+    // sys/uov.h
+    pub fn preadv(
+        fd: c_int,
+        iov: *const crate::iovec,
+        iovcnt: c_int,
+        offset: crate::off_t,
+    ) -> ssize_t;
+    pub fn pwritev(
+        fd: c_int,
+        iov: *const crate::iovec,
+        iovcnt: c_int,
+        offset: crate::off_t,
+    ) -> ssize_t;
+
+    // sys/wait.h
+    pub fn wait4(
+        pid: crate::pid_t,
+        status: *mut c_int,
+        options: c_int,
+        rusage: *mut crate::rusage,
+    ) -> crate::pid_t;
 }

--- a/src/unix/haiku/bsd.rs
+++ b/src/unix/haiku/bsd.rs
@@ -1,0 +1,81 @@
+use crate::prelude::*;
+
+// This file contains the BSD APIs available in Haiku. It corresponds to the
+// header files in `headers/compatibility/bsd`.
+//
+// Note that Haiku's BSD compatibility is a combination of system APIs and
+// utility libraries. There should only be system APIs in `libc`. When you are
+// trying to determine whether something should be included in this file, the
+// best indicator is whether it also exists in the BSD-specific definitions in
+// this libc crate.
+
+// stringlist.h (utility library)
+// Note: this is kept because it was previously introduced
+pub type StringList = _stringlist;
+
+s! {
+    // stringlist.h (utility library)
+    // Note: this is kept because it was previously introduced
+    pub struct _stringlist {
+        pub sl_str: *mut *mut c_char,
+        pub sl_max: size_t,
+        pub sl_cur: size_t,
+    }
+
+    // sys/link_elf.h
+    pub struct dl_phdr_info {
+        pub dlpi_addr: crate::Elf_Addr,
+        pub dlpi_name: *const c_char,
+        pub dlpi_phdr: *const crate::Elf_Phdr,
+        pub dlpi_phnum: crate::Elf_Half,
+    }
+}
+
+#[link(name = "bsd")]
+extern "C" {
+    // stdlib.h
+    pub fn daemon(nochdir: c_int, noclose: c_int) -> c_int;
+    pub fn getprogname() -> *const c_char;
+    pub fn setprogname(progname: *const c_char);
+    pub fn arc4random() -> u32;
+    pub fn arc4random_uniform(upper_bound: u32) -> u32;
+    pub fn arc4random_buf(buf: *mut c_void, n: size_t);
+
+    // pty.h
+    pub fn openpty(
+        amaster: *mut c_int,
+        aslave: *mut c_int,
+        name: *mut c_char,
+        termp: *mut crate::termios,
+        winp: *mut crate::winsize,
+    ) -> c_int;
+    pub fn login_tty(_fd: c_int) -> c_int;
+    pub fn forkpty(
+        amaster: *mut c_int,
+        name: *mut c_char,
+        termp: *mut crate::termios,
+        winp: *mut crate::winsize,
+    ) -> crate::pid_t;
+
+    // string.h
+    pub fn strsep(string: *mut *mut c_char, delimiters: *const c_char) -> *mut c_char;
+    pub fn explicit_bzero(buf: *mut c_void, len: size_t);
+
+    // stringlist.h (utility library)
+    // Note: this is kept because it was previously introduced
+    pub fn sl_init() -> *mut StringList;
+    pub fn sl_add(sl: *mut StringList, n: *mut c_char) -> c_int;
+    pub fn sl_free(sl: *mut StringList, i: c_int);
+    pub fn sl_find(sl: *mut StringList, n: *mut c_char) -> *mut c_char;
+
+    // sys/link_elf.h
+    pub fn dl_iterate_phdr(
+        callback: Option<
+            unsafe extern "C" fn(info: *mut dl_phdr_info, size: usize, data: *mut c_void) -> c_int,
+        >,
+        data: *mut c_void,
+    ) -> c_int;
+
+    // sys/time.h
+    pub fn lutimes(file: *const c_char, times: *const crate::timeval) -> c_int;
+}

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -1,5 +1,29 @@
 use crate::prelude::*;
 
+// This module contains bindings to the native Haiku API. The Haiku API
+// originates from BeOS, and it was the original way to perform low level
+// system and IO operations. The POSIX API was in that era was like a
+// compatibility layer. In current Haiku development, both the POSIX API and
+// the Haiku API are considered to be co-equal status. However, they are not
+// integrated like they are on other UNIX platforms, which means that for many
+// low level concepts there are two versions, like processes (POSIX) and
+// teams (Haiku), or pthreads and native threads.
+//
+// Both the POSIX API and the Haiku API live in libroot.so, the library that is
+// linked to any binary by default. Additionally, Haiku supports several
+// non-POSIX APIs from BSD and GNU, which live in libbsd.so and libgnu.so. These
+// modules are also supported.
+//
+// The module is comprised of the following files:
+// - `mod.rs` (this file) implements the C11 and POSIX API found in
+//     `headers/posix`
+// - `b32.rs`, `b64.rs` and `x86_64.rs` contain platform-specific definitions
+//      of the C11 and POSIX APIs
+// - `native.rs` defines the native Haiku API that is implemented in
+//     `libroot.so` and that are found in `headers/os`.
+// - `bsd.rs` defines the BSD customizations available on Haiku found in
+//     `headers/compatibility/bsd`
+
 pub type rlim_t = crate::uintptr_t;
 pub type sa_family_t = u8;
 pub type pthread_key_t = c_int;
@@ -55,8 +79,6 @@ pub type ACTION = c_int;
 
 pub type posix_spawnattr_t = *mut c_void;
 pub type posix_spawn_file_actions_t = *mut c_void;
-
-pub type StringList = _stringlist;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum timezone {}
@@ -439,19 +461,6 @@ s! {
         pub has_arg: c_int,
         pub flag: *mut c_int,
         pub val: c_int,
-    }
-
-    pub struct _stringlist {
-        pub sl_str: *mut *mut c_char,
-        pub sl_max: size_t,
-        pub sl_cur: size_t,
-    }
-
-    pub struct dl_phdr_info {
-        pub dlpi_addr: crate::Elf_Addr,
-        pub dlpi_name: *const c_char,
-        pub dlpi_phdr: *const crate::Elf_Phdr,
-        pub dlpi_phnum: crate::Elf_Half,
     }
 }
 
@@ -1829,7 +1838,6 @@ extern "C" {
         addr: *mut crate::sockaddr,
         addrlen: *mut crate::socklen_t,
     ) -> ssize_t;
-    pub fn mkstemps(template: *mut c_char, suffixlen: c_int) -> c_int;
     pub fn nl_langinfo(item: crate::nl_item) -> *mut c_char;
 
     pub fn bind(
@@ -2086,46 +2094,6 @@ extern "C" {
     pub fn getentropy(buf: *mut c_void, buflen: size_t) -> c_int;
 }
 
-#[link(name = "bsd")]
-extern "C" {
-    pub fn lutimes(file: *const c_char, times: *const crate::timeval) -> c_int;
-    pub fn daemon(nochdir: c_int, noclose: c_int) -> c_int;
-    pub fn forkpty(
-        amaster: *mut c_int,
-        name: *mut c_char,
-        termp: *mut termios,
-        winp: *mut crate::winsize,
-    ) -> crate::pid_t;
-    pub fn openpty(
-        amaster: *mut c_int,
-        aslave: *mut c_int,
-        name: *mut c_char,
-        termp: *mut termios,
-        winp: *mut crate::winsize,
-    ) -> c_int;
-    pub fn strsep(string: *mut *mut c_char, delimiters: *const c_char) -> *mut c_char;
-    pub fn explicit_bzero(buf: *mut c_void, len: size_t);
-    pub fn login_tty(_fd: c_int) -> c_int;
-
-    pub fn sl_init() -> *mut StringList;
-    pub fn sl_add(sl: *mut StringList, n: *mut c_char) -> c_int;
-    pub fn sl_free(sl: *mut StringList, i: c_int);
-    pub fn sl_find(sl: *mut StringList, n: *mut c_char) -> *mut c_char;
-
-    pub fn getprogname() -> *const c_char;
-    pub fn setprogname(progname: *const c_char);
-    pub fn dl_iterate_phdr(
-        callback: Option<
-            unsafe extern "C" fn(info: *mut dl_phdr_info, size: usize, data: *mut c_void) -> c_int,
-        >,
-        data: *mut c_void,
-    ) -> c_int;
-
-    pub fn arc4random() -> u32;
-    pub fn arc4random_uniform(upper_bound: u32) -> u32;
-    pub fn arc4random_buf(buf: *mut c_void, n: size_t);
-}
-
 #[link(name = "gnu")]
 extern "C" {
     pub fn memmem(
@@ -2168,6 +2136,9 @@ cfg_if! {
         // pub use self::aarch64::*;
     }
 }
+
+mod bsd;
+pub use self::bsd::*;
 
 mod native;
 pub use self::native::*;

--- a/src/unix/haiku/native.rs
+++ b/src/unix/haiku/native.rs
@@ -1,19 +1,7 @@
 use crate::off_t;
 use crate::prelude::*;
 
-// This module contains bindings to the native Haiku API. The Haiku API
-// originates from BeOS, and it was the original way to perform low level
-// system and IO operations. The POSIX API was in that era was like a
-// compatibility layer. In current Haiku development, both the POSIX API and
-// the Haiku API are considered to be co-equal status. However, they are not
-// integrated like they are on other UNIX platforms, which means that for many
-// low level concepts there are two versions, like processes (POSIX) and
-// teams (Haiku), or pthreads and native threads.
-//
-// Both the POSIX API and the Haiku API live in libroot.so, the library that is
-// linked to any binary by default.
-//
-// This file follows the Haiku API for Haiku R1 beta 2. It is organized by the
+// This file follows the Haiku API for Haiku R1 beta 5. It is organized by the
 // C/C++ header files in which the concepts can be found, while adhering to the
 // style guide for this crate.
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Haiku implements various parts of the (non-POSIX) BSD API. This moves it to a separate file, for easier future maintenance. It also adds some missing functionality that is part of other platforms and that may be useful for other crates.

Note that this synchronizes with Haiku R1 Beta 5, which is the latest relaase.


# Sources

See https://github.com/haiku/haiku/tree/r1beta5/headers/compatibility/bsd/ for all the headers that match up with the ones in the `bsd.rs` file.


# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

Note: `semver` is not used by Haiku (yet), so N/A. The test currently fails, but in a panic! in the garando_syntax crate. The panic is the same before and after the changes.