### PR TITLE
musl: fix test build with musl 1.2.0+

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4795,7 +4795,9 @@ fn test_linux(target: &str) {
         (struct_ == "statvfs" && field == "__f_spare") ||
         (struct_ == "statvfs64" && field == "__f_spare") ||
         // the `xsk_tx_metadata_union` field is an anonymous union
-        (struct_ == "xsk_tx_metadata" && field == "xsk_tx_metadata_union")
+        (struct_ == "xsk_tx_metadata" && field == "xsk_tx_metadata_union") ||
+        // FIXME(musl): After musl 1.2.0, the type becomes `int` instead of `long`.
+        (struct_ == "utmpx" && field == "ut_session")
     });
 
     cfg.skip_roundtrip(move |s| match s {


### PR DESCRIPTION
# Description
Since musl 1.2.0, the utmpx.ut_session type changed from long to int (with padding). For now, skip the test for this field. This fixes rust-lang/libc#3305. This change type can probably be changed and this commit reverted when rust-lang/libc#3068 is merged.

# Sources

[diff](https://github.com/bminor/musl/commit/1e7f0fcd7ff2096904fd93a2ee6d12a2392be392)
[permalink](https://github.com/bminor/musl/blob/c47ad25ea3b484e10326f933e927c0bc8cded3da/include/utmpx.h#L30)

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [rust-lang/libc#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated