### PR TITLE
 Add new cfg gnu_file_offset_bits64 corresponding to _FILE_OFFSET_BITS=64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,12 @@ jobs:
           - target: i686-unknown-linux-gnu
             docker: true
             os: ubuntu-24.04
+          - target: i686-unknown-linux-gnu
+            docker: true
+            os: ubuntu-24.04
+            artifact-tag: offset-bits64
+            env:
+              RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS: 64
           - target: x86_64-unknown-linux-gnu
             docker: true
             os: ubuntu-24.04
@@ -128,7 +134,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always() && steps.create_artifacts.outcome == 'success'
         with:
-          name: ${{ env.ARCHIVE_NAME }}-${{ matrix.target }}
+          name: ${{ env.ARCHIVE_NAME }}-${{ matrix.target }}${{ matrix.artifact-tag && format('-{0}', matrix.artifact-tag) }}
           path: ${{ env.ARCHIVE_PATH }}
           retention-days: 5
 
@@ -148,15 +154,11 @@ jobs:
           - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl
           - arm-linux-androideabi
-          - arm-unknown-linux-gnueabihf
           - arm-unknown-linux-musleabihf
           - i686-linux-android
           - i686-unknown-linux-musl
           - loongarch64-unknown-linux-gnu
           - loongarch64-unknown-linux-musl
-          # FIXME(ppc): SIGILL running tests, see
-          # https://github.com/rust-lang/libc/pull/4254#issuecomment-2636288713
-          # - powerpc-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
           - powerpc64le-unknown-linux-gnu
           - riscv64gc-unknown-linux-gnu
@@ -171,6 +173,19 @@ jobs:
           # FIXME: It seems some items in `src/unix/mod.rs`
           # aren't defined on redox actually.
           # - x86_64-unknown-redox
+        include:
+          - target: arm-unknown-linux-gnueabihf
+          - target: arm-unknown-linux-gnueabihf
+            env:
+              RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS: 64
+            artifact-tag: offset-bits64
+          # FIXME(ppc): SIGILL running tests, see
+          # https://github.com/rust-lang/libc/pull/4254#issuecomment-2636288713
+          # - target: powerpc-unknown-linux-gnu
+          # - target: powerpc-unknown-linux-gnu
+          #   env:
+          #     RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS: 64
+          #   artifact-tag: offset-bits64
     timeout-minutes: 25
     env:
       TARGET: ${{ matrix.target }}
@@ -199,7 +214,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always() && steps.create_artifacts.outcome == 'success'
         with:
-          name: ${{ env.ARCHIVE_NAME }}-${{ matrix.target }}
+          name: ${{ env.ARCHIVE_NAME }}-${{ matrix.target }}${{ matrix.artifact-tag && format('-{0}', matrix.artifact-tag) }}
           path: ${{ env.ARCHIVE_PATH }}
           retention-days: 5
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,9 +122,11 @@ jobs:
         run: ./ci/run-docker.sh ${{ matrix.target }}
 
       - name: Create CI artifacts
+        id: create_artifacts
         if: always()
         run: ./ci/create-artifacts.py
       - uses: actions/upload-artifact@v4
+        if: always() && steps.create_artifacts.outcome == 'success'
         with:
           name: ${{ env.ARCHIVE_NAME }}-${{ matrix.target }}
           path: ${{ env.ARCHIVE_PATH }}
@@ -191,9 +193,11 @@ jobs:
         run: ./ci/run-docker.sh ${{ matrix.target }}
 
       - name: Create CI artifacts
+        id: create_artifacts
         if: always()
         run: ./ci/create-artifacts.py
       - uses: actions/upload-artifact@v4
