### PR TITLE
Replace handwritten `Debug` impls with derives

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -5548,9 +5548,9 @@ fn test_aix(target: &str) {
     });
 
     cfg.type_name(move |ty, is_struct, is_union| match ty {
-        "DIR"  => ty.to_string(),
-        "FILE"  => ty.to_string(),
-        "ACTION"  => ty.to_string(),
+        "DIR" => ty.to_string(),
+        "FILE" => ty.to_string(),
+        "ACTION" => ty.to_string(),
 
         // 'sigval' is a struct in Rust, but a union in C.
         "sigval" => format!("union sigval"),
@@ -5637,9 +5637,9 @@ fn test_aix(target: &str) {
             // POSIX-compliant versions in the system libc. As a result,
             // function pointer comparisons between the C and Rust sides
             // would fail.
-            "getpwuid_r" | "getpwnam_r" | "getgrgid_r" | "getgrnam_r"
-            | "aio_cancel" | "aio_error" | "aio_fsync" | "aio_read"
-            | "aio_return" | "aio_suspend" | "aio_write" | "select" => true,
+            "getpwuid_r" | "getpwnam_r" | "getgrgid_r" | "getgrnam_r" | "aio_cancel"
+            | "aio_error" | "aio_fsync" | "aio_read" | "aio_return" | "aio_suspend"
+            | "aio_write" | "select" => true,
 
             // 'getdtablesize' is a constant in the AIX header but it is
             // a real function in libc which the Rust side is resolved to.
@@ -5655,7 +5655,6 @@ fn test_aix(target: &str) {
             _ => false,
         }
     });
-
 
     cfg.volatile_item(|i| {
         use ctest::VolatileItemKind::*;

--- a/libc-test/test/cmsg.rs
+++ b/libc-test/test/cmsg.rs
@@ -70,7 +70,7 @@ mod t {
             for cmsg_len in 0..64 {
                 // Address must be a multiple of 0x4 for testing on AIX.
                 if cfg!(target_os = "aix") && cmsg_len % std::mem::size_of::<cmsghdr>() != 0 {
-                   continue;
+                    continue;
                 }
                 for next_cmsg_len in 0..32 {
                     unsafe {

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -1068,26 +1068,6 @@ cfg_if! {
             }
         }
         impl Eq for sysinfo {}
-        impl fmt::Debug for sysinfo {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sysinfo")
-                    .field("uptime", &self.uptime)
-                    .field("loads", &self.loads)
-                    .field("totalram", &self.totalram)
-                    .field("freeram", &self.freeram)
-                    .field("sharedram", &self.sharedram)
-                    .field("bufferram", &self.bufferram)
-                    .field("totalswap", &self.totalswap)
-                    .field("freeswap", &self.freeswap)
-                    .field("procs", &self.procs)
-                    .field("pad", &self.pad)
-                    .field("totalhigh", &self.totalhigh)
-                    .field("freehigh", &self.freehigh)
-                    .field("mem_unit", &self.mem_unit)
-                    // FIXME(debug): .field("__reserved", &self.__reserved)
-                    .finish()
-            }
-        }
         impl hash::Hash for sysinfo {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uptime.hash(state);
@@ -1118,14 +1098,6 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_un {}
-        impl fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_un")
-                    .field("sun_family", &self.sun_family)
-                    // FIXME(debug): .field("sun_path", &self.sun_path)
-                    .finish()
-            }
-        }
         impl hash::Hash for sockaddr_un {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sun_family.hash(state);
@@ -1145,15 +1117,6 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_storage {}
-        impl fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_storage")
-                    .field("ss_family", &self.ss_family)
-                    .field("__ss_align", &self.__ss_align)
-                    // FIXME(debug): .field("__ss_pad2", &self.__ss_pad2)
-                    .finish()
-            }
-        }
         impl hash::Hash for sockaddr_storage {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_family.hash(state);
@@ -1191,17 +1154,6 @@ cfg_if! {
             }
         }
         impl Eq for utsname {}
-        impl fmt::Debug for utsname {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utsname")
-                    // FIXME(debug): .field("sysname", &self.sysname)
-                    // FIXME(debug): .field("nodename", &self.nodename)
-                    // FIXME(debug): .field("release", &self.release)
-                    // FIXME(debug): .field("version", &self.version)
-                    // FIXME(debug): .field("machine", &self.machine)
-                    .finish()
-            }
-        }
         impl hash::Hash for utsname {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sysname.hash(state);
@@ -1226,17 +1178,6 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_ino", &self.d_ino)
-                    .field("d_off", &self.d_off)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_type", &self.d_type)
-                    // FIXME(debug): .field("d_name", &self.d_name)
-                    .finish()
-            }
-        }
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
@@ -1261,17 +1202,6 @@ cfg_if! {
             }
         }
         impl Eq for dirent64 {}
-        impl fmt::Debug for dirent64 {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent64")
-                    .field("d_ino", &self.d_ino)
-                    .field("d_off", &self.d_off)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_type", &self.d_type)
-                    // FIXME(debug): .field("d_name", &self.d_name)
-                    .finish()
-            }
-        }
         impl hash::Hash for dirent64 {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
@@ -1291,16 +1221,6 @@ cfg_if! {
             }
         }
         impl Eq for mq_attr {}
-        impl fmt::Debug for mq_attr {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("mq_attr")
-                    .field("mq_flags", &self.mq_flags)
-                    .field("mq_maxmsg", &self.mq_maxmsg)
-                    .field("mq_msgsize", &self.mq_msgsize)
-                    .field("mq_curmsgs", &self.mq_curmsgs)
-                    .finish()
-            }
-        }
         impl hash::Hash for mq_attr {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mq_flags.hash(state);
@@ -1318,15 +1238,6 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_nl {}
-        impl fmt::Debug for sockaddr_nl {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_nl")
-                    .field("nl_family", &self.nl_family)
-                    .field("nl_pid", &self.nl_pid)
-                    .field("nl_groups", &self.nl_groups)
-                    .finish()
-            }
-        }
         impl hash::Hash for sockaddr_nl {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.nl_family.hash(state);
@@ -1347,17 +1258,6 @@ cfg_if! {
             }
         }
         impl Eq for sigevent {}
-        impl fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sigevent")
-                    .field("sigev_value", &self.sigev_value)
-                    .field("sigev_signo", &self.sigev_signo)
-                    .field("sigev_notify", &self.sigev_notify)
-                    .field("sigev_notify_function", &self.sigev_notify_function)
-                    .field("sigev_notify_attributes", &self.sigev_notify_attributes)
-                    .finish()
-            }
-        }
         impl hash::Hash for sigevent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sigev_value.hash(state);
@@ -1374,13 +1274,6 @@ cfg_if! {
             }
         }
         impl Eq for pthread_cond_t {}
-        impl fmt::Debug for pthread_cond_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_cond_t")
-                    // FIXME(debug): .field("size", &self.size)
-                    .finish()
-            }
-        }
         impl hash::Hash for pthread_cond_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.size.hash(state);
@@ -1393,13 +1286,6 @@ cfg_if! {
             }
         }
         impl Eq for pthread_mutex_t {}
-        impl fmt::Debug for pthread_mutex_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_mutex_t")
-                    // FIXME(debug): .field("size", &self.size)
-                    .finish()
-            }
-        }
         impl hash::Hash for pthread_mutex_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.size.hash(state);
@@ -1412,13 +1298,6 @@ cfg_if! {
             }
         }
         impl Eq for pthread_rwlock_t {}
-        impl fmt::Debug for pthread_rwlock_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_rwlock_t")
-                    // FIXME(debug): .field("size", &self.size)
-                    .finish()
-            }
-        }
         impl hash::Hash for pthread_rwlock_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.size.hash(state);

--- a/src/fuchsia/x86_64.rs
+++ b/src/fuchsia/x86_64.rs
@@ -94,18 +94,6 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ucontext_t")
-                    .field("uc_flags", &self.uc_flags)
-                    .field("uc_link", &self.uc_link)
-                    .field("uc_stack", &self.uc_stack)
-                    .field("uc_mcontext", &self.uc_mcontext)
-                    .field("uc_sigmask", &self.uc_sigmask)
-                    // FIXME(debug): .field("__private", &self.__private)
-                    .finish()
-            }
-        }
         impl hash::Hash for ucontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_flags.hash(state);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -141,7 +141,8 @@ macro_rules! s_paren {
     )*);
 }
 
-/// Implement `Clone` and `Copy` for a struct with no `extra_traits` feature.
+/// Implement `Clone` and `Copy` for a struct with no `extra_traits` feature, as well as `Debug`
+/// with `extra_traits` since that can always be derived.
 ///
 /// Most items will prefer to use [`s`].
 macro_rules! s_no_extra_traits {
@@ -172,6 +173,7 @@ macro_rules! s_no_extra_traits {
         __item! {
             #[repr(C)]
             #[::core::prelude::v1::derive(::core::clone::Clone, ::core::marker::Copy)]
+            #[cfg_attr(feature = "extra_traits", ::core::prelude::v1::derive(Debug))]
             $(#[$attr])*
             pub struct $i { $($field)* }
         }

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -1,6 +1,5 @@
-use crate::in_addr_t;
-use crate::in_port_t;
 use crate::prelude::*;
+use crate::{in_addr_t, in_port_t};
 
 pub type caddr_t = *mut c_char;
 pub type clockid_t = c_longlong;
@@ -582,18 +581,6 @@ cfg_if! {
             }
         }
         impl Eq for poll_ctl_ext {}
-        impl fmt::Debug for poll_ctl_ext {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                f.debug_struct("poll_ctl_ext")
-                    .field("version", &self.version)
-                    .field("command", &self.command)
-                    .field("events", &self.events)
-                    .field("fd", &self.fd)
-                    .field("u", &self.u)
-                    .field("reserved64", &self.reserved64)
-                    .finish()
-            }
-        }
         impl hash::Hash for poll_ctl_ext {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.version.hash(state);

--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -313,22 +313,6 @@ cfg_if! {
             }
         }
         impl Eq for siginfo_t {}
-        impl fmt::Debug for siginfo_t {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                f.debug_struct("siginfo_t")
-                    .field("si_signo", &self.si_signo)
-                    .field("si_errno", &self.si_errno)
-                    .field("si_code", &self.si_code)
-                    .field("si_pid", &self.si_pid)
-                    .field("si_uid", &self.si_uid)
-                    .field("si_status", &self.si_status)
-                    .field("si_addr", &self.si_addr)
-                    .field("si_band", &self.si_band)
-                    .field("si_value", &self.si_value)
-                    .field("__si_flags", &self.__si_flags)
-                    .finish()
-            }
-        }
         impl hash::Hash for siginfo_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.si_signo.hash(state);
@@ -372,16 +356,6 @@ cfg_if! {
             }
         }
         impl Eq for pollfd_ext {}
-        impl fmt::Debug for pollfd_ext {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                f.debug_struct("pollfd_ext")
-                    .field("fd", &self.fd)
-                    .field("events", &self.events)
-                    .field("revents", &self.revents)
-                    .field("data", &self.data)
-                    .finish()
-            }
-        }
         impl hash::Hash for pollfd_ext {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.fd.hash(state);
@@ -397,12 +371,6 @@ cfg_if! {
         }
 
         impl Eq for fpreg_t {}
-
-        impl fmt::Debug for fpreg_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("fpreg_t").field("d", &self.d).finish()
-            }
-        }
 
         impl hash::Hash for fpreg_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {

--- a/src/unix/bsd/apple/b32/mod.rs
+++ b/src/unix/bsd/apple/b32/mod.rs
@@ -80,14 +80,6 @@ cfg_if! {
             }
         }
         impl Eq for pthread_attr_t {}
-        impl fmt::Debug for pthread_attr_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_attr_t")
-                    .field("__sig", &self.__sig)
-                    // FIXME(debug): .field("__opaque", &self.__opaque)
-                    .finish()
-            }
-        }
         impl hash::Hash for pthread_attr_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__sig.hash(state);
@@ -105,13 +97,6 @@ cfg_if! {
             }
         }
         impl Eq for pthread_once_t {}
-        impl fmt::Debug for pthread_once_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_once_t")
-                    .field("__sig", &self.__sig)
-                    .finish()
-            }
-        }
         impl hash::Hash for pthread_once_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__sig.hash(state);

--- a/src/unix/bsd/apple/b64/mod.rs
+++ b/src/unix/bsd/apple/b64/mod.rs
@@ -73,14 +73,6 @@ cfg_if! {
             }
         }
         impl Eq for pthread_attr_t {}
-        impl fmt::Debug for pthread_attr_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_attr_t")
-                    .field("__sig", &self.__sig)
-                    // FIXME(debug): .field("__opaque", &self.__opaque)
-                    .finish()
-            }
-        }
         impl hash::Hash for pthread_attr_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__sig.hash(state);
@@ -98,13 +90,6 @@ cfg_if! {
             }
         }
         impl Eq for pthread_once_t {}
-        impl fmt::Debug for pthread_once_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_once_t")
-                    .field("__sig", &self.__sig)
-                    .finish()
-            }
-        }
         impl hash::Hash for pthread_once_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__sig.hash(state);

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1706,24 +1706,6 @@ cfg_if! {
             }
         }
         impl Eq for kevent {}
-        impl fmt::Debug for kevent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let ident = self.ident;
-                let filter = self.filter;
-                let flags = self.flags;
-                let fflags = self.fflags;
-                let data = self.data;
-                let udata = self.udata;
-                f.debug_struct("kevent")
-                    .field("ident", &ident)
-                    .field("filter", &filter)
-                    .field("flags", &flags)
-                    .field("fflags", &fflags)
-                    .field("data", &data)
-                    .field("udata", &udata)
-                    .finish()
-            }
-        }
         impl hash::Hash for kevent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let ident = self.ident;
@@ -1758,28 +1740,6 @@ cfg_if! {
             }
         }
         impl Eq for semid_ds {}
-        impl fmt::Debug for semid_ds {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let sem_perm = self.sem_perm;
-                let sem_base = self.sem_base;
-                let sem_nsems = self.sem_nsems;
-                let sem_otime = self.sem_otime;
-                let sem_pad1 = self.sem_pad1;
-                let sem_ctime = self.sem_ctime;
-                let sem_pad2 = self.sem_pad2;
-                let sem_pad3 = self.sem_pad3;
-                f.debug_struct("semid_ds")
-                    .field("sem_perm", &sem_perm)
-                    .field("sem_base", &sem_base)
-                    .field("sem_nsems", &sem_nsems)
-                    .field("sem_otime", &sem_otime)
-                    .field("sem_pad1", &sem_pad1)
-                    .field("sem_ctime", &sem_ctime)
-                    .field("sem_pad2", &sem_pad2)
-                    .field("sem_pad3", &sem_pad3)
-                    .finish()
-            }
-        }
         impl hash::Hash for semid_ds {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let sem_perm = self.sem_perm;
@@ -1817,30 +1777,6 @@ cfg_if! {
             }
         }
         impl Eq for shmid_ds {}
-        impl fmt::Debug for shmid_ds {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let shm_perm = self.shm_perm;
-                let shm_segsz = self.shm_segsz;
-                let shm_lpid = self.shm_lpid;
-                let shm_cpid = self.shm_cpid;
-                let shm_nattch = self.shm_nattch;
-                let shm_atime = self.shm_atime;
-                let shm_dtime = self.shm_dtime;
-                let shm_ctime = self.shm_ctime;
-                let shm_internal = self.shm_internal;
-                f.debug_struct("shmid_ds")
-                    .field("shm_perm", &shm_perm)
-                    .field("shm_segsz", &shm_segsz)
-                    .field("shm_lpid", &shm_lpid)
-                    .field("shm_cpid", &shm_cpid)
-                    .field("shm_nattch", &shm_nattch)
-                    .field("shm_atime", &shm_atime)
-                    .field("shm_dtime", &shm_dtime)
-                    .field("shm_ctime", &shm_ctime)
-                    .field("shm_internal", &shm_internal)
-                    .finish()
-            }
-        }
         impl hash::Hash for shmid_ds {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let shm_perm = self.shm_perm;
@@ -1884,23 +1820,6 @@ cfg_if! {
             }
         }
         impl Eq for proc_threadinfo {}
-        impl fmt::Debug for proc_threadinfo {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("proc_threadinfo")
-                    .field("pth_user_time", &self.pth_user_time)
-                    .field("pth_system_time", &self.pth_system_time)
-                    .field("pth_cpu_usage", &self.pth_cpu_usage)
-                    .field("pth_policy", &self.pth_policy)
-                    .field("pth_run_state", &self.pth_run_state)
-                    .field("pth_flags", &self.pth_flags)
-                    .field("pth_sleep_time", &self.pth_sleep_time)
-                    .field("pth_curpri", &self.pth_curpri)
-                    .field("pth_priority", &self.pth_priority)
-                    .field("pth_maxpriority", &self.pth_maxpriority)
-                    // FIXME(debug): .field("pth_name", &self.pth_name)
-                    .finish()
-            }
-        }
         impl hash::Hash for proc_threadinfo {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.pth_user_time.hash(state);
@@ -1947,28 +1866,6 @@ cfg_if! {
         }
 
         impl Eq for statfs {}
-        impl fmt::Debug for statfs {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("statfs")
-                    .field("f_bsize", &self.f_bsize)
-                    .field("f_iosize", &self.f_iosize)
-                    .field("f_blocks", &self.f_blocks)
-                    .field("f_bfree", &self.f_bfree)
-                    .field("f_bavail", &self.f_bavail)
-                    .field("f_files", &self.f_files)
-                    .field("f_ffree", &self.f_ffree)
-                    .field("f_fsid", &self.f_fsid)
-                    .field("f_owner", &self.f_owner)
-                    .field("f_flags", &self.f_flags)
-                    .field("f_fssubtype", &self.f_fssubtype)
-                    .field("f_fstypename", &self.f_fstypename)
-                    .field("f_type", &self.f_type)
-                    // FIXME(debug): .field("f_mntonname", &self.f_mntonname)
-                    // FIXME(debug): .field("f_mntfromname", &self.f_mntfromname)
-                    .field("f_reserved", &self.f_reserved)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for statfs {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -2006,18 +1903,6 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_ino", &self.d_ino)
-                    .field("d_seekoff", &self.d_seekoff)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_namlen", &self.d_namlen)
-                    .field("d_type", &self.d_type)
-                    // FIXME(debug): .field("d_name", &self.d_name)
-                    .finish()
-            }
-        }
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
@@ -2039,14 +1924,6 @@ cfg_if! {
             }
         }
         impl Eq for pthread_rwlock_t {}
-        impl fmt::Debug for pthread_rwlock_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_rwlock_t")
-                    .field("__sig", &self.__sig)
-                    // FIXME(debug): .field("__opaque", &self.__opaque)
-                    .finish()
-            }
-        }
         impl hash::Hash for pthread_rwlock_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__sig.hash(state);
@@ -2067,15 +1944,6 @@ cfg_if! {
 
         impl Eq for pthread_mutex_t {}
 
-        impl fmt::Debug for pthread_mutex_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_mutex_t")
-                    .field("__sig", &self.__sig)
-                    // FIXME(debug): .field("__opaque", &self.__opaque)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for pthread_mutex_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__sig.hash(state);
@@ -2095,15 +1963,6 @@ cfg_if! {
         }
 
         impl Eq for pthread_cond_t {}
-
-        impl fmt::Debug for pthread_cond_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_cond_t")
-                    .field("__sig", &self.__sig)
-                    // FIXME(debug): .field("__opaque", &self.__opaque)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for pthread_cond_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -2131,18 +1990,6 @@ cfg_if! {
         }
 
         impl Eq for sockaddr_storage {}
