### PR TITLE
adding SO_SPLICE socket option support for freebsd >= 14.2

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2781,6 +2781,9 @@ fn test_freebsd(target: &str) {
             // FIXME(freebsd): Removed in FreeBSD 15, deprecated in libc
             "TCP_PCAP_OUT" | "TCP_PCAP_IN" => true,
 
+            // Added in FreeBSD 14.2
+            "SO_SPLICE" if Some(14) > freebsd_ver => true,
+
             _ => false,
         }
     });
@@ -2831,6 +2834,9 @@ fn test_freebsd(target: &str) {
 
             // FIXME(freebsd): Changed in FreeBSD 15
             "tcp_info" | "sockstat" if Some(15) >= freebsd_ver => true,
+
+            // `splice` introduced in FreeBSD 14.2
+            "splice" if Some(14) > freebsd_ver => true,
 
             _ => false,
         }

--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -1460,6 +1460,7 @@ SO_PROTOTYPE
 SO_REUSEPORT
 SO_REUSEPORT_LB
 SO_SETFIB
+SO_SPLICE
 SO_TIMESTAMP
 SO_TS_BINTIME
 SO_TS_CLOCK
@@ -2353,6 +2354,7 @@ sigwait
 sigwaitinfo
 sockaddr_dl
 sockcred
+splice
 srand
 srand48
 stack_t

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1396,6 +1396,12 @@ s! {
         tqh_first: *mut c_void,
         tqh_last: *mut *mut c_void,
     }
+
+    pub struct splice {
+        pub sp_fd: c_int,
+        pub sp_max: off_t,
+        pub sp_idle: crate::timeval,
+    }
 }
 
 s_no_extra_traits! {
@@ -3186,6 +3192,7 @@ pub const SO_PROTOCOL: c_int = 0x1016;
 pub const SO_PROTOTYPE: c_int = SO_PROTOCOL;
 pub const SO_TS_CLOCK: c_int = 0x1017;
 pub const SO_DOMAIN: c_int = 0x1019;
+pub const SO_SPLICE: c_int = 0x1023;
 pub const SO_VENDOR: c_int = 0x80000000;
 
 pub const SO_TS_REALTIME_MICRO: c_int = 0;


### PR DESCRIPTION
[ref](https://github.com/freebsd/freebsd-src/blob/d3f15bc2a51d1822795135d9ad4627dc1c7f2b18/sys/sys/socket.h#L175) and
[ref](https://github.com/freebsd/freebsd-src/blob/d3f15bc2a51d1822795135d9ad4627dc1c7f2b18/sys/sys/socketvar.h#L76)