### PR TITLE
solarish:  Restrict openpty and forkpty polyfills to illumos, replace Solaris implementation with FFI

### DIFF
--- a/src/unix/solarish/compat.rs
+++ b/src/unix/solarish/compat.rs
@@ -53,6 +53,7 @@ unsafe fn bail(fdm: c_int, fds: c_int) -> c_int {
     return -1;
 }
 
+#[cfg(target_os = "illumos")]
 pub unsafe fn openpty(
     amain: *mut c_int,
     asubord: *mut c_int,
@@ -123,6 +124,7 @@ pub unsafe fn openpty(
     0
 }
 
+#[cfg(target_os = "illumos")]
 pub unsafe fn forkpty(
     amain: *mut c_int,
     name: *mut c_char,

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use crate::{
     exit_status, off_t, NET_MAC_AWARE, NET_MAC_AWARE_INHERIT, PRIV_AWARE_RESET, PRIV_DEBUG,
-    PRIV_PFEXEC, PRIV_XPOLICY,
+    PRIV_PFEXEC, PRIV_XPOLICY, termios,
 };
 
 pub type door_attr_t = c_uint;
@@ -241,4 +241,19 @@ extern "C" {
     pub fn pthread_getattr_np(thread: crate::pthread_t, attr: *mut crate::pthread_attr_t) -> c_int;
 
     pub fn euidaccess(path: *const c_char, amode: c_int) -> c_int;
+
+    pub fn openpty(
+        amain: *mut c_int,
+        asubord: *mut c_int,
+        name: *mut c_char,
+        termp: *mut termios,
+        winp: *mut crate::winsize,
+    ) -> c_int;
+
+    pub fn forkpty(
+        amain: *mut c_int,
+        name: *mut c_char,
+        termp: *mut termios,
+        winp: *mut crate::winsize,
+    ) -> crate::pid_t;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

- This PR modifies the openpty and forkpty implementations in the Solarish layer:
    - Restricts the existing polyfill implementations to illumos using cfg(illumos).
    - Removes the Solaris-specific polyfill implementations.
    - Replaces them with FFI definitions where necessary.

-  Related to #4045 

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->

- Relevant discussion : #4045 

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
