### PR TITLE
Cygwin: Add PTY and group API

### DIFF
--- a/src/unix/cygwin/mod.rs
+++ b/src/unix/cygwin/mod.rs
@@ -2436,4 +2436,40 @@ extern "C" {
         fd: c_int,
         newfd: c_int,
     ) -> c_int;
+
+    pub fn forkpty(
+        amaster: *mut c_int,
+        name: *mut c_char,
+        termp: *const termios,
+        winp: *const crate::winsize,
+    ) -> crate::pid_t;
+    pub fn openpty(
+        amaster: *mut c_int,
+        aslave: *mut c_int,
+        name: *mut c_char,
+        termp: *const termios,
+        winp: *const crate::winsize,
+    ) -> c_int;
+
+    pub fn getgrgid_r(
+        gid: crate::gid_t,
+        grp: *mut crate::group,
+        buf: *mut c_char,
+        buflen: size_t,
+        result: *mut *mut crate::group,
+    ) -> c_int;
+    pub fn getgrouplist(
+        user: *const c_char,
+        group: crate::gid_t,
+        groups: *mut crate::gid_t,
+        ngroups: *mut c_int,
+    ) -> c_int;
+    pub fn getgrnam_r(
+        name: *const c_char,
+        grp: *mut crate::group,
+        buf: *mut c_char,
+        buflen: size_t,
+        result: *mut *mut crate::group,
+    ) -> c_int;
+    pub fn initgroups(user: *const c_char, group: crate::gid_t) -> c_int;
 }


### PR DESCRIPTION
# Description

Some methods required by `nix` crate.

# Sources

* https://github.com/cygwin/cygwin/blob/a3863bfeb73f3c3832038685498c7c4148a06890/winsup/cygwin/include/pty.h#L11-L14
* https://github.com/cygwin/cygwin/blob/a3863bfeb73f3c3832038685498c7c4148a06890/winsup/cygwin/include/cygwin/grp.h#L19
* https://github.com/cygwin/cygwin/blob/a3863bfeb73f3c3832038685498c7c4148a06890/newlib/libc/include/grp.h#L67-L78

# Checklist

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
