### PR TITLE
Fixes for NuttX target

### DIFF
--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -129,7 +129,7 @@ s! {
         pub tm_yday: i32,
         pub tm_isdst: i32,
         pub tm_gmtoff: isize,
-        pub tm_zone: *const i8,
+        pub tm_zone: *const c_char,
         __reserved: [usize; __DEFAULT_RESERVED_SIZE__],
     }
 
@@ -166,7 +166,7 @@ s! {
 
     pub struct dirent {
         pub d_type: u8,
-        pub d_name: [i8; __NAME_MAX__ + 1],
+        pub d_name: [c_char; __NAME_MAX__ + 1],
     }
 
     pub struct fd_set {

--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -54,6 +54,7 @@ s! {
 
     pub struct passwd {
         pub pw_name: *const c_char,
+        pub pw_passwd: *const c_char,
         pub pw_uid: u32,
         pub pw_gid: u32,
         pub pw_gecos: *const c_char,
@@ -247,6 +248,7 @@ s! {
 // for example, struct passwd, https://pubs.opengroup.org/onlinepubs/009695399/basedefs/pwd.h.html,
 // POSIX only defines following fields in struct passwd:
 // char    *pw_name   User's login name.
+// char    *pw_passwd Encrypted password.
 // uid_t    pw_uid    Numerical user ID.
 // gid_t    pw_gid    Numerical group ID.
 // char    *pw_dir    Initial working directory.


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Some fixes for NuttX target:
* Add pw_passwd field to struct passwd
* update type of tm_zone/d_name to use c_char type

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->

src/unix/nuttx/mod.rs

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
