### PR TITLE
chore: lint `libc-test/build.rs`

### DIFF
--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -107,19 +107,5 @@ harness = true
 #              once MSRV is above 1.64 and replaced with `[lints] workspace=true`
 
 [lints.rust]
-# FIXME(cleanup): make ident usage consistent in each file
-unused_qualifications = "allow"
 
 [lints.clippy]
-# FIXME(clippy): fix these
-needless_return = "allow"
-comparison_to_empty = "allow"
-unused_io_amount = "allow"
-write_with_newline = "allow"
-needless_borrows_for_generic_args = "allow"
-only_used_in_recursion = "allow"
-match_like_matches_macro = "allow"
-useless_format = "allow"
-wildcard_in_or_patterns = "allow"
-nonminimal_bool = "allow"
-match_single_binding = "allow"

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1,4 +1,5 @@
 #![deny(warnings)]
+#![allow(clippy::match_like_matches_macro)]
 
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
@@ -50,23 +51,23 @@ fn do_cc() {
 
 fn do_ctest() {
     match &env::var("TARGET").unwrap() {
-        t if t.contains("android") => return test_android(t),
-        t if t.contains("apple") => return test_apple(t),
-        t if t.contains("dragonfly") => return test_dragonflybsd(t),
-        t if t.contains("emscripten") => return test_emscripten(t),
-        t if t.contains("freebsd") => return test_freebsd(t),
-        t if t.contains("haiku") => return test_haiku(t),
-        t if t.contains("linux") => return test_linux(t),
-        t if t.contains("netbsd") => return test_netbsd(t),
-        t if t.contains("openbsd") => return test_openbsd(t),
-        t if t.contains("cygwin") => return test_cygwin(t),
-        t if t.contains("redox") => return test_redox(t),
-        t if t.contains("solaris") => return test_solarish(t),
-        t if t.contains("illumos") => return test_solarish(t),
-        t if t.contains("wasi") => return test_wasi(t),
-        t if t.contains("windows") => return test_windows(t),
-        t if t.contains("vxworks") => return test_vxworks(t),
-        t if t.contains("nto-qnx") => return test_neutrino(t),
+        t if t.contains("android") => test_android(t),
+        t if t.contains("apple") => test_apple(t),
+        t if t.contains("dragonfly") => test_dragonflybsd(t),
+        t if t.contains("emscripten") => test_emscripten(t),
+        t if t.contains("freebsd") => test_freebsd(t),
+        t if t.contains("haiku") => test_haiku(t),
+        t if t.contains("linux") => test_linux(t),
+        t if t.contains("netbsd") => test_netbsd(t),
+        t if t.contains("openbsd") => test_openbsd(t),
+        t if t.contains("cygwin") => test_cygwin(t),
+        t if t.contains("redox") => test_redox(t),
+        t if t.contains("solaris") => test_solarish(t),
+        t if t.contains("illumos") => test_solarish(t),
+        t if t.contains("wasi") => test_wasi(t),
+        t if t.contains("windows") => test_windows(t),
+        t if t.contains("vxworks") => test_vxworks(t),
+        t if t.contains("nto-qnx") => test_neutrino(t),
         t => panic!("unknown target {t}"),
     }
 }
@@ -104,7 +105,7 @@ fn do_semver() {
     process_semver_file(&mut output, &mut semver_root, &os);
     let os_arch = format!("{os}-{arch}");
     process_semver_file(&mut output, &mut semver_root, &os_arch);
-    if target_env != "" {
+    if !target_env.is_empty() {
         let os_env = format!("{os}-{target_env}");
         process_semver_file(&mut output, &mut semver_root, &os_env);
 
@@ -129,21 +130,21 @@ fn process_semver_file<W: Write, P: AsRef<Path>>(output: &mut W, path: &mut Path
     };
     let input = BufReader::new(input_file);
 
-    write!(output, "// Source: {}.\n", path.display()).unwrap();
-    output.write(b"use libc::{\n").unwrap();
+    writeln!(output, "// Source: {}.", path.display()).unwrap();
+    output.write_all(b"use libc::{\n").unwrap();
     for line in input.lines() {
         let line = line.unwrap().into_bytes();
         match line.first() {
             // Ignore comments and empty lines.
             Some(b'#') | None => continue,
             _ => {
-                output.write(b"    ").unwrap();
-                output.write(&line).unwrap();
-                output.write(b",\n").unwrap();
+                output.write_all(b"    ").unwrap();
+                output.write_all(&line).unwrap();
+                output.write_all(b",\n").unwrap();
             }
         }
     }
-    output.write(b"};\n\n").unwrap();
+    output.write_all(b"};\n\n").unwrap();
     path.pop();
 }
 
@@ -165,8 +166,10 @@ fn main() {
     do_semver();
 }
 
+// FIXME(clippy): removing `replace` somehow fails the `Test tier1 (x86_64-pc-windows-msvc, windows-2022)` CI job
+#[allow(clippy::only_used_in_recursion)]
 fn copy_dir_hotfix(src: &Path, dst: &Path, regex: &regex::bytes::Regex, replace: &[u8]) {
-    std::fs::create_dir(&dst).unwrap();
+    std::fs::create_dir(dst).unwrap();
     for entry in src.read_dir().unwrap() {
         let entry = entry.unwrap();
         let src_path = entry.path();
@@ -712,7 +715,7 @@ fn test_cygwin(target: &str) {
             t if t.ends_with("_t") => t.to_string(),
 
             // sigval is a struct in Rust, but a union in C:
-            "sigval" => format!("union sigval"),
+            "sigval" => "union sigval".to_string(),
 
             // put `struct` in front of all structs:.
             t if is_struct => format!("struct {t}"),
@@ -1449,6 +1452,7 @@ fn test_netbsd(target: &str) {
     });
 
     cfg.skip_fn(move |name| {
+        #[expect(clippy::wildcard_in_or_patterns)]
         match name {
             // FIXME(netbsd): netbsd 10 minimum
             "getentropy" | "getrandom" => true,
@@ -1597,7 +1601,7 @@ fn test_dragonflybsd(target: &str) {
             t if t.ends_with("_t") => t.to_string(),
 
             // sigval is a struct in Rust, but a union in C:
-            "sigval" => format!("union sigval"),
+            "sigval" => "union sigval".to_string(),
 
             // put `struct` in front of all structs:.
             t if is_struct => format!("struct {t}"),
@@ -1984,7 +1988,7 @@ fn test_android(target: &str) {
             t if t.ends_with("_t") => t.to_string(),
 
             // sigval is a struct in Rust, but a union in C:
-            "sigval" => format!("union sigval"),
+            "sigval" => "union sigval".to_string(),
 
             // put `struct` in front of all structs:.
             t if is_struct => format!("struct {t}"),
@@ -2346,18 +2350,9 @@ fn test_freebsd(target: &str) {
     // Required for making freebsd11_stat available in the headers
     cfg.define("_WANT_FREEBSD11_STAT", None);
 
-    let freebsd13 = match freebsd_ver {
-        Some(n) if n >= 13 => true,
-        _ => false,
-    };
-    let freebsd14 = match freebsd_ver {
-        Some(n) if n >= 14 => true,
-        _ => false,
-    };
-    let freebsd15 = match freebsd_ver {
-        Some(n) if n >= 15 => true,
-        _ => false,
-    };
+    let freebsd13 = matches!(freebsd_ver, Some(n) if n >= 13);
+    let freebsd14 = matches!(freebsd_ver, Some(n) if n >= 14);
+    let freebsd15 = matches!(freebsd_ver, Some(n) if n >= 15);
 
     headers! { cfg:
                 "aio.h",
@@ -2500,7 +2495,7 @@ fn test_freebsd(target: &str) {
             t if t.ends_with("_t") => t.to_string(),
 
             // sigval is a struct in Rust, but a union in C:
-            "sigval" => format!("union sigval"),
+            "sigval" => "union sigval".to_string(),
 
             // put `struct` in front of all structs:.
             t if is_struct => format!("struct {t}"),
@@ -3237,7 +3232,7 @@ fn test_neutrino(target: &str) {
 
     let mut cfg = ctest_cfg();
     if target.ends_with("_iosock") {
-        let qnx_target_val = std::env::var("QNX_TARGET")
+        let qnx_target_val = env::var("QNX_TARGET")
             .unwrap_or_else(|_| "QNX_TARGET_not_set_please_source_qnxsdp".into());
 
         cfg.include(qnx_target_val + "/usr/include/io-sock");
@@ -3484,17 +3479,17 @@ fn test_neutrino(target: &str) {
         struct_ == "_idle_hook" && field == "time"
     });
 
-    cfg.skip_field(move |struct_, field| {
-        (struct_ == "__sched_param" && field == "reserved") ||
-        (struct_ == "sched_param" && field == "reserved") ||
-        (struct_ == "sigevent" && field == "__padding1") || // ensure alignment
-        (struct_ == "sigevent" && field == "__padding2") || // union
-        (struct_ == "sigevent" && field == "__sigev_un2") || // union
-        // sighandler_t type is super weird
-        (struct_ == "sigaction" && field == "sa_sigaction") ||
-        // does not exist
-        (struct_ == "syspage_entry" && field == "__reserved") ||
-        false // keep me for smaller diffs when something is added above
+    cfg.skip_field(|struct_, field| {
+        matches!(
+            (struct_, field),
+            ("__sched_param", "reserved")
+            | ("sched_param", "reserved")
+            | ("sigevent", "__padding1") // ensure alignment
+            | ("sigevent", "__padding2") // union
+            | ("sigevent", "__sigev_un2") // union
+            | ("sigaction", "sa_sigaction") // sighandler_t type is super weird
+            | ("syspage_entry", "__reserved") // does not exist
+        )
     });
 
     cfg.skip_static(move |name| (name == "__dso_handle"));
@@ -3584,9 +3579,7 @@ fn test_vxworks(target: &str) {
         _ => false,
     });
 
-    cfg.skip_roundtrip(move |s| match s {
-        _ => false,
-    });
+    cfg.skip_roundtrip(|_| false);
 
     cfg.type_name(move |ty, is_struct, is_union| match ty {
         "DIR" | "FILE" | "Dl_info" | "RTP_DESC" => ty.to_string(),
@@ -4846,8 +4839,8 @@ fn test_linux_like_apis(target: &str) {
             "strerror_r" => false,
             _ => true,
         })
-        .skip_const(|_| true)
-        .skip_struct(|_| true);
+            .skip_const(|_| true)
+            .skip_struct(|_| true);
         cfg.generate(src_hotfix_dir().join("lib.rs"), "linux_strerror_r.rs");
     }
 
@@ -4921,10 +4914,10 @@ fn test_linux_like_apis(target: &str) {
             .skip_const(|_| true)
             .skip_struct(|_| true)
             .skip_const(move |name| match name {
-                "IPV6_FLOWINFO"
-                | "IPV6_FLOWLABEL_MGR"
-                | "IPV6_FLOWINFO_SEND"
-                | "IPV6_FLOWINFO_FLOWLABEL"
+                    "IPV6_FLOWINFO"
+                        | "IPV6_FLOWLABEL_MGR"
+                        | "IPV6_FLOWINFO_SEND"
+                        | "IPV6_FLOWINFO_FLOWLABEL"
                 | "IPV6_FLOWINFO_PRIORITY" => false,
                 _ => true,
             })
@@ -5314,7 +5307,7 @@ fn test_haiku(target: &str) {
             }
 
             // is actually a union
-            "sigval" => format!("union sigval"),
+            "sigval" => "union sigval".to_string(),
             t if is_union => format!("union {t}"),
             t if t.ends_with("_t") => t.to_string(),
             t if is_struct => format!("struct {t}"),

--- a/libc-test/test/makedev.rs
+++ b/libc-test/test/makedev.rs
@@ -30,8 +30,8 @@ cfg_if::cfg_if! {
         target_os = "openbsd",
         target_os = "cygwin",
     ))] {
-        pub type MajorRetType = libc::c_uint;
-        pub type MinorRetType = libc::c_uint;
+        pub type MajorRetType = c_uint;
+        pub type MinorRetType = c_uint;
     } else if #[cfg(any(
         target_os = "android",
         target_os = "dragonfly",
@@ -129,7 +129,7 @@ fn test_openbsd_like() {
 ))]
 #[test]
 fn test_fbsd12_like() {
-    if std::mem::size_of::<dev_t>() >= 8 {
+    if size_of::<dev_t>() >= 8 {
         for major_exp in [0, 16, 24, 31] {
             for major in [(1 << major_exp) - 1, (1 << major_exp)] {
                 for minor_exp in [1, 8, 16, 24, 31] {


### PR DESCRIPTION
run `cargo clippy --all-targets` on `libc-test/build.rs`, and fix all default issues.

### Notes
* `copy_dir_hotfix` had a `replace` parameter that was never used

@rustbot label +stable-nominated
