### PR TITLE
Fix reference to build file with guaranteed build platforms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ but this is not guaranteed.
 You can see the platform(target)-specific docs on [docs.rs], select a platform
 you want to see.
 
-See [`ci/build.sh`](https://github.com/rust-lang/libc/blob/HEAD/ci/build.sh) for
+See [`ci/verify-build.sh`](https://github.com/rust-lang/libc/blob/HEAD/ci/verify-build.sh) for
 the platforms on which `libc` is guaranteed to build for each Rust toolchain.
 The test-matrix at [GitHub Actions] and [Cirrus CI] show the platforms in which
 `libc` tests are run.


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

refs https://github.com/rust-lang/libc/issues/4261

This PR fixes a reference in `README.md` that referenced `ci/build.sh` which no longer exists, instead it now references `ci/verify-build.sh`

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
