### PR TITLE
Add missing utmpx apis for linux musl

### DIFF
--- a/libc-test/semver/linux-musl.txt
+++ b/libc-test/semver/linux-musl.txt
@@ -1,3 +1,4 @@
+ACCOUNTING
 AF_IB
 AF_MPLS
 AF_XDP
@@ -37,6 +38,9 @@ RWF_HIPRI
 RWF_NOWAIT
 RWF_SYNC
 USER_PROCESS
+UT_HOSTSIZE
+UT_LINESIZE
+UT_NAMESIZE
 _CS_V6_ENV
 _CS_V7_ENV
 adjtimex
@@ -82,3 +86,4 @@ reallocarray
 setutxent
 tcp_info
 timex
+utmpxname

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -656,7 +656,7 @@ pub const INIT_PROCESS: c_short = 5;
 pub const LOGIN_PROCESS: c_short = 6;
 pub const USER_PROCESS: c_short = 7;
 pub const DEAD_PROCESS: c_short = 8;
-// musl does not define ACCOUNTING
+pub const ACCOUNTING: c_short = 9;
 
 pub const SFD_CLOEXEC: c_int = 0x080000;
 
@@ -888,6 +888,10 @@ pub const _CS_V7_ENV: c_int = 1149;
 
 pub const CLONE_NEWTIME: c_int = 0x80;
 
+pub const UT_HOSTSIZE: usize = 256;
+pub const UT_LINESIZE: usize = 32;
+pub const UT_NAMESIZE: usize = 32;
+
 cfg_if! {
     if #[cfg(target_arch = "s390x")] {
         pub const POSIX_FADV_DONTNEED: c_int = 6;
@@ -987,12 +991,41 @@ extern "C" {
         fd: c_int,
     ) -> c_int;
 
+    #[deprecated(
+        since = "0.2.172",
+        note = "musl provides `utmp` as stubs and an alternative should be preferred; see https://wiki.musl-libc.org/faq.html"
+    )]
     pub fn getutxent() -> *mut utmpx;
+    #[deprecated(
+        since = "0.2.172",
+        note = "musl provides `utmp` as stubs and an alternative should be preferred; see https://wiki.musl-libc.org/faq.html"
+    )]
     pub fn getutxid(ut: *const utmpx) -> *mut utmpx;
+    #[deprecated(
+        since = "0.2.172",
+        note = "musl provides `utmp` as stubs and an alternative should be preferred; see https://wiki.musl-libc.org/faq.html"
+    )]
     pub fn getutxline(ut: *const utmpx) -> *mut utmpx;
+    #[deprecated(
+        since = "0.2.172",
+        note = "musl provides `utmp` as stubs and an alternative should be preferred; see https://wiki.musl-libc.org/faq.html"
+    )]
     pub fn pututxline(ut: *const utmpx) -> *mut utmpx;
+    #[deprecated(
+        since = "0.2.172",
+        note = "musl provides `utmp` as stubs and an alternative should be preferred; see https://wiki.musl-libc.org/faq.html"
+    )]
     pub fn setutxent();
+    #[deprecated(
+        since = "0.2.172",
+        note = "musl provides `utmp` as stubs and an alternative should be preferred; see https://wiki.musl-libc.org/faq.html"
+    )]
     pub fn endutxent();
+    #[deprecated(
+        since = "0.2.172",
+        note = "musl provides `utmp` as stubs and an alternative should be preferred; see https://wiki.musl-libc.org/faq.html"
+    )]
+    pub fn utmpxname(file: *const c_char) -> c_int;
 }
 
 // Alias <foo> to <foo>64 to mimic glibc's LFS64 support


### PR DESCRIPTION
# Description

Add the utmp APIs which were missing from musl.
Close https://github.com/rust-lang/libc/issues/4322

# Sources

This is based on https://git.musl-libc.org/cgit/musl/tree/include/utmpx.h
Note that musl implements only stub functions for utmp functionalities, because they consider it unsafe.

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);  (unrelated error about #include <linux/errqueue.h>)
  especially relevant for platforms that may not be checked in CI
  
Signed-off-by: Etienne Cordonnier <ecordonnier@snap.com>