### PR TITLE
Correct the function signatures for getpriority/setpriority

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -2,7 +2,6 @@ use crate::off64_t;
 use crate::prelude::*;
 
 pub type pthread_t = c_ulong;
-pub type __priority_which_t = c_uint;
 pub type __rlimit_resource_t = c_uint;
 pub type Lmid_t = c_long;
 pub type regoff_t = c_int;
@@ -719,9 +718,9 @@ pub const MAP_HUGE_1GB: c_int = HUGETLB_FLAG_ENCODE_1GB;
 pub const MAP_HUGE_2GB: c_int = HUGETLB_FLAG_ENCODE_2GB;
 pub const MAP_HUGE_16GB: c_int = HUGETLB_FLAG_ENCODE_16GB;
 
-pub const PRIO_PROCESS: crate::__priority_which_t = 0;
-pub const PRIO_PGRP: crate::__priority_which_t = 1;
-pub const PRIO_USER: crate::__priority_which_t = 2;
+pub const PRIO_PROCESS: c_int = 0;
+pub const PRIO_PGRP: c_int = 1;
+pub const PRIO_USER: c_int = 2;
 
 pub const MS_RMT_MASK: c_ulong = 0x02800051;
 
@@ -1305,8 +1304,8 @@ extern "C" {
         cpusetsize: size_t,
         cpuset: *const crate::cpu_set_t,
     ) -> c_int;
-    pub fn getpriority(which: crate::__priority_which_t, who: crate::id_t) -> c_int;
-    pub fn setpriority(which: crate::__priority_which_t, who: crate::id_t, prio: c_int) -> c_int;
+    pub fn getpriority(which: c_int, who: crate::id_t) -> c_int;
+    pub fn setpriority(which: c_int, who: crate::id_t, prio: c_int) -> c_int;
     pub fn pthread_rwlockattr_getkind_np(
         attr: *const crate::pthread_rwlockattr_t,
         val: *mut c_int,


### PR DESCRIPTION
The `__priority_which_t` type was incorrectly exposed as a type alias and defined as unsigned when they should be signed.

# Description

This CL removes the `__priority_which_t` type alias from the `unix::linux_like::linux::gnu` module.  It is not used for the same purpose as in the C++ source (enum value definition) and it is not supposed to be exposed to the user (see `man setpriority`).  The type signatures for `getpriority` and `setpriority` are then updated to use the correct `c_int` type.

# Sources

Libc source references:
 *https://github.com/bminor/glibc/blob/4052d99ead880797cf271309fd87ddd2b95bd353/resource/sys/resource.h#L105
 * https://github.com/bminor/glibc/blob/4052d99ead880797cf271309fd87ddd2b95bd353/sysdeps/unix/sysv/linux/bits/resource.h#L187
 
C++ Standard Reference:
* Default underlying type for an enum is `int`: https://en.cppreference.com/w/cpp/language/enum

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [rust-lang/libc#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

Compilation error when running `cargo test --target x86_64-unknown-linux-gnu`:

```
error[E0061]: this function takes 3 arguments but 2 arguments were supplied
    --> ctest/src/lib.rs:2496:25
     |
2496 |                 Rc::new(macro_rules::compile(self.parse_sess, item)),
     |                         ^^^^^^^^^^^^^^^^^^^^                  ---- argument #2 of type `&RefCell<Features>` is missing
     |
note: function defined here
    --> /usr/local/google/home/chriswailes/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/garando_syntax-0.1.0/src/ext/tt/macro_rules.rs:172:8
     |
172  | pub fn compile(sess: &ParseSess, features: &RefCell<Features>, def: &ast::Item) -> SyntaxExtension {
     |        ^^^^^^^
help: provide the argument
     |
2496 |                 Rc::new(macro_rules::compile(self.parse_sess, /* &RefCell<Features> */, item)),
     |
```

This does not appear to be caused by this PR.
