### PR TITLE
FreeBSD: Deprecate TCP_PCAP_OUT and TCP_PCAP_IN

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2783,6 +2783,9 @@ fn test_freebsd(target: &str) {
             // Added in FreeBSD 14.0
             "TCP_FUNCTION_ALIAS" if Some(14) > freebsd_ver => true,
 
+            // FIXME(freebsd): Removed in FreeBSD 15, deprecated in libc
+            "TCP_PCAP_OUT" | "TCP_PCAP_IN" => true,
+
             _ => false,
         }
     });

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -3762,7 +3762,9 @@ pub const TCP_PERF_INFO: c_int = 78;
 pub const TCP_LRD: c_int = 79;
 pub const TCP_KEEPINIT: c_int = 128;
 pub const TCP_FASTOPEN: c_int = 1025;
+#[deprecated(since = "0.2.171", note = "removed in FreeBSD 15")]
 pub const TCP_PCAP_OUT: c_int = 2048;
+#[deprecated(since = "0.2.171", note = "removed in FreeBSD 15")]
 pub const TCP_PCAP_IN: c_int = 4096;
 pub const TCP_FUNCTION_BLK: c_int = 8192;
 pub const TCP_FUNCTION_ALIAS: c_int = 8193;


### PR DESCRIPTION
FreeBSD removed these upstream in [1], so deprecate them here. This resolves a recent CI failure.

The constants were originally added in [2].

[1]: https://github.com/freebsd/freebsd-src/commit/6e76489098c6dc415ac3f2ae084154c3c22558ec
[2]: https://github.com/rust-lang/libc/pull/1151

Cc @asomers 