### PR TITLE
hurd: Fix CMSG_DATA on 64bit systems

### DIFF
--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -3449,7 +3449,7 @@ f! {
     }
 
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        cmsg.offset(1) as *mut c_uchar
+        (cmsg as *mut c_uchar).offset(CMSG_ALIGN(mem::size_of::<cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {


### PR DESCRIPTION
This was fixed upstream glibc in

https://sourceware.org/git/?p=glibc.git;a=patch;h=cf13f740a91b5bbf6bb60a30b45c2a3933ff1259

# Description

This fixes CMSG_DATA according to the glibc fix in the CMSG_DATA macro.