### PR TITLE
Begin source reorganization with `linux/can.h`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 
 #[macro_use]
 mod macros;
+mod new;
 
 cfg_if! {
     if #[cfg(feature = "rustc-dep-of-std")] {
@@ -30,6 +31,9 @@ cfg_if! {
 }
 
 pub use core::ffi::c_void;
+
+#[allow(unused_imports)] // needed while the module is empty on some platforms
+pub use new::*;
 
 cfg_if! {
     if #[cfg(windows)] {

--- a/src/new/linux_uapi/linux/can.rs
+++ b/src/new/linux_uapi/linux/can.rs
@@ -1,0 +1,137 @@
+//! Header: `uapi/linux/can.h`
+
+// FIXME(ctest): we shouldn't have to specify the path but garando doesn't find modules otherwise
+#[path = "can/j1939.rs"]
+pub(crate) mod j1939;
+#[path = "can/raw.rs"]
+pub(crate) mod raw;
+
+pub use j1939::*;
+pub use raw::*;
+
+use crate::prelude::*;
+
+pub const CAN_EFF_FLAG: canid_t = 0x80000000;
+pub const CAN_RTR_FLAG: canid_t = 0x40000000;
+pub const CAN_ERR_FLAG: canid_t = 0x20000000;
+
+pub const CAN_SFF_MASK: canid_t = 0x000007FF;
+pub const CAN_EFF_MASK: canid_t = 0x1FFFFFFF;
+pub const CAN_ERR_MASK: canid_t = 0x1FFFFFFF;
+pub const CANXL_PRIO_MASK: crate::canid_t = CAN_SFF_MASK;
+
+pub type canid_t = u32;
+
+pub const CAN_SFF_ID_BITS: c_int = 11;
+pub const CAN_EFF_ID_BITS: c_int = 29;
+pub const CANXL_PRIO_BITS: c_int = CAN_SFF_ID_BITS;
+
+pub type can_err_mask_t = u32;
+
+pub const CAN_MAX_DLC: c_int = 8;
+pub const CAN_MAX_DLEN: usize = 8;
+
+pub const CANFD_MAX_DLC: c_int = 15;
+pub const CANFD_MAX_DLEN: usize = 64;
+
+pub const CANXL_MIN_DLC: c_int = 0;
+pub const CANXL_MAX_DLC: c_int = 2047;
+pub const CANXL_MAX_DLC_MASK: c_int = 0x07FF;
+pub const CANXL_MIN_DLEN: usize = 1;
+pub const CANXL_MAX_DLEN: usize = 2048;
+
+s! {
+    #[repr(align(8))]
+    pub struct can_frame {
+        pub can_id: canid_t,
+        // FIXME(1.0): this field was renamed to `len` in Linux 5.11
+        pub can_dlc: u8,
+        __pad: u8,
+        __res0: u8,
+        pub len8_dlc: u8,
+        pub data: [u8; CAN_MAX_DLEN],
+    }
+}
+
+pub const CANFD_BRS: c_int = 0x01;
+pub const CANFD_ESI: c_int = 0x02;
+pub const CANFD_FDF: c_int = 0x04;
+
+s! {
+    #[repr(align(8))]
+    pub struct canfd_frame {
+        pub can_id: canid_t,
+        pub len: u8,
+        pub flags: u8,
+        __res0: u8,
+        __res1: u8,
+        pub data: [u8; CANFD_MAX_DLEN],
+    }
+}
+
+pub const CANXL_XLF: c_int = 0x80;
+pub const CANXL_SEC: c_int = 0x01;
+
+s! {
+    #[repr(align(8))]
+    pub struct canxl_frame {
+        pub prio: canid_t,
+        pub flags: u8,
+        pub sdt: u8,
+        pub len: u16,
+        pub af: u32,
+        pub data: [u8; CANXL_MAX_DLEN],
+    }
+}
+
+pub const CAN_MTU: usize = size_of::<can_frame>();
+pub const CANFD_MTU: usize = size_of::<canfd_frame>();
+pub const CANXL_MTU: usize = size_of::<canxl_frame>();
+// FIXME(offset_of): use `core::mem::offset_of!` once that is available
+// https://github.com/rust-lang/rfcs/pull/3308
+// pub const CANXL_HDR_SIZE: usize = core::mem::offset_of!(canxl_frame, data);
+pub const CANXL_HDR_SIZE: usize = 12;
+pub const CANXL_MIN_MTU: usize = CANXL_HDR_SIZE + 64;
+pub const CANXL_MAX_MTU: usize = CANXL_MTU;
+
+pub const CAN_RAW: c_int = 1;
+pub const CAN_BCM: c_int = 2;
+pub const CAN_TP16: c_int = 3;
+pub const CAN_TP20: c_int = 4;
+pub const CAN_MCNET: c_int = 5;
+pub const CAN_ISOTP: c_int = 6;
+pub const CAN_J1939: c_int = 7;
+pub const CAN_NPROTO: c_int = 8;
+
+pub const SOL_CAN_BASE: c_int = 100;
+
+s_no_extra_traits! {
+    pub struct sockaddr_can {
+        pub can_family: crate::sa_family_t,
+        pub can_ifindex: c_int,
+        pub can_addr: __c_anonymous_sockaddr_can_can_addr,
+    }
+
+    pub union __c_anonymous_sockaddr_can_can_addr {
+        pub tp: __c_anonymous_sockaddr_can_tp,
+        pub j1939: __c_anonymous_sockaddr_can_j1939,
+    }
+
+    pub struct __c_anonymous_sockaddr_can_tp {
+        pub rx_id: canid_t,
+        pub tx_id: canid_t,
+    }
+
+    pub struct __c_anonymous_sockaddr_can_j1939 {
+        pub name: u64,
+        pub pgn: u32,
+        pub addr: u8,
+    }
+
+    pub struct can_filter {
+        pub can_id: canid_t,
+        pub can_mask: canid_t,
+    }
+}
+
+pub const CAN_INV_FILTER: canid_t = 0x20000000;

--- a/src/new/linux_uapi/linux/can/j1939.rs
+++ b/src/new/linux_uapi/linux/can/j1939.rs
@@ -1,0 +1,60 @@
+//! `linux/can/j1939.h`
+
+pub use crate::linux::can::*;
+
+pub const J1939_MAX_UNICAST_ADDR: c_uchar = 0xfd;
+pub const J1939_IDLE_ADDR: c_uchar = 0xfe;
+pub const J1939_NO_ADDR: c_uchar = 0xff;
+pub const J1939_NO_NAME: c_ulong = 0;
+pub const J1939_PGN_REQUEST: c_uint = 0x0ea00;
+pub const J1939_PGN_ADDRESS_CLAIMED: c_uint = 0x0ee00;
+pub const J1939_PGN_ADDRESS_COMMANDED: c_uint = 0x0fed8;
+pub const J1939_PGN_PDU1_MAX: c_uint = 0x3ff00;
+pub const J1939_PGN_MAX: c_uint = 0x3ffff;
+pub const J1939_NO_PGN: c_uint = 0x40000;
+
+pub type pgn_t = u32;
+pub type priority_t = u8;
+pub type name_t = u64;
+
+pub const SOL_CAN_J1939: c_int = SOL_CAN_BASE + CAN_J1939;
+
+// FIXME(cleanup): these could use c_enum if it can accept anonymous enums.
+
+pub const SO_J1939_FILTER: c_int = 1;
+pub const SO_J1939_PROMISC: c_int = 2;
+pub const SO_J1939_SEND_PRIO: c_int = 3;
+pub const SO_J1939_ERRQUEUE: c_int = 4;
+
+pub const SCM_J1939_DEST_ADDR: c_int = 1;
+pub const SCM_J1939_DEST_NAME: c_int = 2;
+pub const SCM_J1939_PRIO: c_int = 3;
+pub const SCM_J1939_ERRQUEUE: c_int = 4;
+
+pub const J1939_NLA_PAD: c_int = 0;
+pub const J1939_NLA_BYTES_ACKED: c_int = 1;
+pub const J1939_NLA_TOTAL_SIZE: c_int = 2;
+pub const J1939_NLA_PGN: c_int = 3;
+pub const J1939_NLA_SRC_NAME: c_int = 4;
+pub const J1939_NLA_DEST_NAME: c_int = 5;
+pub const J1939_NLA_SRC_ADDR: c_int = 6;
+pub const J1939_NLA_DEST_ADDR: c_int = 7;
+
+pub const J1939_EE_INFO_NONE: c_int = 0;
+pub const J1939_EE_INFO_TX_ABORT: c_int = 1;
+pub const J1939_EE_INFO_RX_RTS: c_int = 2;
+pub const J1939_EE_INFO_RX_DPO: c_int = 3;
+pub const J1939_EE_INFO_RX_ABORT: c_int = 4;
+
+s! {
+    pub struct j1939_filter {
+        pub name: name_t,
+        pub name_mask: name_t,
+        pub pgn: pgn_t,
+        pub pgn_mask: pgn_t,
+        pub addr: u8,
+        pub addr_mask: u8,
+    }
+}
+
+pub const J1939_FILTER_MAX: c_int = 512;

--- a/src/new/linux_uapi/linux/can/raw.rs
+++ b/src/new/linux_uapi/linux/can/raw.rs
@@ -1,0 +1,15 @@
+//! `linux/can/raw.h`
+
+pub use crate::linux::can::*;
+
+pub const SOL_CAN_RAW: c_int = SOL_CAN_BASE + CAN_RAW;
+pub const CAN_RAW_FILTER_MAX: c_int = 512;
+
+// FIXME(cleanup): use `c_enum!`, which needs to be adapted to allow omitting a type.
+pub const CAN_RAW_FILTER: c_int = 1;
+pub const CAN_RAW_ERR_FILTER: c_int = 2;
+pub const CAN_RAW_LOOPBACK: c_int = 3;
+pub const CAN_RAW_RECV_OWN_MSGS: c_int = 4;
+pub const CAN_RAW_FD_FRAMES: c_int = 5;
+pub const CAN_RAW_JOIN_FILTERS: c_int = 6;
+pub const CAN_RAW_XL_FRAMES: c_int = 7;

--- a/src/new/linux_uapi/linux/mod.rs
+++ b/src/new/linux_uapi/linux/mod.rs
@@ -1,0 +1,4 @@
+//! The `linux` directory within `include/uapi` in the Linux source tree.
+
+pub(crate) mod can;
+pub use can::*;

--- a/src/new/linux_uapi/mod.rs
+++ b/src/new/linux_uapi/mod.rs
@@ -1,0 +1,4 @@
+//! This directory maps to `include/uapi` in the Linux source tree.
+
+pub(crate) mod linux;
+pub use linux::*;

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -1,0 +1,12 @@
+//! This module contains the future directory structure. If possible, new definitions should
+//! get added here.
+//!
+//! Eventually everything should be moved over, and we will move this directory to the top
+//! level in `src`.
+
+cfg_if! {
+    if #[cfg(target_os = "linux")] {
+        mod linux_uapi;
+        pub use linux_uapi::*;
+    }
+}

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -58,15 +58,6 @@ cfg_if! {
     }
 }
 
