### PR TITLE
musl: loongarch64: Fix the struct ipc_perm bindings

### DIFF
--- a/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
@@ -65,7 +65,6 @@ s! {
         pub cgid: crate::gid_t,
         pub mode: c_uint,
         pub __seq: c_int,
-        __pad2: c_ushort,
         __unused1: c_ulong,
         __unused2: c_ulong,
     }


### PR DESCRIPTION
# Description

Remove the `__pad2` field from `struct ipc_perm`.

Refer: https://git.musl-libc.org/cgit/musl/tree/arch/generic/bits/ipc.h?h=v1.2.5

```c
struct ipc_perm {
	key_t __ipc_perm_key;
	uid_t uid;
	gid_t gid;
	uid_t cuid;
	gid_t cgid;
	mode_t mode;
	int __ipc_perm_seq;
	long __pad1;
	long __pad2;
};
```

# Sources

- src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI