### PR TITLE
Correct the definition of `pthread_t` on Darwin

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4065,8 +4065,7 @@ fn test_linux(target: &str) {
             "epoll_params" => true,
 
             // FIXME(linux): Requires >= 6.12 kernel headers.
-            "dmabuf_cmsg" |
-            "dmabuf_token" => true,
+            "dmabuf_cmsg" | "dmabuf_token" => true,
 
             _ => false,
         }

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -449,6 +449,7 @@ fn test_apple(target: &str) {
             // OSX calls this something else
             "sighandler_t" => "sig_t".to_string(),
 
+            "_opaque_pthread_t" => format!("struct {}", ty),
             t if is_union => format!("union {}", t),
             t if t.ends_with("_t") => t.to_string(),
             t if is_struct => format!("struct {}", t),

--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -1773,7 +1773,6 @@ _UTX_LINESIZE
 _UTX_USERSIZE
 _WSTATUS
 _WSTOPPED
-_opaque_pthread_t
 __PTHREAD_CONDATTR_SIZE__
 __PTHREAD_COND_SIZE__
 __PTHREAD_MUTEX_SIZE__
@@ -1785,6 +1784,7 @@ __darwin_mcontext64
 __darwin_pthread_handler_rec
 __darwin_pthread_t
 __error
+_opaque_pthread_t
 abs
 acct
 aio_cancel

--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -1773,13 +1773,17 @@ _UTX_LINESIZE
 _UTX_USERSIZE
 _WSTATUS
 _WSTOPPED
+_opaque_pthread_t
 __PTHREAD_CONDATTR_SIZE__
 __PTHREAD_COND_SIZE__
 __PTHREAD_MUTEX_SIZE__
 __PTHREAD_ONCE_SIZE__
 __PTHREAD_RWLOCKATTR_SIZE__
 __PTHREAD_RWLOCK_SIZE__
+__PTHREAD_SIZE__
 __darwin_mcontext64
+__darwin_pthread_handler_rec
+__darwin_pthread_t
 __error
 abs
 acct

--- a/src/unix/bsd/apple/b32/mod.rs
+++ b/src/unix/bsd/apple/b32/mod.rs
@@ -125,6 +125,7 @@ cfg_if! {
 #[deprecated(since = "0.2.55")]
 pub const NET_RT_MAXID: c_int = 10;
 
+pub const __PTHREAD_SIZE__: usize = 4088;
 pub const __PTHREAD_MUTEX_SIZE__: usize = 40;
 pub const __PTHREAD_COND_SIZE__: usize = 24;
 pub const __PTHREAD_CONDATTR_SIZE__: usize = 4;

--- a/src/unix/bsd/apple/b64/mod.rs
+++ b/src/unix/bsd/apple/b64/mod.rs
@@ -118,6 +118,7 @@ cfg_if! {
 #[deprecated(since = "0.2.55")]
 pub const NET_RT_MAXID: c_int = 11;
 
+pub const __PTHREAD_SIZE__: usize = 8176;
 pub const __PTHREAD_MUTEX_SIZE__: usize = 56;
 pub const __PTHREAD_COND_SIZE__: usize = 40;
 pub const __PTHREAD_CONDATTR_SIZE__: usize = 8;

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -5,7 +5,6 @@ pub type useconds_t = u32;
 pub type blkcnt_t = i64;
 pub type socklen_t = u32;
 pub type sa_family_t = u8;
-// pub type pthread_t = crate::uintptr_t;
 
 cfg_if! {
     if #[cfg(any(

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -5,7 +5,36 @@ pub type useconds_t = u32;
 pub type blkcnt_t = i64;
 pub type socklen_t = u32;
 pub type sa_family_t = u8;
-pub type pthread_t = crate::uintptr_t;
+// pub type pthread_t = crate::uintptr_t;
+
+cfg_if! {
+    if #[cfg(any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "visionos",
+        ))] {
+        s! {
+            pub struct __darwin_pthread_handler_rec {
+                __routine: Option<unsafe extern "C" fn(*mut c_void)>,
+                __arg: *mut c_void,
+                __next: *mut __darwin_pthread_handler_rec,
+            }
+            pub struct _opaque_pthread_t {
+                __sig: c_long,
+                __cleanup_stack: *mut __darwin_pthread_handler_rec,
+                __opaque: [c_char; __PTHREAD_SIZE__],
+            }
+        }
+        pub type __darwin_pthread_t = *mut _opaque_pthread_t;
+        pub type pthread_t = __darwin_pthread_t;
+    }
+    else {
+        pub type pthread_t = crate::uintptr_t;
+    }
+}
+
 pub type nfds_t = c_uint;
 pub type regoff_t = off_t;
 

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -9,12 +9,14 @@ pub type sa_family_t = u8;
 
 cfg_if! {
     if #[cfg(any(
-            target_os = "macos",
-            target_os = "ios",
-            target_os = "tvos",
-            target_os = "watchos",
-            target_os = "visionos",
-        ))] {
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+    ))] {
+        pub type __darwin_pthread_t = *mut _opaque_pthread_t;
+        pub type pthread_t = __darwin_pthread_t;
         s! {
             pub struct __darwin_pthread_handler_rec {
                 __routine: Option<unsafe extern "C" fn(*mut c_void)>,
@@ -27,10 +29,7 @@ cfg_if! {
                 __opaque: [c_char; __PTHREAD_SIZE__],
             }
         }
-        pub type __darwin_pthread_t = *mut _opaque_pthread_t;
-        pub type pthread_t = __darwin_pthread_t;
-    }
-    else {
+    } else {
         pub type pthread_t = crate::uintptr_t;
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

This PR Fixes rust-lang/libc#2903, however I am not sure if the change to `build.rs` is the right way to do it. MacOS has the `_opaque_pthread_t` type, however in `build.rs` it gets classified as a `type` rather than a struct, resulting in the test case for it using `_opaque_pthread_t` rather than `struct _opaque_pthread_t`. Please let me know if there is a better way to test `_opaque_pthread_t` without having to modify the build.rs file.

# Sources

https://github.com/apple-oss-distributions/xnu/blob/8d741a5de7ff4191bf97d57b9f54c2f6d4a15585/EXTERNAL_HEADERS/sys/_pthread/_pthread_types.h#L103
https://github.com/apple-oss-distributions/libpthread/blob/main/include/sys/_pthread/_pthread_t.h#L31

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