-
-        impl fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_storage")
-                    .field("ss_len", &self.ss_len)
-                    .field("ss_family", &self.ss_family)
-                    .field("__ss_pad1", &self.__ss_pad1)
-                    .field("__ss_align", &self.__ss_align)
-                    // FIXME(debug): .field("__ss_pad2", &self.__ss_pad2)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for sockaddr_storage {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -2176,21 +2023,6 @@ cfg_if! {
 
         impl Eq for utmpx {}
 
-        impl fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utmpx")
-                    // FIXME(debug): .field("ut_user", &self.ut_user)
-                    .field("ut_id", &self.ut_id)
-                    .field("ut_line", &self.ut_line)
-                    .field("ut_pid", &self.ut_pid)
-                    .field("ut_type", &self.ut_type)
-                    .field("ut_tv", &self.ut_tv)
-                    // FIXME(debug): .field("ut_host", &self.ut_host)
-                    .field("ut_pad", &self.ut_pad)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for utmpx {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_user.hash(state);
@@ -2215,17 +2047,6 @@ cfg_if! {
 
         impl Eq for sigevent {}
 
-        impl fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sigevent")
-                    .field("sigev_notify", &self.sigev_notify)
-                    .field("sigev_signo", &self.sigev_signo)
-                    .field("sigev_value", &self.sigev_value)
-                    .field("sigev_notify_attributes", &self.sigev_notify_attributes)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for sigevent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sigev_notify.hash(state);
@@ -2241,13 +2062,6 @@ cfg_if! {
             }
         }
         impl Eq for processor_cpu_load_info {}
-        impl fmt::Debug for processor_cpu_load_info {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("processor_cpu_load_info")
-                    .field("cpu_ticks", &self.cpu_ticks)
-                    .finish()
-            }
-        }
         impl hash::Hash for processor_cpu_load_info {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cpu_ticks.hash(state);
@@ -2264,17 +2078,6 @@ cfg_if! {
             }
         }
         impl Eq for processor_basic_info {}
-        impl fmt::Debug for processor_basic_info {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("processor_basic_info")
-                    .field("cpu_type", &self.cpu_type)
-                    .field("cpu_subtype", &self.cpu_subtype)
-                    .field("running", &self.running)
-                    .field("slot_num", &self.slot_num)
-                    .field("is_master", &self.is_master)
-                    .finish()
-            }
-        }
         impl hash::Hash for processor_basic_info {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cpu_type.hash(state);
@@ -2292,14 +2095,6 @@ cfg_if! {
             }
         }
         impl Eq for processor_set_basic_info {}
-        impl fmt::Debug for processor_set_basic_info {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("processor_set_basic_info")
-                    .field("processor_count", &self.processor_count)
-                    .field("default_policy", &self.default_policy)
-                    .finish()
-            }
-        }
         impl hash::Hash for processor_set_basic_info {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.processor_count.hash(state);
@@ -2316,16 +2111,6 @@ cfg_if! {
             }
         }
         impl Eq for processor_set_load_info {}
-        impl fmt::Debug for processor_set_load_info {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("processor_set_load_info")
-                    .field("task_count", &self.task_count)
-                    .field("thread_count", &self.thread_count)
-                    .field("load_average", &self.load_average)
-                    .field("mach_factor", &self.mach_factor)
-                    .finish()
-            }
-        }
         impl hash::Hash for processor_set_load_info {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.task_count.hash(state);
@@ -2341,14 +2126,6 @@ cfg_if! {
             }
         }
         impl Eq for time_value_t {}
-        impl fmt::Debug for time_value_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("time_value_t")
-                    .field("seconds", &self.seconds)
-                    .field("microseconds", &self.microseconds)
-                    .finish()
-            }
-        }
         impl hash::Hash for time_value_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.seconds.hash(state);
@@ -2368,20 +2145,6 @@ cfg_if! {
             }
         }
         impl Eq for thread_basic_info {}
-        impl fmt::Debug for thread_basic_info {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("thread_basic_info")
-                    .field("user_time", &self.user_time)
-                    .field("system_time", &self.system_time)
-                    .field("cpu_usage", &self.cpu_usage)
-                    .field("policy", &self.policy)
-                    .field("run_state", &self.run_state)
-                    .field("flags", &self.flags)
-                    .field("suspend_count", &self.suspend_count)
-                    .field("sleep_time", &self.sleep_time)
-                    .finish()
-            }
-        }
         impl hash::Hash for thread_basic_info {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.user_time.hash(state);
@@ -2414,23 +2177,6 @@ cfg_if! {
             }
         }
         impl Eq for thread_extended_info {}
-        impl fmt::Debug for thread_extended_info {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("proc_threadinfo")
-                    .field("pth_user_time", &self.pth_user_time)
-                    .field("pth_system_time", &self.pth_system_time)
-                    .field("pth_cpu_usage", &self.pth_cpu_usage)
-                    .field("pth_policy", &self.pth_policy)
-                    .field("pth_run_state", &self.pth_run_state)
-                    .field("pth_flags", &self.pth_flags)
-                    .field("pth_sleep_time", &self.pth_sleep_time)
-                    .field("pth_curpri", &self.pth_curpri)
-                    .field("pth_priority", &self.pth_priority)
-                    .field("pth_maxpriority", &self.pth_maxpriority)
-                    // FIXME(debug): .field("pth_name", &self.pth_name)
-                    .finish()
-            }
-        }
         impl hash::Hash for thread_extended_info {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.pth_user_time.hash(state);
@@ -2454,15 +2200,6 @@ cfg_if! {
             }
         }
         impl Eq for thread_identifier_info {}
-        impl fmt::Debug for thread_identifier_info {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("thread_identifier_info")
-                    .field("thread_id", &self.thread_id)
-                    .field("thread_handle", &self.thread_handle)
-                    .field("dispatch_qaddr", &self.dispatch_qaddr)
-                    .finish()
-            }
-        }
         impl hash::Hash for thread_identifier_info {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.thread_id.hash(state);
@@ -2500,62 +2237,6 @@ cfg_if! {
             }
         }
         impl Eq for if_data64 {}
-        impl fmt::Debug for if_data64 {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let ifi_type = self.ifi_type;
-                let ifi_typelen = self.ifi_typelen;
-                let ifi_physical = self.ifi_physical;
-                let ifi_addrlen = self.ifi_addrlen;
-                let ifi_hdrlen = self.ifi_hdrlen;
-                let ifi_recvquota = self.ifi_recvquota;
-                let ifi_xmitquota = self.ifi_xmitquota;
-                let ifi_unused1 = self.ifi_unused1;
-                let ifi_mtu = self.ifi_mtu;
-                let ifi_metric = self.ifi_metric;
-                let ifi_baudrate = self.ifi_baudrate;
-                let ifi_ipackets = self.ifi_ipackets;
-                let ifi_ierrors = self.ifi_ierrors;
-                let ifi_opackets = self.ifi_opackets;
-                let ifi_oerrors = self.ifi_oerrors;
-                let ifi_collisions = self.ifi_collisions;
-                let ifi_ibytes = self.ifi_ibytes;
-                let ifi_obytes = self.ifi_obytes;
-                let ifi_imcasts = self.ifi_imcasts;
-                let ifi_omcasts = self.ifi_omcasts;
-                let ifi_iqdrops = self.ifi_iqdrops;
-                let ifi_noproto = self.ifi_noproto;
-                let ifi_recvtiming = self.ifi_recvtiming;
-                let ifi_xmittiming = self.ifi_xmittiming;
-                let ifi_lastchange = self.ifi_lastchange;
-                f.debug_struct("if_data64")
-                    .field("ifi_type", &ifi_type)
-                    .field("ifi_typelen", &ifi_typelen)
-                    .field("ifi_physical", &ifi_physical)
-                    .field("ifi_addrlen", &ifi_addrlen)
-                    .field("ifi_hdrlen", &ifi_hdrlen)
-                    .field("ifi_recvquota", &ifi_recvquota)
-                    .field("ifi_xmitquota", &ifi_xmitquota)
-                    .field("ifi_unused1", &ifi_unused1)
-                    .field("ifi_mtu", &ifi_mtu)
-                    .field("ifi_metric", &ifi_metric)
-                    .field("ifi_baudrate", &ifi_baudrate)
-                    .field("ifi_ipackets", &ifi_ipackets)
-                    .field("ifi_ierrors", &ifi_ierrors)
-                    .field("ifi_opackets", &ifi_opackets)
-                    .field("ifi_oerrors", &ifi_oerrors)
-                    .field("ifi_collisions", &ifi_collisions)
-                    .field("ifi_ibytes", &ifi_ibytes)
-                    .field("ifi_obytes", &ifi_obytes)
-                    .field("ifi_imcasts", &ifi_imcasts)
-                    .field("ifi_omcasts", &ifi_omcasts)
-                    .field("ifi_iqdrops", &ifi_iqdrops)
-                    .field("ifi_noproto", &ifi_noproto)
-                    .field("ifi_recvtiming", &ifi_recvtiming)
-                    .field("ifi_xmittiming", &ifi_xmittiming)
-                    .field("ifi_lastchange", &ifi_lastchange)
-                    .finish()
-            }
-        }
         impl hash::Hash for if_data64 {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let ifi_type = self.ifi_type;
@@ -2626,34 +2307,6 @@ cfg_if! {
             }
         }
         impl Eq for if_msghdr2 {}
-        impl fmt::Debug for if_msghdr2 {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let ifm_msglen = self.ifm_msglen;
-                let ifm_version = self.ifm_version;
-                let ifm_type = self.ifm_type;
-                let ifm_addrs = self.ifm_addrs;
-                let ifm_flags = self.ifm_flags;
-                let ifm_index = self.ifm_index;
-                let ifm_snd_len = self.ifm_snd_len;
-                let ifm_snd_maxlen = self.ifm_snd_maxlen;
-                let ifm_snd_drops = self.ifm_snd_drops;
-                let ifm_timer = self.ifm_timer;
-                let ifm_data = self.ifm_data;
-                f.debug_struct("if_msghdr2")
-                    .field("ifm_msglen", &ifm_msglen)
-                    .field("ifm_version", &ifm_version)
-                    .field("ifm_type", &ifm_type)
-                    .field("ifm_addrs", &ifm_addrs)
-                    .field("ifm_flags", &ifm_flags)
-                    .field("ifm_index", &ifm_index)
-                    .field("ifm_snd_len", &ifm_snd_len)
-                    .field("ifm_snd_maxlen", &ifm_snd_maxlen)
-                    .field("ifm_snd_drops", &ifm_snd_drops)
-                    .field("ifm_timer", &ifm_timer)
-                    .field("ifm_data", &ifm_data)
-                    .finish()
-            }
-        }
         impl hash::Hash for if_msghdr2 {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let ifm_msglen = self.ifm_msglen;
@@ -2711,64 +2364,6 @@ cfg_if! {
             }
         }
         impl Eq for vm_statistics64 {}
-        impl fmt::Debug for vm_statistics64 {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let free_count = self.free_count;
-                let active_count = self.active_count;
-                let inactive_count = self.inactive_count;
-                let wire_count = self.wire_count;
-                let zero_fill_count = self.zero_fill_count;
-                let reactivations = self.reactivations;
-                let pageins = self.pageins;
-                let pageouts = self.pageouts;
-                let faults = self.faults;
-                let cow_faults = self.cow_faults;
-                let lookups = self.lookups;
-                let hits = self.hits;
-                let purges = self.purges;
-                let purgeable_count = self.purgeable_count;
-                let speculative_count = self.speculative_count;
-                let decompressions = self.decompressions;
-                let compressions = self.compressions;
-                let swapins = self.swapins;
-                let swapouts = self.swapouts;
-                let compressor_page_count = self.compressor_page_count;
-                let throttled_count = self.throttled_count;
-                let external_page_count = self.external_page_count;
-                let internal_page_count = self.internal_page_count;
-                // Otherwise rustfmt crashes...
-                let total_uncompressed = self.total_uncompressed_pages_in_compressor;
-                f.debug_struct("vm_statistics64")
-                    .field("free_count", &free_count)
-                    .field("active_count", &active_count)
-                    .field("inactive_count", &inactive_count)
-                    .field("wire_count", &wire_count)
-                    .field("zero_fill_count", &zero_fill_count)
-                    .field("reactivations", &reactivations)
-                    .field("pageins", &pageins)
-                    .field("pageouts", &pageouts)
-                    .field("faults", &faults)
-                    .field("cow_faults", &cow_faults)
-                    .field("lookups", &lookups)
-                    .field("hits", &hits)
-                    .field("purges", &purges)
-                    .field("purgeable_count", &purgeable_count)
-                    .field("speculative_count", &speculative_count)
-                    .field("decompressions", &decompressions)
-                    .field("compressions", &compressions)
-                    .field("swapins", &swapins)
-                    .field("swapouts", &swapouts)
-                    .field("compressor_page_count", &compressor_page_count)
-                    .field("throttled_count", &throttled_count)
-                    .field("external_page_count", &external_page_count)
-                    .field("internal_page_count", &internal_page_count)
-                    .field(
-                        "total_uncompressed_pages_in_compressor",
-                        &total_uncompressed,
-                    )
-                    .finish()
-            }
-        }
         impl hash::Hash for vm_statistics64 {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let free_count = self.free_count;
@@ -2835,26 +2430,6 @@ cfg_if! {
             }
         }
         impl Eq for mach_task_basic_info {}
-        impl fmt::Debug for mach_task_basic_info {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let virtual_size = self.virtual_size;
-                let resident_size = self.resident_size;
-                let resident_size_max = self.resident_size_max;
-                let user_time = self.user_time;
-                let system_time = self.system_time;
-                let policy = self.policy;
-                let suspend_count = self.suspend_count;
-                f.debug_struct("mach_task_basic_info")
-                    .field("virtual_size", &virtual_size)
-                    .field("resident_size", &resident_size)
-                    .field("resident_size_max", &resident_size_max)
-                    .field("user_time", &user_time)
-                    .field("system_time", &system_time)
-                    .field("policy", &policy)
-                    .field("suspend_count", &suspend_count)
-                    .finish()
-            }
-        }
         impl hash::Hash for mach_task_basic_info {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let virtual_size = self.virtual_size;
@@ -2882,18 +2457,6 @@ cfg_if! {
             }
         }
         impl Eq for log2phys {}
-        impl fmt::Debug for log2phys {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let l2p_flags = self.l2p_flags;
-                let l2p_contigbytes = self.l2p_contigbytes;
-                let l2p_devoffset = self.l2p_devoffset;
-                f.debug_struct("log2phys")
-                    .field("l2p_flags", &l2p_flags)
-                    .field("l2p_contigbytes", &l2p_contigbytes)
-                    .field("l2p_devoffset", &l2p_devoffset)
-                    .finish()
-            }
-        }
         impl hash::Hash for log2phys {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let l2p_flags = self.l2p_flags;
@@ -2912,14 +2475,6 @@ cfg_if! {
 
         impl Eq for os_unfair_lock {}
 
-        impl fmt::Debug for os_unfair_lock {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("os_unfair_lock")
-                    .field("_os_unfair_lock_opaque", &self._os_unfair_lock_opaque)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for os_unfair_lock {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self._os_unfair_lock_opaque.hash(state);
@@ -2937,24 +2492,6 @@ cfg_if! {
         }
 
         impl Eq for sockaddr_vm {}
-
-        impl fmt::Debug for sockaddr_vm {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let svm_len = self.svm_len;
-                let svm_family = self.svm_family;
-                let svm_reserved1 = self.svm_reserved1;
-                let svm_port = self.svm_port;
-                let svm_cid = self.svm_cid;
-
-                f.debug_struct("sockaddr_vm")
-                    .field("svm_len", &svm_len)
-                    .field("svm_family", &svm_family)
-                    .field("svm_reserved1", &svm_reserved1)
-                    .field("svm_port", &svm_port)
-                    .field("svm_cid", &svm_cid)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for sockaddr_vm {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -2981,16 +2518,6 @@ cfg_if! {
         }
 
         impl Eq for ifdevmtu {}
-
-        impl fmt::Debug for ifdevmtu {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ifdevmtu")
-                    .field("ifdm_current", &self.ifdm_current)
-                    .field("ifdm_min", &self.ifdm_min)
-                    .field("ifdm_max", &self.ifdm_max)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for ifdevmtu {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -3023,15 +2550,6 @@ cfg_if! {
         }
 
         impl Eq for ifkpi {}
-
-        impl fmt::Debug for ifkpi {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ifkpi")
-                    .field("ifk_module_id", &self.ifk_module_id)
-                    .field("ifk_type", &self.ifk_type)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for ifkpi {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -3100,25 +2618,10 @@ cfg_if! {
 
         impl Eq for ifreq {}
 
-        impl fmt::Debug for ifreq {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ifreq")
-                    .field("ifr_name", &self.ifr_name)
-                    .field("ifr_ifru", &self.ifr_ifru)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for ifreq {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ifr_name.hash(state);
                 self.ifr_ifru.hash(state);
-            }
-        }
-
-        impl fmt::Debug for ifconf {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ifconf").finish_non_exhaustive()
             }
         }
 
@@ -3165,15 +2668,6 @@ cfg_if! {
         }
 
         impl Eq for in6_ifreq {}
-
-        impl fmt::Debug for in6_ifreq {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("in6_ifreq")
-                    .field("ifr_name", &self.ifr_name)
-                    .field("ifr_ifru", &self.ifr_ifru)
-                    .finish()
-            }
-        }
     }
 }
 

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -554,24 +554,6 @@ cfg_if! {
             }
         }
         impl Eq for utmpx {}
-        impl fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utmpx")
-                    .field("ut_name", &self.ut_name)
-                    .field("ut_id", &self.ut_id)
-                    .field("ut_line", &self.ut_line)
-                    // FIXME(debug): .field("ut_host", &self.ut_host)
-                    .field("ut_unused", &self.ut_unused)
-                    .field("ut_session", &self.ut_session)
-                    .field("ut_type", &self.ut_type)
-                    .field("ut_pid", &self.ut_pid)
-                    .field("ut_exit", &self.ut_exit)
-                    .field("ut_ss", &self.ut_ss)
-                    .field("ut_tv", &self.ut_tv)
-                    .field("ut_unused2", &self.ut_unused2)
-                    .finish()
-            }
-        }
         impl hash::Hash for utmpx {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_name.hash(state);
@@ -597,16 +579,6 @@ cfg_if! {
             }
         }
         impl Eq for lastlogx {}
-        impl fmt::Debug for lastlogx {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("lastlogx")
-                    .field("ll_tv", &self.ll_tv)
-                    .field("ll_line", &self.ll_line)
-                    .field("ll_host", &self.ll_host)
-                    .field("ll_ss", &self.ll_ss)
-                    .finish()
-            }
-        }
         impl hash::Hash for lastlogx {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ll_tv.hash(state);
@@ -631,18 +603,6 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_fileno", &self.d_fileno)
-                    .field("d_namlen", &self.d_namlen)
-                    .field("d_type", &self.d_type)
-                    // Ignore __unused1
-                    // Ignore __unused2
-                    // FIXME(debug): .field("d_name", &self.d_name)
-                    .finish()
-            }
-        }
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_fileno.hash(state);
@@ -685,29 +645,6 @@ cfg_if! {
             }
         }
         impl Eq for statfs {}
-        impl fmt::Debug for statfs {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("statfs")
-                    .field("f_bsize", &self.f_bsize)
-                    .field("f_iosize", &self.f_iosize)
-                    .field("f_blocks", &self.f_blocks)
-                    .field("f_bfree", &self.f_bfree)
-                    .field("f_bavail", &self.f_bavail)
-                    .field("f_files", &self.f_files)
-                    .field("f_ffree", &self.f_ffree)
-                    .field("f_fsid", &self.f_fsid)
-                    .field("f_owner", &self.f_owner)
-                    .field("f_type", &self.f_type)
-                    .field("f_flags", &self.f_flags)
-                    .field("f_syncwrites", &self.f_syncwrites)
-                    .field("f_asyncwrites", &self.f_asyncwrites)
-                    // FIXME(debug): .field("f_mntonname", &self.f_mntonname)
-                    .field("f_syncreads", &self.f_syncreads)
-                    .field("f_asyncreads", &self.f_asyncreads)
-                    // FIXME(debug): .field("f_mntfromname", &self.f_mntfromname)
-                    .finish()
-            }
-        }
         impl hash::Hash for statfs {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_bsize.hash(state);
@@ -739,15 +676,6 @@ cfg_if! {
             }
         }
         impl Eq for sigevent {}
