### PR TITLE
openbsd: ignore some constants in CI (removed in upcoming OpenBSD 7.8)

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -590,8 +590,11 @@ fn test_openbsd(target: &str) {
 
     cfg.skip_const(move |name| {
         match name {
-            // Removed in OpenBSD 7.7 (unused since 1991)
+            // Removed in OpenBSD 7.7
             "ATF_COM" | "ATF_PERM" | "ATF_PUBL" | "ATF_USETRAILERS" => true,
+
+            // Removed in OpenBSD 7.8
+            "CTL_FS" | "SO_NETPROC" => true,
 
             _ => false,
         }


### PR DESCRIPTION
- `CTL_FS` removed in [sys/sys/sysctl.h rev 1.242](https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/sys/sys/sysctl.h.diff?ipk=ifnwBdVmMgqyUWdkNSPhE-DZj6ClqyPHYQBRbH3H4d4&r1=1.241&r2=1.242)
- `SO_NETPROC` removed in [sys/sys/socket.h rev 1.107](https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/sys/sys/socket.h.diff?ipk=ifnwBdVmMgqyUWdkNSPhE-DZj6ClqyPHYQBRbH3H4d4&r1=1.106&r2=1.107)