### PR TITLE
Add MS_NOSYMFOLLOW flag

### DIFF
--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -654,6 +654,7 @@ pub const MS_SYNCHRONOUS: c_ulong = 0x10;
 pub const MS_REMOUNT: c_ulong = 0x20;
 pub const MS_MANDLOCK: c_ulong = 0x40;
 pub const MS_DIRSYNC: c_ulong = 0x80;
+pub const MS_NOSYMFOLLOW: c_ulong = 0x100;
 pub const MS_NOATIME: c_ulong = 0x0400;
 pub const MS_NODIRATIME: c_ulong = 0x0800;
 pub const MS_BIND: c_ulong = 0x1000;


### PR DESCRIPTION
# Description

Adds the `MS_NOSYMFOLLOW` flag from linux/mount.h

MS_NOSYMFOLLOW ([since Linux 5.10](https://github.com/torvalds/linux/commit/dab741e0e02bd3c4f5e2e97be74b39df2523fc6e)) disallows automatic following of symlinks. 

# Sources

https://github.com/torvalds/linux/blob/ab59a8605604f71bbbc16077270dc3f39648b7fc/include/uapi/linux/mount.h

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