+        if: always() && steps.create_artifacts.outcome == 'success'
         with:
           name: ${{ env.ARCHIVE_NAME }}-${{ matrix.target }}
           path: ${{ env.ARCHIVE_PATH }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,6 +107,13 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
+      - name: Add matrix env variables to the environment
+        if: matrix.env
+        run: |
+          echo '${{ toJson(matrix.env) }}' |
+            jq -r 'to_entries | map("\(.key)=\(.value|tostring)") | .[]' >>$GITHUB_ENV
+        shell: bash
+
       - name: Run natively
         if: "!matrix.docker"
         run: ./ci/run.sh ${{ matrix.target }}
@@ -172,6 +179,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
+
+      - name: Add matrix env variables to the environment
+        if: matrix.env
+        run: |
+          echo '${{ toJson(matrix.env) }}' |
+            jq -r 'to_entries | map("\(.key)=\(.value|tostring)") | .[]' >>$GITHUB_ENV
+        shell: bash
 
       - name: Execute run-docker.sh
         run: ./ci/run-docker.sh ${{ matrix.target }}

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,8 @@ const ALLOWED_CFGS: &'static [&'static str] = &[
     "freebsd13",
     "freebsd14",
     "freebsd15",
+    // Corresponds to `_FILE_OFFSET_BITS=64` in glibc
+    "gnu_file_offset_bits64",
     // FIXME(ctest): this config shouldn't be needed but ctest can't parse `const extern fn`
     "libc_const_extern_fn",
     "libc_deny_warnings",
@@ -43,6 +45,10 @@ fn main() {
     let (rustc_minor_ver, _is_nightly) = rustc_minor_nightly();
     let rustc_dep_of_std = env::var("CARGO_FEATURE_RUSTC_DEP_OF_STD").is_ok();
     let libc_ci = env::var("LIBC_CI").is_ok();
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_ptr_width = env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap_or_default();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
 
     // The ABI of libc used by std is backward compatible with FreeBSD 12.
     // The ABI of libc from crates.io is backward compatible with FreeBSD 12.
@@ -83,6 +89,23 @@ fn main() {
     println!("cargo:rerun-if-env-changed=RUST_LIBC_UNSTABLE_LINUX_TIME_BITS64");
     if linux_time_bits64 {
         set_cfg("linux_time_bits64");
+    }
+    println!("cargo:rerun-if-env-changed=RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS");
+    match env::var("RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS") {
+        Ok(val) if val == "64" => {
+            if target_env == "gnu"
+                && target_os == "linux"
+                && target_ptr_width == "32"
+                && target_arch != "riscv32"
+                && target_arch != "x86_64"
+            {
+                set_cfg("gnu_file_offset_bits64");
+            }
+        }
+        Ok(val) if val != "32" => {
+            panic!("RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS may only be set to '32' or '64'")
+        }
+        _ => {}
     }
 
     // On CI: deny all warnings

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -43,6 +43,7 @@ run() {
         --user "$(id -u)":"$(id -g)" \
         --env LIBC_CI \
         --env LIBC_CI_ZBUILD_STD \
+        --env RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS \
         --env CARGO_HOME=/cargo \
         --env CARGO_TARGET_DIR=/checkout/target \
         --volume "$CARGO_HOME":/cargo \

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -47,8 +47,8 @@ run() {
         --env CARGO_TARGET_DIR=/checkout/target \
         --volume "$CARGO_HOME":/cargo \
         --volume "$(rustc --print sysroot)":/rust:ro \
-        --volume "$(pwd)":/checkout:ro \
-        --volume "$(pwd)"/target:/checkout/target \
+        --volume "$PWD":/checkout:ro \
+        --volume "$PWD"/target:/checkout/target \
         $kvm \
         --init \
         --workdir /checkout \

--- a/ci/verify-build.sh
+++ b/ci/verify-build.sh
@@ -74,6 +74,11 @@ test_target() {
     if [ "$os" = "linux" ]; then
         # Test with the equivalent of __USE_TIME_BITS64
         RUST_LIBC_UNSTABLE_LINUX_TIME_BITS64=1 $cmd
+        case "$target" in
+            # Test with the equivalent of __FILE_OFFSET_BITS=64
+            arm*-gnu*|i*86*-gnu|powerpc-*-gnu*|mips*-gnu|sparc-*-gnu|thumb-*gnu*)
+                RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS=64 $cmd;;
+        esac
     fi
 
     # Test again without default features, i.e. without "std"
@@ -91,7 +96,7 @@ test_target() {
         stable-x86_64-*freebsd*) do_freebsd_checks=1 ;;
         nightly-i686*freebsd*) do_freebsd_checks=1 ;;
     esac
-    
+
     if [ -n "${do_freebsd_checks:-}" ]; then
         for version in $freebsd_versions; do
             export RUST_LIBC_UNSTABLE_FREEBSD_VERSION="$version"
@@ -296,7 +301,7 @@ filter_and_run() {
         if [ "$target" = "wasm32-wasip2" ] && [ "$supports_wasi_pn" = "0" ]; then
             return
         fi
-            
+
         test_target "$target" "$no_dist"
         some_tests_run=1
     fi

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3587,6 +3587,26 @@ fn test_vxworks(target: &str) {
     cfg.generate(src_hotfix_dir().join("lib.rs"), "main.rs");
 }
 
+fn config_gnu_bits(target: &str, cfg: &mut ctest::TestGenerator) {
+    match env::var("RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS") {
+        Ok(val) if val == "64" => {
+            if target.contains("gnu")
+                && target.contains("linux")
+                && !target.ends_with("x32")
+                && !target.contains("riscv32")
+                && env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap() == "32"
+            {
+                cfg.define("_FILE_OFFSET_BITS", Some("64"));
+                cfg.cfg("gnu_file_offset_bits64", None);
+            }
+        }
+        Ok(val) if val != "32" => {
+            panic!("RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS may only be set to '32' or '64'")
+        }
+        _ => {}
+    }
+}
+
 fn test_linux(target: &str) {
     assert!(target.contains("linux"));
 
@@ -3629,6 +3649,8 @@ fn test_linux(target: &str) {
     // deprecated since glibc >= 2.29. This allows Rust binaries to link against
     // glibc versions older than 2.29.
     cfg.define("__GLIBC_USE_DEPRECATED_SCANF", None);
+
+    config_gnu_bits(target, &mut cfg);
 
     headers! { cfg:
                "ctype.h",
@@ -4791,6 +4813,7 @@ fn test_linux_like_apis(target: &str) {
     if linux || android || emscripten {
         // test strerror_r from the `string.h` header
         let mut cfg = ctest_cfg();
+        config_gnu_bits(target, &mut cfg);
         cfg.skip_type(|_| true).skip_static(|_| true);
 
         headers! { cfg: "string.h" }
@@ -4807,6 +4830,7 @@ fn test_linux_like_apis(target: &str) {
         // test fcntl - see:
         // http://man7.org/linux/man-pages/man2/fcntl.2.html
         let mut cfg = ctest_cfg();
+        config_gnu_bits(target, &mut cfg);
 
         if musl {
             cfg.header("fcntl.h");
@@ -4836,6 +4860,7 @@ fn test_linux_like_apis(target: &str) {
     if (linux && !wali) || android {
         // test termios
         let mut cfg = ctest_cfg();
+        config_gnu_bits(target, &mut cfg);
         cfg.header("asm/termbits.h");
         cfg.header("linux/termios.h");
         cfg.skip_type(|_| true)
@@ -4860,6 +4885,7 @@ fn test_linux_like_apis(target: &str) {
     if linux || android {
         // test IPV6_ constants:
         let mut cfg = ctest_cfg();
+        config_gnu_bits(target, &mut cfg);
         headers! {
             cfg:
             "linux/in6.h"
@@ -4891,6 +4917,7 @@ fn test_linux_like_apis(target: &str) {
         // "resolve.h" defines a `p_type` macro that expands to `__p_type`
         // making the tests for these fails when both are included.
         let mut cfg = ctest_cfg();
+        config_gnu_bits(target, &mut cfg);
         cfg.header("elf.h");
         cfg.skip_fn(|_| true)
             .skip_static(|_| true)
@@ -4910,6 +4937,7 @@ fn test_linux_like_apis(target: &str) {
     if (linux && !wali) || android {
         // Test `ARPHRD_CAN`.
         let mut cfg = ctest_cfg();
+        config_gnu_bits(target, &mut cfg);
         cfg.header("linux/if_arp.h");
         cfg.skip_fn(|_| true)
             .skip_static(|_| true)

--- a/src/unix/linux_like/linux/arch/mips/mod.rs
+++ b/src/unix/linux_like/linux/arch/mips/mod.rs
@@ -379,8 +379,13 @@ cfg_if! {
 cfg_if! {
     if #[cfg(all(
         any(target_arch = "mips", target_arch = "mips32r6"),
-        any(target_env = "uclibc", target_env = "gnu"),
-        linux_time_bits64
+        any(
+            all(target_env = "uclibc", linux_time_bits64),
+            all(
+                target_env = "gnu",
+                any(linux_time_bits64, gnu_file_offset_bits64)
+            )
+        )
     ))] {
         pub const RLIM_INFINITY: crate::rlim_t = !0;
     } else if #[cfg(all(

--- a/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
@@ -61,7 +61,7 @@ s! {
     pub struct stat64 {
         pub st_dev: crate::dev_t,
         __pad1: c_uint,
-        __st_ino: crate::ino_t,
+        __st_ino: c_ulong,
         pub st_mode: crate::mode_t,
         pub st_nlink: crate::nlink_t,
         pub st_uid: crate::uid_t,

--- a/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
@@ -397,7 +397,13 @@ pub const MCL_ONFAULT: c_int = 0x0004;
 pub const POLLWRNORM: c_short = 0x100;
 pub const POLLWRBAND: c_short = 0x200;
 
-pub const F_GETLK: c_int = 5;
+cfg_if! {
+    if #[cfg(gnu_file_offset_bits64)] {
+        pub const F_GETLK: c_int = 12;
+    } else {
+        pub const F_GETLK: c_int = 5;
+    }
+}
 pub const F_GETOWN: c_int = 9;
 pub const F_SETOWN: c_int = 8;
 

--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -8,22 +8,36 @@ s! {
         pub st_dev: c_ulong,
 
         st_pad1: [c_long; 3],
+
         pub st_ino: crate::ino_t,
+
         pub st_mode: crate::mode_t,
         pub st_nlink: crate::nlink_t,
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
+
         pub st_rdev: c_ulong,
+
+        #[cfg(not(gnu_file_offset_bits64))]
         st_pad2: [c_long; 2],
+        #[cfg(gnu_file_offset_bits64)]
+        st_pad2: [c_long; 3],
+
         pub st_size: off_t,
+
+        #[cfg(not(gnu_file_offset_bits64))]
         st_pad3: c_long,
+
         pub st_atime: crate::time_t,
         pub st_atime_nsec: c_long,
         pub st_mtime: crate::time_t,
         pub st_mtime_nsec: c_long,
         pub st_ctime: crate::time_t,
         pub st_ctime_nsec: c_long,
+
         pub st_blksize: crate::blksize_t,
+        #[cfg(gnu_file_offset_bits64)]
+        st_pad4: c_long,
         pub st_blocks: crate::blkcnt_t,
         st_pad5: [c_long; 14],
     }

--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -190,9 +190,11 @@ s! {
         pub l_whence: c_short,
         pub l_start: off_t,
         pub l_len: off_t,
+        #[cfg(not(gnu_file_offset_bits64))]
         pub l_sysid: c_long,
         pub l_pid: crate::pid_t,
-        pad: [c_long; 4],
+        #[cfg(not(gnu_file_offset_bits64))]
+        __glibc_reserved0: [c_long; 4],
     }
 }
 

--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -51,7 +51,7 @@ s! {
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
         pub st_rdev: c_ulong,
-        st_pad2: [c_long; 2],
+        st_pad2: [c_long; 3],
         pub st_size: off64_t,
         pub st_atime: crate::time_t,
         pub st_atime_nsec: c_long,

--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -745,7 +745,13 @@ pub const MAP_HUGETLB: c_int = 0x080000;
 
 pub const EFD_NONBLOCK: c_int = 0x80;
 
-pub const F_GETLK: c_int = 14;
+cfg_if! {
+    if #[cfg(gnu_file_offset_bits64)] {
+        pub const F_GETLK: c_int = 33;
+    } else {
+        pub const F_GETLK: c_int = 14;
+    }
+}
 pub const F_GETOWN: c_int = 23;
 pub const F_SETOWN: c_int = 24;
 

--- a/src/unix/linux_like/linux/gnu/b32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mod.rs
@@ -20,7 +20,9 @@ cfg_if! {
     if #[cfg(target_arch = "riscv32")] {
         pub type time_t = i64;
         pub type suseconds_t = i64;
-        pub type ino_t = u64;
+        type __ino_t = c_ulong;
+        type __ino64_t = u64;
+        pub type ino_t = __ino64_t;
         pub type off_t = i64;
         pub type blkcnt_t = i64;
         pub type fsblkcnt_t = u64;
@@ -30,7 +32,9 @@ cfg_if! {
     } else if #[cfg(gnu_file_offset_bits64)] {
         pub type time_t = i32;
         pub type suseconds_t = i32;
-        pub type ino_t = u64;
+        type __ino_t = c_ulong;
+        type __ino64_t = u64;
+        pub type ino_t = __ino64_t;
         pub type off_t = i64;
         pub type blkcnt_t = i64;
         pub type fsblkcnt_t = u64;
@@ -40,7 +44,9 @@ cfg_if! {
     } else {
         pub type time_t = i32;
         pub type suseconds_t = i32;
-        pub type ino_t = u32;
+        type __ino_t = c_ulong;
+        type __ino64_t = u64;
+        pub type ino_t = __ino_t;
         pub type off_t = i32;
         pub type blkcnt_t = i32;
         pub type fsblkcnt_t = c_ulong;
@@ -61,25 +67,40 @@ cfg_if! {
             pub struct stat {
                 pub st_dev: crate::dev_t,
 
-                __pad1: c_short,
+                __pad1: c_uint,
+
+                #[cfg(not(gnu_file_offset_bits64))]
                 pub st_ino: crate::ino_t,
+                #[cfg(all(gnu_file_offset_bits64))]
+                __st_ino: __ino_t,
+
                 pub st_mode: crate::mode_t,
                 pub st_nlink: crate::nlink_t,
                 pub st_uid: crate::uid_t,
                 pub st_gid: crate::gid_t,
+
                 pub st_rdev: crate::dev_t,
-                __pad2: c_short,
+
+                __pad2: c_uint,
+
                 pub st_size: off_t,
+
                 pub st_blksize: crate::blksize_t,
                 pub st_blocks: crate::blkcnt_t,
+
                 pub st_atime: crate::time_t,
                 pub st_atime_nsec: c_long,
                 pub st_mtime: crate::time_t,
                 pub st_mtime_nsec: c_long,
                 pub st_ctime: crate::time_t,
                 pub st_ctime_nsec: c_long,
-                __unused4: c_long,
-                __unused5: c_long,
+
+                #[cfg(not(gnu_file_offset_bits64))]
+                __glibc_reserved4: c_long,
+                #[cfg(not(gnu_file_offset_bits64))]
+                __glibc_reserved5: c_long,
+                #[cfg(gnu_file_offset_bits64)]
+                pub st_ino: crate::ino_t,
             }
         }
     }

--- a/src/unix/linux_like/linux/gnu/b32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mod.rs
@@ -177,9 +177,6 @@ cfg_if! {
 
         pub const PTRACE_DETACH: c_uint = 11;
 
-        pub const F_SETLK: c_int = 8;
-        pub const F_SETLKW: c_int = 9;
-
         pub const F_RDLCK: c_int = 1;
         pub const F_WRLCK: c_int = 2;
         pub const F_UNLCK: c_int = 3;
@@ -223,9 +220,6 @@ cfg_if! {
 
         pub const PTRACE_DETACH: c_uint = 17;
 
-        pub const F_SETLK: c_int = 6;
-        pub const F_SETLKW: c_int = 7;
-
         pub const F_RDLCK: c_int = 0;
         pub const F_WRLCK: c_int = 1;
         pub const F_UNLCK: c_int = 2;
@@ -259,6 +253,24 @@ cfg_if! {
         pub const EPOLL_CLOEXEC: c_int = 0x80000;
 
         pub const EFD_CLOEXEC: c_int = 0x80000;
+    }
+}
+cfg_if! {
+    if #[cfg(target_arch = "sparc")] {
+        pub const F_SETLK: c_int = 8;
+        pub const F_SETLKW: c_int = 9;
+    } else if #[cfg(all(
+        gnu_file_offset_bits64,
+        any(target_arch = "mips", target_arch = "mips32r6")
+    ))] {
+        pub const F_SETLK: c_int = 34;
+        pub const F_SETLKW: c_int = 35;
+    } else if #[cfg(gnu_file_offset_bits64)] {
+        pub const F_SETLK: c_int = 13;
+        pub const F_SETLKW: c_int = 14;
+    } else {
+        pub const F_SETLK: c_int = 6;
+        pub const F_SETLKW: c_int = 7;
     }
 }
 

--- a/src/unix/linux_like/linux/gnu/b32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mod.rs
@@ -54,7 +54,8 @@ cfg_if! {
     if #[cfg(not(any(
         target_arch = "mips",
         target_arch = "mips32r6",
-        target_arch = "powerpc"
+        target_arch = "powerpc",
+        target_arch = "sparc"
     )))] {
         s! {
             pub struct stat {

--- a/src/unix/linux_like/linux/gnu/b32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mod.rs
@@ -51,7 +51,11 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(not(any(target_arch = "mips", target_arch = "mips32r6")))] {
+    if #[cfg(not(any(
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "powerpc"
+    )))] {
         s! {
             pub struct stat {
                 pub st_dev: crate::dev_t,

--- a/src/unix/linux_like/linux/gnu/b32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mod.rs
@@ -27,6 +27,16 @@ cfg_if! {
         pub type fsfilcnt_t = u64;
         pub type rlim_t = u64;
         pub type blksize_t = i64;
+    } else if #[cfg(gnu_file_offset_bits64)] {
+        pub type time_t = i32;
+        pub type suseconds_t = i32;
+        pub type ino_t = u64;
+        pub type off_t = i64;
+        pub type blkcnt_t = i64;
+        pub type fsblkcnt_t = u64;
+        pub type fsfilcnt_t = u64;
+        pub type rlim_t = u64;
+        pub type blksize_t = i32;
     } else {
         pub type time_t = i32;
         pub type suseconds_t = i32;

--- a/src/unix/linux_like/linux/gnu/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/gnu/b32/powerpc.rs
@@ -301,7 +301,13 @@ pub const MCL_ONFAULT: c_int = 0x8000;
 pub const POLLWRNORM: c_short = 0x100;
 pub const POLLWRBAND: c_short = 0x200;
 
-pub const F_GETLK: c_int = 5;
+cfg_if! {
+    if #[cfg(gnu_file_offset_bits64)] {
+        pub const F_GETLK: c_int = 12;
+    } else {
+        pub const F_GETLK: c_int = 5;
+    }
+}
 pub const F_GETOWN: c_int = 9;
 pub const F_SETOWN: c_int = 8;
 

--- a/src/unix/linux_like/linux/gnu/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/gnu/b32/powerpc.rs
@@ -57,6 +57,28 @@ s! {
         __glibc_reserved2: u64,
     }
 
+    pub struct stat {
+        pub st_dev: crate::dev_t,
+        pub st_ino: crate::ino_t,
+        pub st_mode: crate::mode_t,
+        pub st_nlink: crate::nlink_t,
+        pub st_uid: crate::uid_t,
+        pub st_gid: crate::gid_t,
+        pub st_rdev: crate::dev_t,
+        __pad2: c_ushort,
+        pub st_size: off_t,
+        pub st_blksize: crate::blksize_t,
+        pub st_blocks: crate::blkcnt_t,
+        pub st_atime: crate::time_t,
+        pub st_atime_nsec: c_long,
+        pub st_mtime: crate::time_t,
+        pub st_mtime_nsec: c_long,
+        pub st_ctime: crate::time_t,
+        pub st_ctime_nsec: c_long,
+        __glibc_reserved4: c_ulong,
+        __glibc_reserved5: c_ulong,
+    }
+
     pub struct stat64 {
         pub st_dev: crate::dev_t,
         pub st_ino: crate::ino64_t,

--- a/src/unix/linux_like/linux/gnu/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/gnu/b32/powerpc.rs
@@ -59,6 +59,8 @@ s! {
 
     pub struct stat {
         pub st_dev: crate::dev_t,
+        #[cfg(not(gnu_file_offset_bits64))]
+        __pad1: c_ushort,
         pub st_ino: crate::ino_t,
         pub st_mode: crate::mode_t,
         pub st_nlink: crate::nlink_t,

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -26,7 +26,8 @@ s! {
 
         pub f_namelen: crate::__fsword_t,
         pub f_frsize: crate::__fsword_t,
-        f_spare: [crate::__fsword_t; 5],
+        pub f_flags: crate::__fsword_t,
+        f_spare: [crate::__fsword_t; 4],
     }
 
     pub struct siginfo_t {

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -102,7 +102,8 @@ s! {
         pub st_mtime_nsec: c_long,
         pub st_ctime: crate::time_t,
         pub st_ctime_nsec: c_long,
-        __reserved: [c_long; 2],
+        __glibc_reserved4: c_ulong,
+        __glibc_reserved5: c_ulong,
     }
 
     pub struct statfs64 {

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -62,6 +62,7 @@ s! {
 
     pub struct stat {
         pub st_dev: crate::dev_t,
+        #[cfg(not(gnu_file_offset_bits64))]
         __pad1: c_ushort,
         pub st_ino: crate::ino_t,
         pub st_mode: crate::mode_t,

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -131,6 +131,7 @@ s! {
         pub f_ffree: u64,
         pub f_favail: u64,
         pub f_fsid: c_ulong,
+        __f_unused: c_int,
         pub f_flag: c_ulong,
         pub f_namemax: c_ulong,
         __f_spare: [c_int; 6],

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -60,6 +60,29 @@ s! {
         pub ss_size: size_t,
     }
 
+    pub struct stat {
+        pub st_dev: crate::dev_t,
+        __pad1: c_ushort,
+        pub st_ino: crate::ino_t,
+        pub st_mode: crate::mode_t,
+        pub st_nlink: crate::nlink_t,
+        pub st_uid: crate::uid_t,
+        pub st_gid: crate::gid_t,
+        pub st_rdev: crate::dev_t,
+        __pad2: c_ushort,
+        pub st_size: off_t,
+        pub st_blksize: crate::blksize_t,
+        pub st_blocks: crate::blkcnt_t,
+        pub st_atime: crate::time_t,
+        pub st_atime_nsec: c_long,
+        pub st_mtime: crate::time_t,
+        pub st_mtime_nsec: c_long,
+        pub st_ctime: crate::time_t,
+        pub st_ctime_nsec: c_long,
+        __glibc_reserved4: c_ulong,
+        __glibc_reserved5: c_ulong,
+    }
+
     pub struct stat64 {
         pub st_dev: crate::dev_t,
         pub st_ino: crate::ino64_t,

--- a/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
@@ -499,7 +499,13 @@ pub const SA_NOCLDWAIT: c_int = 0x00000002;
 pub const SOCK_STREAM: c_int = 1;
 pub const SOCK_DGRAM: c_int = 2;
 
-pub const F_GETLK: c_int = 5;
+cfg_if! {
+    if #[cfg(gnu_file_offset_bits64)] {
+        pub const F_GETLK: c_int = 12;
+    } else {
+        pub const F_GETLK: c_int = 5;
+    }
+}
 pub const F_GETOWN: c_int = 9;
 pub const F_SETOWN: c_int = 8;
 

--- a/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
@@ -135,7 +135,7 @@ s! {
     pub struct stat64 {
         pub st_dev: crate::dev_t,
         __pad1: c_uint,
-        __st_ino: crate::ino_t,
+        __st_ino: c_ulong,
         pub st_mode: crate::mode_t,
         pub st_nlink: crate::nlink_t,
         pub st_uid: crate::uid_t,

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -451,7 +451,11 @@ s_no_extra_traits! {
         __return_value: ssize_t,
         // FIXME(off64): visible fields depend on __USE_FILE_OFFSET64
         pub aio_offset: off_t,
-        #[cfg(all(not(target_arch = "x86_64"), target_pointer_width = "32"))]
+        #[cfg(all(
+            not(gnu_file_offset_bits64),
+            not(target_arch = "x86_64"),
+            target_pointer_width = "32"
+        ))]
         __pad: [c_char; 4],
         __glibc_reserved: [c_char; 32],
     }

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1203,8 +1203,11 @@ extern "C" {
     pub fn getrlimit64(resource: crate::__rlimit_resource_t, rlim: *mut crate::rlimit64) -> c_int;
     pub fn setrlimit64(resource: crate::__rlimit_resource_t, rlim: *const crate::rlimit64)
         -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "getrlimit64")]
     pub fn getrlimit(resource: crate::__rlimit_resource_t, rlim: *mut crate::rlimit) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "setrlimit64")]
     pub fn setrlimit(resource: crate::__rlimit_resource_t, rlim: *const crate::rlimit) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "prlimit64")]
     pub fn prlimit(
         pid: crate::pid_t,
         resource: crate::__rlimit_resource_t,
@@ -1245,6 +1248,7 @@ extern "C" {
         dirfd: c_int,
         path: *const c_char,
     ) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "preadv64v2")]
     pub fn preadv2(
         fd: c_int,
         iov: *const crate::iovec,
@@ -1252,6 +1256,7 @@ extern "C" {
         offset: off_t,
         flags: c_int,
     ) -> ssize_t;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "pwritev64v2")]
     pub fn pwritev2(
         fd: c_int,
         iov: *const crate::iovec,

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -389,6 +389,24 @@ s! {
         #[cfg(target_pointer_width = "64")]
         __size: [c_char; 32],
     }
+
+    pub struct mbstate_t {
+        __count: c_int,
+        __wchb: [c_char; 4],
+    }
+
+    pub struct fpos64_t {
+        __pos: off64_t,
+        __state: crate::mbstate_t,
+    }
+
+    pub struct fpos_t {
+        #[cfg(not(gnu_file_offset_bits64))]
+        __pos: off_t,
+        #[cfg(gnu_file_offset_bits64)]
+        __pos: off64_t,
+        __state: crate::mbstate_t,
+    }
 }
 
 impl siginfo_t {

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -6260,17 +6260,23 @@ cfg_if! {
 cfg_if! {
     if #[cfg(all(not(target_env = "uclibc"), not(target_env = "ohos")))] {
         extern "C" {
+            #[cfg_attr(gnu_file_offset_bits64, link_name = "aio_read64")]
             pub fn aio_read(aiocbp: *mut aiocb) -> c_int;
+            #[cfg_attr(gnu_file_offset_bits64, link_name = "aio_write64")]
             pub fn aio_write(aiocbp: *mut aiocb) -> c_int;
             pub fn aio_fsync(op: c_int, aiocbp: *mut aiocb) -> c_int;
+            #[cfg_attr(gnu_file_offset_bits64, link_name = "aio_error64")]
             pub fn aio_error(aiocbp: *const aiocb) -> c_int;
+            #[cfg_attr(gnu_file_offset_bits64, link_name = "aio_return64")]
             pub fn aio_return(aiocbp: *mut aiocb) -> ssize_t;
             pub fn aio_suspend(
                 aiocb_list: *const *const aiocb,
                 nitems: c_int,
                 timeout: *const crate::timespec,
             ) -> c_int;
+            #[cfg_attr(gnu_file_offset_bits64, link_name = "aio_cancel64")]
             pub fn aio_cancel(fd: c_int, aiocbp: *mut aiocb) -> c_int;
+            #[cfg_attr(gnu_file_offset_bits64, link_name = "lio_listio64")]
             pub fn lio_listio(
                 mode: c_int,
                 aiocb_list: *const *mut aiocb,
@@ -6284,12 +6290,14 @@ cfg_if! {
 cfg_if! {
     if #[cfg(not(target_env = "uclibc"))] {
         extern "C" {
+            #[cfg_attr(gnu_file_offset_bits64, link_name = "pwritev64")]
             pub fn pwritev(
                 fd: c_int,
                 iov: *const crate::iovec,
                 iovcnt: c_int,
                 offset: off_t,
             ) -> ssize_t;
+            #[cfg_attr(gnu_file_offset_bits64, link_name = "preadv64")]
             pub fn preadv(
                 fd: c_int,
                 iov: *const crate::iovec,
@@ -6454,7 +6462,9 @@ extern "C" {
     pub fn mprotect(addr: *mut c_void, len: size_t, prot: c_int) -> c_int;
     pub fn __errno_location() -> *mut c_int;
 
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "fallocate64")]
     pub fn fallocate(fd: c_int, mode: c_int, offset: off_t, len: off_t) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "posix_fallocate64")]
     pub fn posix_fallocate(fd: c_int, offset: off_t, len: off_t) -> c_int;
     pub fn readahead(fd: c_int, offset: off64_t, count: size_t) -> ssize_t;
     pub fn getxattr(
@@ -6561,12 +6571,14 @@ extern "C" {
         ...
     ) -> *mut c_void;
 
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "glob64")]
     pub fn glob(
         pattern: *const c_char,
         flags: c_int,
         errfunc: Option<extern "C" fn(epath: *const c_char, errno: c_int) -> c_int>,
         pglob: *mut crate::glob_t,
     ) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "globfree64")]
     pub fn globfree(pglob: *mut crate::glob_t);
 
     pub fn posix_madvise(addr: *mut c_void, len: size_t, advice: c_int) -> c_int;
@@ -6592,6 +6604,7 @@ extern "C" {
         addr: *mut crate::sockaddr,
         addrlen: *mut crate::socklen_t,
     ) -> ssize_t;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "mkstemps64")]
     pub fn mkstemps(template: *mut c_char, suffixlen: c_int) -> c_int;
 
     pub fn nl_langinfo(item: crate::nl_item) -> *mut c_char;
@@ -6756,6 +6769,7 @@ extern "C" {
         policy: c_int,
         param: *const crate::sched_param,
     ) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "sendfile64")]
     pub fn sendfile(out_fd: c_int, in_fd: c_int, offset: *mut off_t, count: size_t) -> ssize_t;
     pub fn sigsuspend(mask: *const crate::sigset_t) -> c_int;
     pub fn getgrgid_r(

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -74,9 +74,14 @@ pub type iconv_t = *mut c_void;
 pub type sctp_assoc_t = __s32;
 
 pub type eventfd_t = u64;
-missing! {
-    #[cfg_attr(feature = "extra_traits", derive(Debug))]
-    pub enum fpos64_t {} // FIXME(linux): fill this out with a struct
+
+cfg_if! {
+    if #[cfg(not(target_env = "gnu"))] {
+        missing! {
+            #[cfg_attr(feature = "extra_traits", derive(Debug))]
+            pub enum fpos64_t {} // FIXME(linux): fill this out with a struct
+        }
+    }
 }
 
 e! {

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1791,9 +1791,12 @@ extern "C" {
     pub fn memalign(align: size_t, size: size_t) -> *mut c_void;
     pub fn setgroups(ngroups: size_t, ptr: *const crate::gid_t) -> c_int;
     pub fn pipe2(fds: *mut c_int, flags: c_int) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "statfs64")]
     pub fn statfs(path: *const c_char, buf: *mut statfs) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "fstatfs64")]
     pub fn fstatfs(fd: c_int, buf: *mut statfs) -> c_int;
     pub fn memrchr(cx: *const c_void, c: c_int, n: size_t) -> *mut c_void;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "posix_fadvise64")]
     pub fn posix_fadvise(fd: c_int, offset: off_t, len: off_t, advise: c_int) -> c_int;
     pub fn futimens(fd: c_int, times: *const crate::timespec) -> c_int;
     pub fn utimensat(
@@ -1891,7 +1894,9 @@ extern "C" {
     ) -> size_t;
     pub fn strptime(s: *const c_char, format: *const c_char, tm: *mut crate::tm) -> *mut c_char;
 
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "mkostemp64")]
     pub fn mkostemp(template: *mut c_char, flags: c_int) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "mkostemps64")]
     pub fn mkostemps(template: *mut c_char, suffixlen: c_int, flags: c_int) -> c_int;
 
     pub fn getdomainname(name: *mut c_char, len: size_t) -> c_int;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -578,17 +578,20 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "fopen$UNIX2003"
     )]
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "fopen64")]
     pub fn fopen(filename: *const c_char, mode: *const c_char) -> *mut FILE;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "freopen$UNIX2003"
     )]
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "freopen64")]
     pub fn freopen(filename: *const c_char, mode: *const c_char, file: *mut FILE) -> *mut FILE;
 
     pub fn fflush(file: *mut FILE) -> c_int;
     pub fn fclose(file: *mut FILE) -> c_int;
     pub fn remove(filename: *const c_char) -> c_int;
     pub fn rename(oldname: *const c_char, newname: *const c_char) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "tmpfile64")]
     pub fn tmpfile() -> *mut FILE;
     pub fn setvbuf(stream: *mut FILE, buffer: *mut c_char, mode: c_int, size: size_t) -> c_int;
     pub fn setbuf(stream: *mut FILE, buf: *mut c_char);
