### PR TITLE
android: Add getauxval for 32-bit targets

### DIFF
--- a/libc-test/semver/android.txt
+++ b/libc-test/semver/android.txt
@@ -3329,6 +3329,7 @@ fwrite_unlocked
 gai_strerror
 genlmsghdr
 getaddrinfo
+getauxval
 getchar
 getchar_unlocked
 getcwd

--- a/src/unix/linux_like/android/b64/mod.rs
+++ b/src/unix/linux_like/android/b64/mod.rs
@@ -305,7 +305,6 @@ f! {
 }
 
 extern "C" {
-    pub fn getauxval(type_: c_ulong) -> c_ulong;
     pub fn __system_property_wait(
         pi: *const crate::prop_info,
         __old_serial: u32,

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -4030,6 +4030,8 @@ extern "C" {
 
     pub fn gettid() -> crate::pid_t;
 
+    pub fn getauxval(type_: c_ulong) -> c_ulong;
+
     /// Only available in API Version 28+
     pub fn getrandom(buf: *mut c_void, buflen: size_t, flags: c_uint) -> ssize_t;
     pub fn getentropy(buf: *mut c_void, buflen: size_t) -> c_int;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description


[`getauxval` has been added in Android 4.3 (API level 18)](https://github.com/aosp-mirror/platform_bionic/blob/d3ebc2f7c49a9893b114124d4a6b315f3a328764/libc/include/sys/auxv.h#L49). ([Since Rust 1.68, std requires API level 19+](https://blog.rust-lang.org/2023/01/09/android-ndk-update-r25.html))

(On Android, getauxval is currently only provided for 64-bit targets https://github.com/rust-lang/libc/pull/1991)


<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
