### PR TITLE
Change the range syntax that is giving `ctest` problems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ targets = [
     "armv7r-none-eabihf",
     # FIXME(hexagon): excluded due to duplicate symbol errors
     # "hexagon-unknown-linux-musl",
-    "i586-pc-windows-msvc",
     "i586-unknown-linux-gnu",
     "i586-unknown-linux-musl",
     "i686-linux-android",

--- a/ci/verify-build.sh
+++ b/ci/verify-build.sh
@@ -189,7 +189,6 @@ armebv7r-none-eabihf \
 armv7-wrs-vxworks-eabihf \
 armv7r-none-eabi \
 armv7r-none-eabihf \
-i586-pc-windows-msvc \
 i686-pc-windows-msvc \
 i686-unknown-haiku \
 i686-unknown-netbsd \

--- a/libc-test/test/linux_kernel_version.rs
+++ b/libc-test/test/linux_kernel_version.rs
@@ -1,15 +1,16 @@
 //! Compare libc's KERNEL_VERSION macro against a specific kernel version.
 
-#[cfg(
-    target_os = "linux",
-)]
+#[cfg(target_os = "linux")]
 mod t {
     use libc;
 
     #[test]
     fn test_kernel_version() {
-        unsafe {
-            assert_eq!(libc::KERNEL_VERSION(6, 0, 0), 393216);
-        }
+        assert_eq!(unsafe { libc::KERNEL_VERSION(6, 0, 0) }, 393216);
+        // Check that the patch level saturates
+        assert_eq!(unsafe { libc::KERNEL_VERSION(6, 0, 255) }, 393471);
+        assert_eq!(unsafe { libc::KERNEL_VERSION(6, 0, 256) }, 393471);
+        assert_eq!(unsafe { libc::KERNEL_VERSION(6, 0, 300) }, 393471);
+        assert_eq!(unsafe { libc::KERNEL_VERSION(6, 0, u32::MAX) }, 393471);
     }
 }

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1755,11 +1755,7 @@ safe_f! {
 
     #[allow(ellipsis_inclusive_range_patterns)]
     pub {const} fn KERNEL_VERSION(a: u32, b: u32, c: u32) -> u32 {
-        ((a << 16) + (b << 8))
-            + match c {
-                0..=255 => c,
-                _ => 255,
-            }
+        ((a << 16) + (b << 8)) + if c > 255 { 255 } else { c }
     }
 }
 


### PR DESCRIPTION
`ctest` is iffy about whether or not it accepts `..=` syntax, and I can't figure out what makes it decide whether or not to accept it and sometimes random changes seem to make things fail, so just replace the syntax.

This is simpler anyway, and closer matches the upstream definition [1].

Link: https://github.com/torvalds/linux/blob/80e54e84911a923c40d7bee33a34c1b4be148d7a/Makefile#L1316 [1]