### PR TITLE
Resolve release-plz failure from `publish` mismatch

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -3,6 +3,7 @@ name = "libc"
 changelog_path = "CHANGELOG.md"
 git_release_name = "{{ version }}"
 git_tag_name = "{{ version }}"
+publish = false # On the main branch, we don't want to publish anything
 
 [[package]]
 name = "ctest"


### PR DESCRIPTION
Cargo.toml has `publish = false`, release-plz expects the same in its config file.