-        impl fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sigevent")
-                    .field("sigev_notify", &self.sigev_notify)
-                    .field("sigev_signo", &self.sigev_signo)
-                    .field("sigev_value", &self.sigev_value)
-                    .finish()
-            }
-        }
         impl hash::Hash for sigevent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sigev_notify.hash(state);
@@ -790,42 +718,6 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("mcontext_t")
-                    .field("mc_onstack", &self.mc_onstack)
-                    .field("mc_rdi", &self.mc_rdi)
-                    .field("mc_rsi", &self.mc_rsi)
-                    .field("mc_rdx", &self.mc_rdx)
-                    .field("mc_rcx", &self.mc_rcx)
-                    .field("mc_r8", &self.mc_r8)
-                    .field("mc_r9", &self.mc_r9)
-                    .field("mc_rax", &self.mc_rax)
-                    .field("mc_rbx", &self.mc_rbx)
-                    .field("mc_rbp", &self.mc_rbp)
-                    .field("mc_r10", &self.mc_r10)
-                    .field("mc_r11", &self.mc_r11)
-                    .field("mc_r12", &self.mc_r12)
-                    .field("mc_r13", &self.mc_r13)
-                    .field("mc_r14", &self.mc_r14)
-                    .field("mc_r15", &self.mc_r15)
-                    .field("mc_xflags", &self.mc_xflags)
-                    .field("mc_trapno", &self.mc_trapno)
-                    .field("mc_addr", &self.mc_addr)
-                    .field("mc_flags", &self.mc_flags)
-                    .field("mc_err", &self.mc_err)
-                    .field("mc_rip", &self.mc_rip)
-                    .field("mc_cs", &self.mc_cs)
-                    .field("mc_rflags", &self.mc_rflags)
-                    .field("mc_rsp", &self.mc_rsp)
-                    .field("mc_ss", &self.mc_ss)
-                    .field("mc_len", &self.mc_len)
-                    .field("mc_fpformat", &self.mc_fpformat)
-                    .field("mc_ownedfp", &self.mc_ownedfp)
-                    .field("mc_fpregs", &self.mc_fpregs)
-                    .finish()
-            }
-        }
         impl hash::Hash for mcontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mc_onstack.hash(state);
@@ -875,18 +767,6 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ucontext_t")
-                    .field("uc_sigmask", &self.uc_sigmask)
-                    .field("uc_mcontext", &self.uc_mcontext)
-                    .field("uc_link", &self.uc_link)
-                    .field("uc_stack", &self.uc_stack)
-                    .field("uc_cofunc", &self.uc_cofunc)
-                    .field("uc_arg", &self.uc_arg)
-                    .finish()
-            }
-        }
         impl hash::Hash for ucontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_sigmask.hash(state);

--- a/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
@@ -48,18 +48,6 @@ cfg_if! {
             }
         }
         impl Eq for gpregs {}
-        impl fmt::Debug for gpregs {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("gpregs")
-                    .field("gp_x", &self.gp_x)
-                    .field("gp_lr", &self.gp_lr)
-                    .field("gp_sp", &self.gp_sp)
-                    .field("gp_elr", &self.gp_elr)
-                    .field("gp_spsr", &self.gp_spsr)
-                    .field("gp_pad", &self.gp_pad)
-                    .finish()
-            }
-        }
         impl hash::Hash for gpregs {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.gp_x.hash(state);
@@ -80,17 +68,6 @@ cfg_if! {
             }
         }
         impl Eq for fpregs {}
-        impl fmt::Debug for fpregs {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("fpregs")
-                    .field("fp_q", &self.fp_q)
-                    .field("fp_sr", &self.fp_sr)
-                    .field("fp_cr", &self.fp_cr)
-                    .field("fp_flags", &self.fp_flags)
-                    .field("fp_pad", &self.fp_pad)
-                    .finish()
-            }
-        }
         impl hash::Hash for fpregs {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.fp_q.hash(state);
@@ -114,17 +91,6 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("mcontext_t")
-                    .field("mc_gpregs", &self.mc_gpregs)
-                    .field("mc_fpregs", &self.mc_fpregs)
-                    .field("mc_flags", &self.mc_flags)
-                    .field("mc_pad", &self.mc_pad)
-                    .field("mc_spare", &self.mc_spare)
-                    .finish()
-            }
-        }
         impl hash::Hash for mcontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mc_gpregs.hash(state);

--- a/src/unix/bsd/freebsdlike/freebsd/arm.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/arm.rs
@@ -32,16 +32,6 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("mcontext_t")
-                    .field("__gregs", &self.__gregs)
-                    .field("mc_vfp_size", &self.mc_vfp_size)
-                    .field("mc_vfp_ptr", &self.mc_vfp_ptr)
-                    .field("mc_spare", &self.mc_spare)
-                    .finish()
-            }
-        }
         impl hash::Hash for mcontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__gregs.hash(state);

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
@@ -296,29 +296,6 @@ cfg_if! {
             }
         }
         impl Eq for statfs {}
-        impl fmt::Debug for statfs {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("statfs")
-                    .field("f_bsize", &self.f_bsize)
-                    .field("f_iosize", &self.f_iosize)
-                    .field("f_blocks", &self.f_blocks)
-                    .field("f_bfree", &self.f_bfree)
-                    .field("f_bavail", &self.f_bavail)
-                    .field("f_files", &self.f_files)
-                    .field("f_ffree", &self.f_ffree)
-                    .field("f_syncwrites", &self.f_syncwrites)
-                    .field("f_asyncwrites", &self.f_asyncwrites)
-                    .field("f_syncreads", &self.f_syncreads)
-                    .field("f_asyncreads", &self.f_asyncreads)
-                    .field("f_namemax", &self.f_namemax)
-                    .field("f_owner", &self.f_owner)
-                    .field("f_fsid", &self.f_fsid)
-                    .field("f_fstypename", &self.f_fstypename)
-                    .field("f_mntfromname", &&self.f_mntfromname[..])
-                    .field("f_mntonname", &&self.f_mntonname[..])
-                    .finish()
-            }
-        }
         impl hash::Hash for statfs {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_version.hash(state);
@@ -357,17 +334,6 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_fileno", &self.d_fileno)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_type", &self.d_type)
-                    .field("d_namlen", &self.d_namlen)
-                    .field("d_name", &&self.d_name[..self.d_namlen as _])
-                    .finish()
-            }
-        }
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_fileno.hash(state);
@@ -394,22 +360,6 @@ cfg_if! {
             }
         }
         impl Eq for vnstat {}
-        impl fmt::Debug for vnstat {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let self_vn_devname: &[c_char] = &self.vn_devname;
-
-                f.debug_struct("vnstat")
-                    .field("vn_fileid", &self.vn_fileid)
-                    .field("vn_size", &self.vn_size)
-                    .field("vn_mntdir", &self.vn_mntdir)
-                    .field("vn_dev", &self.vn_dev)
-                    .field("vn_fsid", &self.vn_fsid)
-                    .field("vn_type", &self.vn_type)
-                    .field("vn_mode", &self.vn_mode)
-                    .field("vn_devname", &self_vn_devname)
-                    .finish()
-            }
-        }
         impl hash::Hash for vnstat {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let self_vn_devname: &[c_char] = &self.vn_devname;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -340,29 +340,6 @@ cfg_if! {
             }
         }
         impl Eq for statfs {}
-        impl fmt::Debug for statfs {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("statfs")
-                    .field("f_bsize", &self.f_bsize)
-                    .field("f_iosize", &self.f_iosize)
-                    .field("f_blocks", &self.f_blocks)
-                    .field("f_bfree", &self.f_bfree)
-                    .field("f_bavail", &self.f_bavail)
-                    .field("f_files", &self.f_files)
-                    .field("f_ffree", &self.f_ffree)
-                    .field("f_syncwrites", &self.f_syncwrites)
-                    .field("f_asyncwrites", &self.f_asyncwrites)
-                    .field("f_syncreads", &self.f_syncreads)
-                    .field("f_asyncreads", &self.f_asyncreads)
-                    .field("f_namemax", &self.f_namemax)
-                    .field("f_owner", &self.f_owner)
-                    .field("f_fsid", &self.f_fsid)
-                    .field("f_fstypename", &self.f_fstypename)
-                    .field("f_mntfromname", &&self.f_mntfromname[..])
-                    .field("f_mntonname", &&self.f_mntonname[..])
-                    .finish()
-            }
-        }
         impl hash::Hash for statfs {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_version.hash(state);
@@ -403,18 +380,6 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_fileno", &self.d_fileno)
-                    .field("d_off", &self.d_off)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_type", &self.d_type)
-                    .field("d_namlen", &self.d_namlen)
-                    .field("d_name", &&self.d_name[..self.d_namlen as _])
-                    .finish()
-            }
-        }
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_fileno.hash(state);
@@ -442,22 +407,6 @@ cfg_if! {
             }
         }
         impl Eq for vnstat {}
-        impl fmt::Debug for vnstat {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let self_vn_devname: &[c_char] = &self.vn_devname;
-
-                f.debug_struct("vnstat")
-                    .field("vn_fileid", &self.vn_fileid)
-                    .field("vn_size", &self.vn_size)
-                    .field("vn_dev", &self.vn_dev)
-                    .field("vn_fsid", &self.vn_fsid)
-                    .field("vn_mntdir", &self.vn_mntdir)
-                    .field("vn_type", &self.vn_type)
-                    .field("vn_mode", &self.vn_mode)
-                    .field("vn_devname", &self_vn_devname)
-                    .finish()
-            }
-        }
         impl hash::Hash for vnstat {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let self_vn_devname: &[c_char] = &self.vn_devname;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -353,29 +353,6 @@ cfg_if! {
             }
         }
         impl Eq for statfs {}
-        impl fmt::Debug for statfs {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("statfs")
-                    .field("f_bsize", &self.f_bsize)
-                    .field("f_iosize", &self.f_iosize)
-                    .field("f_blocks", &self.f_blocks)
-                    .field("f_bfree", &self.f_bfree)
-                    .field("f_bavail", &self.f_bavail)
-                    .field("f_files", &self.f_files)
-                    .field("f_ffree", &self.f_ffree)
-                    .field("f_syncwrites", &self.f_syncwrites)
-                    .field("f_asyncwrites", &self.f_asyncwrites)
-                    .field("f_syncreads", &self.f_syncreads)
-                    .field("f_asyncreads", &self.f_asyncreads)
-                    .field("f_namemax", &self.f_namemax)
-                    .field("f_owner", &self.f_owner)
-                    .field("f_fsid", &self.f_fsid)
-                    .field("f_fstypename", &self.f_fstypename)
-                    .field("f_mntfromname", &&self.f_mntfromname[..])
-                    .field("f_mntonname", &&self.f_mntonname[..])
-                    .finish()
-            }
-        }
         impl hash::Hash for statfs {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_version.hash(state);
@@ -416,18 +393,6 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_fileno", &self.d_fileno)
-                    .field("d_off", &self.d_off)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_type", &self.d_type)
-                    .field("d_namlen", &self.d_namlen)
-                    .field("d_name", &&self.d_name[..self.d_namlen as _])
-                    .finish()
-            }
-        }
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_fileno.hash(state);
@@ -455,22 +420,6 @@ cfg_if! {
             }
         }
         impl Eq for vnstat {}
-        impl fmt::Debug for vnstat {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let self_vn_devname: &[c_char] = &self.vn_devname;
-
-                f.debug_struct("vnstat")
-                    .field("vn_fileid", &self.vn_fileid)
-                    .field("vn_size", &self.vn_size)
-                    .field("vn_dev", &self.vn_dev)
-                    .field("vn_fsid", &self.vn_fsid)
-                    .field("vn_mntdir", &self.vn_mntdir)
-                    .field("vn_type", &self.vn_type)
-                    .field("vn_mode", &self.vn_mode)
-                    .field("vn_devname", &self_vn_devname)
-                    .finish()
-            }
-        }
         impl hash::Hash for vnstat {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let self_vn_devname: &[c_char] = &self.vn_devname;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -353,29 +353,6 @@ cfg_if! {
             }
         }
         impl Eq for statfs {}
-        impl fmt::Debug for statfs {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("statfs")
-                    .field("f_bsize", &self.f_bsize)
-                    .field("f_iosize", &self.f_iosize)
-                    .field("f_blocks", &self.f_blocks)
-                    .field("f_bfree", &self.f_bfree)
-                    .field("f_bavail", &self.f_bavail)
-                    .field("f_files", &self.f_files)
-                    .field("f_ffree", &self.f_ffree)
-                    .field("f_syncwrites", &self.f_syncwrites)
-                    .field("f_asyncwrites", &self.f_asyncwrites)
-                    .field("f_syncreads", &self.f_syncreads)
-                    .field("f_asyncreads", &self.f_asyncreads)
-                    .field("f_namemax", &self.f_namemax)
-                    .field("f_owner", &self.f_owner)
-                    .field("f_fsid", &self.f_fsid)
-                    .field("f_fstypename", &self.f_fstypename)
-                    .field("f_mntfromname", &&self.f_mntfromname[..])
-                    .field("f_mntonname", &&self.f_mntonname[..])
-                    .finish()
-            }
-        }
         impl hash::Hash for statfs {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_version.hash(state);
@@ -416,18 +393,6 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_fileno", &self.d_fileno)
-                    .field("d_off", &self.d_off)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_type", &self.d_type)
-                    .field("d_namlen", &self.d_namlen)
-                    .field("d_name", &&self.d_name[..self.d_namlen as _])
-                    .finish()
-            }
-        }
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_fileno.hash(state);
@@ -455,22 +420,6 @@ cfg_if! {
             }
         }
         impl Eq for vnstat {}
-        impl fmt::Debug for vnstat {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let self_vn_devname: &[c_char] = &self.vn_devname;
-
-                f.debug_struct("vnstat")
-                    .field("vn_fileid", &self.vn_fileid)
-                    .field("vn_size", &self.vn_size)
-                    .field("vn_dev", &self.vn_dev)
-                    .field("vn_fsid", &self.vn_fsid)
-                    .field("vn_mntdir", &self.vn_mntdir)
-                    .field("vn_type", &self.vn_type)
-                    .field("vn_mode", &self.vn_mode)
-                    .field("vn_devname", &self_vn_devname)
-                    .finish()
-            }
-        }
         impl hash::Hash for vnstat {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let self_vn_devname: &[c_char] = &self.vn_devname;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
@@ -354,29 +354,6 @@ cfg_if! {
             }
         }
         impl Eq for statfs {}
-        impl fmt::Debug for statfs {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("statfs")
-                    .field("f_bsize", &self.f_bsize)
-                    .field("f_iosize", &self.f_iosize)
-                    .field("f_blocks", &self.f_blocks)
-                    .field("f_bfree", &self.f_bfree)
-                    .field("f_bavail", &self.f_bavail)
-                    .field("f_files", &self.f_files)
-                    .field("f_ffree", &self.f_ffree)
-                    .field("f_syncwrites", &self.f_syncwrites)
-                    .field("f_asyncwrites", &self.f_asyncwrites)
-                    .field("f_syncreads", &self.f_syncreads)
-                    .field("f_asyncreads", &self.f_asyncreads)
-                    .field("f_namemax", &self.f_namemax)
-                    .field("f_owner", &self.f_owner)
-                    .field("f_fsid", &self.f_fsid)
-                    .field("f_fstypename", &self.f_fstypename)
-                    .field("f_mntfromname", &&self.f_mntfromname[..])
-                    .field("f_mntonname", &&self.f_mntonname[..])
-                    .finish()
-            }
-        }
         impl hash::Hash for statfs {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_version.hash(state);
@@ -417,18 +394,6 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_fileno", &self.d_fileno)
-                    .field("d_off", &self.d_off)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_type", &self.d_type)
-                    .field("d_namlen", &self.d_namlen)
-                    .field("d_name", &&self.d_name[..self.d_namlen as _])
-                    .finish()
-            }
-        }
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_fileno.hash(state);
@@ -456,22 +421,6 @@ cfg_if! {
             }
         }
         impl Eq for vnstat {}
-        impl fmt::Debug for vnstat {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let self_vn_devname: &[c_char] = &self.vn_devname;
-
-                f.debug_struct("vnstat")
-                    .field("vn_fileid", &self.vn_fileid)
-                    .field("vn_size", &self.vn_size)
-                    .field("vn_dev", &self.vn_dev)
-                    .field("vn_fsid", &self.vn_fsid)
-                    .field("vn_mntdir", &self.vn_mntdir)
-                    .field("vn_type", &self.vn_type)
-                    .field("vn_mode", &self.vn_mode)
-                    .field("vn_devname", &self_vn_devname)
-                    .finish()
-            }
-        }
         impl hash::Hash for vnstat {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let self_vn_devname: &[c_char] = &self.vn_devname;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1405,14 +1405,12 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[cfg_attr(feature = "extra_traits", derive(Debug))]
     pub struct __aiocb_private {
         status: c_long,
         error: c_long,
         spare: *mut c_void,
     }
 
-    #[cfg_attr(feature = "extra_traits", derive(Debug))]
     pub struct aiocb {
         pub aio_fildes: c_int,
         pub aio_offset: off_t,
@@ -1747,20 +1745,6 @@ cfg_if! {
             }
         }
         impl Eq for utmpx {}
-        impl fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utmpx")
-                    .field("ut_type", &self.ut_type)
-                    .field("ut_tv", &self.ut_tv)
-                    .field("ut_id", &self.ut_id)
-                    .field("ut_pid", &self.ut_pid)
-                    .field("ut_user", &self.ut_user)
-                    .field("ut_line", &self.ut_line)
-                    // FIXME(debug): .field("ut_host", &self.ut_host)
-                    // FIXME(debug): .field("__ut_spare", &self.__ut_spare)
-                    .finish()
-            }
-        }
         impl hash::Hash for utmpx {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_type.hash(state);
@@ -1796,17 +1780,6 @@ cfg_if! {
             }
         }
         impl Eq for xucred {}
-        impl fmt::Debug for xucred {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                f.debug_struct("xucred")
-                    .field("cr_version", &self.cr_version)
-                    .field("cr_uid", &self.cr_uid)
-                    .field("cr_ngroups", &self.cr_ngroups)
-                    .field("cr_groups", &self.cr_groups)
-                    .field("cr_pid__c_anonymous_union", &self.cr_pid__c_anonymous_union)
-                    .finish()
-            }
-        }
         impl hash::Hash for xucred {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cr_version.hash(state);
@@ -1834,20 +1807,6 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_dl {}
-        impl fmt::Debug for sockaddr_dl {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_dl")
-                    .field("sdl_len", &self.sdl_len)
-                    .field("sdl_family", &self.sdl_family)
-                    .field("sdl_index", &self.sdl_index)
-                    .field("sdl_type", &self.sdl_type)
-                    .field("sdl_nlen", &self.sdl_nlen)
-                    .field("sdl_alen", &self.sdl_alen)
-                    .field("sdl_slen", &self.sdl_slen)
-                    // FIXME(debug): .field("sdl_data", &self.sdl_data)
-                    .finish()
-            }
-        }
         impl hash::Hash for sockaddr_dl {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sdl_len.hash(state);
@@ -1870,34 +1829,12 @@ cfg_if! {
             }
         }
         impl Eq for mq_attr {}
