### PR TITLE
adding pid_type enum for Linux.

### DIFF
--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -2171,6 +2171,11 @@ PF_WANPIPE
 PF_WQ_WORKER
 PF_X
 PF_X25
+PIDTYPE_MAX
+PIDTYPE_PGID
+PIDTYPE_PID
+PIDTYPE_SID
+PIDTYPE_TGID
 PIPE_BUF
 PM_STR
 POLLRDBAND
@@ -4037,6 +4042,7 @@ packet_mreq
 pause
 personality
 pgn_t
+pid_type
 pipe2
 popen
 posix_fadvise

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -92,6 +92,16 @@ e! {
     }
 }
 
+c_enum! {
+    pid_type {
+        PIDTYPE_PID,
+        PIDTYPE_TGID,
+        PIDTYPE_PGID,
+        PIDTYPE_SID,
+        PIDTYPE_MAX,
+    }
+}
+
 s! {
     pub struct glob_t {
         pub gl_pathc: size_t,


### PR DESCRIPTION
[ref](https://github.com/torvalds/linux/blob/7cdabafc001202de9984f22c973305f424e0a8b7/include/linux/pid_types.h#L5)