### PR TITLE
Fix typo in waitpid parameter name

### DIFF
--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -1725,7 +1725,7 @@ extern "C" {
     pub fn getppid() -> pid_t;
 
     // wait.h
-    pub fn waitpid(pid: pid_t, status: *mut c_int, optons: c_int) -> pid_t;
+    pub fn waitpid(pid: pid_t, status: *mut c_int, options: c_int) -> pid_t;
 
     // unistd.h
     pub fn sysconf(attr: c_int) -> c_long;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Corrected parameter spelling from 'optons' to 'options' in waitpid declaration. This matches POSIX standard naming for the options parameter used to specify waitpid behavior flags like WNOHANG and WUNTRACED.

ref: https://pubs.opengroup.org/onlinepubs/9699919799/functions/waitpid.html


<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
