### PR TITLE
temporarily define O_DIRECT and SIGINFO for Solaris

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -998,6 +998,13 @@ fn test_solarish(target: &str) {
     cfg.define("__EXTENSIONS__", None);
     cfg.define("_LCONV_C99", None);
 
+    // FIXME(solaris): This should be removed once new Nix crate is released.
+    // See comment in src/unix/solarish/solaris.rs for these.
+    if is_solaris {
+        cfg.define("O_DIRECT", Some("0x2000000"));
+        cfg.define("SIGINFO", Some("41"));
+    }
+
     headers! {
         cfg:
         "aio.h",

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -161,6 +161,14 @@ cfg_if! {
     }
 }
 
+// FIXME(solaris): O_DIRECT and SIGINFO are NOT available on Solaris.
+// But in past they were defined here and thus other crates expected them.
+// Latest version v0.29.0 of Nix crate still expects this. Since last
+// version of Nix crate is almost one year ago let's define these two
+// temporarily before new Nix version is released.
+pub const O_DIRECT: c_int = 0x2000000;
+pub const SIGINFO: c_int = 41;
+
 pub const _UTMP_USER_LEN: usize = 32;
 pub const _UTMP_LINE_LEN: usize = 32;
 pub const _UTMP_ID_LEN: usize = 4;


### PR DESCRIPTION
This is temporary fix before new `Nix` crate version is released. This version will have following commit:
https://github.com/nix-rust/nix/commit/0f4559386404f58803b27807201b4dd6d1411f50

The fix is waiting there for new version for several months now. And meanwhile build of `Rust` on `Solaris` requires patching.

This should allow proceed with following commit to `Rust`:
https://github.com/rust-lang/rust/pull/138699