-        impl fmt::Debug for mq_attr {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("mq_attr")
-                    .field("mq_flags", &self.mq_flags)
-                    .field("mq_maxmsg", &self.mq_maxmsg)
-                    .field("mq_msgsize", &self.mq_msgsize)
-                    .field("mq_curmsgs", &self.mq_curmsgs)
-                    .finish()
-            }
-        }
         impl hash::Hash for mq_attr {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mq_flags.hash(state);
                 self.mq_maxmsg.hash(state);
                 self.mq_msgsize.hash(state);
                 self.mq_curmsgs.hash(state);
-            }
-        }
-
-        impl fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sigevent")
-                    .field("sigev_notify", &self.sigev_notify)
-                    .field("sigev_signo", &self.sigev_signo)
-                    .field("sigev_value", &self.sigev_value)
-                    // Skip _sigev_un, since we can't guarantee that it will be
-                    // properly initialized.
-                    .finish()
             }
         }
 
@@ -1910,16 +1847,6 @@ cfg_if! {
             }
         }
         impl Eq for ptsstat {}
-        impl fmt::Debug for ptsstat {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let self_devname: &[c_char] = &self.devname;
-
-                f.debug_struct("ptsstat")
-                    .field("dev", &self.dev)
-                    .field("devname", &self_devname)
-                    .finish()
-            }
-        }
         impl hash::Hash for ptsstat {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let self_devname: &[c_char] = &self.devname;
@@ -1941,14 +1868,6 @@ cfg_if! {
             }
         }
         impl Eq for Elf32_Auxinfo {}
-        impl fmt::Debug for Elf32_Auxinfo {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("Elf32_Auxinfo")
-                    .field("a_type", &self.a_type)
-                    .field("a_un", &self.a_un)
-                    .finish()
-            }
-        }
 
         impl PartialEq for __c_anonymous_ifr_ifru {
             fn eq(&self, other: &__c_anonymous_ifr_ifru) -> bool {
@@ -1998,14 +1917,6 @@ cfg_if! {
             }
         }
         impl Eq for ifreq {}
-        impl fmt::Debug for ifreq {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ifreq")
-                    .field("ifr_name", &self.ifr_name)
-                    .field("ifr_ifru", &self.ifr_ifru)
-                    .finish()
-            }
-        }
         impl hash::Hash for ifreq {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ifr_name.hash(state);
@@ -2037,16 +1948,6 @@ cfg_if! {
             }
         }
         impl Eq for ifstat {}
-        impl fmt::Debug for ifstat {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let ascii: &[c_char] = &self.ascii;
-
-                f.debug_struct("ifstat")
-                    .field("ifs_name", &self.ifs_name)
-                    .field("ascii", &ascii)
-                    .finish()
-            }
-        }
         impl hash::Hash for ifstat {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ifs_name.hash(state);
@@ -2067,19 +1968,6 @@ cfg_if! {
             }
         }
         impl Eq for ifrsskey {}
-        impl fmt::Debug for ifrsskey {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let ifrk_key: &[u8] = &self.ifrk_key;
-
-                f.debug_struct("ifrsskey")
-                    .field("ifrk_name", &self.ifrk_name)
-                    .field("ifrk_func", &self.ifrk_func)
-                    .field("ifrk_spare0", &self.ifrk_spare0)
-                    .field("ifrk_keylen", &self.ifrk_keylen)
-                    .field("ifrk_key", &ifrk_key)
-                    .finish()
-            }
-        }
         impl hash::Hash for ifrsskey {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ifrk_name.hash(state);
@@ -2102,18 +1990,6 @@ cfg_if! {
             }
         }
         impl Eq for ifdownreason {}
-        impl fmt::Debug for ifdownreason {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let ifdr_msg: &[c_char] = &self.ifdr_msg;
-
-                f.debug_struct("ifdownreason")
-                    .field("ifdr_name", &self.ifdr_name)
-                    .field("ifdr_reason", &self.ifdr_reason)
-                    .field("ifdr_vendor", &self.ifdr_vendor)
-                    .field("ifdr_msg", &ifdr_msg)
-                    .finish()
-            }
-        }
         impl hash::Hash for ifdownreason {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ifdr_name.hash(state);
@@ -2183,37 +2059,6 @@ cfg_if! {
             }
         }
         impl Eq for if_data {}
-        impl fmt::Debug for if_data {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("if_data")
-                    .field("ifi_type", &self.ifi_type)
-                    .field("ifi_physical", &self.ifi_physical)
-                    .field("ifi_addrlen", &self.ifi_addrlen)
-                    .field("ifi_hdrlen", &self.ifi_hdrlen)
-                    .field("ifi_link_state", &self.ifi_link_state)
-                    .field("ifi_vhid", &self.ifi_vhid)
-                    .field("ifi_datalen", &self.ifi_datalen)
-                    .field("ifi_mtu", &self.ifi_mtu)
-                    .field("ifi_metric", &self.ifi_metric)
-                    .field("ifi_baudrate", &self.ifi_baudrate)
-                    .field("ifi_ipackets", &self.ifi_ipackets)
-                    .field("ifi_ierrors", &self.ifi_ierrors)
-                    .field("ifi_opackets", &self.ifi_opackets)
-                    .field("ifi_oerrors", &self.ifi_oerrors)
-                    .field("ifi_collisions", &self.ifi_collisions)
-                    .field("ifi_ibytes", &self.ifi_ibytes)
-                    .field("ifi_obytes", &self.ifi_obytes)
-                    .field("ifi_imcasts", &self.ifi_imcasts)
-                    .field("ifi_omcasts", &self.ifi_omcasts)
-                    .field("ifi_iqdrops", &self.ifi_iqdrops)
-                    .field("ifi_oqdrops", &self.ifi_oqdrops)
-                    .field("ifi_noproto", &self.ifi_noproto)
-                    .field("ifi_hwassist", &self.ifi_hwassist)
-                    .field("__ifi_epoch", &self.__ifi_epoch)
-                    .field("__ifi_lastchange", &self.__ifi_lastchange)
-                    .finish()
-            }
-        }
         impl hash::Hash for if_data {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ifi_type.hash(state);
@@ -2253,16 +2098,6 @@ cfg_if! {
             }
         }
         impl Eq for sctphdr {}
-        impl fmt::Debug for sctphdr {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sctphdr")
-                    .field("src_port", &{ self.src_port })
-                    .field("dest_port", &{ self.dest_port })
-                    .field("v_tag", &{ self.v_tag })
-                    .field("checksum", &{ self.checksum })
-                    .finish()
-            }
-        }
         impl hash::Hash for sctphdr {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.src_port }.hash(state);
@@ -2280,15 +2115,6 @@ cfg_if! {
             }
         }
         impl Eq for sctp_chunkhdr {}
-        impl fmt::Debug for sctp_chunkhdr {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sctp_chunkhdr")
-                    .field("chunk_type", &{ self.chunk_type })
-                    .field("chunk_flags", &{ self.chunk_flags })
-                    .field("chunk_length", &{ self.chunk_length })
-                    .finish()
-            }
-        }
         impl hash::Hash for sctp_chunkhdr {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.chunk_type }.hash(state);
@@ -2305,14 +2131,6 @@ cfg_if! {
             }
         }
         impl Eq for sctp_paramhdr {}
-        impl fmt::Debug for sctp_paramhdr {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sctp_paramhdr")
-                    .field("param_type", &{ self.param_type })
-                    .field("param_length", &{ self.param_length })
-                    .finish()
-            }
-        }
         impl hash::Hash for sctp_paramhdr {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.param_type }.hash(state);
@@ -2331,15 +2149,6 @@ cfg_if! {
             }
         }
         impl Eq for sctp_gen_error_cause {}
-        impl fmt::Debug for sctp_gen_error_cause {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sctp_gen_error_cause")
-                    .field("code", &{ self.code })
-                    .field("length", &{ self.length })
-                    // FIXME(debug): .field("info", &{self.info})
-                    .finish()
-            }
-        }
         impl hash::Hash for sctp_gen_error_cause {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.code }.hash(state);
@@ -2354,14 +2163,6 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_cause {}
-        impl fmt::Debug for sctp_error_cause {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sctp_error_cause")
-                    .field("code", &{ self.code })
-                    .field("length", &{ self.length })
-                    .finish()
-            }
-        }
         impl hash::Hash for sctp_error_cause {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.code }.hash(state);
@@ -2377,14 +2178,6 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_invalid_stream {}
-        impl fmt::Debug for sctp_error_invalid_stream {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sctp_error_invalid_stream")
-                    .field("cause", &{ self.cause })
-                    .field("stream_id", &{ self.stream_id })
-                    .finish()
-            }
-        }
         impl hash::Hash for sctp_error_invalid_stream {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.cause }.hash(state);
@@ -2403,15 +2196,6 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_missing_param {}
-        impl fmt::Debug for sctp_error_missing_param {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sctp_error_missing_param")
-                    .field("cause", &{ self.cause })
-                    .field("num_missing_params", &{ self.num_missing_params })
-                    // FIXME(debug): .field("tpe", &{self.tpe})
-                    .finish()
-            }
-        }
         impl hash::Hash for sctp_error_missing_param {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.cause }.hash(state);
@@ -2428,14 +2212,6 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_stale_cookie {}
-        impl fmt::Debug for sctp_error_stale_cookie {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sctp_error_stale_cookie")
-                    .field("cause", &{ self.cause })
-                    .field("stale_time", &{ self.stale_time })
-                    .finish()
-            }
-        }
         impl hash::Hash for sctp_error_stale_cookie {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.cause }.hash(state);
@@ -2449,13 +2225,6 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_out_of_resource {}
-        impl fmt::Debug for sctp_error_out_of_resource {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sctp_error_out_of_resource")
-                    .field("cause", &{ self.cause })
-                    .finish()
-            }
-        }
         impl hash::Hash for sctp_error_out_of_resource {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.cause }.hash(state);
@@ -2468,13 +2237,6 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_unresolv_addr {}
-        impl fmt::Debug for sctp_error_unresolv_addr {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sctp_error_unresolv_addr")
-                    .field("cause", &{ self.cause })
-                    .finish()
-            }
-        }
         impl hash::Hash for sctp_error_unresolv_addr {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.cause }.hash(state);
@@ -2487,14 +2249,6 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_unrecognized_chunk {}
-        impl fmt::Debug for sctp_error_unrecognized_chunk {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sctp_error_unrecognized_chunk")
-                    .field("cause", &{ self.cause })
-                    .field("ch", &{ self.ch })
-                    .finish()
-            }
-        }
         impl hash::Hash for sctp_error_unrecognized_chunk {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.cause }.hash(state);
@@ -2508,14 +2262,6 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_no_user_data {}
-        impl fmt::Debug for sctp_error_no_user_data {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sctp_error_no_user_data")
-                    .field("cause", &{ self.cause })
-                    .field("tsn", &{ self.tsn })
-                    .finish()
-            }
-        }
         impl hash::Hash for sctp_error_no_user_data {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.cause }.hash(state);
@@ -2529,14 +2275,6 @@ cfg_if! {
             }
         }
         impl Eq for sctp_error_auth_invalid_hmac {}
-        impl fmt::Debug for sctp_error_auth_invalid_hmac {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sctp_error_invalid_hmac")
-                    .field("cause", &{ self.cause })
-                    .field("hmac_id", &{ self.hmac_id })
-                    .finish()
-            }
-        }
         impl hash::Hash for sctp_error_auth_invalid_hmac {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.cause }.hash(state);
@@ -2562,21 +2300,6 @@ cfg_if! {
             }
         }
         impl Eq for kinfo_file {}
-        impl fmt::Debug for kinfo_file {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("kinfo_file")
-                    .field("kf_structsize", &self.kf_structsize)
-                    .field("kf_type", &self.kf_type)
-                    .field("kf_fd", &self.kf_fd)
-                    .field("kf_ref_count", &self.kf_ref_count)
-                    .field("kf_flags", &self.kf_flags)
-                    .field("kf_offset", &self.kf_offset)
-                    .field("kf_status", &self.kf_status)
-                    .field("kf_cap_rights", &self.kf_cap_rights)
-                    .field("kf_path", &&self.kf_path[..])
-                    .finish()
-            }
-        }
         impl hash::Hash for kinfo_file {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.kf_structsize.hash(state);
@@ -2588,18 +2311,6 @@ cfg_if! {
                 self.kf_status.hash(state);
                 self.kf_cap_rights.hash(state);
                 self.kf_path.hash(state);
-            }
-        }
-
-        impl fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ucontext_t")
-                    .field("uc_sigmask", &self.uc_sigmask)
-                    .field("uc_mcontext", &self.uc_mcontext)
-                    .field("uc_link", &self.uc_link)
-                    .field("uc_stack", &self.uc_stack)
-                    .field("uc_flags", &self.uc_flags)
-                    .finish()
             }
         }
     }

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
@@ -37,21 +37,6 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("mcontext_t")
-                    .field("mc_vers", &self.mc_vers)
-                    .field("mc_flags", &self.mc_flags)
-                    .field("mc_onstack", &self.mc_onstack)
-                    .field("mc_len", &self.mc_len)
-                    .field("mc_avec", &self.mc_avec)
-                    .field("mc_av", &self.mc_av)
-                    .field("mc_frame", &self.mc_frame)
-                    .field("mc_fpreg", &self.mc_fpreg)
-                    .field("mc_vsxfpreg", &self.mc_vsxfpreg)
-                    .finish()
-            }
-        }
         impl hash::Hash for mcontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mc_vers.hash(state);

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
@@ -37,21 +37,6 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("mcontext_t")
-                    .field("mc_vers", &self.mc_vers)
-                    .field("mc_flags", &self.mc_flags)
-                    .field("mc_onstack", &self.mc_onstack)
-                    .field("mc_len", &self.mc_len)
-                    .field("mc_avec", &self.mc_avec)
-                    .field("mc_av", &self.mc_av)
-                    .field("mc_frame", &self.mc_frame)
-                    .field("mc_fpreg", &self.mc_fpreg)
-                    .field("mc_vsxfpreg", &self.mc_vsxfpreg)
-                    .finish()
-            }
-        }
         impl hash::Hash for mcontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mc_vers.hash(state);

--- a/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
@@ -51,21 +51,6 @@ cfg_if! {
             }
         }
         impl Eq for gpregs {}
-        impl fmt::Debug for gpregs {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("gpregs")
-                    .field("gp_ra", &self.gp_ra)
-                    .field("gp_sp", &self.gp_sp)
-                    .field("gp_gp", &self.gp_gp)
-                    .field("gp_tp", &self.gp_tp)
-                    .field("gp_t", &self.gp_t)
-                    .field("gp_s", &self.gp_s)
-                    .field("gp_a", &self.gp_a)
-                    .field("gp_sepc", &self.gp_sepc)
-                    .field("gp_sstatus", &self.gp_sstatus)
-                    .finish()
-            }
-        }
         impl hash::Hash for gpregs {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.gp_ra.hash(state);
@@ -88,16 +73,6 @@ cfg_if! {
             }
         }
         impl Eq for fpregs {}
-        impl fmt::Debug for fpregs {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("fpregs")
-                    .field("fp_x", &self.fp_x)
-                    .field("fp_fcsr", &self.fp_fcsr)
-                    .field("fp_flags", &self.fp_flags)
-                    .field("pad", &self.pad)
-                    .finish()
-            }
-        }
         impl hash::Hash for fpregs {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.fp_x.hash(state);
@@ -120,17 +95,6 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("mcontext_t")
-                    .field("mc_gpregs", &self.mc_gpregs)
-                    .field("mc_fpregs", &self.mc_fpregs)
-                    .field("mc_flags", &self.mc_flags)
-                    .field("mc_pad", &self.mc_pad)
-                    .field("mc_spare", &self.mc_spare)
-                    .finish()
-            }
-        }
         impl hash::Hash for mcontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mc_gpregs.hash(state);

--- a/src/unix/bsd/freebsdlike/freebsd/x86.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86.rs
@@ -89,42 +89,6 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("mcontext_t")
-                    .field("mc_onstack", &self.mc_onstack)
-                    .field("mc_gs", &self.mc_gs)
-                    .field("mc_fs", &self.mc_fs)
-                    .field("mc_es", &self.mc_es)
-                    .field("mc_ds", &self.mc_ds)
-                    .field("mc_edi", &self.mc_edi)
-                    .field("mc_esi", &self.mc_esi)
-                    .field("mc_ebp", &self.mc_ebp)
-                    .field("mc_isp", &self.mc_isp)
-                    .field("mc_ebx", &self.mc_ebx)
-                    .field("mc_edx", &self.mc_edx)
-                    .field("mc_ecx", &self.mc_ecx)
-                    .field("mc_eax", &self.mc_eax)
-                    .field("mc_trapno", &self.mc_trapno)
-                    .field("mc_err", &self.mc_err)
-                    .field("mc_eip", &self.mc_eip)
-                    .field("mc_cs", &self.mc_cs)
-                    .field("mc_eflags", &self.mc_eflags)
-                    .field("mc_esp", &self.mc_esp)
-                    .field("mc_ss", &self.mc_ss)
-                    .field("mc_len", &self.mc_len)
-                    .field("mc_fpformat", &self.mc_fpformat)
-                    .field("mc_ownedfp", &self.mc_ownedfp)
-                    .field("mc_flags", &self.mc_flags)
-                    .field("mc_fpstate", &self.mc_fpstate)
-                    .field("mc_fsbase", &self.mc_fsbase)
-                    .field("mc_gsbase", &self.mc_gsbase)
-                    .field("mc_xfpustate", &self.mc_xfpustate)
-                    .field("mc_xfpustate_len", &self.mc_xfpustate_len)
-                    .field("mc_spare2", &self.mc_spare2)
-                    .finish()
-            }
-        }
         impl hash::Hash for mcontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mc_onstack.hash(state);

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -156,16 +156,6 @@ cfg_if! {
             }
         }
         impl Eq for fpreg32 {}
-        impl fmt::Debug for fpreg32 {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("fpreg32")
-                    .field("fpr_env", &&self.fpr_env[..])
-                    .field("fpr_acc", &self.fpr_acc)
-                    .field("fpr_ex_sw", &self.fpr_ex_sw)
-                    .field("fpr_pad", &&self.fpr_pad[..])
-                    .finish()
-            }
-        }
         impl hash::Hash for fpreg32 {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.fpr_env.hash(state);
@@ -184,16 +174,6 @@ cfg_if! {
             }
         }
         impl Eq for fpreg {}
-        impl fmt::Debug for fpreg {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("fpreg")
-                    .field("fpr_env", &self.fpr_env)
-                    .field("fpr_acc", &self.fpr_acc)
-                    .field("fpr_xacc", &self.fpr_xacc)
-                    .field("fpr_spare", &self.fpr_spare)
-                    .finish()
-            }
-        }
         impl hash::Hash for fpreg {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.fpr_env.hash(state);
@@ -216,16 +196,6 @@ cfg_if! {
             }
         }
         impl Eq for xmmreg {}
