### PR TITLE
triagebot: Set `issue-links.check-commits = false`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -13,6 +13,7 @@ contributing_url = "https://github.com/rust-lang/libc/blob/HEAD/CONTRIBUTING.md"
 
 # Ensure issue links link to this repo
 [issue-links]
+check-commits = false # don't forbid links to issues
 
 # Prevents mentions in commits to avoid users being spammed
 [no-mentions]


### PR DESCRIPTION
Disable warnings when crosslinking issues, since we do want contributors to do this.

Cc: https://github.com/rust-lang/triagebot/pull/1966