### PR TITLE
Update Redox SA_ constants.

### DIFF
--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -661,14 +661,14 @@ pub const SIGPWR: c_int = 30;
 pub const SIGSYS: c_int = 31;
 pub const NSIG: c_int = 32;
 
-pub const SA_NOCLDSTOP: c_ulong = 0x00000001;
-pub const SA_NOCLDWAIT: c_ulong = 0x00000002;
-pub const SA_SIGINFO: c_ulong = 0x00000004;
-pub const SA_RESTORER: c_ulong = 0x04000000;
-pub const SA_ONSTACK: c_ulong = 0x08000000;
-pub const SA_RESTART: c_ulong = 0x10000000;
-pub const SA_NODEFER: c_ulong = 0x40000000;
-pub const SA_RESETHAND: c_ulong = 0x80000000;
+pub const SA_NOCLDWAIT: c_ulong = 0x0000_0002;
+pub const SA_RESTORER: c_ulong = 0x0000_0004; // FIXME(redox): remove after relibc removes it
+pub const SA_SIGINFO: c_ulong = 0x0200_0000;
+pub const SA_ONSTACK: c_ulong = 0x0400_0000;
+pub const SA_RESTART: c_ulong = 0x0800_0000;
+pub const SA_NODEFER: c_ulong = 0x1000_0000;
+pub const SA_RESETHAND: c_ulong = 0x2000_0000;
+pub const SA_NOCLDSTOP: c_ulong = 0x4000_0000;
 
 // sys/file.h
 pub const LOCK_SH: c_int = 1;


### PR DESCRIPTION
# Description

Redox completely redesigned its signal handling code last summer, but this wasn't upstreamed to the libc crate, making crates like signal-hook segfault.

It would be appreciated if a 0.2 minor version could be released with these changes.

Closes: https://github.com/rust-lang/libc/pull/4262

# Sources

https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/signal/redox.rs?ref_type=heads#L43-50

underlying diff

https://gitlab.redox-os.org/redox-os/relibc/-/merge_requests/480/diffs#d174caa1d6ee478ceffe421ab58c6f035a7e7285_72_39

# Checklist

- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included
- [x] Tested locally using https://gitlab.redox-os.org/redox-os/acid/-/blob/master/src/proc.rs?ref_type=heads#L649-667 with and without this patch, respectively

@rustbot label +stable-nominated