@@ -614,8 +617,10 @@ extern "C" {
     pub fn ftell(stream: *mut FILE) -> c_long;
     pub fn rewind(stream: *mut FILE);
     #[cfg_attr(target_os = "netbsd", link_name = "__fgetpos50")]
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "fgetpos64")]
     pub fn fgetpos(stream: *mut FILE, ptr: *mut fpos_t) -> c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__fsetpos50")]
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "fsetpos64")]
     pub fn fsetpos(stream: *mut FILE, ptr: *const fpos_t) -> c_int;
     pub fn feof(stream: *mut FILE) -> c_int;
     pub fn ferror(stream: *mut FILE) -> c_int;
@@ -827,6 +832,7 @@ extern "C" {
         all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "fstat@FBSD_1.0"
     )]
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "fstat64")]
     pub fn fstat(fildes: c_int, buf: *mut stat) -> c_int;
 
     pub fn mkdir(path: *const c_char, mode: mode_t) -> c_int;
@@ -840,6 +846,7 @@ extern "C" {
         all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "stat@FBSD_1.0"
     )]
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "stat64")]
     pub fn stat(path: *const c_char, buf: *mut stat) -> c_int;
 
     pub fn pclose(stream: *mut crate::FILE) -> c_int;
@@ -854,16 +861,19 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "open$UNIX2003"
     )]
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "open64")]
     pub fn open(path: *const c_char, oflag: c_int, ...) -> c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "creat$UNIX2003"
     )]
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "creat64")]
     pub fn creat(path: *const c_char, mode: mode_t) -> c_int;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "fcntl$UNIX2003"
     )]
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "__fcntl_time64")]
     pub fn fcntl(fd: c_int, cmd: c_int, ...) -> c_int;
 
     #[cfg_attr(