-        impl fmt::Debug for xmmreg {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("xmmreg")
-                    .field("xmm_env", &self.xmm_env)
-                    .field("xmm_acc", &self.xmm_acc)
-                    .field("xmm_reg", &self.xmm_reg)
-                    .field("xmm_pad", &&self.xmm_pad[..])
-                    .finish()
-            }
-        }
         impl hash::Hash for xmmreg {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.xmm_env.hash(state);
@@ -253,14 +223,6 @@ cfg_if! {
             }
         }
         impl Eq for Elf64_Auxinfo {}
-        impl fmt::Debug for Elf64_Auxinfo {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("Elf64_Auxinfo")
-                    .field("a_type", &self.a_type)
-                    .field("a_un", &self.a_un)
-                    .finish()
-            }
-        }
 
         impl PartialEq for mcontext_t {
             fn eq(&self, other: &mcontext_t) -> bool {
@@ -309,50 +271,6 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("mcontext_t")
-                    .field("mc_onstack", &self.mc_onstack)
-                    .field("mc_rdi", &self.mc_rdi)
-                    .field("mc_rsi", &self.mc_rsi)
-                    .field("mc_rdx", &self.mc_rdx)
-                    .field("mc_rcx", &self.mc_rcx)
-                    .field("mc_r8", &self.mc_r8)
-                    .field("mc_r9", &self.mc_r9)
-                    .field("mc_rax", &self.mc_rax)
-                    .field("mc_rbx", &self.mc_rbx)
-                    .field("mc_rbp", &self.mc_rbp)
-                    .field("mc_r10", &self.mc_r10)
-                    .field("mc_r11", &self.mc_r11)
-                    .field("mc_r12", &self.mc_r12)
-                    .field("mc_r13", &self.mc_r13)
-                    .field("mc_r14", &self.mc_r14)
-                    .field("mc_r15", &self.mc_r15)
-                    .field("mc_trapno", &self.mc_trapno)
-                    .field("mc_fs", &self.mc_fs)
-                    .field("mc_gs", &self.mc_gs)
-                    .field("mc_addr", &self.mc_addr)
-                    .field("mc_flags", &self.mc_flags)
-                    .field("mc_es", &self.mc_es)
-                    .field("mc_ds", &self.mc_ds)
-                    .field("mc_err", &self.mc_err)
-                    .field("mc_rip", &self.mc_rip)
-                    .field("mc_cs", &self.mc_cs)
-                    .field("mc_rflags", &self.mc_rflags)
-                    .field("mc_rsp", &self.mc_rsp)
-                    .field("mc_ss", &self.mc_ss)
-                    .field("mc_len", &self.mc_len)
-                    .field("mc_fpformat", &self.mc_fpformat)
-                    .field("mc_ownedfp", &self.mc_ownedfp)
-                    // FIXME(debug): .field("mc_fpstate", &self.mc_fpstate)
-                    .field("mc_fsbase", &self.mc_fsbase)
-                    .field("mc_gsbase", &self.mc_gsbase)
-                    .field("mc_xfpustate", &self.mc_xfpustate)
-                    .field("mc_xfpustate_len", &self.mc_xfpustate_len)
-                    .field("mc_spare", &self.mc_spare)
-                    .finish()
-            }
-        }
         impl hash::Hash for mcontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mc_onstack.hash(state);

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -414,17 +414,6 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_storage {}
-        impl fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_storage")
-                    .field("ss_len", &self.ss_len)
-                    .field("ss_family", &self.ss_family)
-                    .field("__ss_pad1", &self.__ss_pad1)
-                    .field("__ss_align", &self.__ss_align)
-                    // FIXME(debug): .field("__ss_pad2", &self.__ss_pad2)
-                    .finish()
-            }
-        }
         impl hash::Hash for sockaddr_storage {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_len.hash(state);

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -180,16 +180,6 @@ cfg_if! {
 
         impl Eq for sockaddr_un {}
 
-        impl fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_un")
-                    .field("sun_len", &self.sun_len)
-                    .field("sun_family", &self.sun_family)
-                    // FIXME(debug): .field("sun_path", &self.sun_path)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for sockaddr_un {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sun_len.hash(state);
@@ -228,18 +218,6 @@ cfg_if! {
         }
 
         impl Eq for utsname {}
-
-        impl fmt::Debug for utsname {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utsname")
-                    // FIXME(debug): .field("sysname", &self.sysname)
-                    // FIXME(debug): .field("nodename", &self.nodename)
-                    // FIXME(debug): .field("release", &self.release)
-                    // FIXME(debug): .field("version", &self.version)
-                    // FIXME(debug): .field("machine", &self.machine)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for utsname {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -940,24 +940,6 @@ cfg_if! {
 
         impl Eq for utmpx {}
 
-        impl fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utmpx")
-                    .field("ut_name", &self.ut_name)
-                    .field("ut_id", &self.ut_id)
-                    .field("ut_line", &self.ut_line)
-                    // FIXME(debug) .field("ut_host", &self.ut_host)
-                    .field("ut_session", &self.ut_session)
-                    .field("ut_type", &self.ut_type)
-                    .field("ut_pid", &self.ut_pid)
-                    .field("ut_exit", &self.ut_exit)
-                    .field("ut_ss", &self.ut_ss)
-                    .field("ut_tv", &self.ut_tv)
-                    // FIXME(debug) .field("ut_pad", &self.ut_pad)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for utmpx {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_name.hash(state);
@@ -989,17 +971,6 @@ cfg_if! {
 
         impl Eq for lastlogx {}
 
-        impl fmt::Debug for lastlogx {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("lastlogx")
-                    .field("ll_tv", &self.ll_tv)
-                    .field("ll_line", &self.ll_line)
-                    // FIXME(debug).field("ll_host", &self.ll_host)
-                    .field("ll_ss", &self.ll_ss)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for lastlogx {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ll_tv.hash(state);
@@ -1015,14 +986,6 @@ cfg_if! {
             }
         }
         impl Eq for in_pktinfo {}
-        impl fmt::Debug for in_pktinfo {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("in_pktinfo")
-                    .field("ipi_addr", &self.ipi_addr)
-                    .field("ipi_ifindex", &self.ipi_ifindex)
-                    .finish()
-            }
-        }
         impl hash::Hash for in_pktinfo {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ipi_addr.hash(state);
@@ -1040,20 +1003,6 @@ cfg_if! {
             }
         }
         impl Eq for arphdr {}
-        impl fmt::Debug for arphdr {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let ar_hrd = self.ar_hrd;
-                let ar_pro = self.ar_pro;
-                let ar_op = self.ar_op;
-                f.debug_struct("arphdr")
-                    .field("ar_hrd", &ar_hrd)
-                    .field("ar_pro", &ar_pro)
-                    .field("ar_hln", &self.ar_hln)
-                    .field("ar_pln", &self.ar_pln)
-                    .field("ar_op", &ar_op)
-                    .finish()
-            }
-        }
         impl hash::Hash for arphdr {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let ar_hrd = self.ar_hrd;
@@ -1073,12 +1022,6 @@ cfg_if! {
             }
         }
         impl Eq for in_addr {}
-        impl fmt::Debug for in_addr {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let s_addr = self.s_addr;
-                f.debug_struct("in_addr").field("s_addr", &s_addr).finish()
-            }
-        }
         impl hash::Hash for in_addr {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let s_addr = self.s_addr;
@@ -1093,14 +1036,6 @@ cfg_if! {
             }
         }
         impl Eq for ip_mreq {}
-        impl fmt::Debug for ip_mreq {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ip_mreq")
-                    .field("imr_multiaddr", &self.imr_multiaddr)
-                    .field("imr_interface", &self.imr_interface)
-                    .finish()
-            }
-        }
         impl hash::Hash for ip_mreq {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.imr_multiaddr.hash(state);
@@ -1118,17 +1053,6 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_in {}
-        impl fmt::Debug for sockaddr_in {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_in")
-                    .field("sin_len", &self.sin_len)
-                    .field("sin_family", &self.sin_family)
-                    .field("sin_port", &self.sin_port)
-                    .field("sin_addr", &self.sin_addr)
-                    .field("sin_zero", &self.sin_zero)
-                    .finish()
-            }
-        }
         impl hash::Hash for sockaddr_in {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sin_len.hash(state);
@@ -1153,17 +1077,6 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_fileno", &self.d_fileno)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_namlen", &self.d_namlen)
-                    .field("d_type", &self.d_type)
-                    // FIXME(debug): .field("d_name", &self.d_name)
-                    .finish()
-            }
-        }
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_fileno.hash(state);
@@ -1211,36 +1124,6 @@ cfg_if! {
             }
         }
         impl Eq for statvfs {}
-        impl fmt::Debug for statvfs {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("statvfs")
-                    .field("f_flag", &self.f_flag)
-                    .field("f_bsize", &self.f_bsize)
-                    .field("f_frsize", &self.f_frsize)
-                    .field("f_iosize", &self.f_iosize)
-                    .field("f_blocks", &self.f_blocks)
-                    .field("f_bfree", &self.f_bfree)
-                    .field("f_bavail", &self.f_bavail)
-                    .field("f_bresvd", &self.f_bresvd)
-                    .field("f_files", &self.f_files)
-                    .field("f_ffree", &self.f_ffree)
-                    .field("f_favail", &self.f_favail)
-                    .field("f_fresvd", &self.f_fresvd)
-                    .field("f_syncreads", &self.f_syncreads)
-                    .field("f_syncwrites", &self.f_syncwrites)
-                    .field("f_asyncreads", &self.f_asyncreads)
-                    .field("f_asyncwrites", &self.f_asyncwrites)
-                    .field("f_fsidx", &self.f_fsidx)
-                    .field("f_fsid", &self.f_fsid)
-                    .field("f_namemax", &self.f_namemax)
-                    .field("f_owner", &self.f_owner)
-                    .field("f_spare", &self.f_spare)
-                    .field("f_fstypename", &self.f_fstypename)
-                    // FIXME(debug): .field("f_mntonname", &self.f_mntonname)
-                    // FIXME(debug): .field("f_mntfromname", &self.f_mntfromname)
-                    .finish()
-            }
-        }
         impl hash::Hash for statvfs {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.f_flag.hash(state);
@@ -1284,17 +1167,6 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_storage {}
-        impl fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_storage")
-                    .field("ss_len", &self.ss_len)
-                    .field("ss_family", &self.ss_family)
-                    .field("__ss_pad1", &self.__ss_pad1)
-                    .field("__ss_pad2", &self.__ss_pad2)
-                    // FIXME(debug): .field("__ss_pad3", &self.__ss_pad3)
-                    .finish()
-            }
-        }
         impl hash::Hash for sockaddr_storage {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_len.hash(state);
@@ -1314,16 +1186,6 @@ cfg_if! {
             }
         }
         impl Eq for sigevent {}
-        impl fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sigevent")
-                    .field("sigev_notify", &self.sigev_notify)
-                    .field("sigev_signo", &self.sigev_signo)
-                    .field("sigev_value", &self.sigev_value)
-                    .field("sigev_notify_attributes", &self.sigev_notify_attributes)
-                    .finish()
-            }
-        }
         impl hash::Hash for sigevent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sigev_notify.hash(state);

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -772,19 +772,6 @@ cfg_if! {
 
         impl Eq for dirent {}
 
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_fileno", &self.d_fileno)
-                    .field("d_off", &self.d_off)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_type", &self.d_type)
-                    .field("d_namlen", &self.d_namlen)
-                    // FIXME(debug): .field("d_name", &self.d_name)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_fileno.hash(state);
@@ -804,15 +791,6 @@ cfg_if! {
 
         impl Eq for sockaddr_storage {}
 
-        impl fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_storage")
-                    .field("ss_len", &self.ss_len)
-                    .field("ss_family", &self.ss_family)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for sockaddr_storage {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_len.hash(state);
@@ -830,17 +808,6 @@ cfg_if! {
         }
 
         impl Eq for siginfo_t {}
-
-        impl fmt::Debug for siginfo_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("siginfo_t")
-                    .field("si_signo", &self.si_signo)
-                    .field("si_code", &self.si_code)
-                    .field("si_errno", &self.si_errno)
-                    .field("si_addr", &self.si_addr)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for siginfo_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -868,16 +835,6 @@ cfg_if! {
         }
 
         impl Eq for lastlog {}
-
-        impl fmt::Debug for lastlog {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("lastlog")
-                    .field("ll_time", &self.ll_time)
-                    // FIXME(debug): .field("ll_line", &self.ll_line)
-                    // FIXME(debug): .field("ll_host", &self.ll_host)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for lastlog {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -909,17 +866,6 @@ cfg_if! {
         }
 
         impl Eq for utmp {}
-
-        impl fmt::Debug for utmp {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utmp")
-                    // FIXME(debug): .field("ut_line", &self.ut_line)
-                    // FIXME(debug): .field("ut_name", &self.ut_name)
-                    // FIXME(debug): .field("ut_host", &self.ut_host)
-                    .field("ut_time", &self.ut_time)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for utmp {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -1027,35 +973,6 @@ cfg_if! {
         }
 
         impl Eq for statfs {}
-
-        impl fmt::Debug for statfs {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("statfs")
-                    .field("f_flags", &self.f_flags)
-                    .field("f_bsize", &self.f_bsize)
-                    .field("f_iosize", &self.f_iosize)
-                    .field("f_blocks", &self.f_blocks)
-                    .field("f_bfree", &self.f_bfree)
-                    .field("f_bavail", &self.f_bavail)
-                    .field("f_files", &self.f_files)
-                    .field("f_ffree", &self.f_ffree)
-                    .field("f_favail", &self.f_favail)
-                    .field("f_syncwrites", &self.f_syncwrites)
-                    .field("f_syncreads", &self.f_syncreads)
-                    .field("f_asyncwrites", &self.f_asyncwrites)
-                    .field("f_asyncreads", &self.f_asyncreads)
-                    .field("f_fsid", &self.f_fsid)
-                    .field("f_namemax", &self.f_namemax)
-                    .field("f_owner", &self.f_owner)
-                    .field("f_ctime", &self.f_ctime)
-                    // FIXME(debug): .field("f_fstypename", &self.f_fstypename)
-                    // FIXME(debug): .field("f_mntonname", &self.f_mntonname)
-                    // FIXME(debug): .field("f_mntfromname", &self.f_mntfromname)
-                    // FIXME(debug): .field("f_mntfromspec", &self.f_mntfromspec)
-                    .field("mount_info", &self.mount_info)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for statfs {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {

--- a/src/unix/bsd/netbsdlike/openbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/x86_64.rs
@@ -81,22 +81,6 @@ cfg_if! {
             }
         }
         impl Eq for fxsave64 {}
-        impl fmt::Debug for fxsave64 {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("fxsave64")
-                    .field("fx_fcw", &{ self.fx_fcw })
-                    .field("fx_fsw", &{ self.fx_fsw })
-                    .field("fx_ftw", &{ self.fx_ftw })
-                    .field("fx_fop", &{ self.fx_fop })
-                    .field("fx_rip", &{ self.fx_rip })
-                    .field("fx_rdp", &{ self.fx_rdp })
-                    .field("fx_mxcsr", &{ self.fx_mxcsr })
-                    .field("fx_mxcsr_mask", &{ self.fx_mxcsr_mask })
-                    // FIXME(debug): .field("fx_st", &{self.fx_st})
-                    // FIXME(debug): .field("fx_xmm", &{self.fx_xmm})
-                    .finish()
-            }
-        }
         impl hash::Hash for fxsave64 {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 { self.fx_fcw }.hash(state);

--- a/src/unix/cygwin/mod.rs
+++ b/src/unix/cygwin/mod.rs
@@ -583,19 +583,6 @@ cfg_if! {
 
         impl Eq for siginfo_t {}
 
-        impl fmt::Debug for siginfo_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("siginfo_t")
-                    .field("si_signo", &self.si_signo)
-                    .field("si_code", &self.si_code)
-                    .field("si_pid", &self.si_pid)
-                    .field("si_uid", &self.si_uid)
-                    .field("si_errno", &self.si_errno)
-                    // Ignore __pad
-                    .finish()
-            }
-        }
-
         impl hash::Hash for siginfo_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.si_signo.hash(state);
@@ -604,24 +591,6 @@ cfg_if! {
                 self.si_uid.hash(state);
                 self.si_errno.hash(state);
                 // Ignore __pad
-            }
-        }
-
-        impl fmt::Debug for ifreq {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ifreq")
-                    .field("ifr_name", &self.ifr_name)
-                    .field("ifr_ifru", &self.ifr_ifru)
-                    .finish()
-            }
-        }
-
-        impl fmt::Debug for ifconf {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ifconf")
-                    .field("ifc_len", &self.ifc_len)
-                    .field("ifc_ifcu", &self.ifc_ifcu)
-                    .finish()
             }
         }
 
@@ -638,16 +607,6 @@ cfg_if! {
         }
 
         impl Eq for dirent {}
-
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_ino", &self.d_ino)
-                    .field("d_type", &self.d_type)
-                    // FIXME: .field("d_name", &self.d_name)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -669,15 +628,6 @@ cfg_if! {
         }
 
         impl Eq for sockaddr_un {}
-
-        impl fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_un")
-                    .field("sun_family", &self.sun_family)
-                    // FIXME: .field("sun_path", &self.sun_path)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for sockaddr_un {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -721,19 +671,6 @@ cfg_if! {
         }
 
         impl Eq for utsname {}
-
-        impl fmt::Debug for utsname {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utsname")
-                    // FIXME: .field("sysname", &self.sysname)
-                    // FIXME: .field("nodename", &self.nodename)
-                    // FIXME: .field("release", &self.release)
-                    // FIXME: .field("version", &self.version)
-                    // FIXME: .field("machine", &self.machine)
-                    // FIXME: .field("domainname", &self.domainname)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for utsname {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -517,22 +517,6 @@ cfg_if! {
         }
 
         impl Eq for utmpx {}
-
-        impl fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utmpx")
-                    .field("ut_type", &self.ut_type)
-                    .field("ut_tv", &self.ut_tv)
-                    .field("ut_id", &self.ut_id)
-                    .field("ut_pid", &self.ut_pid)
-                    .field("ut_user", &self.ut_user)
-                    .field("ut_line", &self.ut_line)
-                    .field("ut_host", &self.ut_host)
-                    .field("__ut_reserved", &self.__ut_reserved)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for utmpx {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_type.hash(state);
@@ -557,15 +541,6 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_un {}
-        impl fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_un")
-                    .field("sun_len", &self.sun_len)
-                    .field("sun_family", &self.sun_family)
-                    // FIXME(debug): .field("sun_path", &self.sun_path)
-                    .finish()
-            }
-        }
         impl hash::Hash for sockaddr_un {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sun_len.hash(state);
@@ -592,17 +567,6 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_storage {}
-        impl fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_storage")
-                    .field("ss_len", &self.ss_len)
-                    .field("ss_family", &self.ss_family)
-                    .field("__ss_pad1", &self.__ss_pad1)
-                    .field("__ss_pad2", &self.__ss_pad2)
-                    // FIXME(debug): .field("__ss_pad3", &self.__ss_pad3)
-                    .finish()
-            }
-        }
         impl hash::Hash for sockaddr_storage {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_len.hash(state);
@@ -628,18 +592,6 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_dev", &self.d_dev)
-                    .field("d_pdev", &self.d_pdev)
-                    .field("d_ino", &self.d_ino)
-                    .field("d_pino", &self.d_pino)
-                    .field("d_reclen", &self.d_reclen)
-                    // FIXME(debug): .field("d_name", &self.d_name)
-                    .finish()
-            }
-        }
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_dev.hash(state);
@@ -660,16 +612,6 @@ cfg_if! {
             }
         }
         impl Eq for sigevent {}
