### PR TITLE
[0.2] Revert "Also skip `MFD_EXEC` and `MFD_NOEXEC_SEAL` on sparc64"

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4358,10 +4358,7 @@ fn test_linux(target: &str) {
                 if ppc64 || riscv64 => true,
 
             // FIXME(linux): requires more recent kernel headers on CI
-            | "MFD_EXEC"
-            | "MFD_NOEXEC_SEAL"
-            | "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV"
-                if sparc64 => true,
+            "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV" if sparc64 => true,
 
             // FIXME(linux): Not currently available in headers on ARM and musl.
             "NETLINK_GET_STRICT_CHK" if arm => true,


### PR DESCRIPTION
First commit: backport https://github.com/rust-lang/libc/pull/4282

---

This commit was included in [1] but was not present in the original commmit. This was likely needed because of previous differences in CI setup and MSRV between the two branches.

Now that the two branches are much more similar, the same kernel verion and Rust versions are tested so this should no longer be needed.

This reverts commit 61331df06f425934fa43a506e25217f49a039a7c.

[1]: https://github.com/rust-lang/libc/pull/3708