### PR TITLE
[AIX] Use sa_sigaction instead of the union

### DIFF
--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -533,20 +533,15 @@ s! {
         pub it_interval: crate::timespec,
         pub it_value: crate::timespec,
     }
-}
-
-s_no_extra_traits! {
-    pub union __sigaction_sa_union {
-        pub __su_handler: extern "C" fn(c: c_int),
-        pub __su_sigaction: extern "C" fn(c: c_int, info: *mut siginfo_t, ptr: *mut c_void),
-    }
 
     pub struct sigaction {
-        pub sa_union: __sigaction_sa_union,
+        pub sa_sigaction: crate::sighandler_t, // FIXME(union): this field is actually a union
         pub sa_mask: sigset_t,
         pub sa_flags: c_int,
     }
+}
 
+s_no_extra_traits! {
     pub union __poll_ctl_ext_u {
         pub addr: *mut c_void,
         pub data32: u32,
@@ -565,49 +560,6 @@ s_no_extra_traits! {
 
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
-        impl PartialEq for __sigaction_sa_union {
-            fn eq(&self, other: &__sigaction_sa_union) -> bool {
-                unsafe {
-                    self.__su_handler == other.__su_handler
-                        && self.__su_sigaction == other.__su_sigaction
-                }
-            }
-        }
-        impl Eq for __sigaction_sa_union {}
-        impl hash::Hash for __sigaction_sa_union {
-            fn hash<H: hash::Hasher>(&self, state: &mut H) {
-                unsafe {
-                    self.__su_handler.hash(state);
-                    self.__su_sigaction.hash(state);
-                }
-            }
-        }
-
-        impl PartialEq for sigaction {
-            fn eq(&self, other: &sigaction) -> bool {
-                self.sa_mask == other.sa_mask
-                    && self.sa_flags == other.sa_flags
-                    && self.sa_union == other.sa_union
-            }
-        }
-        impl Eq for sigaction {}
-        impl fmt::Debug for sigaction {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                f.debug_struct("sigaction")
-                    .field("sa_union", &self.sa_union)
-                    .field("sa_mask", &self.sa_mask)
-                    .field("sa_flags", &self.sa_flags)
-                    .finish()
-            }
-        }
-        impl hash::Hash for sigaction {
-            fn hash<H: hash::Hasher>(&self, state: &mut H) {
-                self.sa_union.hash(state);
-                self.sa_mask.hash(state);
-                self.sa_flags.hash(state);
-            }
-        }
-
         impl PartialEq for __poll_ctl_ext_u {
             fn eq(&self, other: &__poll_ctl_ext_u) -> bool {
                 unsafe {


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
The current `libc` crate implementation for AIX defines `struct sigaction` as containing a union `sa_union` with two members: `__su_handler` and `__su_sigaction`. This mirrors the `struct sigaction` definition in the AIX system header. Consequently, any reference to `sa_sigaction` in Rust code, whether in shipped crates or user code, must be replaced with `sa_union.__su_sigaction` for AIX. Additionally, the types of these two union members are declared as function pointers rather than `sighandler_t` (i.e., `usize`), as is the case on other platforms. This discrepancy causes compiler errors when `sighandler_t` is used as the type for signal handlers. Other operating systems, such as Linux, also define a union for `sa_handler` and `sa_sigaction` in `struct sigaction`. However, the `libc` crate implementations on these platforms define `sa_sigaction` directly as a member of `struct sigaction` rather than as part of a union. This patch modifies the `libc` crate implementation for AIX to define `sa_sigaction` as a direct member of `struct sigaction`, aligning it with implementations for other similar platforms. We will also update affected crates and test cases to reflect this change.
<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->


# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