-        impl fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sigevent")
-                    .field("sigev_notify", &self.sigev_notify)
-                    .field("sigev_signo", &self.sigev_signo)
-                    .field("sigev_value", &self.sigev_value)
-                    .field("sigev_notify_attributes", &self.sigev_notify_attributes)
-                    .finish()
-            }
-        }
         impl hash::Hash for sigevent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sigev_notify.hash(state);

--- a/src/unix/haiku/native.rs
+++ b/src/unix/haiku/native.rs
@@ -520,15 +520,6 @@ cfg_if! {
         }
 
         impl Eq for cpu_topology_node_info {}
-        impl fmt::Debug for cpu_topology_node_info {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("cpu_topology_node_info")
-                    .field("id", &self.id)
-                    .field("type", &self.type_)
-                    .field("level", &self.level)
-                    .finish()
-            }
-        }
     }
 }
 

--- a/src/unix/haiku/x86_64.rs
+++ b/src/unix/haiku/x86_64.rs
@@ -83,23 +83,6 @@ cfg_if! {
             }
         }
         impl Eq for fpu_state {}
-        impl fmt::Debug for fpu_state {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("fpu_state")
-                    .field("control", &self.control)
-                    .field("status", &self.status)
-                    .field("tag", &self.tag)
-                    .field("opcode", &self.opcode)
-                    .field("rip", &self.rip)
-                    .field("rdp", &self.rdp)
-                    .field("mxcsr", &self.mxcsr)
-                    .field("mscsr_mask", &self.mscsr_mask)
-                    // FIXME(debug): .field("_fpreg", &self._fpreg)
-                    // FIXME(debug): .field("_xmm", &self._xmm)
-                    // FIXME(debug): .field("_reserved_416_511", &self._reserved_416_511)
-                    .finish()
-            }
-        }
         impl hash::Hash for fpu_state {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.control.hash(state);
@@ -128,15 +111,6 @@ cfg_if! {
             }
         }
         impl Eq for xstate_hdr {}
-        impl fmt::Debug for xstate_hdr {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("xstate_hdr")
-                    .field("bv", &self.bv)
-                    .field("xcomp_bv", &self.xcomp_bv)
-                    // FIXME(debug): .field("_reserved", &field._reserved)
-                    .finish()
-            }
-        }
         impl hash::Hash for xstate_hdr {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.bv.hash(state);
@@ -157,15 +131,6 @@ cfg_if! {
             }
         }
         impl Eq for savefpu {}
-        impl fmt::Debug for savefpu {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("savefpu")
-                    .field("fp_fxsave", &self.fp_fxsave)
-                    .field("fp_xstate", &self.fp_xstate)
-                    // FIXME(debug): .field("_fp_ymm", &field._fp_ymm)
-                    .finish()
-            }
-        }
         impl hash::Hash for savefpu {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.fp_fxsave.hash(state);
@@ -198,31 +163,6 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("mcontext_t")
-                    .field("rax", &self.rax)
-                    .field("rbx", &self.rbx)
-                    .field("rcx", &self.rcx)
-                    .field("rdx", &self.rdx)
-                    .field("rdi", &self.rdi)
-                    .field("rsi", &self.rsi)
-                    .field("rbp", &self.rbp)
-                    .field("r8", &self.r8)
-                    .field("r9", &self.r9)
-                    .field("r10", &self.r10)
-                    .field("r11", &self.r11)
-                    .field("r12", &self.r12)
-                    .field("r13", &self.r13)
-                    .field("r14", &self.r14)
-                    .field("r15", &self.r15)
-                    .field("rsp", &self.rsp)
-                    .field("rip", &self.rip)
-                    .field("rflags", &self.rflags)
-                    .field("fpu", &self.fpu)
-                    .finish()
-            }
-        }
         impl hash::Hash for mcontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.rax.hash(state);
@@ -256,16 +196,6 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ucontext_t")
-                    .field("uc_link", &self.uc_link)
-                    .field("uc_sigmask", &self.uc_sigmask)
-                    .field("uc_stack", &self.uc_stack)
-                    .field("uc_mcontext", &self.uc_mcontext)
-                    .finish()
-            }
-        }
         impl hash::Hash for ucontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_link.hash(state);

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -1084,24 +1084,6 @@ cfg_if! {
 
         impl Eq for utmpx {}
 
-        impl fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utmpx")
-                    .field("ut_type", &self.ut_type)
-                    .field("ut_pid", &self.ut_pid)
-                    .field("ut_line", &self.ut_line)
-                    .field("ut_id", &self.ut_id)
-                    .field("ut_user", &self.ut_user)
-                    // FIXME(debug): .field("ut_host", &self.ut_host)
-                    .field("ut_exit", &self.ut_exit)
-                    .field("ut_session", &self.ut_session)
-                    .field("ut_tv", &self.ut_tv)
-                    .field("ut_addr_v6", &self.ut_addr_v6)
-                    .field("__glibc_reserved", &self.__glibc_reserved)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for utmpx {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_type.hash(state);

--- a/src/unix/linux_like/android/b32/arm.rs
+++ b/src/unix/linux_like/android/b32/arm.rs
@@ -65,14 +65,6 @@ cfg_if! {
             }
         }
         impl Eq for __c_anonymous_uc_sigmask_with_padding {}
-        impl fmt::Debug for __c_anonymous_uc_sigmask_with_padding {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("uc_sigmask_with_padding")
-                    .field("uc_sigmask_with_padding", &self.uc_sigmask)
-                    // Ignore padding
-                    .finish()
-            }
-        }
         impl hash::Hash for __c_anonymous_uc_sigmask_with_padding {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_sigmask.hash(state)
@@ -104,22 +96,6 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ucontext_t")
-                    .field("uc_flags", &self.uc_flags)
-                    .field("uc_link", &self.uc_link)
-                    .field("uc_stack", &self.uc_stack)
-                    .field("uc_mcontext", &self.uc_mcontext)
-                    .field(
-                        "uc_sigmask__c_anonymous_union",
-                        &self.uc_sigmask__c_anonymous_union,
-                    )
-                    .field("uc_regspace", &&self.uc_regspace[..])
-                    // Ignore padding field
-                    .finish()
-            }
-        }
         impl hash::Hash for ucontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_flags.hash(state);

--- a/src/unix/linux_like/android/b32/mod.rs
+++ b/src/unix/linux_like/android/b32/mod.rs
@@ -181,18 +181,6 @@ s_no_extra_traits! {
     }
 }
 
-cfg_if! {
-    if #[cfg(feature = "extra_traits")] {
-        impl fmt::Debug for sigset64_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sigset64_t")
-                    .field("__bits", &self.__bits)
-                    .finish()
-            }
-        }
-    }
-}
-
 // These constants must be of the same type of sigaction.sa_flags
 pub const SA_NOCLDSTOP: c_int = 0x00000001;
 pub const SA_NOCLDWAIT: c_int = 0x00000002;

--- a/src/unix/linux_like/android/b32/x86/mod.rs
+++ b/src/unix/linux_like/android/b32/x86/mod.rs
@@ -67,14 +67,6 @@ cfg_if! {
             }
         }
         impl Eq for __c_anonymous_uc_sigmask_with_padding {}
-        impl fmt::Debug for __c_anonymous_uc_sigmask_with_padding {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("uc_sigmask_with_padding")
-                    .field("uc_sigmask_with_padding", &self.uc_sigmask)
-                    // Ignore padding
-                    .finish()
-            }
-        }
         impl hash::Hash for __c_anonymous_uc_sigmask_with_padding {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_sigmask.hash(state)
@@ -105,21 +97,6 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ucontext_t")
-                    .field("uc_flags", &self.uc_flags)
-                    .field("uc_link", &self.uc_link)
-                    .field("uc_stack", &self.uc_stack)
-                    .field("uc_mcontext", &self.uc_mcontext)
-                    .field(
-                        "uc_sigmask__c_anonymous_union",
-                        &self.uc_sigmask__c_anonymous_union,
-                    )
-                    // Ignore padding field
-                    .finish()
-            }
-        }
         impl hash::Hash for ucontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_flags.hash(state);

--- a/src/unix/linux_like/android/b64/mod.rs
+++ b/src/unix/linux_like/android/b64/mod.rs
@@ -155,15 +155,6 @@ cfg_if! {
 
         impl Eq for pthread_mutex_t {}
 
-        impl fmt::Debug for pthread_mutex_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_mutex_t")
-                    .field("value", &self.value)
-                    // FIXME(debug): .field("__reserved", &self.__reserved)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for pthread_mutex_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.value.hash(state);
@@ -183,15 +174,6 @@ cfg_if! {
         }
 
         impl Eq for pthread_cond_t {}
-
-        impl fmt::Debug for pthread_cond_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_cond_t")
-                    .field("value", &self.value)
-                    // FIXME(debug): .field("__reserved", &self.__reserved)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for pthread_cond_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -217,19 +199,6 @@ cfg_if! {
 
         impl Eq for pthread_rwlock_t {}
 
-        impl fmt::Debug for pthread_rwlock_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_rwlock_t")
-                    .field("numLocks", &self.numLocks)
-                    .field("writerThreadId", &self.writerThreadId)
-                    .field("pendingReaders", &self.pendingReaders)
-                    .field("pendingWriters", &self.pendingWriters)
-                    .field("attr", &self.attr)
-                    // FIXME(debug): .field("__reserved", &self.__reserved)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for pthread_rwlock_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.numLocks.hash(state);
@@ -238,14 +207,6 @@ cfg_if! {
                 self.pendingWriters.hash(state);
                 self.attr.hash(state);
                 self.__reserved.hash(state);
-            }
-        }
-
-        impl fmt::Debug for sigset64_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sigset64_t")
-                    .field("__bits", &self.__bits)
-                    .finish()
             }
         }
     }

--- a/src/unix/linux_like/android/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/android/b64/x86_64/mod.rs
@@ -195,15 +195,6 @@ cfg_if! {
             }
         }
         impl Eq for _libc_fpxreg {}
-        impl fmt::Debug for _libc_fpxreg {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("_libc_fpxreg")
-                    .field("significand", &self.significand)
-                    .field("exponent", &self.exponent)
-                    // Ignore padding field
-                    .finish()
-            }
-        }
         impl hash::Hash for _libc_fpxreg {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.significand.hash(state);
@@ -228,23 +219,6 @@ cfg_if! {
             }
         }
         impl Eq for _libc_fpstate {}
-        impl fmt::Debug for _libc_fpstate {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("_libc_fpstate")
-                    .field("cwd", &self.cwd)
-                    .field("swd", &self.swd)
-                    .field("ftw", &self.ftw)
-                    .field("fop", &self.fop)
-                    .field("rip", &self.rip)
-                    .field("rdp", &self.rdp)
-                    .field("mxcsr", &self.mxcsr)
-                    .field("mxcr_mask", &self.mxcr_mask)
-                    .field("_st", &self._st)
-                    .field("_xmm", &self._xmm)
-                    // Ignore padding field
-                    .finish()
-            }
-        }
         impl hash::Hash for _libc_fpstate {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cwd.hash(state);
@@ -268,15 +242,6 @@ cfg_if! {
             }
         }
         impl Eq for mcontext_t {}
-        impl fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("mcontext_t")
-                    .field("gregs", &self.gregs)
-                    .field("fpregs", &self.fpregs)
-                    // Ignore padding field
-                    .finish()
-            }
-        }
         impl hash::Hash for mcontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.gregs.hash(state);
@@ -296,18 +261,6 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ucontext_t")
-                    .field("uc_flags", &self.uc_flags)
-                    .field("uc_link", &self.uc_link)
-                    .field("uc_stack", &self.uc_stack)
-                    .field("uc_mcontext", &self.uc_mcontext)
-                    .field("uc_sigmask64", &self.uc_sigmask64)
-                    // Ignore padding field
-                    .finish()
-            }
-        }
         impl hash::Hash for ucontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_flags.hash(state);
@@ -340,24 +293,6 @@ cfg_if! {
         }
 
         impl Eq for user_fpregs_struct {}
-
-        impl fmt::Debug for user_fpregs_struct {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("user_fpregs_struct")
-                    .field("cwd", &self.cwd)
-                    .field("swd", &self.swd)
-                    .field("ftw", &self.ftw)
-                    .field("fop", &self.fop)
-                    .field("rip", &self.rip)
-                    .field("rdp", &self.rdp)
-                    .field("mxcsr", &self.mxcsr)
-                    .field("mxcr_mask", &self.mxcr_mask)
-                    .field("st_space", &self.st_space)
-                    // FIXME(debug): .field("xmm_space", &self.xmm_space)
-                    // Ignore padding field
-                    .finish()
-            }
-        }
 
         impl hash::Hash for user_fpregs_struct {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -651,15 +651,6 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_nl {}
-        impl fmt::Debug for sockaddr_nl {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_nl")
-                    .field("nl_family", &self.nl_family)
-                    .field("nl_pid", &self.nl_pid)
-                    .field("nl_groups", &self.nl_groups)
-                    .finish()
-            }
-        }
         impl hash::Hash for sockaddr_nl {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.nl_family.hash(state);
@@ -683,18 +674,6 @@ cfg_if! {
         }
 
         impl Eq for dirent {}
-
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_ino", &self.d_ino)
-                    .field("d_off", &self.d_off)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_type", &self.d_type)
-                    // FIXME(debug): .field("d_name", &self.d_name)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -722,18 +701,6 @@ cfg_if! {
 
         impl Eq for dirent64 {}
 
-        impl fmt::Debug for dirent64 {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent64")
-                    .field("d_ino", &self.d_ino)
-                    .field("d_off", &self.d_off)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_type", &self.d_type)
-                    // FIXME(debug): .field("d_name", &self.d_name)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for dirent64 {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
@@ -755,18 +722,6 @@ cfg_if! {
         }
 
         impl Eq for siginfo_t {}
-
-        impl fmt::Debug for siginfo_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("siginfo_t")
-                    .field("si_signo", &self.si_signo)
-                    .field("si_errno", &self.si_errno)
-                    .field("si_code", &self.si_code)
-                    // Ignore _pad
-                    // Ignore _align
-                    .finish()
-            }
-        }
 
         impl hash::Hash for siginfo_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -795,16 +750,6 @@ cfg_if! {
         }
 
         impl Eq for lastlog {}
-
-        impl fmt::Debug for lastlog {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("lastlog")
-                    .field("ll_time", &self.ll_time)
-                    .field("ll_line", &self.ll_line)
-                    // FIXME(debug): .field("ll_host", &self.ll_host)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for lastlog {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -844,24 +789,6 @@ cfg_if! {
 
         impl Eq for utmp {}
 
-        impl fmt::Debug for utmp {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utmp")
-                    .field("ut_type", &self.ut_type)
-                    .field("ut_pid", &self.ut_pid)
-                    .field("ut_line", &self.ut_line)
-                    .field("ut_id", &self.ut_id)
-                    .field("ut_user", &self.ut_user)
-                    // FIXME(debug): .field("ut_host", &self.ut_host)
-                    .field("ut_exit", &self.ut_exit)
-                    .field("ut_session", &self.ut_session)
-                    .field("ut_tv", &self.ut_tv)
-                    .field("ut_addr_v6", &self.ut_addr_v6)
-                    .field("unused", &self.unused)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for utmp {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_type.hash(state);
@@ -898,18 +825,6 @@ cfg_if! {
 
         impl Eq for sockaddr_alg {}
 
-        impl fmt::Debug for sockaddr_alg {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_alg")
-                    .field("salg_family", &self.salg_family)
-                    .field("salg_type", &self.salg_type)
-                    .field("salg_feat", &self.salg_feat)
-                    .field("salg_mask", &self.salg_mask)
-                    .field("salg_name", &&self.salg_name[..])
-                    .finish()
-            }
-        }
-
         impl hash::Hash for sockaddr_alg {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.salg_family.hash(state);
@@ -928,16 +843,6 @@ cfg_if! {
             }
         }
         impl Eq for uinput_setup {}
-
-        impl fmt::Debug for uinput_setup {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("uinput_setup")
-                    .field("id", &self.id)
-                    .field("name", &&self.name[..])
-                    .field("ff_effects_max", &self.ff_effects_max)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for uinput_setup {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -960,20 +865,6 @@ cfg_if! {
         }
         impl Eq for uinput_user_dev {}
 
-        impl fmt::Debug for uinput_user_dev {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("uinput_setup")
-                    .field("name", &&self.name[..])
-                    .field("id", &self.id)
-                    .field("ff_effects_max", &self.ff_effects_max)
-                    .field("absmax", &&self.absmax[..])
-                    .field("absmin", &&self.absmin[..])
-                    .field("absfuzz", &&self.absfuzz[..])
-                    .field("absflat", &&self.absflat[..])
-                    .finish()
-            }
-        }
-
         impl hash::Hash for uinput_user_dev {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.name.hash(state);
@@ -986,24 +877,6 @@ cfg_if! {
             }
         }
 
-        impl fmt::Debug for ifreq {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ifreq")
-                    .field("ifr_name", &self.ifr_name)
-                    .field("ifr_ifru", &self.ifr_ifru)
-                    .finish()
-            }
-        }
-
-        impl fmt::Debug for ifconf {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ifconf")
-                    .field("ifc_len", &self.ifc_len)
-                    .field("ifc_ifcu", &self.ifc_ifcu)
-                    .finish()
-            }
-        }
-
         impl PartialEq for prop_info {
             fn eq(&self, other: &prop_info) -> bool {
                 self.__name == other.__name
@@ -1012,15 +885,6 @@ cfg_if! {
             }
         }
         impl Eq for prop_info {}
-        impl fmt::Debug for prop_info {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("prop_info")
-                    .field("__name", &self.__name)
-                    .field("__serial", &self.__serial)
-                    .field("__value", &self.__value)
-                    .finish()
-            }
-        }
     }
 }
 

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -403,17 +403,6 @@ cfg_if! {
             }
         }
         impl Eq for dirent {}
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_ino", &self.d_ino)
-                    .field("d_off", &self.d_off)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_type", &self.d_type)
-                    // FIXME(debug): .field("d_name", &self.d_name)
-                    .finish()
-            }
-        }
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
@@ -447,26 +436,6 @@ cfg_if! {
             }
         }
         impl Eq for sysinfo {}
-        impl fmt::Debug for sysinfo {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sysinfo")
-                    .field("uptime", &self.uptime)
-                    .field("loads", &self.loads)
-                    .field("totalram", &self.totalram)
-                    .field("freeram", &self.freeram)
-                    .field("sharedram", &self.sharedram)
-                    .field("bufferram", &self.bufferram)
-                    .field("totalswap", &self.totalswap)
-                    .field("freeswap", &self.freeswap)
-                    .field("procs", &self.procs)
-                    .field("pad", &self.pad)
-                    .field("totalhigh", &self.totalhigh)
-                    .field("freehigh", &self.freehigh)
-                    .field("mem_unit", &self.mem_unit)
-                    // FIXME(debug): .field("__reserved", &self.__reserved)
-                    .finish()
-            }
-        }
         impl hash::Hash for sysinfo {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uptime.hash(state);
@@ -495,16 +464,6 @@ cfg_if! {
             }
         }
         impl Eq for mq_attr {}
-        impl fmt::Debug for mq_attr {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("mq_attr")
-                    .field("mq_flags", &self.mq_flags)
-                    .field("mq_maxmsg", &self.mq_maxmsg)
-                    .field("mq_msgsize", &self.mq_msgsize)
-                    .field("mq_curmsgs", &self.mq_curmsgs)
-                    .finish()
-            }
-        }
         impl hash::Hash for mq_attr {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mq_flags.hash(state);
@@ -520,13 +479,6 @@ cfg_if! {
             }
         }
         impl Eq for pthread_cond_t {}
