### PR TITLE
Correct values for SI_TIMER, SI_MESGQ, SI_ASYNCIO on Linux MIPS

### DIFF
--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1292,9 +1292,17 @@ pub const SI_LOAD_SHIFT: c_uint = 16;
 pub const SI_USER: c_int = 0;
 pub const SI_KERNEL: c_int = 0x80;
 pub const SI_QUEUE: c_int = -1;
-pub const SI_TIMER: c_int = -2;
-pub const SI_MESGQ: c_int = -3;
-pub const SI_ASYNCIO: c_int = -4;
+cfg_if! {
+    if #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))] {
+        pub const SI_TIMER: c_int = -2;
+        pub const SI_MESGQ: c_int = -3;
+        pub const SI_ASYNCIO: c_int = -4;
+    } else {
+        pub const SI_TIMER: c_int = -3;
+        pub const SI_MESGQ: c_int = -4;
+        pub const SI_ASYNCIO: c_int = -2;
+    }
+}
 pub const SI_SIGIO: c_int = -5;
 pub const SI_TKILL: c_int = -6;
 pub const SI_ASYNCNL: c_int = -60;


### PR DESCRIPTION
# Description

Correct values for SI_TIMER, SI_MESGQ, SI_ASYNCIO for Linux MIPS

# Sources

https://github.com/torvalds/linux/blob/99fa936e8e4f117d62f229003c9799686f74cebc/arch/mips/include/uapi/asm/siginfo.h#L26-L28

# Checklist

- [x ] Relevant tests in `libc-test/semver` have been updated
- [ x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

It's not possible to test mips at the moment.  I found these issues by cross-compiling the tests in yocto with rust 1.82.