@@ -886,6 +896,7 @@ extern "C" {
         all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "readdir@FBSD_1.0"
     )]
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "readdir64")]
     pub fn readdir(dirp: *mut crate::DIR) -> *mut crate::dirent;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
@@ -924,6 +935,7 @@ extern "C" {
         all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "fstatat@FBSD_1.1"
     )]
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "fstatat64")]
     pub fn fstatat(dirfd: c_int, pathname: *const c_char, buf: *mut stat, flags: c_int) -> c_int;
     pub fn linkat(
         olddirfd: c_int,
@@ -993,6 +1005,7 @@ extern "C" {
     pub fn isatty(fd: c_int) -> c_int;
     #[cfg_attr(target_os = "solaris", link_name = "__link_xpg4")]
     pub fn link(src: *const c_char, dst: *const c_char) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "lseek64")]
     pub fn lseek(fd: c_int, offset: off_t, whence: c_int) -> off_t;
     pub fn pathconf(path: *const c_char, name: c_int) -> c_long;
     pub fn pipe(fds: *mut c_int) -> c_int;
@@ -1055,11 +1068,13 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "pread$UNIX2003"
     )]
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "pread64")]
     pub fn pread(fd: c_int, buf: *mut c_void, count: size_t, offset: off_t) -> ssize_t;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "pwrite$UNIX2003"
     )]
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "pwrite64")]
     pub fn pwrite(fd: c_int, buf: *const c_void, count: size_t, offset: off_t) -> ssize_t;
     pub fn umask(mask: mode_t) -> mode_t;
 