-// linux/can.h
-pub type canid_t = u32;
-
-// linux/can/j1939.h
-pub type can_err_mask_t = u32;
-pub type pgn_t = u32;
-pub type priority_t = u8;
-pub type name_t = u64;
-
 pub type iconv_t = *mut c_void;
 
 // linux/sctp.h
@@ -728,33 +719,6 @@ s! {
         pub ee_pad: u8,
         pub ee_info: u32,
         pub ee_data: u32,
-    }
-
-    // linux/can.h
-    pub struct __c_anonymous_sockaddr_can_tp {
-        pub rx_id: canid_t,
-        pub tx_id: canid_t,
-    }
-
-    pub struct __c_anonymous_sockaddr_can_j1939 {
-        pub name: u64,
-        pub pgn: u32,
-        pub addr: u8,
-    }
-
-    pub struct can_filter {
-        pub can_id: canid_t,
-        pub can_mask: canid_t,
-    }
-
-    // linux/can/j1939.h
-    pub struct j1939_filter {
-        pub name: name_t,
-        pub name_mask: name_t,
-        pub pgn: pgn_t,
-        pub pgn_mask: pgn_t,
-        pub addr: u8,
-        pub addr_mask: u8,
     }
 
     // linux/seccomp.h
@@ -1739,49 +1703,6 @@ s_no_extra_traits! {
     pub struct sock_txtime {
         pub clockid: crate::clockid_t,
         pub flags: __u32,
-    }
-
-    // linux/can.h
-    #[repr(align(8))]
-    pub struct can_frame {
-        pub can_id: canid_t,
-        // FIXME(1.0): this field was renamed to `len` in Linux 5.11
-        pub can_dlc: u8,
-        __pad: u8,
-        __res0: u8,
-        pub len8_dlc: u8,
-        pub data: [u8; CAN_MAX_DLEN],
-    }
-
-    #[repr(align(8))]
-    pub struct canfd_frame {
-        pub can_id: canid_t,
-        pub len: u8,
-        pub flags: u8,
-        __res0: u8,
-        __res1: u8,
-        pub data: [u8; CANFD_MAX_DLEN],
-    }
-
-    #[repr(align(8))]
-    pub struct canxl_frame {
-        pub prio: canid_t,
-        pub flags: u8,
-        pub sdt: u8,
-        pub len: u16,
-        pub af: u32,
-        pub data: [u8; CANXL_MAX_DLEN],
-    }
-
-    pub union __c_anonymous_sockaddr_can_can_addr {
-        pub tp: __c_anonymous_sockaddr_can_tp,
-        pub j1939: __c_anonymous_sockaddr_can_j1939,
-    }
-
-    pub struct sockaddr_can {
-        pub can_family: crate::sa_family_t,
-        pub can_ifindex: c_int,
-        pub can_addr: __c_anonymous_sockaddr_can_can_addr,
     }
 
     // linux/wireless.h
@@ -5368,112 +5289,6 @@ pub const EPIPE: c_int = 32;
 pub const EDOM: c_int = 33;
 pub const ERANGE: c_int = 34;
 pub const EWOULDBLOCK: c_int = EAGAIN;
-
-// linux/can.h
-pub const CAN_EFF_FLAG: canid_t = 0x80000000;
-pub const CAN_RTR_FLAG: canid_t = 0x40000000;
-pub const CAN_ERR_FLAG: canid_t = 0x20000000;
-pub const CAN_SFF_MASK: canid_t = 0x000007FF;
-pub const CAN_EFF_MASK: canid_t = 0x1FFFFFFF;
-pub const CAN_ERR_MASK: canid_t = 0x1FFFFFFF;
-pub const CANXL_PRIO_MASK: crate::canid_t = CAN_SFF_MASK;
-
-pub const CAN_SFF_ID_BITS: c_int = 11;
-pub const CAN_EFF_ID_BITS: c_int = 29;
-pub const CANXL_PRIO_BITS: c_int = CAN_SFF_ID_BITS;
-
-pub const CAN_MAX_DLC: c_int = 8;
-pub const CAN_MAX_DLEN: usize = 8;
-pub const CANFD_MAX_DLC: c_int = 15;
-pub const CANFD_MAX_DLEN: usize = 64;
-
-pub const CANFD_BRS: c_int = 0x01;
-pub const CANFD_ESI: c_int = 0x02;
-pub const CANFD_FDF: c_int = 0x04;
-
-pub const CANXL_MIN_DLC: c_int = 0;
-pub const CANXL_MAX_DLC: c_int = 2047;
-pub const CANXL_MAX_DLC_MASK: c_int = 0x07FF;
-pub const CANXL_MIN_DLEN: usize = 1;
-pub const CANXL_MAX_DLEN: usize = 2048;
-
-pub const CANXL_XLF: c_int = 0x80;
-pub const CANXL_SEC: c_int = 0x01;
-
-pub const CAN_MTU: usize = size_of::<can_frame>();
-pub const CANFD_MTU: usize = size_of::<canfd_frame>();
-pub const CANXL_MTU: usize = size_of::<canxl_frame>();
-// FIXME(offset_of): use `core::mem::offset_of!` once that is available
-// https://github.com/rust-lang/rfcs/pull/3308
-// pub const CANXL_HDR_SIZE: usize = core::mem::offset_of!(canxl_frame, data);
-pub const CANXL_HDR_SIZE: usize = 12;
-pub const CANXL_MIN_MTU: usize = CANXL_HDR_SIZE + 64;
-pub const CANXL_MAX_MTU: usize = CANXL_MTU;
-
-pub const CAN_RAW: c_int = 1;
-pub const CAN_BCM: c_int = 2;
-pub const CAN_TP16: c_int = 3;
-pub const CAN_TP20: c_int = 4;
-pub const CAN_MCNET: c_int = 5;
-pub const CAN_ISOTP: c_int = 6;
-pub const CAN_J1939: c_int = 7;
-pub const CAN_NPROTO: c_int = 8;
-
-pub const SOL_CAN_BASE: c_int = 100;
-
-pub const CAN_INV_FILTER: canid_t = 0x20000000;
-pub const CAN_RAW_FILTER_MAX: c_int = 512;
-
-// linux/can/raw.h
-pub const SOL_CAN_RAW: c_int = SOL_CAN_BASE + CAN_RAW;
-pub const CAN_RAW_FILTER: c_int = 1;
-pub const CAN_RAW_ERR_FILTER: c_int = 2;
-pub const CAN_RAW_LOOPBACK: c_int = 3;
-pub const CAN_RAW_RECV_OWN_MSGS: c_int = 4;
-pub const CAN_RAW_FD_FRAMES: c_int = 5;
-pub const CAN_RAW_JOIN_FILTERS: c_int = 6;
-pub const CAN_RAW_XL_FRAMES: c_int = 7;
-
-// linux/can/j1939.h
-pub const SOL_CAN_J1939: c_int = SOL_CAN_BASE + CAN_J1939;
-
-pub const J1939_MAX_UNICAST_ADDR: c_uchar = 0xfd;
-pub const J1939_IDLE_ADDR: c_uchar = 0xfe;
-pub const J1939_NO_ADDR: c_uchar = 0xff;
-pub const J1939_NO_NAME: c_ulong = 0;
-pub const J1939_PGN_REQUEST: c_uint = 0x0ea00;
-pub const J1939_PGN_ADDRESS_CLAIMED: c_uint = 0x0ee00;
-pub const J1939_PGN_ADDRESS_COMMANDED: c_uint = 0x0fed8;
-pub const J1939_PGN_PDU1_MAX: c_uint = 0x3ff00;
-pub const J1939_PGN_MAX: c_uint = 0x3ffff;
-pub const J1939_NO_PGN: c_uint = 0x40000;
-
-pub const SO_J1939_FILTER: c_int = 1;
-pub const SO_J1939_PROMISC: c_int = 2;
-pub const SO_J1939_SEND_PRIO: c_int = 3;
-pub const SO_J1939_ERRQUEUE: c_int = 4;
-
-pub const SCM_J1939_DEST_ADDR: c_int = 1;
-pub const SCM_J1939_DEST_NAME: c_int = 2;
-pub const SCM_J1939_PRIO: c_int = 3;
-pub const SCM_J1939_ERRQUEUE: c_int = 4;
-
-pub const J1939_NLA_PAD: c_int = 0;
-pub const J1939_NLA_BYTES_ACKED: c_int = 1;
-pub const J1939_NLA_TOTAL_SIZE: c_int = 2;
-pub const J1939_NLA_PGN: c_int = 3;
-pub const J1939_NLA_SRC_NAME: c_int = 4;
-pub const J1939_NLA_DEST_NAME: c_int = 5;
-pub const J1939_NLA_SRC_ADDR: c_int = 6;
-pub const J1939_NLA_DEST_ADDR: c_int = 7;
-
-pub const J1939_EE_INFO_NONE: c_int = 0;
-pub const J1939_EE_INFO_TX_ABORT: c_int = 1;
-pub const J1939_EE_INFO_RX_RTS: c_int = 2;
-pub const J1939_EE_INFO_RX_DPO: c_int = 3;
-pub const J1939_EE_INFO_RX_ABORT: c_int = 4;
-
-pub const J1939_FILTER_MAX: c_int = 512;
 
 // linux/sctp.h
 pub const SCTP_FUTURE_ASSOC: c_int = 0;

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -61,7 +61,10 @@ trigger_files = [
 trigger_files = ["src/unix/solarish/illumos.rs"]
 
 [autolabel."O-linux"]
-trigger_files = ["src/unix/linux_like/linux"]
+trigger_files = [
+    "src/unix/linux_like/linux",
+    "src/reorg/linux_uapi",
+]
 
 [autolabel."O-linux-like"]
 trigger_files = ["src/unix/linux_like/mod.rs"]


### PR DESCRIPTION
This is a small module so it is easy to adapt to the future directory structure.

Sources:

* https://github.com/torvalds/linux/blob/92a09c47464d040866cf2b4cd052bc60555185fb/include/uapi/linux/can.h
* https://github.com/torvalds/linux/blob/92a09c47464d040866cf2b4cd052bc60555185fb/include/uapi/linux/can/j1939.h
* https://github.com/torvalds/linux/blob/92a09c47464d040866cf2b4cd052bc60555185fb/include/uapi/linux/can/raw.h