### PR TITLE
[0.2] Re-add the test for `primitive_types`

### DIFF
--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -88,3 +88,8 @@ harness = true
 name = "semver"
 path = "test/semver.rs"
 harness = false
+
+[[test]]
+name = "primitive_types"
+path = "test/primitive_types.rs"
+harness = true


### PR DESCRIPTION
This was added in d4da6c866a ("Move testing of primitive types from std"), with cherry pick 69ce8953a4. However, I accidentally reverted this part of the patch in 65c90726e2 ("added wireless struct and constants to Linux"), the cherry pick for 1ee94df243.

Add this back here.