### PR TITLE
ci: Fixes for sparc and s390x

### DIFF
--- a/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
@@ -1,11 +1,4 @@
-# FIXME(sparc): newer versions of Ubuntu get the following errors
-# ```
-# /prog: /lib/sparc64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by /prog)
-# /prog: /lib/sparc64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /prog)
-# ```
-# Not sure if this is a problem from rustc, our libc, or Ubuntu so we just
-# stick with an old LTS for now.
-FROM ubuntu:22.04
+FROM ubuntu:24.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl ca-certificates \

--- a/ci/linux-s390x.sh
+++ b/ci/linux-s390x.sh
@@ -6,8 +6,8 @@ mkdir -m 777 /qemu
 cd /qemu
 
 curl --retry 5 -LO https://github.com/qemu/qemu/raw/HEAD/pc-bios/s390-ccw.img
-curl --retry 5 -LO http://ftp.debian.org/debian/dists/testing/main/installer-s390x/20230607/images/generic/kernel.debian
-curl --retry 5 -LO http://ftp.debian.org/debian/dists/testing/main/installer-s390x/20230607/images/generic/initrd.debian
+curl --retry 5 -LO http://ftp.debian.org/debian/dists/testing/main/installer-s390x/20241227/images/generic/kernel.debian
+curl --retry 5 -LO http://ftp.debian.org/debian/dists/testing/main/installer-s390x/20241227/images/generic/initrd.debian
 
 mv kernel.debian kernel
 mv initrd.debian initrd.gz

--- a/ci/linux-sparc64.sh
+++ b/ci/linux-sparc64.sh
@@ -5,11 +5,11 @@ set -eux
 mkdir -m 777 /qemu
 cd /qemu
 
-curl --retry 5 -LO https://cdimage.debian.org/cdimage/ports/snapshots/2022-12-09/debian-11.0.0-sparc64-NETINST-1.iso
-7z e debian-11.0.0-sparc64-NETINST-1.iso install/initrd.gz
-7z e debian-11.0.0-sparc64-NETINST-1.iso install/vmlinux
+curl --retry 5 -LO https://cdimage.debian.org/cdimage/ports/snapshots/2024-12-24/debian-12.0.0-sparc64-NETINST-1.iso
+7z e debian-12.0.0-sparc64-NETINST-1.iso install/initrd.gz
+7z e debian-12.0.0-sparc64-NETINST-1.iso install/vmlinux
 mv vmlinux kernel
-rm debian-11.0.0-sparc64-NETINST-1.iso
+rm debian-12.0.0-sparc64-NETINST-1.iso
 
 mkdir init
 cd init

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -87,7 +87,6 @@ test_flags="--skip check_style"
 case "$target" in
     # Only run `libc-test` 
     # FIXME(android): unit tests fail to start on Android
-    # FIXME(s390x): unit tests fail to locate glibc
     *android*) cmd="$cmd --manifest-path libc-test/Cargo.toml" ;;
     *s390x*) cmd="$cmd --manifest-path libc-test/Cargo.toml" ;;
     # For all other platforms, test everything in the workspace

--- a/src/unix/linux_like/linux/gnu/b64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mod.rs
@@ -77,7 +77,8 @@ s! {
             target_arch = "mips64r6",
             target_arch = "powerpc64",
             target_arch = "riscv64",
-            target_arch = "sparc64"
+            target_arch = "sparc64",
+            target_arch = "s390x",
         )))]
         __reserved: crate::__syscall_ulong_t,
         pub sem_ctime: crate::time_t,
@@ -88,7 +89,8 @@ s! {
             target_arch = "mips64r6",
             target_arch = "powerpc64",
             target_arch = "riscv64",
-            target_arch = "sparc64"
+            target_arch = "sparc64",
+            target_arch = "s390x",
         )))]
         __reserved2: crate::__syscall_ulong_t,
         pub sem_nsems: crate::__syscall_ulong_t,


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Fixes the 'cannot find libc' error plaguing s390x and sparc. A side effect is that now these CIs will be tested on much more recent kernel headers (6.11).

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
