### PR TITLE
redox: make CMSG_ALIGN, CMSG_LEN, and CMSG_SPACE const functions

### DIFF
--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -1014,8 +1014,19 @@ pub const PRIO_PROCESS: c_int = 0;
 pub const PRIO_PGRP: c_int = 1;
 pub const PRIO_USER: c_int = 2;
 
-// wait.h
 f! {
+    //sys/socket.h
+    pub {const} fn CMSG_ALIGN(len: size_t) -> size_t {
+        (len + mem::size_of::<size_t>() - 1) & !(mem::size_of::<size_t>() - 1)
+    }
+    pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
+        (CMSG_ALIGN(mem::size_of::<cmsghdr>()) + length as usize) as c_uint
+    }
+    pub {const} fn CMSG_SPACE(len: c_uint) -> c_uint {
+        (CMSG_ALIGN(len as size_t) + CMSG_ALIGN(mem::size_of::<cmsghdr>())) as c_uint
+    }
+
+    // wait.h
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
         let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
@@ -1228,12 +1239,9 @@ extern "C" {
     pub fn setrlimit(resource: c_int, rlim: *const crate::rlimit) -> c_int;
 
     // sys/socket.h
-    pub fn CMSG_ALIGN(len: size_t) -> size_t;
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar;
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr;
-    pub fn CMSG_LEN(len: c_uint) -> c_uint;
     pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr;
-    pub fn CMSG_SPACE(len: c_uint) -> c_uint;
     pub fn bind(
         socket: c_int,
         address: *const crate::sockaddr,


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

This makes CMSG_ALIGN, CMSG_LEN, and CMSG_SPACE const functions, which matches other platforms and fixes issues in rustix.

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

The function implementations came from https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/sys_socket/mod.rs#L72

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [rust-lang/libc#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