-        impl fmt::Debug for pthread_cond_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_cond_t")
-                    // FIXME(debug): .field("size", &self.size)
-                    .finish()
-            }
-        }
         impl hash::Hash for pthread_cond_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.size.hash(state);

--- a/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
@@ -260,17 +260,6 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ucontext_t")
-                    .field("uc_flags", &self.uc_link)
-                    .field("uc_link", &self.uc_link)
-                    .field("uc_stack", &self.uc_stack)
-                    .field("uc_mcontext", &self.uc_mcontext)
-                    .field("uc_sigmask", &self.uc_sigmask)
-                    .finish()
-            }
-        }
         impl hash::Hash for ucontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_flags.hash(state);

--- a/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
@@ -314,26 +314,6 @@ cfg_if! {
 
         impl Eq for user_fpxregs_struct {}
 
-        impl fmt::Debug for user_fpxregs_struct {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("user_fpxregs_struct")
-                    .field("cwd", &self.cwd)
-                    .field("swd", &self.swd)
-                    .field("twd", &self.twd)
-                    .field("fop", &self.fop)
-                    .field("fip", &self.fip)
-                    .field("fcs", &self.fcs)
-                    .field("foo", &self.foo)
-                    .field("fos", &self.fos)
-                    .field("mxcsr", &self.mxcsr)
-                    // Ignore __reserved field
-                    .field("st_space", &self.st_space)
-                    .field("xmm_space", &self.xmm_space)
-                    // Ignore padding field
-                    .finish()
-            }
-        }
-
         impl hash::Hash for user_fpxregs_struct {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cwd.hash(state);
@@ -364,19 +344,6 @@ cfg_if! {
         }
 
         impl Eq for ucontext_t {}
-
-        impl fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ucontext_t")
-                    .field("uc_flags", &self.uc_flags)
-                    .field("uc_link", &self.uc_link)
-                    .field("uc_stack", &self.uc_stack)
-                    .field("uc_mcontext", &self.uc_mcontext)
-                    .field("uc_sigmask", &self.uc_sigmask)
-                    // Ignore __private field
-                    .finish()
-            }
-        }
 
         impl hash::Hash for ucontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {

--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -227,12 +227,6 @@ cfg_if! {
 
         impl Eq for fpreg_t {}
 
-        impl fmt::Debug for fpreg_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("fpreg_t").field("d", &self.d).finish()
-            }
-        }
-
         impl hash::Hash for fpreg_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let d: u64 = self.d.to_bits();

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -346,23 +346,6 @@ cfg_if! {
 
         impl Eq for user_fpregs_struct {}
 
-        impl fmt::Debug for user_fpregs_struct {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("user_fpregs_struct")
-                    .field("cwd", &self.cwd)
-                    .field("ftw", &self.ftw)
-                    .field("fop", &self.fop)
-                    .field("rip", &self.rip)
-                    .field("rdp", &self.rdp)
-                    .field("mxcsr", &self.mxcsr)
-                    .field("mxcr_mask", &self.mxcr_mask)
-                    .field("st_space", &self.st_space)
-                    // FIXME(debug): .field("xmm_space", &self.xmm_space)
-                    // Ignore padding field
-                    .finish()
-            }
-        }
-
         impl hash::Hash for user_fpregs_struct {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cwd.hash(state);
@@ -390,19 +373,6 @@ cfg_if! {
         }
 
         impl Eq for ucontext_t {}
-
-        impl fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ucontext_t")
-                    .field("uc_flags", &self.uc_flags)
-                    .field("uc_link", &self.uc_link)
-                    .field("uc_stack", &self.uc_stack)
-                    .field("uc_mcontext", &self.uc_mcontext)
-                    .field("uc_sigmask", &self.uc_sigmask)
-                    // Ignore __private field
-                    .finish()
-            }
-        }
 
         impl hash::Hash for ucontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -376,7 +376,6 @@ impl siginfo_t {
 }
 
 s_no_extra_traits! {
-    #[cfg_attr(feature = "extra_traits", derive(Debug))]
     pub struct aiocb {
         pub aio_fildes: c_int,
         pub aio_lio_opcode: c_int,
@@ -459,19 +458,13 @@ impl siginfo_t {
     }
 }
 
-pub union __c_anonymous_ptrace_syscall_info_data {
-    pub entry: __c_anonymous_ptrace_syscall_info_entry,
-    pub exit: __c_anonymous_ptrace_syscall_info_exit,
-    pub seccomp: __c_anonymous_ptrace_syscall_info_seccomp,
-}
-impl Copy for __c_anonymous_ptrace_syscall_info_data {}
-impl Clone for __c_anonymous_ptrace_syscall_info_data {
-    fn clone(&self) -> __c_anonymous_ptrace_syscall_info_data {
-        *self
-    }
-}
-
 s_no_extra_traits! {
+    pub union __c_anonymous_ptrace_syscall_info_data {
+        pub entry: __c_anonymous_ptrace_syscall_info_entry,
+        pub exit: __c_anonymous_ptrace_syscall_info_exit,
+        pub seccomp: __c_anonymous_ptrace_syscall_info_seccomp,
+    }
+
     pub struct utmpx {
         pub ut_type: c_short,
         pub ut_pid: crate::pid_t,
@@ -541,24 +534,6 @@ cfg_if! {
 
         impl Eq for utmpx {}
 
-        impl fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utmpx")
-                    .field("ut_type", &self.ut_type)
-                    .field("ut_pid", &self.ut_pid)
-                    .field("ut_line", &self.ut_line)
-                    .field("ut_id", &self.ut_id)
-                    .field("ut_user", &self.ut_user)
-                    // FIXME(debug): .field("ut_host", &self.ut_host)
-                    .field("ut_exit", &self.ut_exit)
-                    .field("ut_session", &self.ut_session)
-                    .field("ut_tv", &self.ut_tv)
-                    .field("ut_addr_v6", &self.ut_addr_v6)
-                    .field("__glibc_reserved", &self.__glibc_reserved)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for utmpx {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_type.hash(state);
@@ -586,18 +561,6 @@ cfg_if! {
         }
 
         impl Eq for __c_anonymous_ptrace_syscall_info_data {}
-
-        impl fmt::Debug for __c_anonymous_ptrace_syscall_info_data {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                unsafe {
-                    f.debug_struct("__c_anonymous_ptrace_syscall_info_data")
-                        .field("entry", &self.entry)
-                        .field("exit", &self.exit)
-                        .field("seccomp", &self.seccomp)
-                        .finish()
-                }
-            }
-        }
 
         impl hash::Hash for __c_anonymous_ptrace_syscall_info_data {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1874,15 +1874,6 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_nl {}
-        impl fmt::Debug for sockaddr_nl {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_nl")
-                    .field("nl_family", &self.nl_family)
-                    .field("nl_pid", &self.nl_pid)
-                    .field("nl_groups", &self.nl_groups)
-                    .finish()
-            }
-        }
         impl hash::Hash for sockaddr_nl {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.nl_family.hash(state);
@@ -1906,18 +1897,6 @@ cfg_if! {
         }
 
         impl Eq for dirent {}
-
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_ino", &self.d_ino)
-                    .field("d_off", &self.d_off)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_type", &self.d_type)
-                    // FIXME(debug): .field("d_name", &self.d_name)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -1945,18 +1924,6 @@ cfg_if! {
 
         impl Eq for dirent64 {}
 
-        impl fmt::Debug for dirent64 {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent64")
-                    .field("d_ino", &self.d_ino)
-                    .field("d_off", &self.d_off)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_type", &self.d_type)
-                    // FIXME(debug): .field("d_name", &self.d_name)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for dirent64 {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
@@ -1975,14 +1942,6 @@ cfg_if! {
 
         impl Eq for pthread_cond_t {}
 
-        impl fmt::Debug for pthread_cond_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_cond_t")
-                    // FIXME(debug): .field("size", &self.size)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for pthread_cond_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.size.hash(state);
@@ -1996,14 +1955,6 @@ cfg_if! {
         }
 
         impl Eq for pthread_mutex_t {}
-
-        impl fmt::Debug for pthread_mutex_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_mutex_t")
-                    // FIXME(debug): .field("size", &self.size)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for pthread_mutex_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -2019,14 +1970,6 @@ cfg_if! {
 
         impl Eq for pthread_rwlock_t {}
 
-        impl fmt::Debug for pthread_rwlock_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_rwlock_t")
-                    // FIXME(debug): .field("size", &self.size)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for pthread_rwlock_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.size.hash(state);
@@ -2040,14 +1983,6 @@ cfg_if! {
         }
 
         impl Eq for pthread_barrier_t {}
-
-        impl fmt::Debug for pthread_barrier_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_barrier_t")
-                    .field("size", &self.size)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for pthread_barrier_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -2075,18 +2010,6 @@ cfg_if! {
 
         impl Eq for sockaddr_alg {}
 
-        impl fmt::Debug for sockaddr_alg {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_alg")
-                    .field("salg_family", &self.salg_family)
-                    .field("salg_type", &self.salg_type)
-                    .field("salg_feat", &self.salg_feat)
-                    .field("salg_mask", &self.salg_mask)
-                    .field("salg_name", &&self.salg_name[..])
-                    .finish()
-            }
-        }
-
         impl hash::Hash for sockaddr_alg {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.salg_family.hash(state);
@@ -2105,16 +2028,6 @@ cfg_if! {
             }
         }
         impl Eq for uinput_setup {}
-
-        impl fmt::Debug for uinput_setup {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("uinput_setup")
-                    .field("id", &self.id)
-                    .field("name", &&self.name[..])
-                    .field("ff_effects_max", &self.ff_effects_max)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for uinput_setup {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -2137,20 +2050,6 @@ cfg_if! {
         }
         impl Eq for uinput_user_dev {}
 
-        impl fmt::Debug for uinput_user_dev {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("uinput_setup")
-                    .field("name", &&self.name[..])
-                    .field("id", &self.id)
-                    .field("ff_effects_max", &self.ff_effects_max)
-                    .field("absmax", &&self.absmax[..])
-                    .field("absmin", &&self.absmin[..])
-                    .field("absfuzz", &&self.absfuzz[..])
-                    .field("absflat", &&self.absflat[..])
-                    .finish()
-            }
-        }
-
         impl hash::Hash for uinput_user_dev {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.name.hash(state);
@@ -2172,47 +2071,12 @@ cfg_if! {
             }
         }
         impl Eq for mq_attr {}
-        impl fmt::Debug for mq_attr {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("mq_attr")
-                    .field("mq_flags", &self.mq_flags)
-                    .field("mq_maxmsg", &self.mq_maxmsg)
-                    .field("mq_msgsize", &self.mq_msgsize)
-                    .field("mq_curmsgs", &self.mq_curmsgs)
-                    .finish()
-            }
-        }
         impl hash::Hash for mq_attr {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mq_flags.hash(state);
                 self.mq_maxmsg.hash(state);
                 self.mq_msgsize.hash(state);
                 self.mq_curmsgs.hash(state);
-            }
-        }
-        impl fmt::Debug for ifreq {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ifreq")
-                    .field("ifr_name", &self.ifr_name)
-                    .field("ifr_ifru", &self.ifr_ifru)
-                    .finish()
-            }
-        }
-        impl fmt::Debug for ifconf {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ifconf")
-                    .field("ifc_len", &self.ifc_len)
-                    .field("ifc_ifcu", &self.ifc_ifcu)
-                    .finish()
-            }
-        }
-        impl fmt::Debug for hwtstamp_config {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("hwtstamp_config")
-                    .field("flags", &self.flags)
-                    .field("tx_type", &self.tx_type)
-                    .field("rx_filter", &self.rx_filter)
-                    .finish()
             }
         }
         impl PartialEq for hwtstamp_config {
@@ -2231,20 +2095,6 @@ cfg_if! {
             }
         }
 
-        impl fmt::Debug for sched_attr {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sched_attr")
-                    .field("size", &self.size)
-                    .field("sched_policy", &self.sched_policy)
-                    .field("sched_flags", &self.sched_flags)
-                    .field("sched_nice", &self.sched_nice)
-                    .field("sched_priority", &self.sched_priority)
-                    .field("sched_runtime", &self.sched_runtime)
-                    .field("sched_deadline", &self.sched_deadline)
-                    .field("sched_period", &self.sched_period)
-                    .finish()
-            }
-        }
         impl PartialEq for sched_attr {
             fn eq(&self, other: &sched_attr) -> bool {
                 self.size == other.size
@@ -2268,25 +2118,6 @@ cfg_if! {
                 self.sched_runtime.hash(state);
                 self.sched_deadline.hash(state);
                 self.sched_period.hash(state);
-            }
-        }
-
-        impl fmt::Debug for iw_event {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("iw_event")
-                    .field("len", &self.len)
-                    .field("cmd", &self.cmd)
-                    .field("u", &self.u)
-                    .finish()
-            }
-        }
-
-        impl fmt::Debug for iwreq {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("iwreq")
-                    .field("ifr_ifrn", &self.ifr_ifrn)
-                    .field("u", &self.u)
-                    .finish()
             }
         }
     }

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -162,17 +162,6 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ucontext_t")
-                    .field("uc_flags", &self.uc_link)
-                    .field("uc_link", &self.uc_link)
-                    .field("uc_stack", &self.uc_stack)
-                    .field("uc_mcontext", &self.uc_mcontext)
-                    .field("uc_sigmask", &self.uc_sigmask)
-                    .finish()
-            }
-        }
         impl hash::Hash for ucontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uc_flags.hash(state);

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -167,26 +167,6 @@ cfg_if! {
 
         impl Eq for user_fpxregs_struct {}
 
-        impl fmt::Debug for user_fpxregs_struct {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("user_fpxregs_struct")
-                    .field("cwd", &self.cwd)
-                    .field("swd", &self.swd)
-                    .field("twd", &self.twd)
-                    .field("fop", &self.fop)
-                    .field("fip", &self.fip)
-                    .field("fcs", &self.fcs)
-                    .field("foo", &self.foo)
-                    .field("fos", &self.fos)
-                    .field("mxcsr", &self.mxcsr)
-                    // Ignore __reserved field
-                    .field("st_space", &self.st_space)
-                    .field("xmm_space", &self.xmm_space)
-                    // Ignore padding field
-                    .finish()
-            }
-        }
-
         impl hash::Hash for user_fpxregs_struct {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cwd.hash(state);
@@ -221,19 +201,6 @@ cfg_if! {
         }
 
         impl Eq for ucontext_t {}
-
-        impl fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ucontext_t")
-                    .field("uc_flags", &self.uc_flags)
-                    .field("uc_link", &self.uc_link)
-                    .field("uc_stack", &self.uc_stack)
-                    .field("uc_mcontext", &self.uc_mcontext)
-                    .field("uc_sigmask", &self.uc_sigmask)
-                    // Ignore __private field
-                    .finish()
-            }
-        }
 
         impl hash::Hash for ucontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {

--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -88,12 +88,6 @@ cfg_if! {
 
         impl Eq for fpreg_t {}
 
-        impl fmt::Debug for fpreg_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("fpreg_t").field("d", &self.d).finish()
-            }
-        }
-
         impl hash::Hash for fpreg_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let d: u64 = self.d.to_bits();

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -202,23 +202,6 @@ cfg_if! {
 
         impl Eq for user_fpregs_struct {}
 
-        impl fmt::Debug for user_fpregs_struct {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("user_fpregs_struct")
-                    .field("cwd", &self.cwd)
-                    .field("ftw", &self.ftw)
-                    .field("fop", &self.fop)
-                    .field("rip", &self.rip)
-                    .field("rdp", &self.rdp)
-                    .field("mxcsr", &self.mxcsr)
-                    .field("mxcr_mask", &self.mxcr_mask)
-                    .field("st_space", &self.st_space)
-                    // FIXME(debug): .field("xmm_space", &self.xmm_space)
-                    // Ignore padding field
-                    .finish()
-            }
-        }
-
         impl hash::Hash for user_fpregs_struct {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.cwd.hash(state);
@@ -250,19 +233,6 @@ cfg_if! {
         }
 
         impl Eq for ucontext_t {}
-
-        impl fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ucontext_t")
-                    .field("uc_flags", &self.uc_flags)
-                    .field("uc_link", &self.uc_link)
-                    .field("uc_stack", &self.uc_stack)
-                    .field("uc_mcontext", &self.uc_mcontext)
-                    .field("uc_sigmask", &self.uc_sigmask)
-                    // Ignore __private field
-                    .finish()
-            }
-        }
 
         impl hash::Hash for ucontext_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -393,7 +393,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[cfg_attr(feature = "extra_traits", derive(Debug))]
     pub struct aiocb {
         pub aio_fildes: c_int,
         pub aio_lio_opcode: c_int,
@@ -494,27 +493,6 @@ cfg_if! {
 
         impl Eq for sysinfo {}
 
-        impl fmt::Debug for sysinfo {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sysinfo")
-                    .field("uptime", &self.uptime)
-                    .field("loads", &self.loads)
-                    .field("totalram", &self.totalram)
-                    .field("freeram", &self.freeram)
-                    .field("sharedram", &self.sharedram)
-                    .field("bufferram", &self.bufferram)
-                    .field("totalswap", &self.totalswap)
-                    .field("freeswap", &self.freeswap)
-                    .field("procs", &self.procs)
-                    .field("pad", &self.pad)
-                    .field("totalhigh", &self.totalhigh)
-                    .field("freehigh", &self.freehigh)
-                    .field("mem_unit", &self.mem_unit)
-                    // FIXME(debug): .field("__reserved", &self.__reserved)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for sysinfo {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.uptime.hash(state);
@@ -558,27 +536,6 @@ cfg_if! {
         }
 
         impl Eq for utmpx {}
-
-        impl fmt::Debug for utmpx {
-            #[allow(deprecated)]
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utmpx")
-                    .field("ut_type", &self.ut_type)
-                    //.field("__ut_pad1", &self.__ut_pad1)
-                    .field("ut_pid", &self.ut_pid)
-                    .field("ut_line", &self.ut_line)
-                    .field("ut_id", &self.ut_id)
-                    .field("ut_user", &self.ut_user)
-                    //FIXME(debug): .field("ut_host", &self.ut_host)
-                    .field("ut_exit", &self.ut_exit)
-                    .field("ut_session", &self.ut_session)
-                    //.field("__ut_pad2", &self.__ut_pad2)
-                    .field("ut_tv", &self.ut_tv)
-                    .field("ut_addr_v6", &self.ut_addr_v6)
-                    .field("__unused", &self.__unused)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for utmpx {
             #[allow(deprecated)]

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -339,16 +339,6 @@ cfg_if! {
             }
         }
         impl Eq for epoll_event {}
-        impl fmt::Debug for epoll_event {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let events = self.events;
-                let u64 = self.u64;
-                f.debug_struct("epoll_event")
-                    .field("events", &events)
-                    .field("u64", &u64)
-                    .finish()
-            }
-        }
         impl hash::Hash for epoll_event {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let events = self.events;
@@ -369,14 +359,6 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_un {}
-        impl fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_un")
-                    .field("sun_family", &self.sun_family)
-                    // FIXME(debug): .field("sun_path", &self.sun_path)
-                    .finish()
-            }
-        }
         impl hash::Hash for sockaddr_un {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sun_family.hash(state);
@@ -396,16 +378,6 @@ cfg_if! {
         }
 
         impl Eq for sockaddr_storage {}
-
-        impl fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_storage")
-                    .field("ss_family", &self.ss_family)
-                    .field("__ss_align", &self.__ss_align)
-                    // FIXME(debug): .field("__ss_pad2", &self.__ss_pad2)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for sockaddr_storage {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -450,19 +422,6 @@ cfg_if! {
 
         impl Eq for utsname {}
 
-        impl fmt::Debug for utsname {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utsname")
-                    // FIXME(debug): .field("sysname", &self.sysname)
-                    // FIXME(debug): .field("nodename", &self.nodename)
-                    // FIXME(debug): .field("release", &self.release)
-                    // FIXME(debug): .field("version", &self.version)
-                    // FIXME(debug): .field("machine", &self.machine)
-                    // FIXME(debug): .field("domainname", &self.domainname)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for utsname {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sysname.hash(state);
@@ -471,18 +430,6 @@ cfg_if! {
                 self.version.hash(state);
                 self.machine.hash(state);
                 self.domainname.hash(state);
-            }
-        }
-
-        impl fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sigevent")
-                    .field("sigev_value", &self.sigev_value)
-                    .field("sigev_signo", &self.sigev_signo)
-                    .field("sigev_notify", &self.sigev_notify)
-                    // Skip _sigev_un, since we can't guarantee that it will be
-                    // properly initialized.
-                    .finish()
             }
         }
     }

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -811,16 +811,6 @@ cfg_if! {
             }
         }
         impl Eq for sigevent {}
