### PR TITLE
Add constants from linux/cn_proc.h and linux/connector.h

### DIFF
--- a/ci/style.sh
+++ b/ci/style.sh
@@ -26,7 +26,7 @@ while IFS= read -r file; do
 
     # Turn all braced macro `foo! { /* ... */ }` invocations into
     # `fn foo_fmt_tmp() { /* ... */ }`.
-    perl -pi -e 's/(?!macro_rules)\b(\w+)!\s*\{/fn $1_fmt_tmp() {/g' "$file"
+    perl -pi -e 's/(?!macro_rules|c_enum)\b(\w+)!\s*\{/fn $1_fmt_tmp() {/g' "$file"
 
     # Replace `if #[cfg(...)]` within `cfg_if` with `if cfg_tmp!([...])` which
     # `rustfmt` will format. We put brackets within the parens so it is easy to

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3805,6 +3805,8 @@ fn test_linux(target: &str) {
             "linux/can.h",
             "linux/can/raw.h",
             "linux/can/j1939.h",
+            "linux/cn_proc.h",
+            "linux/connector.h",
             "linux/dccp.h",
             "linux/errqueue.h",
             "linux/falloc.h",
@@ -4624,6 +4626,9 @@ fn test_linux(target: &str) {
             | "SCM_DEVMEM_DMABUF" => true,
             // FIXME(linux): Requires >= 6.4 kernel headers.
             "PTRACE_SET_SYSCALL_USER_DISPATCH_CONFIG" | "PTRACE_GET_SYSCALL_USER_DISPATCH_CONFIG" => true,
+
+            // FIXME(linux): Requires >= 6.6 kernel headers.
+            "PROC_EVENT_NONZERO_EXIT" => true,
 
             _ => false,
         }

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -4694,6 +4694,51 @@ pub const RTNLGRP_MCTP_IFADDR: c_uint = 0x22;
 pub const RTNLGRP_TUNNEL: c_uint = 0x23;
 pub const RTNLGRP_STATS: c_uint = 0x24;
 
+// linux/cn_proc.h
+c_enum! {
+    proc_cn_mcast_op {
+        PROC_CN_MCAST_LISTEN = 1,
+        PROC_CN_MCAST_IGNORE = 2,
+    }
+}
+
+c_enum! {
+    proc_cn_event {
+        PROC_EVENT_NONE = 0x00000000,
+        PROC_EVENT_FORK = 0x00000001,
+        PROC_EVENT_EXEC = 0x00000002,
+        PROC_EVENT_UID = 0x00000004,
+        PROC_EVENT_GID = 0x00000040,
+        PROC_EVENT_SID = 0x00000080,
+        PROC_EVENT_PTRACE = 0x00000100,
+        PROC_EVENT_COMM = 0x00000200,
+        PROC_EVENT_NONZERO_EXIT = 0x20000000,
+        PROC_EVENT_COREDUMP = 0x40000000,
+        PROC_EVENT_EXIT = 0x80000000,
+    }
+}
+
+// linux/connector.h
+pub const CN_IDX_PROC: c_uint = 0x1;
+pub const CN_VAL_PROC: c_uint = 0x1;
+pub const CN_IDX_CIFS: c_uint = 0x2;
+pub const CN_VAL_CIFS: c_uint = 0x1;
+pub const CN_W1_IDX: c_uint = 0x3;
+pub const CN_W1_VAL: c_uint = 0x1;
+pub const CN_IDX_V86D: c_uint = 0x4;
+pub const CN_VAL_V86D_UVESAFB: c_uint = 0x1;
+pub const CN_IDX_BB: c_uint = 0x5;
+pub const CN_DST_IDX: c_uint = 0x6;
+pub const CN_DST_VAL: c_uint = 0x1;
+pub const CN_IDX_DM: c_uint = 0x7;
+pub const CN_VAL_DM_USERSPACE_LOG: c_uint = 0x1;
+pub const CN_IDX_DRBD: c_uint = 0x8;
+pub const CN_VAL_DRBD: c_uint = 0x1;
+pub const CN_KVP_IDX: c_uint = 0x9;
+pub const CN_KVP_VAL: c_uint = 0x1;
+pub const CN_VSS_IDX: c_uint = 0xA;
+pub const CN_VSS_VAL: c_uint = 0x1;
+
 // linux/module.h
 pub const MODULE_INIT_IGNORE_MODVERSIONS: c_uint = 0x0001;
 pub const MODULE_INIT_IGNORE_VERMAGIC: c_uint = 0x0002;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->
Add constants from linux/cn_proc.h and linux/connector.h

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->
https://github.com/torvalds/linux/blob/b6ea1680d0ac0e45157a819c41b46565f4616186/include/uapi/linux/cn_proc.h
https://github.com/torvalds/linux/blob/b6ea1680d0ac0e45157a819c41b46565f4616186/include/uapi/linux/connector.h

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [rust-lang/libc#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
