### PR TITLE
emscripten: Assume version is at least 3.1.42

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ use std::{env, str};
 // need to know all the possible cfgs that this script will set. If you need to set another cfg
 // make sure to add it to this list as well.
 const ALLOWED_CFGS: &'static [&'static str] = &[
-    "emscripten_new_stat_abi",
+    "emscripten_old_stat_abi",
     "espidf_time32",
     "freebsd10",
     "freebsd11",
@@ -76,9 +76,9 @@ fn main() {
     }
 
     match emcc_version_code() {
-        Some(v) if (v >= 30142) => set_cfg("emscripten_new_stat_abi"),
-        // Non-Emscripten or version < 3.1.42.
-        Some(_) | None => (),
+        Some(v) if (v < 30142) => set_cfg("emscripten_old_stat_abi"),
+        // Non-Emscripten or version >= 3.1.42.
+        _ => (),
     }
 
     if linux_time_bits64 {

--- a/ci/emscripten.sh
+++ b/ci/emscripten.sh
@@ -3,7 +3,7 @@
 set -eux
 
 # Note: keep in sync with:
-# https://github.com/rust-lang/rust/blob/master/src/ci/docker/scripts/emscripten.sh
+# https://github.com/rust-lang/rust/blob/master/src/doc/rustc/src/platform-support/wasm32-unknown-emscripten.md#requirements
 emsdk_version=3.1.68
 
 git clone https://github.com/emscripten-core/emsdk.git /emsdk-portable

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -227,16 +227,16 @@ s! {
     }
     pub struct stat {
         pub st_dev: crate::dev_t,
-        #[cfg(not(emscripten_new_stat_abi))]
+        #[cfg(emscripten_old_stat_abi)]
         __st_dev_padding: c_int,
-        #[cfg(not(emscripten_new_stat_abi))]
+        #[cfg(emscripten_old_stat_abi)]
         __st_ino_truncated: c_long,
         pub st_mode: crate::mode_t,
         pub st_nlink: crate::nlink_t,
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
-        #[cfg(not(emscripten_new_stat_abi))]
+        #[cfg(emscripten_old_stat_abi)]
         __st_rdev_padding: c_int,
         pub st_size: off_t,
         pub st_blksize: crate::blksize_t,


### PR DESCRIPTION
This revises commit 63b0d673eaf2a177ff208c5c50999738bdd1bf0d to assume that Emscripten 3.1.42 or later is being used whenever `emcc` is not available. Since Emscripten 3.1.42 was released on June 23, 2023, the majority of users are expected to have upgraded to a more recent version.

Resolves: https://github.com/rust-lang/rust/issues/131467.