### PR TITLE
cygwin: fix member types of statfs

### DIFF
--- a/src/unix/cygwin/mod.rs
+++ b/src/unix/cygwin/mod.rs
@@ -437,16 +437,16 @@ s! {
     }
 
     pub struct statfs {
-        pub f_type: c_ulong,
-        pub f_bsize: c_ulong,
-        pub f_blocks: c_ulong,
-        pub f_bfree: c_ulong,
-        pub f_bavail: c_ulong,
-        pub f_files: c_ulong,
-        pub f_ffree: c_ulong,
-        pub f_fsid: c_ulong,
-        pub f_namelen: c_ulong,
-        pub f_spare: [c_ulong; 6],
+        pub f_type: c_long,
+        pub f_bsize: c_long,
+        pub f_blocks: c_long,
+        pub f_bfree: c_long,
+        pub f_bavail: c_long,
+        pub f_files: c_long,
+        pub f_ffree: c_long,
+        pub f_fsid: c_long,
+        pub f_namelen: c_long,
+        pub f_spare: [c_long; 6],
     }
 }
 


### PR DESCRIPTION
# Description

This is a fix for #4321 . The member types of `statfs` should be `c_long` instead of `c_ulong`.

# Sources

https://github.com/cygwin/cygwin/blob/bc026427bd5408999e73ff61ca2b91a343176864/winsup/cygwin/include/sys/vfs.h

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
