### PR TITLE
Add more windows time.h functions

### DIFF
--- a/libc-test/semver/windows.txt
+++ b/libc-test/semver/windows.txt
@@ -174,12 +174,15 @@ c_void
 calloc
 chdir
 chmod
+clock
 clock_t
 close
 commit
 connect
 creat
+ctime
 dev_t
+difftime
 dup
 dup2
 errno_t
@@ -214,7 +217,11 @@ fsetpos
 fstat
 ftell
 fwrite
+get_daylight
+get_dstbias
 get_osfhandle
+get_timezone
+get_tzname
 getchar
 getcwd
 getenv
@@ -326,6 +333,7 @@ tm
 tmpfile
 tolower
 toupper
+tzset
 uint16_t
 uint32_t
 uint64_t

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -374,12 +374,25 @@ extern "C" {
     pub fn signal(signum: c_int, handler: sighandler_t) -> sighandler_t;
     pub fn raise(signum: c_int) -> c_int;
 
+    pub fn clock() -> clock_t;
+    pub fn ctime(sourceTime: *const time_t) -> *mut c_char;
+    pub fn difftime(timeEnd: time_t, timeStart: time_t) -> c_double;
     #[link_name = "_gmtime64_s"]
     pub fn gmtime_s(destTime: *mut tm, srcTime: *const time_t) -> c_int;
+    #[link_name = "_get_daylight"]
+    pub fn get_daylight(hours: *mut c_int) -> errno_t;
+    #[link_name = "_get_dstbias"]
+    pub fn get_dstbias(seconds: *mut c_long) -> errno_t;
+    #[link_name = "_get_timezone"]
+    pub fn get_timezone(seconds: *mut c_long) -> errno_t;
+    #[link_name = "_get_tzname"]
+    pub fn get_tzname(p_return_value: *mut size_t, time_zone_name: *mut c_char, size_in_bytes: size_t, index: c_int) -> errno_t;
     #[link_name = "_localtime64_s"]
     pub fn localtime_s(tmDest: *mut tm, sourceTime: *const time_t) -> crate::errno_t;
     #[link_name = "_time64"]
     pub fn time(destTime: *mut time_t) -> time_t;
+    #[link_name = "_tzset"]
+    pub fn tzset();
     #[link_name = "_chmod"]
     pub fn chmod(path: *const c_char, mode: c_int) -> c_int;
     #[link_name = "_wchmod"]


### PR DESCRIPTION
# Description

Adds some windows time functions

Related issue: rust-lang/libc#1245

# Sources

```c
clock_t clock( void );
char *ctime( const time_t *sourceTime );
double difftime( time_t timeEnd, time_t timeStart );
error_t _get_daylight( int* hours );
error_t _get_dstbias( long* seconds );
error_t _get_timezone(long* seconds);
errno_t _get_tzname(
    size_t* pReturnValue,
    char* timeZoneName,
    size_t sizeInBytes,
    int index
);
void _tzset( void );
```
# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [rust-lang/libc#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
