### PR TITLE
Bump FreeBSD CI to 13.4 and 14.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,13 +12,13 @@ task:
       env:
         TARGET: i686-unknown-freebsd
       freebsd_instance:
-        image_family: freebsd-13-3
+        image_family: freebsd-13-4
     - name: nightly freebsd-13 x86_64
       freebsd_instance:
-        image_family: freebsd-13-3
+        image_family: freebsd-13-4
     - name: nightly freebsd-14 x86_64
       freebsd_instance:
-        image: freebsd-14-1-release-amd64-ufs
+        image: freebsd-14-2-release-amd64-ufs
     - name: nightly freebsd-15 x86_64
       freebsd_instance:
        image_family: freebsd-15-0-snap


### PR DESCRIPTION
13.3 is marked EOL and 14.1 is marked legacy. Update these runners to the latest version.

This should resolve some current CI failures.

Cc @asomers