### PR TITLE
chore: cleanup Cargo.toml and rm perl

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,7 +255,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - run: |
-        msrv="$(perl -ne 'print if s/rust-version\s*=\s*"(.*)"/\1/g' ctest/Cargo.toml)"
+        msrv="$(cargo metadata --format-version 1 | jq -r --arg CRATE_NAME ctest  '.packages | map(select(.name == $CRATE_NAME)) | first | .rust_version')"
         echo "MSRV: $msrv"
         echo "MSRV=$msrv" >> "$GITHUB_ENV"
     - name: Install Rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,16 @@
 [package]
 name = "libc"
 version = "1.0.0-alpha.1"
-authors = ["The Rust Project Developers"]
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-edition = "2021"
-repository = "https://github.com/rust-lang/libc"
-homepage = "https://github.com/rust-lang/libc"
-documentation = "https://docs.rs/libc/"
 keywords = ["libc", "ffi", "bindings", "operating", "system"]
 categories = ["external-ffi-bindings", "no-std", "os"]
-build = "build.rs"
 exclude = ["/ci/*", "/.github/*", "/.cirrus.yml", "/triagebot.toml"]
-rust-version = "1.63"
 description = "Raw FFI bindings to platform libraries like libc."
 publish = false # On the main branch, we don't want to publish anything
+authors = ["The Rust Project Developers"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-lang/libc"
+rust-version = "1.63"
 
 [package.metadata.docs.rs]
 features = ["extra_traits"]

--- a/ctest-test/Cargo.toml
+++ b/ctest-test/Cargo.toml
@@ -2,9 +2,8 @@
 name = "ctest-test"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-build = "build.rs"
-edition = "2021"
 publish = false
+edition = "2021"
 
 [build-dependencies]
 ctest = { path = "../ctest" }

--- a/ctest/Cargo.toml
+++ b/ctest/Cargo.toml
@@ -1,16 +1,11 @@
 [package]
 name = "ctest"
 version = "0.4.11"
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/rust-lang/libc"
-homepage = "https://github.com/rust-lang/libc"
-documentation = "https://docs.rs/ctest"
-description = """
-Automated tests of FFI bindings.
-"""
+description = "Automated tests of FFI bindings."
 exclude = ["CHANGELOG.md"]
 edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-lang/libc"
 rust-version = "1.63.0"
 
 [dependencies]

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -1,16 +1,12 @@
 [package]
 name = "libc-test"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Rust Project Developers"]
-license = "MIT OR Apache-2.0"
-build = "build.rs"
+description = "A test crate for the libc crate."
 publish = false
+authors = ["The Rust Project Developers"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/libc"
-homepage = "https://github.com/rust-lang/libc"
-description = """
-A test crate for the libc crate.
-"""
 
 [dependencies]
 cfg-if = "1.0.0"


### PR DESCRIPTION
This PR is a part of the #4406 per @tgross35 suggestion

* Remove Cargo settings that are identical to the defaults (per Cargo [recommendations](https://doc.rust-lang.org/cargo/reference/manifest.html))
* Fix perl-based method to extract MSRV
* Note that the order of the values is such as to make it easier to switch to the inherited ones from workspace once MSRV is bumped

@rustbot label +stable-nominated
