### PR TITLE
Pin cc to `<1.2.18`

### DIFF
--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -23,7 +23,9 @@ glob = "0.3.2"
 annotate-snippets = { version = "0.11.5", features = ["testing-colors"] }
 
 [build-dependencies]
-cc = "1.0.83"
+# FIXME(cc): pinned until a fix for https://github.com/rust-lang/cc-rs/issues/1452
+# is released.
+cc = ">=1.0.83, <1.2.18"
 ctest = { path = "../ctest" }
 regex = "1.11.1"
 


### PR DESCRIPTION
Work around a `cc` issue that doesn't have a fix released yet [1], which is causing CI failures for musl targets.

[1]: https://github.com/rust-lang/cc-rs/issues/1452