### PR TITLE
xous: include prelude to define c_int

### DIFF
--- a/src/xous.rs
+++ b/src/xous.rs
@@ -1,5 +1,7 @@
 //! Xous C type definitions
 
+use crate::prelude::*;
+
 pub type intmax_t = i64;
 pub type uintmax_t = u64;
 


### PR DESCRIPTION
# Description

Include the prelude on Xous to fix the build in Rust `libstd`. This PR is against `main`, as opposed to the PR against `libc-0.2`.

# Sources

N/A

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

# Extra

With the latest changes, libstd no longer builds:

```
   Compiling libc v0.2.170 (/opt/Xous/libc)
error[E0412]: cannot find type `c_int` in this scope
  --> /opt/Xous/libc/src/xous.rs:17:20
   |
17 | pub const INT_MIN: c_int = -2147483648;
   |                    ^^^^^ not found in this scope
   |
help: consider importing one of these type aliases
   |
5  + use crate::c_int;
   |
5  + use rustc_std_workspace_core::ffi::c_int;
   |

error[E0412]: cannot find type `c_int` in this scope
  --> /opt/Xous/libc/src/xous.rs:18:20
   |
18 | pub const INT_MAX: c_int = 2147483647;
   |                    ^^^^^ not found in this scope
   |
help: consider importing one of these type aliases
   |
5  + use crate::c_int;
   |
5  + use rustc_std_workspace_core::ffi::c_int;
   |

For more information about this error, try `rustc --explain E0412`.
error: could not compile `libc` (lib) due to 2 previous errors
```