### PR TITLE
fix: Revert vita's c_char back to i8

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -21,6 +21,7 @@ cfg_if! {
     if #[cfg(all(
         not(windows),
         not(target_vendor = "apple"),
+        not(target_os = "vita"),
         any(
             target_arch = "aarch64",
             target_arch = "arm",


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Hi,

https://github.com/rust-lang/libc/pull/4199 changed the definition of `c_char` from i8 to u8 for most ARM targets. While that would usually be correct, [VITASDK uses signed chars by default](https://github.com/vitasdk/buildscripts/blob/master/patches/gcc/0001-gcc-10.patch#L33-L34).

This will surely conflict with #4256, but I can rebase it after that one is merged. I opened that one first because in the off-chance it was just accepted, this fix would only be needed on rustc. I'll also create a rustc PR.

# Sources

https://github.com/vitasdk/buildscripts/blob/master/patches/gcc/0001-gcc-10.patch#L33-L34

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [X] Relevant tests in `libc-test/semver` have been updated (API didn't change)
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
