### PR TITLE
Add timerfd APIs for illumos and NetBSD.

### DIFF
--- a/libc-test/semver/illumos.txt
+++ b/libc-test/semver/illumos.txt
@@ -15,6 +15,10 @@ POSIX_FADV_RANDOM
 POSIX_FADV_SEQUENTIAL
 POSIX_FADV_WILLNEED
 POSIX_SPAWN_SETSID
+TFD_CLOEXEC
+TFD_NONBLOCK
+TFD_TIMER_ABSTIME
+TFD_TIMER_CANCEL_ON_SET
 posix_fadvise
 posix_fallocate
 posix_spawn_file_actions_addfchdir_np
@@ -23,3 +27,6 @@ pthread_attr_getstackaddr
 pthread_attr_setstack
 ptsname_r
 syncfs
+timerfd_create
+timerfd_gettime
+timerfd_settime

--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -1042,6 +1042,10 @@ TCP_KEEPINIT
 TCP_KEEPINTVL
 TCP_MAXSEG
 TCP_MD5SIG
+TFD_CLOEXEC
+TFD_NONBLOCK
+TFD_TIMER_ABSTIME
+TFD_TIMER_CANCEL_ON_SET
 THOUSEP
 TIMER_ABSTIME
 TIME_DEL
@@ -1613,6 +1617,9 @@ timer_getoverrun
 timer_gettime
 timer_settime
 timer_t
+timerfd_create
+timerfd_gettime
+timerfd_settime
 timex
 truncate
 ttyname_r

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2409,6 +2409,12 @@ pub const RTA_TAG: c_int = 0x100;
 pub const RTAX_TAG: c_int = 8;
 pub const RTAX_MAX: c_int = 9;
 
+// sys/timerfd.h
+pub const TFD_CLOEXEC: i32 = crate::O_CLOEXEC;
+pub const TFD_NONBLOCK: i32 = crate::O_NONBLOCK;
+pub const TFD_TIMER_ABSTIME: i32 = crate::O_WRONLY;
+pub const TFD_TIMER_CANCEL_ON_SET: i32 = crate::O_RDWR;
+
 const_fn! {
     {const} fn _ALIGN(p: usize) -> usize {
         (p + _ALIGNBYTES) & !_ALIGNBYTES
@@ -2853,6 +2859,16 @@ extern "C" {
     #[link_name = "__getmntinfo13"]
     pub fn getmntinfo(mntbufp: *mut *mut crate::statvfs, flags: c_int) -> c_int;
     pub fn getvfsstat(buf: *mut statvfs, bufsize: size_t, flags: c_int) -> c_int;
+
+    // Added in `NetBSD` 10.0
+    pub fn timerfd_create(clockid: crate::clockid_t, flags: c_int) -> c_int;
+    pub fn timerfd_gettime(fd: c_int, curr_value: *mut itimerspec) -> c_int;
+    pub fn timerfd_settime(
+        fd: c_int,
+        flags: c_int,
+        new_value: *const itimerspec,
+        old_value: *mut itimerspec,
+    ) -> c_int;
 }
 
 #[link(name = "rt")]

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -286,6 +286,12 @@ pub const B4000000: crate::speed_t = 31;
 // sys/systeminfo.h
 pub const SI_ADDRESS_WIDTH: c_int = 520;
 
+// sys/timerfd.h
+pub const TFD_CLOEXEC: i32 = 0o2000000;
+pub const TFD_NONBLOCK: i32 = 0o4000;
+pub const TFD_TIMER_ABSTIME: i32 = 1 << 0;
+pub const TFD_TIMER_CANCEL_ON_SET: i32 = 1 << 1;
+
 extern "C" {
     pub fn eventfd(init: c_uint, flags: c_int) -> c_int;
 
@@ -352,5 +358,14 @@ extern "C" {
         s2: *const c_char,
         n: size_t,
         loc: crate::locale_t,
+    ) -> c_int;
+
+    pub fn timerfd_create(clockid: c_int, flags: c_int) -> c_int;
+    pub fn timerfd_gettime(fd: c_int, curr_value: *mut crate::itimerspec) -> c_int;
+    pub fn timerfd_settime(
+        fd: c_int,
+        flags: c_int,
+        new_value: *const crate::itimerspec,
+        old_value: *mut crate::itimerspec,
     ) -> c_int;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Add timerfd APIs for illumos and NetBSD.

illumos and NetBSD >= 10 support Linux-compatble timerfd APIs.

# Sources

This is based on the headers for [illumos] and [NetBSD].

[illumos]: https://code.illumos.org/plugins/gitiles/illumos-gate/+/refs/heads/master/usr/src/uts/common/sys/timerfd.h#34
[NetBSD]: https://nxr.netbsd.org/xref/src/sys/sys/timerfd.h#44

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
