### PR TITLE
linux: add missing pthread_attr_setstack

### DIFF
--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -4031,6 +4031,7 @@ pthread_attr_setguardsize
 pthread_attr_setinheritsched
 pthread_attr_setschedparam
 pthread_attr_setschedpolicy
+pthread_attr_setstack
 pthread_barrier_destroy
 pthread_barrier_init
 pthread_barrier_t

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1783,6 +1783,11 @@ extern "C" {
         stackaddr: *mut *mut c_void,
         stacksize: *mut size_t,
     ) -> c_int;
+    pub fn pthread_attr_setstack(
+        attr: *mut crate::pthread_attr_t,
+        stackaddr: *mut c_void,
+        stacksize: size_t,
+    ) -> c_int;
     pub fn memalign(align: size_t, size: size_t) -> *mut c_void;
     pub fn setgroups(ngroups: size_t, ptr: *const crate::gid_t) -> c_int;
     pub fn pipe2(fds: *mut c_int, flags: c_int) -> c_int;


### PR DESCRIPTION
# Description

This PR adds the missing pthread_attr_setstack function for linux-like architectures. The getter pthread_attr_getstack is already defined.

# Sources

- [pthread_attr_setstack man page](https://www.man7.org/linux/man-pages/man3/pthread_attr_setstack.3.html)
- https://github.com/bminor/glibc/blob/c6e2895695118ab59c7b17feb0fcb75a53e3478c/sysdeps/htl/pthread.h#L158
- https://github.com/kraj/musl/blob/1880359b54ff7dd9f5016002bfdae4b136007dde/include/pthread.h#L159
- https://github.com/emscripten-core/emscripten/blob/14193a094b8b6668d28bb82527e616ab327fae7b/system/lib/libc/musl/src/thread/pthread_attr_setstack.c#L3
- https://cs.android.com/android/platform/superproject/main/+/main:bionic/libc/include/pthread.h;l=124;drc=1960f1c7dcd60b29628bc96717a98efaad9e6c64

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
