### PR TITLE
Add cygwin support for ctest

### DIFF
--- a/ctest/src/lib.rs
+++ b/ctest/src/lib.rs
@@ -1144,6 +1144,8 @@ fn default_cfg(target: &str) -> Vec<(String, Option<String>)> {
         ("aix", "unix", "")
     } else if target.contains("hurd") {
         ("hurd", "unix", "gnu")
+    } else if target.contains("cygwin") {
+        ("cygwin", "unix", "")
     } else {
         panic!("unknown os/family: {}", target)
     };


### PR DESCRIPTION
# Description

From https://github.com/JohnTitor/ctest2/pull/70

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
