### PR TITLE
Add arc4random and arc4random_buf to NuttX

### DIFF
--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -591,4 +591,6 @@ extern "C" {
     pub fn pthread_setname_np(thread: pthread_t, name: *const c_char) -> i32;
     pub fn pthread_getname_np(thread: pthread_t, name: *mut c_char, len: usize) -> i32;
     pub fn getrandom(buf: *mut c_void, buflen: usize, flags: u32) -> isize;
+    pub fn arc4random() -> u32;
+    pub fn arc4random_buf(bytes: *mut c_void, nbytes: usize);
 }


### PR DESCRIPTION
# Description
* Declare `arc4random` and `arc4random_buf` as extern "C" functions in the NuttX module
* Enable access to system-provided random number generation for NuttX targets
* Aligns NuttX FFI with other Unix platforms that expose these functions

This change allows Rust code targeting NuttX to use `arc4random` and `arc4random_buf` for secure random number generation, improving compatibility and feature parity with other targets.

# Sources

https://github.com/apache/nuttx/blob/302ceb701b2d28ab16aa421e2dc5c70ec0dd594e/include/stdlib.h#L155-L156

@rustbot label +stable-nominated

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->



<!-- Add a short description about what this change does -->


<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
