### PR TITLE
NetBSD: fix getmntinfo for NetBSD

### DIFF
--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2849,7 +2849,7 @@ extern "C" {
         ntargets: size_t,
         hint: *const c_void,
     ) -> c_int;
-
+    #[link_name = "__getmntinfo13"]
     pub fn getmntinfo(mntbufp: *mut *mut crate::statvfs, flags: c_int) -> c_int;
     pub fn getvfsstat(buf: *mut statvfs, bufsize: size_t, flags: c_int) -> c_int;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

This patch fixes libc::getmntinfo on NetBSD.

# Sources

The problem is that NetBSD provides binary compatibility in a way that was not considered when initially providing the implementation.
Once a symbol name has been used, it stays the same, so the original `getmntinfo()` in NetBSD, using `struct statfs`, will always be available as `getmntinfo`. When `getmntinfo` was changed to provide `struct statvfs` (note the 'v') a long time ago, a new symbol was introduced, `__getmntinfo13` and the system headers rename access to `getmntinfo` to call `__getmntinfo13` instead.
The rust implementation called the old symbol (providing `struct statfs`) but parsed the returned information as `struct statvfs`, leading to wrong data and segfaults.

# Checklist

The change has been tested on NetBSD 9, 10, and -current (all supported versions).
No compatibility for NetBSD 8 or older is required, since these versions are not supported any longer; the symbol rename happened before NetBSD 9.