### PR TITLE
Make triagebot warn on non-default branches

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,3 +37,9 @@ or mark it as a draft if you are not sure. -->
   included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
 - [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
   especially relevant for platforms that may not be checked in CI
+
+<!-- labels: is this PR a breaking change? If not, we can probably get it in a
+0.2 release. Just uncomment the following:
+
+@rustbot label +stable-nominated
+-->

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -8,6 +8,7 @@ allow-unauthenticated = [
 ]
 
 [assign]
+warn_non_default_branch.enable = true
 contributing_url = "https://github.com/rust-lang/libc/blob/HEAD/CONTRIBUTING.md"
 
 [assign.owners]


### PR DESCRIPTION
This should help catch PRs that are accidentally made against `libc-0.2` rather than `main`.