### PR TITLE
Revert "Pin cc to `<1.2.18`"

### DIFF
--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -23,9 +23,7 @@ glob = "0.3.2"
 annotate-snippets = { version = "0.11.5", features = ["testing-colors"] }
 
 [build-dependencies]
-# FIXME(cc): pinned until a fix for https://github.com/rust-lang/cc-rs/issues/1452
-# is released.
-cc = ">=1.0.83, <1.2.18"
+cc = "1.0.83"
 ctest = { path = "../ctest" }
 regex = "1.11.1"
 


### PR DESCRIPTION
`cc` version 1.2.19 has been released which resolves the musl issue, so this no longer needs to be pinned.

This reverts commit 8fe98813f5f6e65a0bd440d35f2cbe3a01a209b1.