### PR TITLE
openbsd: add devname(3)

### DIFF
--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -1831,6 +1831,7 @@ cpu_type_t
 ctime
 ctime_r
 ctl_info
+devname
 difftime
 dirfd
 dirname

--- a/libc-test/semver/dragonfly.txt
+++ b/libc-test/semver/dragonfly.txt
@@ -1303,6 +1303,7 @@ cpuctl_cpuid_count_args_t
 cpuctl_msr_args_t
 cpuctl_update_args_t
 daemon
+devname
 devname_r
 difftime
 dirfd

--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -1900,6 +1900,7 @@ cpuset_setid
 cpusetid_t
 daemon
 dallocx
+devname
 devname_r
 difftime
 dirfd

--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -1255,6 +1255,7 @@ clock_settime
 cmsghdr
 consttime_memequal
 daemon
+devname
 difftime
 dirfd
 dirname

--- a/libc-test/semver/openbsd.txt
+++ b/libc-test/semver/openbsd.txt
@@ -1066,6 +1066,7 @@ clock_getres
 clock_settime
 cmsghdr
 daemon
+devname
 difftime
 dirfd
 dirname

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -964,6 +964,8 @@ extern "C" {
         timeptr: *const crate::tm,
         locale: crate::locale_t,
     ) -> size_t;
+
+    pub fn devname(dev: crate::dev_t, mode_t: crate::mode_t) -> *mut c_char;
 }
 
 cfg_if! {


### PR DESCRIPTION
# Description

I'm planning to add OpenBSD support to the drm crate, for that I need [devname(3)](https://man.openbsd.org/devname.3)  to replace devname_r which is used on FreeBSD but not available on OpenBSD.

# Sources

https://man.openbsd.org/devname.3
https://github.com/openbsd/src/blob/master/include/stdlib.h#L283
https://github.com/openbsd/src/blob/master/lib/libc/gen/devname.c#L73

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
