### PR TITLE
Fix release-plz on the main branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,9 +24,6 @@ jobs:
         run: rustup update stable --no-self-update && rustup default stable
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
-        with:
-          # On the main branch, only release ctest
-          manifest_path: ctest/Cargo.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ build = "build.rs"
 exclude = ["/ci/*", "/.github/*", "/.cirrus.yml", "/triagebot.toml"]
 rust-version = "1.63"
 description = "Raw FFI bindings to platform libraries like libc."
+publish = false # On the main branch, we don't want to publish anything
 
 [package.metadata.docs.rs]
 features = ["extra_traits"]


### PR DESCRIPTION
This can still use the workspace root, but we generally aren't interested in publishing `libc` from this branch (only `ctest`).