### PR TITLE
Add missing macos proc types and constants

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1265,6 +1265,12 @@ s! {
         pub ctl_id: u32,
         pub ctl_name: [c_char; MAX_KCTL_NAME],
     }
+
+    // sys/proc_info.h
+    pub struct proc_fdinfo {
+        pub proc_fd: i32,
+        pub proc_fdtype: u32,
+    }
 }
 
 s_no_extra_traits! {
@@ -4968,6 +4974,21 @@ pub const PROC_PIDTASKINFO: c_int = 4;
 pub const PROC_PIDTHREADINFO: c_int = 5;
 pub const PROC_PIDVNODEPATHINFO: c_int = 9;
 pub const PROC_PIDPATHINFO_MAXSIZE: c_int = 4096;
+
+pub const PROC_PIDLISTFDS: c_int = 1;
+pub const PROC_PIDLISTFD_SIZE: c_int = mem::size_of::<proc_fdinfo>() as c_int;
+pub const PROX_FDTYPE_ATALK: c_int = 0;
+pub const PROX_FDTYPE_VNODE: c_int = 1;
+pub const PROX_FDTYPE_SOCKET: c_int = 2;
+pub const PROX_FDTYPE_PSHM: c_int = 3;
+pub const PROX_FDTYPE_PSEM: c_int = 4;
+pub const PROX_FDTYPE_KQUEUE: c_int = 5;
+pub const PROX_FDTYPE_PIPE: c_int = 6;
+pub const PROX_FDTYPE_FSEVENTS: c_int = 7;
+pub const PROX_FDTYPE_NETPOLICY: c_int = 9;
+pub const PROX_FDTYPE_CHANNEL: c_int = 10;
+pub const PROX_FDTYPE_NEXUS: c_int = 11;
+
 pub const PROC_CSM_ALL: c_uint = 0x0001;
 pub const PROC_CSM_NOSMT: c_uint = 0x0002;
 pub const PROC_CSM_TECS: c_uint = 0x0004;


### PR DESCRIPTION
More items needed for `sysinfo` to be able to add a new feature.

Sources:

* https://github.com/apple-oss-distributions/xnu/blob/8d741a5de7ff4191bf97d57b9f54c2f6d4a15585/bsd/sys/proc_info.h#L673-L676
* https://github.com/apple-oss-distributions/xnu/blob/8d741a5de7ff4191bf97d57b9f54c2f6d4a15585/bsd/sys/proc_info.h#L718-L719
* https://github.com/apple-oss-distributions/xnu/blob/8d741a5de7ff4191bf97d57b9f54c2f6d4a15585/bsd/sys/proc_info.h#L661-L671