### PR TITLE
Fix querying emcc on windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -235,7 +235,13 @@ fn which_freebsd() -> Option<i32> {
 }
 
 fn emcc_version_code() -> Option<u64> {
-    let output = Command::new("emcc").arg("-dumpversion").output().ok()?;
+    let emcc = if cfg!(target_os = "windows") {
+        "emcc.bat"
+    } else {
+        "emcc"
+    };
+
+    let output = Command::new(emcc).arg("-dumpversion").output().ok()?;
     if !output.status.success() {
         return None;
     }


### PR DESCRIPTION
Pretty minor change, just queries emcc.bat since `emcc` will not work on windows

For example this simple script will output this on windows
```rs
fn main() {
    let output = std::process::Command::new("emcc.bat").arg("-dumpversion").output().ok();
    println!("{:?}", output);
    let output1 = std::process::Command::new("emcc").arg("-dumpversion").output().ok();
    println!("{:?}", output1);
}
```
```
rustc test.rs && ./test.exe
Some(Output { status: ExitStatus(ExitStatus(0)), stdout: "3.1.74\r\n", stderr: "" })
None
```
