### PR TITLE
hurd: Fix build from missing `fpos_t`

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -567,7 +567,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(not(target_env = "gnu"))] {
+    if #[cfg(not(all(target_os = "linux", target_env = "gnu")))] {
         missing! {
             #[cfg_attr(feature = "extra_traits", derive(Debug))]
             pub enum fpos_t {} // FIXME(unix): fill this out with a struct


### PR DESCRIPTION
In 872642ad ("gnu: Add proper structs for fpos_t and fpos64_t"), `fpos_t` was changed from an opaque struct to one with a definition on Linux GNU, with the Unix fallback configured as for targets without a GNU `target_env`. However, GNU hurd matches `target_env = "gnu"`, but doesn't have a `fpos` implementation.

Fix the build by adjusting the fallback `cfg` to be more specific. Eventually we probably want the same definition on Hurd as on Linux.