### PR TITLE
Add missing `filedesc` and `fdescenttbl` in FreeBSD

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
@@ -51,9 +51,8 @@ s! {
         // This is normally "struct vnode".
         /// Pointer to executable file.
         pub ki_textvp: *mut c_void,
-        // This is normally "struct filedesc".
         /// Pointer to open file info.
-        pub ki_fd: *mut c_void,
+        pub ki_fd: *mut crate::filedesc,
         // This is normally "struct vmspace".
         /// Pointer to kernel vmspace struct.
         pub ki_vmspace: *mut c_void,

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -59,9 +59,8 @@ s! {
         // This is normally "struct vnode".
         /// Pointer to executable file.
         pub ki_textvp: *mut c_void,
-        // This is normally "struct filedesc".
         /// Pointer to open file info.
-        pub ki_fd: *mut c_void,
+        pub ki_fd: *mut crate::filedesc,
         // This is normally "struct vmspace".
         /// Pointer to kernel vmspace struct.
         pub ki_vmspace: *mut c_void,

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -69,9 +69,8 @@ s! {
         // This is normally "struct vnode".
         /// Pointer to executable file.
         pub ki_textvp: *mut c_void,
-        // This is normally "struct filedesc".
         /// Pointer to open file info.
-        pub ki_fd: *mut c_void,
+        pub ki_fd: *mut crate::filedesc,
         // This is normally "struct vmspace".
         /// Pointer to kernel vmspace struct.
         pub ki_vmspace: *mut c_void,

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -69,9 +69,8 @@ s! {
         // This is normally "struct vnode".
         /// Pointer to executable file.
         pub ki_textvp: *mut c_void,
-        // This is normally "struct filedesc".
         /// Pointer to open file info.
-        pub ki_fd: *mut c_void,
+        pub ki_fd: *mut crate::filedesc,
         // This is normally "struct vmspace".
         /// Pointer to kernel vmspace struct.
         pub ki_vmspace: *mut c_void,

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
@@ -69,9 +69,8 @@ s! {
         // This is normally "struct vnode".
         /// Pointer to executable file.
         pub ki_textvp: *mut c_void,
-        // This is normally "struct filedesc".
         /// Pointer to open file info.
-        pub ki_fd: *mut c_void,
+        pub ki_fd: *mut crate::filedesc,
         // This is normally "struct vmspace".
         /// Pointer to kernel vmspace struct.
         pub ki_vmspace: *mut c_void,

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1355,6 +1355,47 @@ s! {
         pub strchange_instrms: u16,
         pub strchange_outstrms: u16,
     }
+
+    pub struct filedesc {
+        pub fd_files: *mut fdescenttbl,
+        pub fd_map: *mut c_ulong,
+        pub fd_freefile: c_int,
+        pub fd_refcnt: c_int,
+        pub fd_holdcnt: c_int,
+        fd_sx: sx,
+        fd_kqlist: kqlist,
+        pub fd_holdleaderscount: c_int,
+        pub fd_holdleaderswakeup: c_int,
+    }
+
+    pub struct fdescenttbl {
+        pub fdt_nfiles: c_int,
+        fdt_ofiles: [*mut c_void; 0],
+    }
+
+    // FIXME: Should be private.
+    #[doc(hidden)]
+    pub struct sx {
+        lock_object: lock_object,
+        sx_lock: crate::uintptr_t,
+    }
+
+    // FIXME: Should be private.
+    #[doc(hidden)]
+    pub struct lock_object {
+        lo_name: *const c_char,
+        lo_flags: c_uint,
+        lo_data: c_uint,
+        // This is normally `struct  witness`.
+        lo_witness: *mut c_void,
+    }
+
+    // FIXME: Should be private.
+    #[doc(hidden)]
+    pub struct kqlist {
+        tqh_first: *mut c_void,
+        tqh_last: *mut *mut c_void,
+    }
 }
 
 s_no_extra_traits! {


### PR DESCRIPTION
Types I need for sysinfo to allow to know how many open files a FreeBSD process has.

Item declarations can be found there:
 * https://github.com/freebsd/freebsd-src/blob/58164dcb55d62ca73b5e550b8344bf61e2d8a47a/sys/sys/_lock.h
 * https://github.com/freebsd/freebsd-src/blob/58164dcb55d62ca73b5e550b8344bf61e2d8a47a/sys/sys/filedesc.h
 * https://github.com/freebsd/freebsd-src/blob/58164dcb55d62ca73b5e550b8344bf61e2d8a47a/sys/sys/_sx.h