### PR TITLE
Fixes Solaris CI after solaris-vm was update to Solaris 11.4.81 CBE.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,7 +259,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: test on Solaris
-        uses: vmactions/solaris-vm@v1
+        uses: vmactions/solaris-vm@v1.1.3
         with:
           release: "11.4-gcc"
           usesh: true

--- a/src/unix/solarish/x86_64.rs
+++ b/src/unix/solarish/x86_64.rs
@@ -91,7 +91,9 @@ s_no_extra_traits! {
         #[cfg(target_os = "solaris")]
         pub uc_xrs: solaris::xrs_t,
         #[cfg(target_os = "solaris")]
-        pub uc_filler: [c_long; 3],
+        pub uc_lwpid: c_uint,
+        #[cfg(target_os = "solaris")]
+        pub uc_filler: [c_long; 2],
     }
 }
 


### PR DESCRIPTION
It also specifies exact solaris-vm version to avoid future disruptions.
