### PR TITLE
ctest: Revise generate function to return Result

### DIFF
--- a/ctest-test/Cargo.toml
+++ b/ctest-test/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 ctest = { path = "../ctest" }
 cc = "1.0"
 
+[dev-dependencies]
+ctest = { path = "../ctest" }
+
 [dependencies]
 cfg-if = "1.0.0"
 libc = { path = ".." }

--- a/ctest-test/tests/all.rs
+++ b/ctest-test/tests/all.rs
@@ -128,3 +128,75 @@ fn t2_cxx() {
         panic!();
     }
 }
+
+#[test]
+fn test_missing_out_dir() {
+    // Save original OUT_DIR
+    let orig_out_dir = env::var_os("OUT_DIR");
+    env::remove_var("OUT_DIR");
+
+    // Test error handling for OUT_DIR missing
+    let result = ctest::TestGenerator::new()
+        .header("t1.h")
+        .try_generate("src/t1.rs", "out_dir_gen.rs");
+
+    // Restore OUT_DIR
+    if let Some(dir) = orig_out_dir {
+        env::set_var("OUT_DIR", dir);
+    }
+
+    assert!(result.is_err(), "Expected error when OUT_DIR is missing");
+}
+
+#[test]
+fn test_invalid_output_path() {
+    // Test error handling for invalid output path
+    let err = ctest::TestGenerator::new()
+        .header("t1.h")
+        .include("src")
+        .out_dir("/nonexistent_dir") // Should fail with permission error
+        .try_generate("src/t1.rs", "out_path_gen.rs");
+
+    assert!(err.is_err(), "Expected error with invalid output path");
+}
+
+#[test]
+fn test_parsing_error() {
+    // Test parsing error
+    // Create a temporary file with invalid Rust syntax
+    let temp_dir = env::temp_dir();
+    let invalid_file = temp_dir.join("invalid.rs");
+    std::fs::write(&invalid_file, "fn invalid_syntax {").unwrap();
+
+    let err = ctest::TestGenerator::new()
+        .header("t1.h")
+        .include("src")
+        .target("x86_64-unknown-linux-gnu")
+        .try_generate(&invalid_file, "parse_gen.rs");
+
+    assert!(err.is_err(), "Expected error when parsing invalid syntax");
+    let _ = std::fs::remove_file(invalid_file);
+}
+
+#[test]
+fn test_non_existent_header() {
+    // Test non-existent header
+    let err = ctest::TestGenerator::new()
+        .header("nonexistent_header.h")
+        .include("src")
+        .try_generate("src/t1.rs", "missing_header_gen.rs");
+
+    assert!(err.is_err(), "Expected error with non-existent header");
+}
+
+#[test]
+fn test_invalid_include_path() {
+    // Test invalid include path
+    let err = ctest::TestGenerator::new()
+        .header("t1.h")
+        .include("nonexistent_directory")
+        .try_generate("src/t1.rs", "invalid_include_gen.rs");
+
+    assert!(err.is_err(), "Expected error with invalid include path");
+}
+

--- a/ctest/Cargo.toml
+++ b/ctest/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/rust-lang/libc"
 rust-version = "1.63.0"
 
 [dependencies]
+anyhow = "1.0"
 garando_syntax = "0.1"
 cc = "1.0.1"
 rustc_version = "0.4"


### PR DESCRIPTION
# Description

As per rust-lang/libc#4369 , the generate function should return a Result instead of returning nothing. 

This PR is a continuation of rust-lang/libc#4424 which was closed due to bad rebase.

# Checklist


- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [rust-lang/libc#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

