### PR TITLE
Use unsafe callbacks

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4064,8 +4064,7 @@ fn test_linux(target: &str) {
             "epoll_params" => true,
 
             // FIXME(linux): Requires >= 6.12 kernel headers.
-            "dmabuf_cmsg" |
-            "dmabuf_token" => true,
+            "dmabuf_cmsg" | "dmabuf_token" => true,
 
             _ => false,
         }

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -3616,7 +3616,7 @@ extern "C" {
     pub fn abort() -> !;
     pub fn exit(status: c_int) -> !;
     pub fn _exit(status: c_int) -> !;
-    pub fn atexit(cb: extern "C" fn()) -> c_int;
+    pub fn atexit(cb: unsafe extern "C" fn()) -> c_int;
     pub fn system(s: *const c_char) -> c_int;
     pub fn getenv(s: *const c_char) -> *mut c_char;
 
@@ -4317,7 +4317,7 @@ extern "C" {
         abstime: *const crate::timespec,
     ) -> c_int;
     pub fn clone(
-        cb: extern "C" fn(*mut c_void) -> c_int,
+        cb: unsafe extern "C" fn(*mut c_void) -> c_int,
         child_stack: *mut c_void,
         flags: c_int,
         arg: *mut c_void,

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -3887,7 +3887,7 @@ extern "C" {
     pub fn pthread_spin_trylock(lock: *mut crate::pthread_spinlock_t) -> c_int;
     pub fn pthread_spin_unlock(lock: *mut crate::pthread_spinlock_t) -> c_int;
     pub fn clone(
-        cb: extern "C" fn(*mut c_void) -> c_int,
+        cb: unsafe extern "C" fn(*mut c_void) -> c_int,
         child_stack: *mut c_void,
         flags: c_int,
         arg: *mut c_void,

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -6573,7 +6573,7 @@ extern "C" {
     pub fn pthread_spin_trylock(lock: *mut crate::pthread_spinlock_t) -> c_int;
     pub fn pthread_spin_unlock(lock: *mut crate::pthread_spinlock_t) -> c_int;
     pub fn clone(
-        cb: extern "C" fn(*mut c_void) -> c_int,
+        cb: unsafe extern "C" fn(*mut c_void) -> c_int,
         child_stack: *mut c_void,
         flags: c_int,
         arg: *mut c_void,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1671,7 +1671,7 @@ cfg_if! {
             ) -> ssize_t;
             pub fn fmemopen(buf: *mut c_void, size: size_t, mode: *const c_char) -> *mut FILE;
             pub fn open_memstream(ptr: *mut *mut c_char, sizeloc: *mut size_t) -> *mut FILE;
-            pub fn atexit(cb: extern "C" fn()) -> c_int;
+            pub fn atexit(cb: unsafe extern "C" fn()) -> c_int;
             #[cfg_attr(target_os = "netbsd", link_name = "__sigaction14")]
             pub fn sigaction(signum: c_int, act: *const sigaction, oldact: *mut sigaction)
                 -> c_int;

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -3418,10 +3418,14 @@ extern "C" {
 
 // Models the implementation in stdlib.h.  Ctest will fail if trying to use the
 // default symbol from libc
-pub unsafe fn atexit(cb: extern "C" fn()) -> c_int {
+pub unsafe fn atexit(cb: unsafe extern "C" fn()) -> c_int {
     extern "C" {
         static __dso_handle: *mut c_void;
-        pub fn __cxa_atexit(cb: extern "C" fn(), __arg: *mut c_void, __dso: *mut c_void) -> c_int;
+        pub fn __cxa_atexit(
+            cb: unsafe extern "C" fn(),
+            __arg: *mut c_void,
+            __dso: *mut c_void,
+        ) -> c_int;
     }
     __cxa_atexit(cb, 0 as *mut c_void, __dso_handle)
 }

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -1197,7 +1197,7 @@ extern "C" {
     pub fn free(p: *mut c_void);
     pub fn abort() -> !;
     pub fn exit(status: c_int) -> !;
-    pub fn atexit(cb: extern "C" fn()) -> c_int;
+    pub fn atexit(cb: unsafe extern "C" fn()) -> c_int;
     pub fn system(s: *const c_char) -> c_int;
     pub fn getenv(s: *const c_char) -> *mut c_char;
 

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -334,7 +334,7 @@ extern "C" {
     pub fn abort() -> !;
     pub fn exit(status: c_int) -> !;
     pub fn _exit(status: c_int) -> !;
-    pub fn atexit(cb: extern "C" fn()) -> c_int;
+    pub fn atexit(cb: unsafe extern "C" fn()) -> c_int;
     pub fn system(s: *const c_char) -> c_int;
     pub fn getenv(s: *const c_char) -> *mut c_char;
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->
This PR changes the callback function type to be unsafe rather than safe in (i believe) all functions that need a callback function, as per the discussion in #2198.

Closes #2198 

# Sources

<!-- All API changes must have links to headers and/or documentation,
preferably both -->
As no APIs were changes (other than making the callback type unsafe), and safe vs unsafe functions are not documented in the linux documentation/header files, there are no sources.

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
