### PR TITLE
chore: consolidate workspace settings [MSRV 1.64+]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
     name: Verify build
     strategy:
       matrix:
-        toolchain: [stable, nightly, 1.63.0]
+        toolchain: [stable, nightly, 1.64.0]
         os: [ubuntu-24.04, macos-14, windows-2022]
         include:
           - toolchain: beta
@@ -65,7 +65,7 @@ jobs:
       - name: Update RUSTFLAGS
         run: |
           set -eux
-          [ "${{ matrix.toolchain }}" = "1.63.0" ] && echo 'RUSTFLAGS=' >> "$GITHUB_ENV" || true
+          [ "${{ matrix.toolchain }}" = "1.64.0" ] && echo 'RUSTFLAGS=' >> "$GITHUB_ENV" || true
           
       - name: Setup Rust toolchain
         run: ./ci/install-rust.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ categories = ["external-ffi-bindings", "no-std", "os"]
 exclude = ["/ci/*", "/.github/*", "/.cirrus.yml", "/triagebot.toml"]
 description = "Raw FFI bindings to platform libraries like libc."
 publish = false # On the main branch, we don't want to publish anything
-authors = ["The Rust Project Developers"]
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/rust-lang/libc"
-rust-version = "1.63"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 features = ["extra_traits"]
@@ -143,14 +143,18 @@ members = [
     "libc-test",
 ]
 
-# FIXME(msrv): These should be renamed as `[workspace.lints.*]` once MSRV is above 1.64
-#       This way all crates can use it with `[lints] workspace=true` section
+[workspace.package]
+authors = ["The Rust Project Developers"]
+license = "MIT OR Apache-2.0"
+edition = "2021"
+repository = "https://github.com/rust-lang/libc"
+rust-version = "1.64"
 
-[lints.rust]
+[workspace.lints.rust]
 # FIXME(cleanup): make ident usage consistent in each file
 unused_qualifications = "allow"
 
-[lints.clippy]
+[workspace.lints.clippy]
 missing_safety_doc = "allow"
 
 # FIXME(clippy): all these are default lints and should probably be fixed

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ libc = "0.2"
 
 ## Rust version support
 
-The minimum supported Rust toolchain version is currently **Rust 1.63**.
+The minimum supported Rust toolchain version is currently **Rust 1.64**.
 
 Increases to the MSRV are allowed to change without a major (i.e. semver-
 breaking) release in order to avoid a ripple effect in the ecosystem. A policy

--- a/ctest-test/Cargo.toml
+++ b/ctest-test/Cargo.toml
@@ -3,7 +3,7 @@ name = "ctest-test"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 publish = false
-edition = "2021"
+edition.workspace = true
 
 [build-dependencies]
 ctest = { path = "../ctest" }

--- a/ctest/Cargo.toml
+++ b/ctest/Cargo.toml
@@ -3,10 +3,10 @@ name = "ctest"
 version = "0.4.11"
 description = "Automated tests of FFI bindings."
 exclude = ["CHANGELOG.md"]
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/rust-lang/libc"
-rust-version = "1.63.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 garando_syntax = "0.1"

--- a/ctest/README.md
+++ b/ctest/README.md
@@ -10,7 +10,7 @@ APIs in Rust match the APIs defined in C.
 
 ## MSRV (Minimum Supported Rust Version)
 
-The MSRV is 1.63.0 because of the transitive dependencies.
+The MSRV is 1.64.0 because of the transitive dependencies.
 Note that MSRV may be changed anytime by dependencies.
 
 ## Example

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -3,10 +3,10 @@ name = "libc-test"
 version = "0.1.0"
 description = "A test crate for the libc crate."
 publish = false
-authors = ["The Rust Project Developers"]
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/rust-lang/libc"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 cfg-if = "1.0.0"


### PR DESCRIPTION
* Move common workspace settings to the `[workspace]` sections in the root.
* Add common clippy lint configuration

@rustbot label +stable-nominated
