### PR TITLE
musl: fix CPU_SETSIZE

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4795,7 +4795,9 @@ fn test_linux(target: &str) {
         (struct_ == "statvfs" && field == "__f_spare") ||
         (struct_ == "statvfs64" && field == "__f_spare") ||
         // the `xsk_tx_metadata_union` field is an anonymous union
-        (struct_ == "xsk_tx_metadata" && field == "xsk_tx_metadata_union")
+        (struct_ == "xsk_tx_metadata" && field == "xsk_tx_metadata_union") ||
+        // FIXME(musl): After musl 1.2.0, the type becomes `int` instead of `long`.
+        (struct_ == "utmpx" && field == "ut_session")
     });
 
     cfg.skip_roundtrip(move |s| match s {

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -731,9 +731,6 @@ pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
 pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: usize = 8;
 pub const __SIZEOF_PTHREAD_BARRIERATTR_T: usize = 4;
 
-#[cfg(not(target_arch = "loongarch64"))]
-pub const CPU_SETSIZE: c_int = 128;
-#[cfg(target_arch = "loongarch64")]
 pub const CPU_SETSIZE: c_int = 1024;
 
 pub const PTRACE_TRACEME: c_int = 0;


### PR DESCRIPTION
# Description
musl upstream has changed the size from 128 to 1024 in upstream commit
bc695a5, which is in versions 1.2.4+. I see this was fixed for loongarch in this repository, but this change applies to all architectures.

# Sources
[loongarch commit that changes this](https://github.com/rust-lang/libc/commit/bfdc3708196b02b854648b5f245f1304e8875029)
[upstream change](https://github.com/bminor/musl/commit/bc695a5ac1d7929e5c1ad5297eb47e146cccd157)
[upstream permalink](https://github.com/bminor/musl/blob/c47ad25ea3b484e10326f933e927c0bc8cded3da/include/sched.h#L126)
# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [rust-lang/libc#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

I'm not sure if this can be nominated for 0.2. I would appreciate if someone could confirm.

NOTE: review/merge after rust-lang/libc#4438 - it includes a commit from that PR.