@@ -1086,6 +1101,7 @@ extern "C" {
         all(target_os = "macos", target_arch = "x86"),
         link_name = "mmap$UNIX2003"
     )]
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "mmap64")]
     pub fn mmap(
         addr: *mut c_void,
         len: size_t,
@@ -1112,6 +1128,7 @@ extern "C" {
         all(target_os = "freebsd", any(freebsd11, freebsd10)),
         link_name = "lstat@FBSD_1.0"
     )]
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "lstat64")]
     pub fn lstat(path: *const c_char, buf: *mut stat) -> c_int;
 
     #[cfg_attr(
@@ -1134,7 +1151,9 @@ extern "C" {
 
     pub fn symlink(path1: *const c_char, path2: *const c_char) -> c_int;
 
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "truncate64")]
     pub fn truncate(path: *const c_char, length: off_t) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "ftruncate64")]
     pub fn ftruncate(fd: c_int, length: off_t) -> c_int;
 
     pub fn signal(signum: c_int, handler: sighandler_t) -> sighandler_t;
@@ -1439,7 +1458,9 @@ extern "C" {
     pub fn sem_wait(sem: *mut sem_t) -> c_int;
     pub fn sem_trywait(sem: *mut sem_t) -> c_int;
     pub fn sem_post(sem: *mut sem_t) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "statvfs64")]
     pub fn statvfs(path: *const c_char, buf: *mut statvfs) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "fstatvfs64")]
     pub fn fstatvfs(fd: c_int, buf: *mut statvfs) -> c_int;
 
     #[cfg_attr(target_os = "netbsd", link_name = "__sigemptyset14")]
