### PR TITLE
Resolve various CI issues

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,6 +3,9 @@ task:
   env:
     HOME: /tmp  # cargo cache needs it
     TARGET: x86_64-unknown-freebsd
+    # FIXME(freebsd): FreeBSD has a segfault when `RUST_BACKTRACE` is set
+    # https://github.com/rust-lang/rust/issues/132185
+    RUST_BACKTRACE: "0"
   matrix:
     - name: nightly freebsd-13 i686
       # Test i686 FreeBSD in 32-bit emulation on a 64-bit host.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,9 @@ jobs:
           - i686-unknown-linux-musl
           - loongarch64-unknown-linux-gnu
           - loongarch64-unknown-linux-musl
-          - powerpc-unknown-linux-gnu
+          # FIXME(ppc): SIGILL running tests, see
+          # https://github.com/rust-lang/libc/pull/4254#issuecomment-2636288713
+          # - powerpc-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
           - powerpc64le-unknown-linux-gnu
           - riscv64gc-unknown-linux-gnu

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -243,7 +243,7 @@ cfg_if! {
             )*) => ($(
                 #[inline]
                 $(#[$attr])*
-                pub $($constness)* unsafe extern fn $i($($arg: $argty),*) -> $ret
+                pub $($constness)* unsafe extern "C" fn $i($($arg: $argty),*) -> $ret
                     $body
             )*)
         }
@@ -257,7 +257,7 @@ cfg_if! {
             )*) => ($(
                 #[inline]
                 $(#[$attr])*
-                pub $($constness)* extern fn $i($($arg: $argty),*) -> $ret
+                pub $($constness)* extern "C" fn $i($($arg: $argty),*) -> $ret
                     $body
             )*)
         }
@@ -285,7 +285,7 @@ cfg_if! {
             )*) => ($(
                 #[inline]
                 $(#[$attr])*
-                pub unsafe extern fn $i($($arg: $argty),*) -> $ret
+                pub unsafe extern "C" fn $i($($arg: $argty),*) -> $ret
                     $body
             )*)
         }
@@ -299,7 +299,7 @@ cfg_if! {
             )*) => ($(
                 #[inline]
                 $(#[$attr])*
-                pub extern fn $i($($arg: $argty),*) -> $ret
+                pub extern "C" fn $i($($arg: $argty),*) -> $ret
                     $body
             )*)
         }

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
@@ -266,7 +266,8 @@ s! {
         pub st_blksize: crate::blksize_t,
         pub st_flags: crate::fflags_t,
         pub st_gen: u64,
-        pub st_spare: [u64; 10],
+        pub st_filerev: u64,
+        pub st_spare: [u64; 9],
     }
 }
 


### PR DESCRIPTION
Fix the `missing_abi` lint

Recent versions of Rust require the ABI always be specified for `extern` functions, whereas it historically defaulted to `extern "C"`. Fix a few cases where this lint now gets raised by specifying `extern "C"`.

--- 

Disable RUST_BACKTRACE for FreeBSD CI 

Having this environment variable set causes a segfault https://github.com/rust-lang/rust/issues/132185. Just disable backtraces for now.

--- 

FreeBSD: Add the new `st_filerev` field to `stat32` for FreeBSD 15 

This field appears to have been added recently https://github.com/freebsd/freebsd-src/commit/b4663a8d111767206bb3ebcfec5b95a6b88bc720.

---

Temporarily disable powerpc-unknown-linux-gnu tests 

As mentioned in [1], this test has started to fail for unclear reasons. Disable this until it can be investigated further.

[1]: https://github.com/rust-lang/libc/pull/4254#issuecomment-2636288713