### PR TITLE
Make msqid_ds.__msg_cbytes public.

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -807,7 +807,7 @@ s! {
         pub msg_stime: crate::time_t,
         pub msg_rtime: crate::time_t,
         pub msg_ctime: crate::time_t,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -272,7 +272,7 @@ s! {
         pub msg_stime: crate::time_t,
         pub msg_rtime: crate::time_t,
         pub msg_ctime: crate::time_t,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
@@ -135,7 +135,7 @@ s! {
         __glibc_reserved2: c_ulong,
         pub msg_ctime: crate::time_t,
         __glibc_reserved3: c_ulong,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
@@ -134,7 +134,7 @@ s! {
         __glibc_reserved2: c_ulong,
         pub msg_ctime: crate::time_t,
         __glibc_reserved3: c_ulong,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
@@ -134,7 +134,7 @@ s! {
         __glibc_reserved2: c_uint,
         pub msg_ctime: crate::time_t,
         __glibc_reserved3: c_uint,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -162,7 +162,7 @@ s! {
         pub msg_ctime: crate::time_t,
         #[cfg(target_endian = "little")]
         __glibc_reserved3: c_ulong,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/gnu/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/gnu/b32/powerpc.rs
@@ -135,7 +135,7 @@ s! {
         pub msg_rtime: crate::time_t,
         __glibc_reserved3: c_uint,
         pub msg_ctime: crate::time_t,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
@@ -11,7 +11,7 @@ s! {
         pub msg_stime: crate::time_t,
         pub msg_rtime: crate::time_t,
         pub msg_ctime: crate::time_t,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -149,7 +149,7 @@ s! {
         pub msg_rtime: crate::time_t,
         __pad3: c_uint,
         pub msg_ctime: crate::time_t,
-        __msg_cbytes: c_ushort,
+        pub __msg_cbytes: c_ushort,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
@@ -209,7 +209,7 @@ s! {
         __glibc_reserved2: c_ulong,
         pub msg_ctime: crate::time_t,
         __glibc_reserved3: c_ulong,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/gnu/b64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mod.rs
@@ -58,7 +58,7 @@ s! {
         pub msg_stime: crate::time_t,
         pub msg_rtime: crate::time_t,
         pub msg_ctime: crate::time_t,
-        __msg_cbytes: u64,
+        pub __msg_cbytes: u64,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -90,7 +90,7 @@ s! {
         __unused2: c_int,
         pub msg_ctime: crate::time_t,
         __unused3: c_int,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/musl/b32/hexagon.rs
+++ b/src/unix/linux_like/linux/musl/b32/hexagon.rs
@@ -67,7 +67,7 @@ s! {
         __unused2: c_int,
         pub msg_ctime: crate::time_t,
         __unused3: c_int,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -98,7 +98,7 @@ s! {
         pub msg_ctime: crate::time_t,
         #[cfg(target_endian = "little")]
         __unused3: c_int,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -90,7 +90,7 @@ s! {
         pub msg_rtime: crate::time_t,
         __unused3: c_int,
         pub msg_ctime: crate::time_t,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
@@ -91,7 +91,7 @@ s! {
         __unused2: c_int,
         pub msg_ctime: crate::time_t,
         __unused3: c_int,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -94,7 +94,7 @@ s! {
         __unused2: c_int,
         pub msg_ctime: crate::time_t,
         __unused3: c_int,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/musl/b64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/mod.rs
@@ -35,7 +35,7 @@ s! {
         pub msg_stime: crate::time_t,
         pub msg_rtime: crate::time_t,
         pub msg_ctime: crate::time_t,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/uclibc/arm/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/arm/mod.rs
@@ -216,7 +216,7 @@ s! {
         __unused2: c_ulong,
         pub msg_ctime: crate::time_t,
         __unused3: c_ulong,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
@@ -164,7 +164,7 @@ s! {
         pub msg_ctime: crate::time_t,
         #[cfg(target_endian = "little")]
         __glibc_reserved3: c_ulong,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
@@ -120,7 +120,7 @@ s! {
         pub msg_stime: crate::time_t,
         pub msg_rtime: crate::time_t,
         pub msg_ctime: crate::time_t,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,

--- a/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
@@ -81,7 +81,7 @@ s! {
         pub msg_stime: crate::time_t,
         pub msg_rtime: crate::time_t,
         pub msg_ctime: crate::time_t,
-        __msg_cbytes: c_ulong,
+        pub __msg_cbytes: c_ulong,
         pub msg_qnum: crate::msgqnum_t,
         pub msg_qbytes: crate::msglen_t,
         pub msg_lspid: crate::pid_t,


### PR DESCRIPTION
Make `msqid_ds.__msg_cbytes` public, making the field accessible. In C, `struct msqid_ds` is defined in `<sys/msg.h>`.

Closes #4300.

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
