### PR TITLE
Fix size of time_t in vxworks

### DIFF
--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -34,7 +34,7 @@ pub type ino_t = c_ulong;
 
 pub type rlim_t = c_ulong;
 pub type suseconds_t = c_long;
-pub type time_t = c_long;
+pub type time_t = c_longlong;
 
 pub type errno_t = c_int;
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

This fixes the size of time_t in VxWorks which was incorrectly set to c_long. This broke compatibility with 32-bit targets.

Requesting stable-nomination.

<!-- Add a short description about what this change does -->

# Sources

VxWorks sources are copyrighted.

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Checked locally on VxWorks.
