### PR TITLE
chore: inline format args

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -124,17 +124,17 @@ fn main() {
     if rustc_minor_ver >= 80 {
         for cfg in ALLOWED_CFGS {
             if rustc_minor_ver >= 75 {
-                println!("cargo:rustc-check-cfg=cfg({})", cfg);
+                println!("cargo:rustc-check-cfg=cfg({cfg})");
             } else {
-                println!("cargo:rustc-check-cfg=values({})", cfg);
+                println!("cargo:rustc-check-cfg=values({cfg})");
             }
         }
         for &(name, values) in CHECK_CFG_EXTRA {
             let values = values.join("\",\"");
             if rustc_minor_ver >= 75 {
-                println!("cargo:rustc-check-cfg=cfg({},values(\"{}\"))", name, values);
+                println!("cargo:rustc-check-cfg=cfg({name},values(\"{values}\"))");
             } else {
-                println!("cargo:rustc-check-cfg=values({},\"{}\")", name, values);
+                println!("cargo:rustc-check-cfg=values({name},\"{values}\")");
             }
         }
     }
@@ -255,7 +255,7 @@ fn emcc_version_code() -> Option<u64> {
 
 fn set_cfg(cfg: &str) {
     if !ALLOWED_CFGS.contains(&cfg) {
-        panic!("trying to set cfg {}, but it is not in ALLOWED_CFGS", cfg);
+        panic!("trying to set cfg {cfg}, but it is not in ALLOWED_CFGS");
     }
-    println!("cargo:rustc-cfg={}", cfg);
+    println!("cargo:rustc-cfg={cfg}");
 }

--- a/ci/ios/deploy_and_run_on_ios_simulator.rs
+++ b/ci/ios/deploy_and_run_on_ios_simulator.rs
@@ -16,7 +16,7 @@ use std::process::Command;
 macro_rules! t {
     ($e:expr) => (match $e {
         Ok(e) => e,
-        Err(e) => panic!("{} failed with: {}", stringify!($e), e),
+        Err(e) => panic!("{} failed with: {e}", stringify!($e)),
     })
 }
 
@@ -143,7 +143,7 @@ trait CheckStatus {
 
 impl CheckStatus for Command {
     fn check_status(&mut self) {
-        println!("\trunning: {:?}", self);
+        println!("\trunning: {self:?}");
         assert!(t!(self.status()).success());
     }
 }

--- a/ci/runtest-android.rs
+++ b/ci/runtest-android.rs
@@ -37,8 +37,8 @@ fn main() {
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     println!(
-        "status: {}\nstdout ---\n{}\nstderr ---\n{}",
-        output.status, stdout, stderr
+        "status: {}\nstdout ---\n{stdout}\nstderr ---\n{stderr}",
+        output.status,
     );
 
     if !stderr.lines().any(|l| {

--- a/ctest-test/build.rs
+++ b/ctest-test/build.rs
@@ -30,8 +30,8 @@ fn main() {
         .type_name(move |ty, is_struct, is_union| match ty {
             "T1Union" => ty.to_string(),
             "Transparent" => ty.to_string(),
-            t if is_struct => format!("struct {}", t),
-            t if is_union => format!("union {}", t),
+            t if is_struct => format!("struct {t}"),
+            t if is_union => format!("union {t}"),
             t => t.to_string(),
         })
         .volatile_item(t1_volatile)
@@ -43,8 +43,8 @@ fn main() {
         .include("src")
         .type_name(move |ty, is_struct, is_union| match ty {
             "T2Union" => ty.to_string(),
-            t if is_struct => format!("struct {}", t),
-            t if is_union => format!("union {}", t),
+            t if is_struct => format!("struct {t}"),
+            t if is_union => format!("union {t}"),
             t => t.to_string(),
         })
         .skip_roundtrip(|_| true)
@@ -64,8 +64,8 @@ fn main() {
             .type_name(move |ty, is_struct, is_union| match ty {
                 "T1Union" => ty.to_string(),
                 "Transparent" => ty.to_string(),
-                t if is_struct => format!("struct {}", t),
-                t if is_union => format!("union {}", t),
+                t if is_struct => format!("struct {t}"),
+                t if is_union => format!("union {t}"),
                 t => t.to_string(),
             })
             .volatile_item(t1_volatile)
@@ -78,8 +78,8 @@ fn main() {
             .include("src")
             .type_name(move |ty, is_struct, is_union| match ty {
                 "T2Union" => ty.to_string(),
-                t if is_struct => format!("struct {}", t),
-                t if is_union => format!("union {}", t),
+                t if is_struct => format!("struct {t}"),
+                t if is_union => format!("union {t}"),
                 t => t.to_string(),
             })
             .skip_roundtrip(|_| true)

--- a/ctest-test/tests/all.rs
+++ b/ctest-test/tests/all.rs
@@ -28,8 +28,8 @@ fn output(cmd: &mut Command) -> (String, ExitStatus) {
 fn t1() {
     let (o, status) = output(&mut cmd("t1"));
     assert!(status.success(), "output: {o}");
-    assert!(!o.contains("bad "), "{}", o);
-    eprintln!("o: {}", o);
+    assert!(!o.contains("bad "), "{o}");
+    eprintln!("o: {o}");
 }
 
 #[test]
@@ -37,7 +37,7 @@ fn t1() {
 fn t1_cxx() {
     let (o, status) = output(&mut cmd("t1_cxx"));
     assert!(status.success(), "output: {o}");
-    assert!(!o.contains("bad "), "{}", o);
+    assert!(!o.contains("bad "), "{o}");
 }
 
 #[test]
@@ -69,17 +69,17 @@ fn t2() {
     for line in o.lines().filter(|l| l.starts_with("bad ")) {
         let msg = &line[..line.find(":").unwrap()];
         if !errors.remove(&msg) {
-            println!("unknown error: {}", msg);
+            println!("unknown error: {msg}");
             bad = true;
         }
     }
 
     for error in errors {
-        println!("didn't find error: {}", error);
+        println!("didn't find error: {error}");
         bad = true;
     }
     if bad {
-        println!("output was:\n\n{}", o);
+        println!("output was:\n\n{o}");
         panic!();
     }
 }
@@ -114,17 +114,17 @@ fn t2_cxx() {
     for line in o.lines().filter(|l| l.starts_with("bad ")) {
         let msg = &line[..line.find(":").unwrap()];
         if !errors.remove(&msg) {
-            println!("unknown error: {}", msg);
+            println!("unknown error: {msg}");
             bad = true;
         }
     }
 
     for error in errors {
-        println!("didn't find error: {}", error);
+        println!("didn't find error: {error}");
         bad = true;
     }
     if bad {
-        println!("output was:\n\n{}", o);
+        println!("output was:\n\n{o}");
         panic!();
     }
 }

--- a/ctest/src/template.rs
+++ b/ctest/src/template.rs
@@ -22,19 +22,19 @@ trait Pretty {
 
 impl<'a> Pretty for &'a str {
     fn pretty(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 
 impl<T> Pretty for *const T {
     fn pretty(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 
 impl<T> Pretty for *mut T {
     fn pretty(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 
@@ -42,7 +42,7 @@ macro_rules! impl_pretty {
     ($($i:ident)*) => ($(
         impl Pretty for $i {
             fn pretty(&self) -> String {
-                format!("{} ({:#x})", self, self)
+                format!("{self} ({self:#x})")
             }
         }
     )*)
@@ -52,7 +52,7 @@ impl_pretty! { i8 i16 i32 i64 u8 u16 u32 u64 usize isize }
 
 fn same<T: Eq + Pretty>(rust: T, c: T, attr: &str) {
     if rust != c {
-        eprintln!("bad {}: rust: {} != c {}", attr, rust.pretty(), c.pretty());
+        eprintln!("bad {attr}: rust: {} != c {}", rust.pretty(), c.pretty());
         FAILED.store(true, Ordering::Relaxed);
     } else {
         NTESTS.fetch_add(1, Ordering::Relaxed);

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -67,7 +67,7 @@ fn do_ctest() {
         t if t.contains("windows") => return test_windows(t),
         t if t.contains("vxworks") => return test_vxworks(t),
         t if t.contains("nto-qnx") => return test_neutrino(t),
-        t => panic!("unknown target {}", t),
+        t => panic!("unknown target {t}"),
     }
 }
 
@@ -102,13 +102,13 @@ fn do_semver() {
         process_semver_file(&mut output, &mut semver_root, &vendor);
     }
     process_semver_file(&mut output, &mut semver_root, &os);
-    let os_arch = format!("{}-{}", os, arch);
+    let os_arch = format!("{os}-{arch}");
     process_semver_file(&mut output, &mut semver_root, &os_arch);
     if target_env != "" {
-        let os_env = format!("{}-{}", os, target_env);
+        let os_env = format!("{os}-{target_env}");
         process_semver_file(&mut output, &mut semver_root, &os_env);
 
-        let os_env_arch = format!("{}-{}-{}", os, target_env, arch);
+        let os_env_arch = format!("{os}-{target_env}-{arch}");
         process_semver_file(&mut output, &mut semver_root, &os_env_arch);
     }
 }
@@ -125,7 +125,7 @@ fn process_semver_file<W: Write, P: AsRef<Path>>(output: &mut W, path: &mut Path
             path.pop();
             return;
         }
-        Err(err) => panic!("unexpected error opening file: {}", err),
+        Err(err) => panic!("unexpected error opening file: {err}"),
     };
     let input = BufReader::new(input_file);
 
@@ -447,9 +447,9 @@ fn test_apple(target: &str) {
             // OSX calls this something else
             "sighandler_t" => "sig_t".to_string(),
 
-            t if is_union => format!("union {}", t),
+            t if is_union => format!("union {t}"),
             t if t.ends_with("_t") => t.to_string(),
-            t if is_struct => format!("struct {}", t),
+            t if is_struct => format!("struct {t}"),
             t => t.to_string(),
         }
     });
@@ -608,9 +608,9 @@ fn test_openbsd(target: &str) {
             // OSX calls this something else
             "sighandler_t" => "sig_t".to_string(),
 
-            t if is_union => format!("union {}", t),
+            t if is_union => format!("union {t}"),
             t if t.ends_with("_t") => t.to_string(),
-            t if is_struct => format!("struct {}", t),
+            t if is_struct => format!("struct {t}"),
             t => t.to_string(),
         }
     });
@@ -707,7 +707,7 @@ fn test_cygwin(target: &str) {
 
             "Ioctl" => "int".to_string(),
 
-            t if is_union => format!("union {}", t),
+            t if is_union => format!("union {t}"),
 
             t if t.ends_with("_t") => t.to_string(),
 
@@ -715,7 +715,7 @@ fn test_cygwin(target: &str) {
             "sigval" => format!("union sigval"),
 
             // put `struct` in front of all structs:.
-            t if is_struct => format!("struct {}", t),
+            t if is_struct => format!("struct {t}"),
 
             t => t.to_string(),
         }
@@ -859,7 +859,7 @@ fn test_windows(target: &str) {
             "sighandler_t" if !gnu => "_crt_signal_t".to_string(),
             "sighandler_t" if gnu => "__p_sig_fn_t".to_string(),
 
-            t if is_union => format!("union {}", t),
+            t if is_union => format!("union {t}"),
             t if t.ends_with("_t") => t.to_string(),
 
             // Windows uppercase structs don't have `struct` in front:
@@ -872,7 +872,7 @@ fn test_windows(target: &str) {
                     "struct __utimbuf64".to_string()
                 } else {
                     // put `struct` in front of all structs:
-                    format!("struct {}", t)
+                    format!("struct {t}")
                 }
             }
             t => t.to_string(),
@@ -1111,8 +1111,8 @@ fn test_solarish(target: &str) {
         "FILE" => "__FILE".to_string(),
         "DIR" | "Dl_info" => ty.to_string(),
         t if t.ends_with("_t") => t.to_string(),
-        t if is_struct => format!("struct {}", t),
-        t if is_union => format!("union {}", t),
+        t if is_struct => format!("struct {t}"),
+        t if is_union => format!("union {t}"),
         t => t.to_string(),
     });
 
@@ -1378,12 +1378,12 @@ fn test_netbsd(target: &str) {
             // OSX calls this something else
             "sighandler_t" => "sig_t".to_string(),
 
-            t if is_union => format!("union {}", t),
+            t if is_union => format!("union {t}"),
 
             t if t.ends_with("_t") => t.to_string(),
 
             // put `struct` in front of all structs:.
-            t if is_struct => format!("struct {}", t),
+            t if is_struct => format!("struct {t}"),
 
             t => t.to_string(),
         }
@@ -1592,7 +1592,7 @@ fn test_dragonflybsd(target: &str) {
             // FIXME(dragonflybsd): OSX calls this something else
             "sighandler_t" => "sig_t".to_string(),
 
-            t if is_union => format!("union {}", t),
+            t if is_union => format!("union {t}"),
 
             t if t.ends_with("_t") => t.to_string(),
 
@@ -1600,7 +1600,7 @@ fn test_dragonflybsd(target: &str) {
             "sigval" => format!("union sigval"),
 
             // put `struct` in front of all structs:.
-            t if is_struct => format!("struct {}", t),
+            t if is_struct => format!("struct {t}"),
 
             t => t.to_string(),
         }
@@ -1767,11 +1767,11 @@ fn test_wasi(target: &str) {
 
     cfg.type_name(move |ty, is_struct, is_union| match ty {
         "FILE" | "fd_set" | "DIR" => ty.to_string(),
-        t if is_union => format!("union {}", t),
-        t if t.starts_with("__wasi") && t.ends_with("_u") => format!("union {}", t),
-        t if t.starts_with("__wasi") && is_struct => format!("struct {}", t),
+        t if is_union => format!("union {t}"),
+        t if t.starts_with("__wasi") && t.ends_with("_u") => format!("union {t}"),
+        t if t.starts_with("__wasi") && is_struct => format!("struct {t}"),
         t if t.ends_with("_t") => t.to_string(),
-        t if is_struct => format!("struct {}", t),
+        t if is_struct => format!("struct {t}"),
         t => t.to_string(),
     });
 
@@ -1820,7 +1820,7 @@ fn test_android(target: &str) {
     let target_pointer_width = match target {
         t if t.contains("aarch64") || t.contains("x86_64") => 64,
         t if t.contains("i686") || t.contains("arm") => 32,
-        t => panic!("unsupported target: {}", t),
+        t => panic!("unsupported target: {t}"),
     };
     let x86 = target.contains("i686") || target.contains("x86_64");
     let aarch64 = target.contains("aarch64");
@@ -1979,7 +1979,7 @@ fn test_android(target: &str) {
             // Just pass all these through, no need for a "struct" prefix
             "FILE" | "fd_set" | "Dl_info" | "Elf32_Phdr" | "Elf64_Phdr" => ty.to_string(),
 
-            t if is_union => format!("union {}", t),
+            t if is_union => format!("union {t}"),
 
             t if t.ends_with("_t") => t.to_string(),
 
@@ -1987,7 +1987,7 @@ fn test_android(target: &str) {
             "sigval" => format!("union sigval"),
 
             // put `struct` in front of all structs:.
-            t if is_struct => format!("struct {}", t),
+            t if is_struct => format!("struct {t}"),
 
             t => t.to_string(),
         }
@@ -2495,7 +2495,7 @@ fn test_freebsd(target: &str) {
             // FIXME(freebsd): https://github.com/rust-lang/libc/issues/1273
             "sighandler_t" => "sig_t".to_string(),
 
-            t if is_union => format!("union {}", t),
+            t if is_union => format!("union {t}"),
 
             t if t.ends_with("_t") => t.to_string(),
 
@@ -2503,7 +2503,7 @@ fn test_freebsd(target: &str) {
             "sigval" => format!("union sigval"),
 
             // put `struct` in front of all structs:.
-            t if is_struct => format!("struct {}", t),
+            t if is_struct => format!("struct {t}"),
 
             t => t.to_string(),
         }
@@ -3082,10 +3082,10 @@ fn test_emscripten(target: &str) {
             t if t.ends_with("_t") => t.to_string(),
 
             // put `struct` in front of all structs:.
-            t if is_struct => format!("struct {}", t),
+            t if is_struct => format!("struct {t}"),
 
             // put `union` in front of all unions:
-            t if is_union => format!("union {}", t),
+            t if is_union => format!("union {t}"),
 
             t => t.to_string(),
         }
@@ -3367,12 +3367,12 @@ fn test_neutrino(target: &str) {
 
             "Ioctl" => "int".to_string(),
 
-            t if is_union => format!("union {}", t),
+            t if is_union => format!("union {t}"),
 
             t if t.ends_with("_t") => t.to_string(),
 
             // put `struct` in front of all structs:.
-            t if is_struct => format!("struct {}", t),
+            t if is_struct => format!("struct {t}"),
 
             t => t.to_string(),
         }
@@ -3590,9 +3590,9 @@ fn test_vxworks(target: &str) {
 
     cfg.type_name(move |ty, is_struct, is_union| match ty {
         "DIR" | "FILE" | "Dl_info" | "RTP_DESC" => ty.to_string(),
-        t if is_union => format!("union {}", t),
+        t if is_union => format!("union {t}"),
         t if t.ends_with("_t") => t.to_string(),
-        t if is_struct => format!("struct {}", t),
+        t if is_struct => format!("struct {t}"),
         t => t.to_string(),
     });
 
@@ -3642,10 +3642,7 @@ fn test_linux(target: &str) {
         (true, false, false) => (),
         (false, true, false) => (),
         (false, false, true) => (),
-        (_, _, _) => panic!(
-            "linux target lib is gnu: {}, musl: {}, uclibc: {}",
-            gnu, musl, uclibc
-        ),
+        (_, _, _) => panic!("linux target lib is gnu: {gnu}, musl: {musl}, uclibc: {uclibc}"),
     }
 
     let arm = target.contains("arm");
@@ -3885,9 +3882,9 @@ fn test_linux(target: &str) {
             // typedefs don't need any keywords
             t if t.ends_with("_t") => t.to_string(),
             // put `struct` in front of all structs:.
-            t if is_struct => format!("struct {}", t),
+            t if is_struct => format!("struct {t}"),
             // put `union` in front of all unions:
-            t if is_union => format!("union {}", t),
+            t if is_union => format!("union {t}"),
 
             t => t.to_string(),
         }
@@ -4877,8 +4874,8 @@ fn test_linux_like_apis(target: &str) {
                 _ => true,
             })
             .type_name(move |ty, is_struct, is_union| match ty {
-                t if is_struct => format!("struct {}", t),
-                t if is_union => format!("union {}", t),
+                t if is_struct => format!("struct {t}"),
+                t if is_union => format!("union {t}"),
                 t => t.to_string(),
             });
 
@@ -4903,8 +4900,8 @@ fn test_linux_like_apis(target: &str) {
             .type_name(move |ty, is_struct, is_union| match ty {
                 "Ioctl" if gnu => "unsigned long".to_string(),
                 "Ioctl" => "int".to_string(),
-                t if is_struct => format!("struct {}", t),
-                t if is_union => format!("union {}", t),
+                t if is_struct => format!("struct {t}"),
+                t if is_union => format!("union {t}"),
                 t => t.to_string(),
             });
         cfg.generate(src_hotfix_dir().join("lib.rs"), "linux_termios.rs");
@@ -4932,8 +4929,8 @@ fn test_linux_like_apis(target: &str) {
                 _ => true,
             })
             .type_name(move |ty, is_struct, is_union| match ty {
-                t if is_struct => format!("struct {}", t),
-                t if is_union => format!("union {}", t),
+                t if is_struct => format!("struct {t}"),
+                t if is_union => format!("union {t}"),
                 t => t.to_string(),
             });
         cfg.generate(src_hotfix_dir().join("lib.rs"), "linux_ipv6.rs");
@@ -5318,9 +5315,9 @@ fn test_haiku(target: &str) {
 
             // is actually a union
             "sigval" => format!("union sigval"),
-            t if is_union => format!("union {}", t),
+            t if is_union => format!("union {t}"),
             t if t.ends_with("_t") => t.to_string(),
-            t if is_struct => format!("struct {}", t),
+            t if is_struct => format!("struct {t}"),
             t => t.to_string(),
         }
     });


### PR DESCRIPTION
Most of this was done with this command:

```shell
cargo clippy --fix --allow-dirty --workspace -- -A clippy::all -W clippy::uninlined_format_args
```

@rustbot label +stable-nominated