-        impl fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sigevent")
-                    .field("sigev_notify", &self.sigev_notify)
-                    .field("sigev_signo", &self.sigev_signo)
-                    .field("sigev_value", &self.sigev_value)
-                    .field("__sigev_un2", &self.__sigev_un2)
-                    .finish()
-            }
-        }
         impl hash::Hash for sigevent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sigev_notify.hash(state);
@@ -842,15 +832,6 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_un {}
-        impl fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_un")
-                    .field("sun_len", &self.sun_len)
-                    .field("sun_family", &self.sun_family)
-                    // FIXME(debug): .field("sun_path", &self.sun_path)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for sockaddr_un {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -867,13 +848,6 @@ cfg_if! {
             }
         }
         impl Eq for sigset_t {}
-        impl fmt::Debug for sigset_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sigset_t")
-                    .field("__val", &self.__val)
-                    .finish()
-            }
-        }
         impl hash::Hash for sigset_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.__val.hash(state);
@@ -881,50 +855,10 @@ cfg_if! {
         }
 
         // msg
-        impl fmt::Debug for msg {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("msg")
-                    .field("msg_next", &self.msg_next)
-                    .field("msg_type", &self.msg_type)
-                    .field("msg_ts", &self.msg_ts)
-                    .field("msg_spot", &self.msg_spot)
-                    .finish()
-            }
-        }
 
         // msqid_ds
-        impl fmt::Debug for msqid_ds {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("msqid_ds")
-                    .field("msg_perm", &self.msg_perm)
-                    .field("msg_first", &self.msg_first)
-                    .field("msg_cbytes", &self.msg_cbytes)
-                    .field("msg_qnum", &self.msg_qnum)
-                    .field("msg_qbytes", &self.msg_qbytes)
-                    .field("msg_lspid", &self.msg_lspid)
-                    .field("msg_lrpid", &self.msg_lrpid)
-                    .field("msg_stime", &self.msg_stime)
-                    .field("msg_rtime", &self.msg_rtime)
-                    .field("msg_ctime", &self.msg_ctime)
-                    .finish()
-            }
-        }
 
         // sockaddr_dl
-        impl fmt::Debug for sockaddr_dl {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_dl")
-                    .field("sdl_len", &self.sdl_len)
-                    .field("sdl_family", &self.sdl_family)
-                    .field("sdl_index", &self.sdl_index)
-                    .field("sdl_type", &self.sdl_type)
-                    .field("sdl_nlen", &self.sdl_nlen)
-                    .field("sdl_alen", &self.sdl_alen)
-                    .field("sdl_slen", &self.sdl_slen)
-                    .field("sdl_data", &self.sdl_data)
-                    .finish()
-            }
-        }
         impl PartialEq for sockaddr_dl {
             fn eq(&self, other: &sockaddr_dl) -> bool {
                 self.sdl_len == other.sdl_len
@@ -952,73 +886,6 @@ cfg_if! {
                 self.sdl_alen.hash(state);
                 self.sdl_slen.hash(state);
                 self.sdl_data.hash(state);
-            }
-        }
-
-        // sync_t
-        impl fmt::Debug for sync_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sync_t")
-                    .field("__owner", &self.__owner)
-                    .field("__u", &self.__u)
-                    .finish()
-            }
-        }
-
-        // pthread_barrier_t
-        impl fmt::Debug for pthread_barrier_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_barrier_t")
-                    .field("__pad", &self.__pad)
-                    .finish()
-            }
-        }
-
-        // pthread_rwlock_t
-        impl fmt::Debug for pthread_rwlock_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("pthread_rwlock_t")
-                    .field("__active", &self.__active)
-                    .field("__blockedwriters", &self.__blockedwriters)
-                    .field("__blockedreaders", &self.__blockedreaders)
-                    .field("__heavy", &self.__heavy)
-                    .field("__lock", &self.__lock)
-                    .field("__rcond", &self.__rcond)
-                    .field("__wcond", &self.__wcond)
-                    .field("__owner", &self.__owner)
-                    .field("__spare", &self.__spare)
-                    .finish()
-            }
-        }
-
-        // syspage_entry
-        impl fmt::Debug for syspage_entry {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("syspage_entry")
-                    .field("size", &self.size)
-                    .field("total_size", &self.total_size)
-                    .field("type_", &self.type_)
-                    .field("num_cpu", &self.num_cpu)
-                    .field("system_private", &self.system_private)
-                    .field("old_asinfo", &self.old_asinfo)
-                    .field("hwinfo", &self.hwinfo)
-                    .field("old_cpuinfo", &self.old_cpuinfo)
-                    .field("old_cacheattr", &self.old_cacheattr)
-                    .field("qtime", &self.qtime)
-                    .field("callout", &self.callout)
-                    .field("callin", &self.callin)
-                    .field("typed_strings", &self.typed_strings)
-                    .field("strings", &self.strings)
-                    .field("old_intrinfo", &self.old_intrinfo)
-                    .field("smp", &self.smp)
-                    .field("pminfo", &self.pminfo)
-                    .field("old_mdriver", &self.old_mdriver)
-                    .field("new_asinfo", &self.new_asinfo)
-                    .field("new_cpuinfo", &self.new_cpuinfo)
-                    .field("new_cacheattr", &self.new_cacheattr)
-                    .field("new_intrinfo", &self.new_intrinfo)
-                    .field("new_mdriver", &self.new_mdriver)
-                    .finish()
             }
         }
 
@@ -1053,18 +920,6 @@ cfg_if! {
 
         impl Eq for utsname {}
 
-        impl fmt::Debug for utsname {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utsname")
-                    // FIXME(debug): .field("sysname", &self.sysname)
-                    // FIXME(debug): .field("nodename", &self.nodename)
-                    // FIXME(debug): .field("release", &self.release)
-                    // FIXME(debug): .field("version", &self.version)
-                    // FIXME(debug): .field("machine", &self.machine)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for utsname {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sysname.hash(state);
@@ -1089,19 +944,6 @@ cfg_if! {
 
         impl Eq for mq_attr {}
 
-        impl fmt::Debug for mq_attr {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("mq_attr")
-                    .field("mq_maxmsg", &self.mq_maxmsg)
-                    .field("mq_msgsize", &self.mq_msgsize)
-                    .field("mq_flags", &self.mq_flags)
-                    .field("mq_curmsgs", &self.mq_curmsgs)
-                    .field("mq_msgsize", &self.mq_msgsize)
-                    .field("mq_sendwait", &self.mq_sendwait)
-                    .field("mq_recvwait", &self.mq_recvwait)
-                    .finish()
-            }
-        }
         impl hash::Hash for mq_attr {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.mq_maxmsg.hash(state);
@@ -1129,18 +971,6 @@ cfg_if! {
 
         impl Eq for sockaddr_storage {}
 
-        impl fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_storage")
-                    .field("ss_len", &self.ss_len)
-                    .field("ss_family", &self.ss_family)
-                    .field("__ss_pad1", &self.__ss_pad1)
-                    .field("__ss_align", &self.__ss_align)
-                    // FIXME(debug): .field("__ss_pad2", &self.__ss_pad2)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for sockaddr_storage {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_len.hash(state);
@@ -1165,18 +995,6 @@ cfg_if! {
         }
 
         impl Eq for dirent {}
-
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_ino", &self.d_ino)
-                    .field("d_offset", &self.d_offset)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_namelen", &self.d_namelen)
-                    .field("d_name", &&self.d_name[..self.d_namelen as _])
-                    .finish()
-            }
-        }
 
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -1305,18 +1305,6 @@ cfg_if! {
 
         impl Eq for dirent {}
 
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_ino", &self.d_ino)
-                    .field("d_off", &self.d_off)
-                    .field("d_reclen", &self.d_reclen)
-                    .field("d_type", &self.d_type)
-                    // FIXME(debug): .field("d_name", &self.d_name)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for dirent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.d_ino.hash(state);
@@ -1340,15 +1328,6 @@ cfg_if! {
 
         impl Eq for sockaddr_un {}
 
-        impl fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_un")
-                    .field("sun_family", &self.sun_family)
-                    // FIXME(debug): .field("sun_path", &self.sun_path)
-                    .finish()
-            }
-        }
-
         impl hash::Hash for sockaddr_un {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sun_family.hash(state);
@@ -1369,16 +1348,6 @@ cfg_if! {
         }
 
         impl Eq for sockaddr_storage {}
-
-        impl fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_storage")
-                    .field("ss_family", &self.ss_family)
-                    .field("__ss_align", &self.__ss_align)
-                    // FIXME(debug): .field("__ss_padding", &self.__ss_padding)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for sockaddr_storage {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -1423,19 +1392,6 @@ cfg_if! {
         }
 
         impl Eq for utsname {}
-
-        impl fmt::Debug for utsname {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utsname")
-                    // FIXME(debug): .field("sysname", &self.sysname)
-                    // FIXME(debug): .field("nodename", &self.nodename)
-                    // FIXME(debug): .field("release", &self.release)
-                    // FIXME(debug): .field("version", &self.version)
-                    // FIXME(debug): .field("machine", &self.machine)
-                    // FIXME(debug): .field("domainname", &self.domainname)
-                    .finish()
-            }
-        }
 
         impl hash::Hash for utsname {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -89,24 +89,6 @@ cfg_if! {
 
         impl Eq for utmpx {}
 
-        impl fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utmpx")
-                    .field("ut_user", &self.ut_user)
-                    .field("ut_id", &self.ut_id)
-                    .field("ut_line", &self.ut_line)
-                    .field("ut_pid", &self.ut_pid)
-                    .field("ut_type", &self.ut_type)
-                    .field("ut_exit", &self.ut_exit)
-                    .field("ut_tv", &self.ut_tv)
-                    .field("ut_session", &self.ut_session)
-                    .field("ut_pad", &self.ut_pad)
-                    .field("ut_syslen", &self.ut_syslen)
-                    .field("ut_host", &&self.ut_host[..])
-                    .finish()
-            }
-        }
-
         impl hash::Hash for utmpx {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_user.hash(state);
@@ -129,16 +111,6 @@ cfg_if! {
             }
         }
         impl Eq for epoll_event {}
-        impl fmt::Debug for epoll_event {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let events = self.events;
-                let u64 = self.u64;
-                f.debug_struct("epoll_event")
-                    .field("events", &events)
-                    .field("u64", &u64)
-                    .finish()
-            }
-        }
         impl hash::Hash for epoll_event {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 let events = self.events;

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -585,14 +585,6 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_un {}
-        impl fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_un")
-                    .field("sun_family", &self.sun_family)
-                    // FIXME(debug): .field("sun_path", &self.sun_path)
-                    .finish()
-            }
-        }
         impl hash::Hash for sockaddr_un {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sun_family.hash(state);
@@ -629,17 +621,6 @@ cfg_if! {
             }
         }
         impl Eq for utsname {}
-        impl fmt::Debug for utsname {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utsname")
-                    // FIXME(debug): .field("sysname", &self.sysname)
-                    // FIXME(debug): .field("nodename", &self.nodename)
-                    // FIXME(debug): .field("release", &self.release)
-                    // FIXME(debug): .field("version", &self.version)
-                    // FIXME(debug): .field("machine", &self.machine)
-                    .finish()
-            }
-        }
         impl hash::Hash for utsname {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sysname.hash(state);
@@ -659,13 +640,6 @@ cfg_if! {
             }
         }
         impl Eq for fd_set {}
-        impl fmt::Debug for fd_set {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("fd_set")
-                    // FIXME(debug): .field("fds_bits", &self.fds_bits)
-                    .finish()
-            }
-        }
         impl hash::Hash for fd_set {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.fds_bits.hash(state);
@@ -685,16 +659,6 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_storage {}
-        impl fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_storage")
-                    .field("ss_family", &self.ss_family)
-                    .field("__ss_pad1", &self.__ss_pad1)
-                    .field("__ss_align", &self.__ss_align)
-                    // FIXME(debug): .field("__ss_pad2", &self.__ss_pad2)
-                    .finish()
-            }
-        }
         impl hash::Hash for sockaddr_storage {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ss_family.hash(state);
@@ -754,16 +718,6 @@ cfg_if! {
             }
         }
         impl Eq for siginfo_t {}
-        impl fmt::Debug for siginfo_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("siginfo_t")
-                    .field("si_signo", &self.si_signo)
-                    .field("si_code", &self.si_code)
-                    .field("si_errno", &self.si_errno)
-                    // FIXME(debug): .field("__pad", &self.__pad)
-                    .finish()
-            }
-        }
         impl hash::Hash for siginfo_t {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.si_signo.hash(state);
@@ -794,19 +748,6 @@ cfg_if! {
             }
         }
         impl Eq for sockaddr_dl {}
-        impl fmt::Debug for sockaddr_dl {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_dl")
-                    .field("sdl_family", &self.sdl_family)
-                    .field("sdl_index", &self.sdl_index)
-                    .field("sdl_type", &self.sdl_type)
-                    .field("sdl_nlen", &self.sdl_nlen)
-                    .field("sdl_alen", &self.sdl_alen)
-                    .field("sdl_slen", &self.sdl_slen)
-                    // FIXME(debug): .field("sdl_data", &self.sdl_data)
-                    .finish()
-            }
-        }
         impl hash::Hash for sockaddr_dl {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sdl_family.hash(state);
@@ -829,17 +770,6 @@ cfg_if! {
             }
         }
         impl Eq for sigevent {}
-        impl fmt::Debug for sigevent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sigevent")
-                    .field("sigev_notify", &self.sigev_notify)
-                    .field("sigev_signo", &self.sigev_signo)
-                    .field("sigev_value", &self.sigev_value)
-                    .field("ss_sp", &self.ss_sp)
-                    .field("sigev_notify_attributes", &self.sigev_notify_attributes)
-                    .finish()
-            }
-        }
         impl hash::Hash for sigevent {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.sigev_notify.hash(state);

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -125,24 +125,6 @@ cfg_if! {
 
         impl Eq for utmpx {}
 
-        impl fmt::Debug for utmpx {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("utmpx")
-                    .field("ut_user", &self.ut_user)
-                    .field("ut_id", &self.ut_id)
-                    .field("ut_line", &self.ut_line)
-                    .field("ut_pid", &self.ut_pid)
-                    .field("ut_type", &self.ut_type)
-                    .field("ut_exit", &self.ut_exit)
-                    .field("ut_tv", &self.ut_tv)
-                    .field("ut_session", &self.ut_session)
-                    .field("pad", &self.pad)
-                    .field("ut_syslen", &self.ut_syslen)
-                    .field("ut_host", &&self.ut_host[..])
-                    .finish()
-            }
-        }
-
         impl hash::Hash for utmpx {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 self.ut_user.hash(state);

--- a/src/unix/solarish/x86_64.rs
+++ b/src/unix/solarish/x86_64.rs
@@ -118,27 +118,12 @@ cfg_if! {
             }
         }
         impl Eq for fpregset_t {}
-        impl fmt::Debug for fpregset_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("fpregset_t")
-                    .field("fp_reg_set", &self.fp_reg_set)
-                    .finish()
-            }
-        }
         impl PartialEq for mcontext_t {
             fn eq(&self, other: &mcontext_t) -> bool {
                 self.gregs == other.gregs && self.fpregs == other.fpregs
             }
         }
         impl Eq for mcontext_t {}
-        impl fmt::Debug for mcontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("mcontext_t")
-                    .field("gregs", &self.gregs)
-                    .field("fpregs", &self.fpregs)
-                    .finish()
-            }
-        }
         impl PartialEq for ucontext_t {
             fn eq(&self, other: &ucontext_t) -> bool {
                 self.uc_flags == other.uc_flags
@@ -150,18 +135,6 @@ cfg_if! {
             }
         }
         impl Eq for ucontext_t {}
-        impl fmt::Debug for ucontext_t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("ucontext_t")
-                    .field("uc_flags", &self.uc_flags)
-                    .field("uc_link", &self.uc_link)
-                    .field("uc_sigmask", &self.uc_sigmask)
-                    .field("uc_stack", &self.uc_stack)
-                    .field("uc_mcontext", &self.uc_mcontext)
-                    .field("uc_filler", &self.uc_filler)
-                    .finish()
-            }
-        }
     }
 }
 

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -462,53 +462,6 @@ s_no_extra_traits! {
 
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
-        impl fmt::Debug for dirent {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("dirent")
-                    .field("d_ino", &self.d_ino)
-                    .field("d_name", &&self.d_name[..])
-                    .field("d_type", &self.d_type)
-                    .finish()
-            }
-        }
-
-        impl fmt::Debug for sockaddr_un {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_un")
-                    .field("sun_len", &self.sun_len)
-                    .field("sun_family", &self.sun_family)
-                    .field("sun_path", &&self.sun_path[..])
-                    .finish()
-            }
-        }
-
-        impl fmt::Debug for RTP_DESC {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("RTP_DESC")
-                    .field("status", &self.status)
-                    .field("options", &self.options)
-                    .field("entrAddr", &self.entrAddr)
-                    .field("initTaskId", &self.initTaskId)
-                    .field("parentId", &self.parentId)
-                    .field("pathName", &&self.pathName[..])
-                    .field("taskCnt", &self.taskCnt)
-                    .field("textStart", &self.textStart)
-                    .field("textEnd", &self.textEnd)
-                    .finish()
-            }
-        }
-        impl fmt::Debug for sockaddr_storage {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_struct("sockaddr_storage")
-                    .field("ss_len", &self.ss_len)
-                    .field("ss_family", &self.ss_family)
-                    .field("__ss_pad1", &&self.__ss_pad1[..])
-                    .field("__ss_align", &self.__ss_align)
-                    .field("__ss_pad2", &&self.__ss_pad2[..])
-                    .finish()
-            }
-        }
-
         impl PartialEq for sa_u_t {
             fn eq(&self, other: &sa_u_t) -> bool {
                 unsafe {


### PR DESCRIPTION
`s_no_extra_traits!` doesn't derive `Debug` so there are a lot of handwritten implementations. However, since we have a derive-like solution for unions now (printing them like an opaque struct), there really isn't any reason these can't all be derived.

Add `derive(Debug)` to `s_no_extra_traits`, still gated behind `feature = "extra_traits"`, which allows getting rid of manual implementations.