### PR TITLE
hermit: make `stat::st_size` signed

### DIFF
--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -100,7 +100,7 @@ s! {
         pub st_uid: u32,
         pub st_gid: u32,
         pub st_rdev: u64,
-        pub st_size: u64,
+        pub st_size: i64,
         pub st_blksize: i64,
         pub st_blocks: i64,
         pub st_atim: timespec,


### PR DESCRIPTION
# Description

This PR changes Hermit's `stat::st_size` from `u64` to `i64`.

# Sources

This was done upstream in https://github.com/hermit-os/kernel/pull/1576 to comply with POSIX.

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