@@ -1463,7 +1484,9 @@ extern "C" {
 
     pub fn mkfifo(path: *const c_char, mode: mode_t) -> c_int;
 
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "fseeko64")]
     pub fn fseeko(stream: *mut crate::FILE, offset: off_t, whence: c_int) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "ftello64")]
     pub fn ftello(stream: *mut crate::FILE) -> off_t;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
@@ -1480,6 +1503,7 @@ extern "C" {
     pub fn tcflush(fd: c_int, action: c_int) -> c_int;
     pub fn tcgetsid(fd: c_int) -> crate::pid_t;
     pub fn tcsendbreak(fd: c_int, duration: c_int) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "mkstemp64")]
     pub fn mkstemp(template: *mut c_char) -> c_int;
     pub fn mkdtemp(template: *mut c_char) -> *mut c_char;
 
@@ -1504,6 +1528,7 @@ extern "C" {
     pub fn strcasestr(cs: *const c_char, ct: *const c_char) -> *mut c_char;
     pub fn getline(lineptr: *mut *mut c_char, n: *mut size_t, stream: *mut FILE) -> ssize_t;
 
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "lockf64")]
     pub fn lockf(fd: c_int, cmd: c_int, len: off_t) -> c_int;
 
 }
@@ -1604,6 +1629,7 @@ cfg_if! {
             pub fn pause() -> c_int;
 
             pub fn mkdirat(dirfd: c_int, pathname: *const c_char, mode: crate::mode_t) -> c_int;
+            #[cfg_attr(gnu_file_offset_bits64, link_name = "openat64")]
             pub fn openat(dirfd: c_int, pathname: *const c_char, flags: c_int, ...) -> c_int;
 
             #[cfg_attr(
@@ -1632,6 +1658,7 @@ cfg_if! {
             /// https://illumos.org/man/3lib/libc
             /// https://docs.oracle.com/cd/E36784_01/html/E36873/libc-3lib.html
             /// https://www.unix.com/man-page/opensolaris/3LIB/libc/
+            #[cfg_attr(gnu_file_offset_bits64, link_name = "readdir64_r")]
             pub fn readdir_r(
                 dirp: *mut crate::DIR,
                 entry: *mut crate::dirent,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -539,11 +539,18 @@ cfg_if! {
     }
 }
 
+cfg_if! {
+    if #[cfg(not(target_env = "gnu"))] {
+        missing! {
+            #[cfg_attr(feature = "extra_traits", derive(Debug))]
+            pub enum fpos_t {} // FIXME(unix): fill this out with a struct
+        }
+    }
+}
+
 missing! {
     #[cfg_attr(feature = "extra_traits", derive(Debug))]
     pub enum FILE {}
-    #[cfg_attr(feature = "extra_traits", derive(Debug))]
-    pub enum fpos_t {} // FIXME(unix): fill this out with a struct
 }
 
 extern "C" {


### PR DESCRIPTION
# Description

Add a new cfg `gnu_file_offset_bits64` corresponding to
`-D_FILE_OFFSET_BITS=64`.
The cfg can also be enabled by setting the environment variable
`RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS64=1`. 

This is the second part of what was #3175 .

# Sources

1. `off_t` 
   1. https://sourceware.org/git/?p=glibc.git;a=blob;f=posix/sys/types.h;h=ab3037a9dab25fdbbe4eccb3875b2a3305c7f342;hb=HEAD#l83
3. `ino_t` 
   1. https://sourceware.org/git/?p=glibc.git;a=blob;f=posix/sys/types.h;h=ab3037a9dab25fdbbe4eccb3875b2a3305c7f342;hb=HEAD#l45
4. `blkcnt_t` 
   1. https://sourceware.org/git/?p=glibc.git;a=blob;f=posix/sys/types.h;h=ab3037a9dab25fdbbe4eccb3875b2a3305c7f342;hb=HEAD#l191
5. `fsblkcnt_t` 
   1. https://sourceware.org/git?p=glibc.git;a=blob;f=posix/sys/types.h;h=ab3037a9dab25fdbbe4eccb3875b2a3305c7f342;hb=HEAD#l208
6. `fsfilcnt_t` 
   1. https://sourceware.org/git?p=glibc.git;a=blob;f=posix/sys/types.h;h=ab3037a9dab25fdbbe4eccb3875b2a3305c7f342;hb=HEAD#l213
7. `rlim_t`
   1. https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/bits/resource.h;h=51c07da01933a696853e17b4c32e2c5f8e10acf5;hb=HEAD#l130
   2. https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/resource.h;h=05f8e6ad353a471b347af2b750c30d8c160da08d;hb=HEAD#l138
   3. https://sourceware.org/git?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/resource.h;h=05f8e6ad353a471b347af2b750c30d8c160da08d;hb=HEAD#l138
8. `F_GETLK`
   1. https://github.com/torvalds/linux/blob/4701f33a10702d5fc577c32434eb62adde0a1ae1/include/uapi/asm-generic/fcntl.h#L104
   2. https://github.com/torvalds/linux/blob/4701f33a10702d5fc577c32434eb62adde0a1ae1/include/uapi/asm-generic/fcntl.h#L119 
   3. https://github.com/torvalds/linux/blob/4701f33a10702d5fc577c32434eb62adde0a1ae1/arch/mips/include/uapi/asm/fcntl.h#L40
   4. https://github.com/torvalds/linux/blob/4701f33a10702d5fc577c32434eb62adde0a1ae1/arch/mips/include/uapi/asm/fcntl.h#L48
9. `F_SETLK` and `F_SETLKW`
   1. https://github.com/torvalds/linux/blob/4701f33a10702d5fc577c32434eb62adde0a1ae1/include/uapi/asm-generic/fcntl.h#L105
   2. https://github.com/torvalds/linux/blob/4701f33a10702d5fc577c32434eb62adde0a1ae1/include/uapi/asm-generic/fcntl.h#L106
   3. https://github.com/torvalds/linux/blob/4701f33a10702d5fc577c32434eb62adde0a1ae1/include/uapi/asm-generic/fcntl.h#L120
   4. https://github.com/torvalds/linux/blob/4701f33a10702d5fc577c32434eb62adde0a1ae1/include/uapi/asm-generic/fcntl.h#L121
   5. https://github.com/torvalds/linux/blob/4701f33a10702d5fc577c32434eb62adde0a1ae1/arch/mips/include/uapi/asm/fcntl.h#L41
   6. https://github.com/torvalds/linux/blob/4701f33a10702d5fc577c32434eb62adde0a1ae1/arch/mips/include/uapi/asm/fcntl.h#L42
   7. https://github.com/torvalds/linux/blob/4701f33a10702d5fc577c32434eb62adde0a1ae1/arch/mips/include/uapi/asm/fcntl.h#L49
   8. https://github.com/torvalds/linux/blob/4701f33a10702d5fc577c32434eb62adde0a1ae1/arch/mips/include/uapi/asm/fcntl.h#L50
   10. https://github.com/torvalds/linux/blob/4701f33a10702d5fc577c32434eb62adde0a1ae1/arch/sparc/include/uapi/asm/fcntl.h#L44
   11. https://github.com/torvalds/linux/blob/4701f33a10702d5fc577c32434eb62adde0a1ae1/arch/sparc/include/uapi/asm/fcntl.h#L45
9. `RLIM_INFINITY`
   1. https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/resource.h#L58
9. `getrlimit`, `setrlimit`, `prlimit`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/resource/sys/resource.h#L49
   2. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/resource/sys/resource.h#L61
   3. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/sysdeps/unix/sysv/linux/bits/resource.h#L202
1. `pread`,  `pwrite`, `preadv2`, `pwritev2`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/misc/sys/uio.h#L57
   2. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/misc/sys/uio.h#L131
1. `aio_read`, `aio_write`, `aio_error`, `aio_return`, `aio_cancel`, `lio_listio`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/rt/aio.h#L141
1. `fallocate`, `posix_fallocate`, `posix_fadvise`, `open`, `creat`, `fcntl`,
    `lockf`, `openat`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/sysdeps/unix/sysv/linux/bits/fcntl-linux.h#L427
   2. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/io/fcntl.h#L322
   3. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/io/fcntl.h#L297
   4. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/io/fcntl.h#L208
   5. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/io/fcntl.h#L254
   6. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/io/fcntl.h#L176
   7. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/io/fcntl.h#L283
   9. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/io/fcntl.h#L232
1. `glob`, `globfree`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/posix/glob.h#L145
1. `mkstemps`, `mkostemp`, `mkostemps`, `mkstemp`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/stdlib/stdlib.h#L826
   3. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/stdlib/stdlib.h#L880
   4. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/stdlib/stdlib.h#L900
   5. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/stdlib/stdlib.h#L826
1. `sendfile`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/io/sys/sendfile.h#L32
1. `statfs`, `fstatfs`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/io/sys/statfs.h#L30
   2. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/io/sys/statfs.h#L49
1. `fopen`, `freopen`, `tmpfile`, `fgetpos`, `fsetpos`, `fseeko`, `ftello`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/libio/stdio.h#L259
   2. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/libio/stdio.h#L193
   3. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/libio/stdio.h#L811
   4. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/libio/stdio.h#L785
1. `stat`, `fstat`, `fstatat`, `lstat`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/io/sys/stat.h#L203
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/io/sys/stat.h#L310
2. `statfs`, `fstatfs`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/io/sys/statfs.h
2. `readdir`, `readdir_r`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/dirent/dirent.h#L163
   2. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/dirent/dirent.h#L184
2. `lseek`, `pread`, `pwrite`, truncate, `ftruncate`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/posix/unistd.h#L338
   2. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/posix/unistd.h#L382
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/posix/unistd.h#L1025
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/posix/unistd.h#L1048
2. `mmap`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/misc/sys/mman.h#L56
2. `struct statvfs`, `struct fstatvfs`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/io/sys/statvfs.h
1. `struct stat`, `struct stat64`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/sysdeps/unix/sysv/linux/bits/struct_stat.h
   2. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/sysdeps/unix/sysv/linux/mips/bits/struct_stat.h
   3. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/sysdeps/unix/sysv/linux/powerpc/bits/struct_stat.h
   3. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/sysdeps/unix/sysv/linux/sparc/bits/struct_stat.h
1. `struct statfs`, `struct statfs64`
   1. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/sysdeps/unix/sysv/linux/bits/statfs.h
   2. https://github.com/bminor/glibc/blob/bfb2f2f481147da54237ade3266f2586a51d43c9/sysdeps/unix/sysv/linux/mips/bits/statfs.h
1. `struct fpos_t`, `struct fpos64_t`
   1. https://github.com/bminor/glibc/blob/c5113a838b28a8894da19794ca7a69c5ace959a3/libio/bits/types/__fpos_t.h#L10
   2. https://github.com/bminor/glibc/blob/c5113a838b28a8894da19794ca7a69c5ace959a3/libio/bits/types/__fpos64_t.h#L10
1. `struct aiocb`
   1. https://github.com/bminor/glibc/blob/c5113a838b28a8894da19794ca7a69c5ace959a3/rt/aio.h#L50
1. `struct flock`
   1. https://github.com/bminor/glibc/blob/c5113a838b28a8894da19794ca7a69c5ace959a3/sysdeps/unix/sysv/linux/mips/bits/fcntl.h#L67


# Checklist

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

I've tested this as widely as possible, but I have not been able to
run the sparc tests.  mips and powerpc tests have been run on rust
1.85 using the yocto project, but it's not a fully compatible
environment for some reason. 
