### PR TITLE
chore: use auto-derived copy/clone impls

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -81,30 +81,16 @@ pub type rlim_t = c_ulonglong;
 // FIXME(fuchsia): why are these uninhabited types? that seems... wrong?
 // Presumably these should be `()` or an `extern type` (when that stabilizes).
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum timezone {}
-impl Copy for timezone {}
-impl Clone for timezone {
-    fn clone(&self) -> timezone {
-        *self
-    }
-}
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
-pub enum DIR {}
-impl Copy for DIR {}
-impl Clone for DIR {
-    fn clone(&self) -> DIR {
-        *self
-    }
-}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
+pub enum DIR {}
+
+#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum fpos64_t {} // FIXME(fuchsia): fill this out with a struct
-impl Copy for fpos64_t {}
-impl Clone for fpos64_t {
-    fn clone(&self) -> fpos64_t {
-        *self
-    }
-}
 
 // PUB_STRUCT
 
@@ -3541,21 +3527,12 @@ fn __MHDR_END(mhdr: *const msghdr) -> *mut c_uchar {
 extern "C" {}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum FILE {}
-impl Copy for FILE {}
-impl Clone for FILE {
-    fn clone(&self) -> FILE {
-        *self
-    }
-}
+
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum fpos_t {} // FIXME(fuchsia): fill this out with a struct
-impl Copy for fpos_t {}
-impl Clone for fpos_t {
-    fn clone(&self) -> fpos_t {
-        *self
-    }
-}
 
 extern "C" {
     pub fn isalnum(c: c_int) -> c_int;

--- a/src/solid/mod.rs
+++ b/src/solid/mod.rs
@@ -396,21 +396,12 @@ pub const SIGUSR2: c_int = 31;
 pub const SIGPWR: c_int = 32;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum FILE {}
-impl Copy for FILE {}
-impl Clone for FILE {
-    fn clone(&self) -> FILE {
-        *self
-    }
-}
+
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum fpos_t {}
-impl Copy for fpos_t {}
-impl Clone for fpos_t {
-    fn clone(&self) -> fpos_t {
-        *self
-    }
-}
 
 extern "C" {
     // ctype.h

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -176,15 +176,11 @@ pub type attrgroup_t = u32;
 pub type vol_capabilities_set_t = [u32; 4];
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum timezone {}
-impl Copy for timezone {}
-impl Clone for timezone {
-    fn clone(&self) -> timezone {
-        *self
-    }
-}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 #[repr(u32)]
 pub enum qos_class_t {
     QOS_CLASS_USER_INTERACTIVE = 0x21,
@@ -194,14 +190,9 @@ pub enum qos_class_t {
     QOS_CLASS_BACKGROUND = 0x09,
     QOS_CLASS_UNSPECIFIED = 0x00,
 }
-impl Copy for qos_class_t {}
-impl Clone for qos_class_t {
-    fn clone(&self) -> qos_class_t {
-        *self
-    }
-}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 #[repr(u32)]
 pub enum sysdir_search_path_directory_t {
     SYSDIR_DIRECTORY_APPLICATION = 1,
@@ -229,14 +220,9 @@ pub enum sysdir_search_path_directory_t {
     SYSDIR_DIRECTORY_ALL_APPLICATIONS = 100,
     SYSDIR_DIRECTORY_ALL_LIBRARIES = 101,
 }
-impl Copy for sysdir_search_path_directory_t {}
-impl Clone for sysdir_search_path_directory_t {
-    fn clone(&self) -> sysdir_search_path_directory_t {
-        *self
-    }
-}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 #[repr(u32)]
 pub enum sysdir_search_path_domain_mask_t {
     SYSDIR_DOMAIN_MASK_USER = (1 << 0),
@@ -244,12 +230,6 @@ pub enum sysdir_search_path_domain_mask_t {
     SYSDIR_DOMAIN_MASK_NETWORK = (1 << 2),
     SYSDIR_DOMAIN_MASK_SYSTEM = (1 << 3),
     SYSDIR_DOMAIN_MASK_ALL = 0x0ffff,
-}
-impl Copy for sysdir_search_path_domain_mask_t {}
-impl Clone for sysdir_search_path_domain_mask_t {
-    fn clone(&self) -> sysdir_search_path_domain_mask_t {
-        *self
-    }
 }
 
 s! {

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -46,13 +46,8 @@ pub type vm_map_entry_t = *mut vm_map_entry;
 pub type pmap = __c_anonymous_pmap;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum sem {}
-impl Copy for sem {}
-impl Clone for sem {
-    fn clone(&self) -> sem {
-        *self
-    }
-}
 
 e! {
     #[repr(u32)]

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/b32.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/b32.rs
@@ -3,6 +3,7 @@ use crate::prelude::*;
 
 #[repr(C)]
 #[cfg_attr(feature = "extra_traits", derive(Debug, Eq, Hash, PartialEq))]
+#[derive(Clone, Copy)]
 pub struct stat {
     pub st_dev: crate::dev_t,
     pub st_ino: crate::ino_t,
@@ -26,11 +27,4 @@ pub struct stat {
     pub st_birthtime: crate::time_t,
     pub st_birthtime_nsec: c_long,
     __unused: [u8; 8],
-}
-
-impl Copy for crate::stat {}
-impl Clone for crate::stat {
-    fn clone(&self) -> crate::stat {
-        *self
-    }
 }

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/b64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/b64.rs
@@ -3,6 +3,7 @@ use crate::prelude::*;
 
 #[repr(C)]
 #[cfg_attr(feature = "extra_traits", derive(Debug, Eq, Hash, PartialEq))]
+#[derive(Clone, Copy)]
 pub struct stat {
     pub st_dev: crate::dev_t,
     pub st_ino: crate::ino_t,
@@ -25,11 +26,4 @@ pub struct stat {
     pub st_lspare: i32,
     pub st_birthtime: crate::time_t,
     pub st_birthtime_nsec: c_long,
-}
-
-impl Copy for crate::stat {}
-impl Clone for crate::stat {
-    fn clone(&self) -> crate::stat {
-        *self
-    }
 }

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -51,6 +51,7 @@ pub type sctp_assoc_t = u32;
 pub type eventfd_t = u64;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug, Hash, PartialEq, Eq))]
+#[derive(Clone, Copy)]
 #[repr(u32)]
 pub enum devstat_support_flags {
     DEVSTAT_ALL_SUPPORTED = 0x00,
@@ -58,14 +59,9 @@ pub enum devstat_support_flags {
     DEVSTAT_NO_ORDERED_TAGS = 0x02,
     DEVSTAT_BS_UNAVAILABLE = 0x04,
 }
-impl Copy for devstat_support_flags {}
-impl Clone for devstat_support_flags {
-    fn clone(&self) -> devstat_support_flags {
-        *self
-    }
-}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug, Hash, PartialEq, Eq))]
+#[derive(Clone, Copy)]
 #[repr(u32)]
 pub enum devstat_trans_flags {
     DEVSTAT_NO_DATA = 0x00,
@@ -74,14 +70,8 @@ pub enum devstat_trans_flags {
     DEVSTAT_FREE = 0x03,
 }
 
-impl Copy for devstat_trans_flags {}
-impl Clone for devstat_trans_flags {
-    fn clone(&self) -> devstat_trans_flags {
-        *self
-    }
-}
-
 #[cfg_attr(feature = "extra_traits", derive(Debug, Hash, PartialEq, Eq))]
+#[derive(Clone, Copy)]
 #[repr(u32)]
 pub enum devstat_tag_type {
     DEVSTAT_TAG_SIMPLE = 0x00,
@@ -89,14 +79,9 @@ pub enum devstat_tag_type {
     DEVSTAT_TAG_ORDERED = 0x02,
     DEVSTAT_TAG_NONE = 0x03,
 }
-impl Copy for devstat_tag_type {}
-impl Clone for devstat_tag_type {
-    fn clone(&self) -> devstat_tag_type {
-        *self
-    }
-}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug, Hash, PartialEq, Eq))]
+#[derive(Clone, Copy)]
 #[repr(u32)]
 pub enum devstat_match_flags {
     DEVSTAT_MATCH_NONE = 0x00,
@@ -104,14 +89,9 @@ pub enum devstat_match_flags {
     DEVSTAT_MATCH_IF = 0x02,
     DEVSTAT_MATCH_PASS = 0x04,
 }
-impl Copy for devstat_match_flags {}
-impl Clone for devstat_match_flags {
-    fn clone(&self) -> devstat_match_flags {
-        *self
-    }
-}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug, Hash, PartialEq, Eq))]
+#[derive(Clone, Copy)]
 #[repr(u32)]
 pub enum devstat_priority {
     DEVSTAT_PRIORITY_MIN = 0x000,
@@ -125,14 +105,9 @@ pub enum devstat_priority {
     DEVSTAT_PRIORITY_ARRAY = 0x120,
     DEVSTAT_PRIORITY_MAX = 0xfff,
 }
-impl Copy for devstat_priority {}
-impl Clone for devstat_priority {
-    fn clone(&self) -> devstat_priority {
-        *self
-    }
-}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug, Hash, PartialEq, Eq))]
+#[derive(Clone, Copy)]
 #[repr(u32)]
 pub enum devstat_type_flags {
     DEVSTAT_TYPE_DIRECT = 0x000,
@@ -157,14 +132,9 @@ pub enum devstat_type_flags {
     DEVSTAT_TYPE_IF_MASK = 0x0f0,
     DEVSTAT_TYPE_PASS = 0x100,
 }
-impl Copy for devstat_type_flags {}
-impl Clone for devstat_type_flags {
-    fn clone(&self) -> devstat_type_flags {
-        *self
-    }
-}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug, Hash, PartialEq, Eq))]
+#[derive(Clone, Copy)]
 #[repr(u32)]
 pub enum devstat_metric {
     DSM_NONE,
@@ -214,26 +184,15 @@ pub enum devstat_metric {
     DSM_TOTAL_BUSY_TIME,
     DSM_MAX,
 }
-impl Copy for devstat_metric {}
-impl Clone for devstat_metric {
-    fn clone(&self) -> devstat_metric {
-        *self
-    }
-}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug, Hash, PartialEq, Eq))]
+#[derive(Clone, Copy)]
 #[repr(u32)]
 pub enum devstat_select_mode {
     DS_SELECT_ADD,
     DS_SELECT_ONLY,
     DS_SELECT_REMOVE,
     DS_SELECT_ADDONLY,
-}
-impl Copy for devstat_select_mode {}
-impl Clone for devstat_select_mode {
-    fn clone(&self) -> devstat_select_mode {
-        *self
-    }
 }
 
 s! {
@@ -2600,6 +2559,7 @@ cfg_if! {
 }
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 #[repr(u32)]
 pub enum dot3Vendors {
     dot3VendorAMD = 1,
@@ -2608,12 +2568,6 @@ pub enum dot3Vendors {
     dot3VendorFujitsu = 5,
     dot3VendorDigital = 6,
     dot3VendorWesternDigital = 7,
-}
-impl Copy for dot3Vendors {}
-impl Clone for dot3Vendors {
-    fn clone(&self) -> dot3Vendors {
-        *self
-    }
 }
 
 // aio.h

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -60,13 +60,8 @@ cfg_if! {
 // link.h
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum timezone {}
-impl Copy for timezone {}
-impl Clone for timezone {
-    fn clone(&self) -> timezone {
-        *self
-    }
-}
 
 impl siginfo_t {
     pub unsafe fn si_addr(&self) -> *mut c_void {

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -17,21 +17,12 @@ pub type sem_t = *mut sem;
 pub type key_t = c_long;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum timezone {}
-impl Copy for timezone {}
-impl Clone for timezone {
-    fn clone(&self) -> timezone {
-        *self
-    }
-}
+
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum sem {}
-impl Copy for sem {}
-impl Clone for sem {
-    fn clone(&self) -> sem {
-        *self
-    }
-}
 
 s! {
     pub struct sched_param {

--- a/src/unix/cygwin/mod.rs
+++ b/src/unix/cygwin/mod.rs
@@ -29,13 +29,8 @@ pub type suseconds_t = c_long;
 pub type useconds_t = c_ulong;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum timezone {}
-impl Copy for timezone {}
-impl Clone for timezone {
-    fn clone(&self) -> timezone {
-        *self
-    }
-}
 
 pub type sigset_t = c_ulong;
 
@@ -76,13 +71,8 @@ pub type nfds_t = c_uint;
 pub type sem_t = *mut sem;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum sem {}
-impl Copy for sem {}
-impl Clone for sem {
-    fn clone(&self) -> sem {
-        *self
-    }
-}
 
 pub type tcflag_t = c_uint;
 pub type speed_t = c_uint;

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -59,13 +59,8 @@ pub type posix_spawn_file_actions_t = *mut c_void;
 pub type StringList = _stringlist;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum timezone {}
-impl Copy for timezone {}
-impl Clone for timezone {
-    fn clone(&self) -> timezone {
-        *self
-    }
-}
 
 impl siginfo_t {
     pub unsafe fn si_addr(&self) -> *mut c_void {

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -226,22 +226,12 @@ pub type nl_item = c_int;
 pub type iconv_t = *mut c_void;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum fpos64_t {} // FIXME(hurd): fill this out with a struct
-impl Copy for fpos64_t {}
-impl Clone for fpos64_t {
-    fn clone(&self) -> fpos64_t {
-        *self
-    }
-}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum timezone {}
-impl Copy for timezone {}
-impl Clone for timezone {
-    fn clone(&self) -> timezone {
-        *self
-    }
-}
 
 // structs
 s! {

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -4202,18 +4202,13 @@ impl siginfo_t {
 
 // Internal, for casts to access union fields
 #[repr(C)]
+#[derive(Clone, Copy)]
 struct sifields_sigchld {
     si_pid: crate::pid_t,
     si_uid: crate::uid_t,
     si_status: c_int,
     si_utime: c_long,
     si_stime: c_long,
-}
-impl Copy for sifields_sigchld {}
-impl Clone for sifields_sigchld {
-    fn clone(&self) -> sifields_sigchld {
-        *self
-    }
 }
 
 // Internal, for casts to access union fields

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -42,13 +42,8 @@ pub type statvfs64 = crate::statvfs;
 pub type dirent64 = crate::dirent;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum fpos64_t {} // FIXME(emscripten): fill this out with a struct
-impl Copy for fpos64_t {}
-impl Clone for fpos64_t {
-    fn clone(&self) -> fpos64_t {
-        *self
-    }
-}
 
 s! {
     pub struct glob_t {

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -470,18 +470,13 @@ s_no_extra_traits! {
 
 // Internal, for casts to access union fields
 #[repr(C)]
+#[derive(Clone, Copy)]
 struct sifields_sigchld {
     si_pid: crate::pid_t,
     si_uid: crate::uid_t,
     si_status: c_int,
     si_utime: c_long,
     si_stime: c_long,
-}
-impl Copy for sifields_sigchld {}
-impl Clone for sifields_sigchld {
-    fn clone(&self) -> sifields_sigchld {
-        *self
-    }
 }
 
 // Internal, for casts to access union fields
@@ -526,16 +521,11 @@ impl siginfo_t {
     }
 }
 
+#[derive(Clone, Copy)]
 pub union __c_anonymous_ptrace_syscall_info_data {
     pub entry: __c_anonymous_ptrace_syscall_info_entry,
     pub exit: __c_anonymous_ptrace_syscall_info_exit,
     pub seccomp: __c_anonymous_ptrace_syscall_info_seccomp,
-}
-impl Copy for __c_anonymous_ptrace_syscall_info_data {}
-impl Clone for __c_anonymous_ptrace_syscall_info_data {
-    fn clone(&self) -> __c_anonymous_ptrace_syscall_info_data {
-        *self
-    }
 }
 
 s_no_extra_traits! {

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -65,18 +65,13 @@ impl siginfo_t {
 
 // Internal, for casts to access union fields
 #[repr(C)]
+#[derive(Clone, Copy)]
 struct sifields_sigchld {
     si_pid: crate::pid_t,
     si_uid: crate::uid_t,
     si_status: c_int,
     si_utime: c_long,
     si_stime: c_long,
-}
-impl Copy for sifields_sigchld {}
-impl Clone for sifields_sigchld {
-    fn clone(&self) -> sifields_sigchld {
-        *self
-    }
 }
 
 // Internal, for casts to access union fields

--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -180,18 +180,13 @@ impl siginfo_t {
 
 // Internal, for casts to access union fields
 #[repr(C)]
+#[derive(Clone, Copy)]
 struct sifields_sigchld {
     si_pid: crate::pid_t,
     si_uid: crate::uid_t,
     si_status: c_int,
     si_utime: c_long,
     si_stime: c_long,
-}
-impl Copy for sifields_sigchld {}
-impl Clone for sifields_sigchld {
-    fn clone(&self) -> sifields_sigchld {
-        *self
-    }
 }
 
 // Internal, for casts to access union fields

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -73,13 +73,8 @@ pub type sem_t = sync_t;
 pub type nl_item = c_int;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum timezone {}
-impl Copy for timezone {}
-impl Clone for timezone {
-    fn clone(&self) -> timezone {
-        *self
-    }
-}
 
 s! {
     pub struct dirent_extra {

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -33,13 +33,8 @@ pub type uid_t = u32;
 pub type gid_t = u32;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum timezone {}
-impl Copy for timezone {}
-impl Clone for timezone {
-    fn clone(&self) -> timezone {
-        *self
-    }
-}
 
 s_no_extra_traits! {
     #[repr(C)]

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -58,22 +58,12 @@ pub type posix_spawnattr_t = *mut c_void;
 pub type posix_spawn_file_actions_t = *mut c_void;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum timezone {}
-impl Copy for timezone {}
-impl Clone for timezone {
-    fn clone(&self) -> timezone {
-        *self
-    }
-}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum ucred_t {}
-impl Copy for ucred_t {}
-impl Clone for ucred_t {
-    fn clone(&self) -> ucred_t {
-        *self
-    }
-}
 
 s! {
     pub struct in_addr {
@@ -896,71 +886,46 @@ cfg_if! {
 }
 
 #[repr(C)]
+#[derive(Clone, Copy)]
 struct siginfo_fault {
     addr: *mut c_void,
     trapno: c_int,
     pc: *mut crate::caddr_t,
 }
-impl Copy for siginfo_fault {}
-impl Clone for siginfo_fault {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 
 #[repr(C)]
+#[derive(Clone, Copy)]
 struct siginfo_cldval {
     utime: crate::clock_t,
     status: c_int,
     stime: crate::clock_t,
 }
-impl Copy for siginfo_cldval {}
-impl Clone for siginfo_cldval {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 
 #[repr(C)]
+#[derive(Clone, Copy)]
 struct siginfo_killval {
     uid: crate::uid_t,
     value: crate::sigval,
     // Pad out to match the SIGCLD value size
     _pad: *mut c_void,
 }
-impl Copy for siginfo_killval {}
-impl Clone for siginfo_killval {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 
 #[repr(C)]
+#[derive(Clone, Copy)]
 struct siginfo_sigcld {
     pid: crate::pid_t,
     val: siginfo_cldval,
     ctid: crate::ctid_t,
     zoneid: crate::zoneid_t,
 }
-impl Copy for siginfo_sigcld {}
-impl Clone for siginfo_sigcld {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
 
 #[repr(C)]
+#[derive(Clone, Copy)]
 struct siginfo_kill {
     pid: crate::pid_t,
     val: siginfo_killval,
     ctid: crate::ctid_t,
     zoneid: crate::zoneid_t,
-}
-impl Copy for siginfo_kill {}
-impl Clone for siginfo_kill {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 
 impl siginfo_t {

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -6,13 +6,8 @@ use core::ptr::null_mut;
 use crate::prelude::*;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum DIR {}
-impl Copy for DIR {}
-impl Clone for DIR {
-    fn clone(&self) -> DIR {
-        *self
-    }
-}
 
 pub type intmax_t = i64;
 pub type uintmax_t = u64;
@@ -97,13 +92,8 @@ pub type sa_family_t = c_uchar;
 pub type mqd_t = c_int;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum _Vx_semaphore {}
-impl Copy for _Vx_semaphore {}
-impl Clone for _Vx_semaphore {
-    fn clone(&self) -> _Vx_semaphore {
-        *self
-    }
-}
 
 impl siginfo_t {
     pub unsafe fn si_addr(&self) -> *mut c_void {
@@ -1110,21 +1100,12 @@ pub const MAP_CONTIG: c_int = 0x0020;
 pub const MAP_FAILED: *mut c_void = !0 as *mut c_void;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum FILE {}
-impl Copy for FILE {}
-impl Clone for FILE {
-    fn clone(&self) -> FILE {
-        *self
-    }
-}
+
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum fpos_t {} // FIXME(vxworks): fill this out with a struct
-impl Copy for fpos_t {}
-impl Clone for fpos_t {
-    fn clone(&self) -> fpos_t {
-        *self
-    }
-}
 
 f! {
     pub {const} fn CMSG_ALIGN(len: usize) -> usize {

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -30,13 +30,9 @@ pub type off_t = i32;
 pub type dev_t = u32;
 pub type ino_t = u16;
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum timezone {}
-impl Copy for timezone {}
-impl Clone for timezone {
-    fn clone(&self) -> timezone {
-        *self
-    }
-}
+
 pub type time64_t = i64;
 
 pub type SOCKET = crate::uintptr_t;
@@ -244,21 +240,12 @@ pub const SIG_SGE: crate::sighandler_t = 3;
 pub const SIG_ACK: crate::sighandler_t = 4;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum FILE {}
-impl Copy for FILE {}
-impl Clone for FILE {
-    fn clone(&self) -> FILE {
-        *self
-    }
-}
+
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Clone, Copy)]
 pub enum fpos_t {} // FIXME(windows): fill this out with a struct
-impl Copy for fpos_t {}
-impl Clone for fpos_t {
-    fn clone(&self) -> fpos_t {
-        *self
-    }
-}
 
 // Special handling for all print and scan type functions because of https://github.com/rust-lang/libc/issues/2860
 cfg_if! {


### PR DESCRIPTION
Unless there is something really magical, it doesn't seem to make sense to have manual impl for the most commonly used traits

@rustbot label +stable-nominated
