### PR TITLE
Switch back to matching `target_os` rather than `target_vendor`

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -20,7 +20,14 @@ pub type c_double = f64;
 cfg_if! {
     if #[cfg(all(
         not(windows),
-        not(target_vendor = "apple"),
+        // FIXME(ctest): just use `target_vendor` = "apple"` once `ctest` supports it
+        not(any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "visionos",
+        )),
         not(target_os = "vita"),
         any(
             target_arch = "aarch64",


### PR DESCRIPTION
`ctest` is very particular about this and the current configuration, though working most of the time, seems to cause occasional CI errors that can't easily be explained or mitigated. Switch back to matching all Apple `target_os` options until `ctest` is fixed.