### PR TITLE
Add new CANFD_FDF flag for the 'flags' field of 'canfd_frame'.

### DIFF
--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -5307,6 +5307,7 @@ pub const CANFD_MAX_DLEN: usize = 64;
 
 pub const CANFD_BRS: c_int = 0x01;
 pub const CANFD_ESI: c_int = 0x02;
+pub const CANFD_FDF: c_int = 0x04;
 
 pub const CANXL_MIN_DLC: c_int = 0;
 pub const CANXL_MAX_DLC: c_int = 2047;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

Adds a bitflag for the `flags` member of `canfd_frame`. This flag was added to the Linux kernel via `can.h` in v5.14

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
