### PR TITLE
adding secure_getenv for solaris/illumos.

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1253,6 +1253,10 @@ fn test_solarish(target: &str) {
             // https://github.com/gnzlbg/ctest/issues/68
             "lio_listio" => true,
 
+            // Exists on illumos too but, for now, is
+            // [a recent addition](https://www.illumos.org/issues/17094).
+            "secure_getenv" if is_illumos => true,
+
             _ => false,
         }
     });
@@ -4064,8 +4068,7 @@ fn test_linux(target: &str) {
             "epoll_params" => true,
 
             // FIXME(linux): Requires >= 6.12 kernel headers.
-            "dmabuf_cmsg" |
-            "dmabuf_token" => true,
+            "dmabuf_cmsg" | "dmabuf_token" => true,
 
             _ => false,
         }

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -3201,6 +3201,8 @@ extern "C" {
     pub fn arc4random() -> u32;
     pub fn arc4random_buf(buf: *mut c_void, nbytes: size_t);
     pub fn arc4random_uniform(upper_bound: u32) -> u32;
+
+    pub fn secure_getenv(name: *const c_char) -> *mut c_char;
 }
 
 #[link(name = "sendfile")]


### PR DESCRIPTION
[solaris](https://docs.oracle.com/cd/E88353_01/html/E37843/secure-getenv-3c.html) [illumos](https://github.com/illumos/illumos-gate/blob/dc7ec32189c86a0f330aee77229dad2ad57eac71/usr/src/man/man3c/getenv.3c#L12)
