### PR TITLE
Update Redox's signal constants

### DIFF
--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -645,14 +645,14 @@ pub const SIGPWR: c_int = 30;
 pub const SIGSYS: c_int = 31;
 pub const NSIG: c_int = 32;
 
-pub const SA_NOCLDSTOP: c_ulong = 0x00000001;
-pub const SA_NOCLDWAIT: c_ulong = 0x00000002;
-pub const SA_SIGINFO: c_ulong = 0x00000004;
-pub const SA_RESTORER: c_ulong = 0x04000000;
-pub const SA_ONSTACK: c_ulong = 0x08000000;
-pub const SA_RESTART: c_ulong = 0x10000000;
-pub const SA_NODEFER: c_ulong = 0x40000000;
-pub const SA_RESETHAND: c_ulong = 0x80000000;
+pub const SA_NOCLDWAIT: usize = 0x0000_0002;
+pub const SA_RESTORER: usize = 0x0000_0004;
+pub const SA_SIGINFO: usize = 0x0200_0000;
+pub const SA_ONSTACK: usize = 0x0400_0000;
+pub const SA_RESTART: usize = 0x0800_0000;
+pub const SA_NODEFER: usize = 0x1000_0000;
+pub const SA_RESETHAND: usize = 0x2000_0000;
+pub const SA_NOCLDSTOP: usize = 0x4000_0000;
 
 // sys/file.h
 pub const LOCK_SH: c_int = 1;


### PR DESCRIPTION
Redox changed its signal ABI last year:
https://gitlab.redox-os.org/redox-os/relibc/-/commit/63509e75ce127fdb05c07a464e975687e8ef2977

The old definitions (unsurprisingly) cause weird crashes. Use the new ones from Redox's relibc.

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
Redox changed its signal ABI last year. The old definitions (unsurprisingly) cause weird crashes. Use the new ones from Redox's relibc.

# Sources

https://gitlab.redox-os.org/redox-os/relibc/-/commit/63509e75ce127fdb05c07a464e975687e8ef2977

# Checklist

I'm still working out how to run tests inside of redox, so I'm leaving this as a draft until I figure that out.

- [X] Relevant tests in `libc-test/semver` have been updated (No update required)
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
