### PR TITLE
closefrom: add NetBSD, OpenBSD, DragonflyBSD

### DIFF
--- a/libc-test/semver/dragonfly.txt
+++ b/libc-test/semver/dragonfly.txt
@@ -1296,6 +1296,7 @@ clock_getcpuclockid
 clock_getres
 clock_nanosleep
 clock_settime
+closefrom
 cmsgcred
 cmsghdr
 cpuctl_cpuid_args_t

--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -1252,6 +1252,7 @@ clearerr
 clock_getres
 clock_nanosleep
 clock_settime
+closefrom
 cmsghdr
 consttime_memequal
 daemon

--- a/libc-test/semver/openbsd.txt
+++ b/libc-test/semver/openbsd.txt
@@ -1064,6 +1064,7 @@ chroot
 clearerr
 clock_getres
 clock_settime
+closefrom
 cmsghdr
 daemon
 devname

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1702,6 +1702,8 @@ extern "C" {
         mntvbufp: *mut *mut crate::statvfs,
         flags: c_int,
     ) -> c_int;
+
+    pub fn closefrom(lowfd: c_int) -> c_int;
 }
 
 #[link(name = "rt")]

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -856,6 +856,8 @@ extern "C" {
         flags: c_int,
         timeout: *mut crate::timespec,
     ) -> c_int;
+
+    pub fn closefrom(lowfd: c_int) -> c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
# Description

closefrom is actually widely adopted in *BSD. The only one that seems to not support it at this point is macOS.
This effectively adds closefrom for NetBSD, OpenBSD and DragonFly.

# Sources

https://leaf.dragonflybsd.org/cgi/web-man?command=closefrom
https://man.netbsd.org/closefrom.3
https://man.openbsd.org/closefrom.2

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
