### PR TITLE
Split out the stat struct for gnu/b32/mips

### DIFF
--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -5,50 +5,26 @@ pub type wchar_t = i32;
 
 s! {
     pub struct stat {
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        pub st_dev: crate::dev_t,
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
         pub st_dev: c_ulong,
 
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        __pad1: c_short,
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
         st_pad1: [c_long; 3],
         pub st_ino: crate::ino_t,
         pub st_mode: crate::mode_t,
         pub st_nlink: crate::nlink_t,
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        pub st_rdev: crate::dev_t,
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
         pub st_rdev: c_ulong,
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        __pad2: c_short,
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
         st_pad2: [c_long; 2],
         pub st_size: off_t,
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
         st_pad3: c_long,
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        pub st_blksize: crate::blksize_t,
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        pub st_blocks: crate::blkcnt_t,
         pub st_atime: crate::time_t,
         pub st_atime_nsec: c_long,
         pub st_mtime: crate::time_t,
         pub st_mtime_nsec: c_long,
         pub st_ctime: crate::time_t,
         pub st_ctime_nsec: c_long,
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        __unused4: c_long,
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        __unused5: c_long,
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
         pub st_blksize: crate::blksize_t,
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
         pub st_blocks: crate::blkcnt_t,
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
         st_pad5: [c_long; 14],
     }
 

--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -4,6 +4,54 @@ use crate::{off64_t, off_t};
 pub type wchar_t = i32;
 
 s! {
+    pub struct stat {
+        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
+        pub st_dev: crate::dev_t,
+        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+        pub st_dev: c_ulong,
+
+        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
+        __pad1: c_short,
+        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+        st_pad1: [c_long; 3],
+        pub st_ino: crate::ino_t,
+        pub st_mode: crate::mode_t,
+        pub st_nlink: crate::nlink_t,
+        pub st_uid: crate::uid_t,
+        pub st_gid: crate::gid_t,
+        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
+        pub st_rdev: crate::dev_t,
+        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+        pub st_rdev: c_ulong,
+        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
+        __pad2: c_short,
+        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+        st_pad2: [c_long; 2],
+        pub st_size: off_t,
+        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+        st_pad3: c_long,
+        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
+        pub st_blksize: crate::blksize_t,
+        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
+        pub st_blocks: crate::blkcnt_t,
+        pub st_atime: crate::time_t,
+        pub st_atime_nsec: c_long,
+        pub st_mtime: crate::time_t,
+        pub st_mtime_nsec: c_long,
+        pub st_ctime: crate::time_t,
+        pub st_ctime_nsec: c_long,
+        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
+        __unused4: c_long,
+        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
+        __unused5: c_long,
+        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+        pub st_blksize: crate::blksize_t,
+        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+        pub st_blocks: crate::blkcnt_t,
+        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+        st_pad5: [c_long; 14],
+    }
+
     pub struct stat64 {
         pub st_dev: c_ulong,
         st_pad1: [c_long; 3],

--- a/src/unix/linux_like/linux/gnu/b32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mod.rs
@@ -40,55 +40,61 @@ cfg_if! {
     }
 }
 
-s! {
-    pub struct stat {
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        pub st_dev: crate::dev_t,
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-        pub st_dev: c_ulong,
+cfg_if! {
+    if #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))] {
+        s! {
+            pub struct stat {
+                #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
+                pub st_dev: crate::dev_t,
+                #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+                pub st_dev: c_ulong,
 
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        __pad1: c_short,
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-        st_pad1: [c_long; 3],
-        pub st_ino: crate::ino_t,
-        pub st_mode: crate::mode_t,
-        pub st_nlink: crate::nlink_t,
-        pub st_uid: crate::uid_t,
-        pub st_gid: crate::gid_t,
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        pub st_rdev: crate::dev_t,
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-        pub st_rdev: c_ulong,
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        __pad2: c_short,
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-        st_pad2: [c_long; 2],
-        pub st_size: off_t,
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-        st_pad3: c_long,
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        pub st_blksize: crate::blksize_t,
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        pub st_blocks: crate::blkcnt_t,
-        pub st_atime: crate::time_t,
-        pub st_atime_nsec: c_long,
-        pub st_mtime: crate::time_t,
-        pub st_mtime_nsec: c_long,
-        pub st_ctime: crate::time_t,
-        pub st_ctime_nsec: c_long,
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        __unused4: c_long,
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
-        __unused5: c_long,
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-        pub st_blksize: crate::blksize_t,
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-        pub st_blocks: crate::blkcnt_t,
-        #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-        st_pad5: [c_long; 14],
+                #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
+                __pad1: c_short,
+                #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+                st_pad1: [c_long; 3],
+                pub st_ino: crate::ino_t,
+                pub st_mode: crate::mode_t,
+                pub st_nlink: crate::nlink_t,
+                pub st_uid: crate::uid_t,
+                pub st_gid: crate::gid_t,
+                #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
+                pub st_rdev: crate::dev_t,
+                #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+                pub st_rdev: c_ulong,
+                #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
+                __pad2: c_short,
+                #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+                st_pad2: [c_long; 2],
+                pub st_size: off_t,
+                #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+                st_pad3: c_long,
+                #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
+                pub st_blksize: crate::blksize_t,
+                #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
+                pub st_blocks: crate::blkcnt_t,
+                pub st_atime: crate::time_t,
+                pub st_atime_nsec: c_long,
+                pub st_mtime: crate::time_t,
+                pub st_mtime_nsec: c_long,
+                pub st_ctime: crate::time_t,
+                pub st_ctime_nsec: c_long,
+                #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
+                __unused4: c_long,
+                #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
+                __unused5: c_long,
+                #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+                pub st_blksize: crate::blksize_t,
+                #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+                pub st_blocks: crate::blkcnt_t,
+                #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+                st_pad5: [c_long; 14],
+            }
+        }
     }
+}
 
+s! {
     pub struct statvfs {
         pub f_bsize: c_ulong,
         pub f_frsize: c_ulong,

--- a/src/unix/linux_like/linux/gnu/b32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mod.rs
@@ -44,34 +44,18 @@ cfg_if! {
     if #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))] {
         s! {
             pub struct stat {
-                #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
                 pub st_dev: crate::dev_t,
-                #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-                pub st_dev: c_ulong,
 
-                #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
                 __pad1: c_short,
-                #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-                st_pad1: [c_long; 3],
                 pub st_ino: crate::ino_t,
                 pub st_mode: crate::mode_t,
                 pub st_nlink: crate::nlink_t,
                 pub st_uid: crate::uid_t,
                 pub st_gid: crate::gid_t,
-                #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
                 pub st_rdev: crate::dev_t,
-                #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-                pub st_rdev: c_ulong,
-                #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
                 __pad2: c_short,
-                #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-                st_pad2: [c_long; 2],
                 pub st_size: off_t,
-                #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-                st_pad3: c_long,
-                #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
                 pub st_blksize: crate::blksize_t,
-                #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
                 pub st_blocks: crate::blkcnt_t,
                 pub st_atime: crate::time_t,
                 pub st_atime_nsec: c_long,
@@ -79,16 +63,8 @@ cfg_if! {
                 pub st_mtime_nsec: c_long,
                 pub st_ctime: crate::time_t,
                 pub st_ctime_nsec: c_long,
-                #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
                 __unused4: c_long,
-                #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))]
                 __unused5: c_long,
-                #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-                pub st_blksize: crate::blksize_t,
-                #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-                pub st_blocks: crate::blkcnt_t,
-                #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
-                st_pad5: [c_long; 14],
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

The stat struct is significantly different for GNU 32 bit mips.  Split it out to make future work on `_FILE_OFFSET_BITS=64` and `_TIME_BITS=64` easier. 

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

There is no way to test mips builds at the moment.  This change does not add, change or remove any constants, structs or functions. 
