### PR TITLE
musl: rename __ipc_perm_key

### DIFF
--- a/src/fuchsia/aarch64.rs
+++ b/src/fuchsia/aarch64.rs
@@ -52,7 +52,7 @@ s! {
     }
 
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/fuchsia/riscv64.rs
+++ b/src/fuchsia/riscv64.rs
@@ -33,7 +33,7 @@ s! {
 
     // Not actually used, IPC calls just return ENOSYS
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/fuchsia/x86_64.rs
+++ b/src/fuchsia/x86_64.rs
@@ -54,7 +54,7 @@ s! {
     }
 
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -166,7 +166,7 @@ s! {
     }
 
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -55,7 +55,7 @@ s! {
     }
 
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/unix/linux_like/linux/musl/b32/hexagon.rs
+++ b/src/unix/linux_like/linux/musl/b32/hexagon.rs
@@ -34,7 +34,7 @@ s! {
     }
 
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -57,7 +57,7 @@ s! {
     }
 
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -53,7 +53,7 @@ s! {
     }
 
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -59,7 +59,7 @@ s! {
     }
 
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -60,7 +60,7 @@ s! {
     }
 
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -57,7 +57,7 @@ s! {
     }
 
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -51,7 +51,7 @@ s! {
     }
 
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -10,7 +10,7 @@ pub type __s64 = i64;
 
 s! {
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/unix/linux_like/linux/musl/b64/wasm32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/wasm32/mod.rs
@@ -53,7 +53,7 @@ s! {
     }
 
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -112,7 +112,7 @@ s! {
     }
 
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,


### PR DESCRIPTION
# Description

This change renames the internal name `__ipc_perm_key` to `__key` in the `ipc_perm` struct for musl libc, to be consistent with the `__seq` field as well as the glibc version of the same type. This works, because `__ipc_perm_key` is defined as `__key`, effectively adding an alias to the field. `__seq` is defined in the same way, as an alias to `__ipc_perm_seq`, however unlike `__key` this internal name was not present [in the first commit](https://github.com/rust-lang/libc/commit/58501564c49b904893363be6a1e50218f3e11d54#diff-e2066a648bc4789135edf04b19af40368fa89cc7adf8571a4f8b00ec5711b64dR86) `__seq` 

# Sources
[musl: __key define/alias](https://github.com/bminor/musl/blob/c47ad25ea3b484e10326f933e927c0bc8cded3da/include/sys/ipc.h#L16)
[musl: ipc_perm type](https://github.com/bminor/musl/blob/c47ad25ea3b484e10326f933e927c0bc8cded3da/arch/generic/bits/ipc.h#L2)
[glibc version of ipc_perm in libc crate](https://github.com/rust-lang/libc/blob/50a2acf7a3a8d4cb50883692608d025e2a73a169/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs#L239)
[code search for `__ipc_perm_key` (only auto generated code and musl mirrors)](https://github.com/search?q=__ipc_perm_key&type=code)

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated (not applicable)
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [rust-lang/libc#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

