### PR TITLE
Update lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,6 @@
     bad_style,
     overflowing_literals,
     improper_ctypes,
-    // This lint is renamed but we run CI for old stable rustc so should be here.
-    redundant_semicolon,
-    redundant_semicolons,
     unused_macros,
     unused_macro_rules,
     // FIXME(1.0): temporarily allow dead_code to fix CI:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,6 @@
     improper_ctypes,
     unused_macros,
     unused_macro_rules,
-    // FIXME(1.0): temporarily allow dead_code to fix CI:
-    // - https://github.com/rust-lang/libc/issues/3740
-    // - https://github.com/rust-lang/rust/pull/126456
-    dead_code,
 )]
 #![cfg_attr(libc_deny_warnings, deny(warnings))]
 // Attributes needed when building as part of the standard library

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@
 #![cfg_attr(feature = "rustc-dep-of-std", feature(link_cfg, no_core))]
 #![cfg_attr(feature = "rustc-dep-of-std", allow(internal_features))]
 // Enable extra lints:
-#![cfg_attr(feature = "extra_traits", deny(missing_debug_implementations))]
-#![deny(missing_copy_implementations, safe_packed_borrows)]
+#![cfg_attr(feature = "extra_traits", warn(missing_debug_implementations))]
+#![warn(missing_copy_implementations, safe_packed_borrows)]
 #![cfg_attr(not(feature = "rustc-dep-of-std"), no_std)]
 #![cfg_attr(feature = "rustc-dep-of-std", no_core)]
 

--- a/src/unix/linux_like/linux/arch/generic/mod.rs
+++ b/src/unix/linux_like/linux/arch/generic/mod.rs
@@ -40,8 +40,6 @@ pub const SO_PASSCRED: c_int = 16;
 pub const SO_PEERCRED: c_int = 17;
 pub const SO_RCVLOWAT: c_int = 18;
 pub const SO_SNDLOWAT: c_int = 19;
-const SO_RCVTIMEO_OLD: c_int = 20;
-const SO_SNDTIMEO_OLD: c_int = 21;
 pub const SO_SECURITY_AUTHENTICATION: c_int = 22;
 pub const SO_SECURITY_ENCRYPTION_TRANSPORT: c_int = 23;
 pub const SO_SECURITY_ENCRYPTION_NETWORK: c_int = 24;
@@ -50,9 +48,6 @@ pub const SO_ATTACH_FILTER: c_int = 26;
 pub const SO_DETACH_FILTER: c_int = 27;
 pub const SO_GET_FILTER: c_int = SO_ATTACH_FILTER;
 pub const SO_PEERNAME: c_int = 28;
-const SO_TIMESTAMP_OLD: c_int = 29;
-const SO_TIMESTAMPNS_OLD: c_int = 35;
-const SO_TIMESTAMPING_OLD: c_int = 37;
 
 cfg_if! {
     if #[cfg(all(
@@ -76,6 +71,12 @@ cfg_if! {
         pub const SO_RCVTIMEO: c_int = 66;
         pub const SO_SNDTIMEO: c_int = 67;
     } else {
+        const SO_TIMESTAMP_OLD: c_int = 29;
+        const SO_TIMESTAMPNS_OLD: c_int = 35;
+        const SO_TIMESTAMPING_OLD: c_int = 37;
+        const SO_RCVTIMEO_OLD: c_int = 20;
+        const SO_SNDTIMEO_OLD: c_int = 21;
+
         pub const SO_TIMESTAMP: c_int = SO_TIMESTAMP_OLD;
         pub const SO_TIMESTAMPNS: c_int = SO_TIMESTAMPNS_OLD;
         pub const SO_TIMESTAMPING: c_int = SO_TIMESTAMPING_OLD;

--- a/src/unix/linux_like/linux/arch/mips/mod.rs
+++ b/src/unix/linux_like/linux/arch/mips/mod.rs
@@ -33,16 +33,17 @@ pub const SO_SNDBUF: c_int = 0x1001;
 pub const SO_RCVBUF: c_int = 0x1002;
 pub const SO_SNDLOWAT: c_int = 0x1003;
 pub const SO_RCVLOWAT: c_int = 0x1004;
-// NOTE: These definitions are now being renamed with _OLD postfix,
-// but CI haven't support them yet.
-// Some related consts could be found in b32.rs and b64.rs
-const SO_SNDTIMEO_OLD: c_int = 0x1005;
-const SO_RCVTIMEO_OLD: c_int = 0x1006;
 cfg_if! {
     if #[cfg(linux_time_bits64)] {
+        const SO_RCVTIMEO_NEW: c_int = 66;
+        const SO_SNDTIMEO_NEW: c_int = 67;
+
         pub const SO_SNDTIMEO: c_int = SO_SNDTIMEO_NEW;
         pub const SO_RCVTIMEO: c_int = SO_RCVTIMEO_NEW;
     } else {
+        const SO_SNDTIMEO_OLD: c_int = 0x1005;
+        const SO_RCVTIMEO_OLD: c_int = 0x1006;
+
         pub const SO_SNDTIMEO: c_int = SO_SNDTIMEO_OLD;
         pub const SO_RCVTIMEO: c_int = SO_RCVTIMEO_OLD;
     }
@@ -95,28 +96,27 @@ pub const SO_ZEROCOPY: c_int = 60;
 pub const SO_TXTIME: c_int = 61;
 pub const SCM_TXTIME: c_int = SO_TXTIME;
 pub const SO_BINDTOIFINDEX: c_int = 62;
-// NOTE: These definitions are now being renamed with _OLD postfix,
-// but CI haven't support them yet.
-// Some related consts could be found in b32.rs and b64.rs
-const SO_TIMESTAMP_OLD: c_int = 29;
-const SO_RCVTIMEO_NEW: c_int = 66;
-const SO_SNDTIMEO_NEW: c_int = 67;
-const SO_TIMESTAMPNS_OLD: c_int = 35;
-const SO_TIMESTAMPING_OLD: c_int = 37;
-const SO_TIMESTAMP_NEW: c_int = 63;
-const SO_TIMESTAMPNS_NEW: c_int = 64;
-const SO_TIMESTAMPING_NEW: c_int = 65;
+
 cfg_if! {
     if #[cfg(linux_time_bits64)] {
+        const SO_TIMESTAMP_NEW: c_int = 63;
+        const SO_TIMESTAMPNS_NEW: c_int = 64;
+        const SO_TIMESTAMPING_NEW: c_int = 65;
+
         pub const SO_TIMESTAMP: c_int = SO_TIMESTAMP_NEW;
         pub const SO_TIMESTAMPNS: c_int = SO_TIMESTAMPNS_NEW;
         pub const SO_TIMESTAMPING: c_int = SO_TIMESTAMPING_NEW;
     } else {
+        const SO_TIMESTAMP_OLD: c_int = 29;
+        const SO_TIMESTAMPNS_OLD: c_int = 35;
+        const SO_TIMESTAMPING_OLD: c_int = 37;
+
         pub const SO_TIMESTAMP: c_int = SO_TIMESTAMP_OLD;
         pub const SO_TIMESTAMPNS: c_int = SO_TIMESTAMPNS_OLD;
         pub const SO_TIMESTAMPING: c_int = SO_TIMESTAMPING_OLD;
     }
 }
+
 // pub const SO_DETACH_REUSEPORT_BPF: c_int = 68;
 pub const SO_PREFER_BUSY_POLL: c_int = 69;
 pub const SO_BUSY_POLL_BUDGET: c_int = 70;

--- a/src/unix/linux_like/linux/arch/powerpc/mod.rs
+++ b/src/unix/linux_like/linux/arch/powerpc/mod.rs
@@ -24,17 +24,23 @@ pub const SO_REUSEPORT: c_int = 15;
 // powerpc only differs in these
 pub const SO_RCVLOWAT: c_int = 16;
 pub const SO_SNDLOWAT: c_int = 17;
+
 cfg_if! {
     if #[cfg(linux_time_bits64)] {
-        pub const SO_SNDTIMEO: c_int = 67;
-        pub const SO_RCVTIMEO: c_int = 66;
+        const SO_RCVTIMEO_NEW: c_int = 66;
+        const SO_SNDTIMEO_NEW: c_int = 67;
+
+        pub const SO_RCVTIMEO: c_int = SO_RCVTIMEO_NEW;
+        pub const SO_SNDTIMEO: c_int = SO_SNDTIMEO_NEW;
     } else {
-        pub const SO_SNDTIMEO: c_int = 19;
-        pub const SO_RCVTIMEO: c_int = 18;
+        const SO_RCVTIMEO_OLD: c_int = 18;
+        const SO_SNDTIMEO_OLD: c_int = 19;
+
+        pub const SO_RCVTIMEO: c_int = SO_RCVTIMEO_OLD;
+        pub const SO_SNDTIMEO: c_int = SO_SNDTIMEO_OLD;
     }
 }
-// pub const SO_RCVTIMEO_OLD: c_int = 18;
-// pub const SO_SNDTIMEO_OLD: c_int = 19;
+
 pub const SO_PASSCRED: c_int = 20;
 pub const SO_PEERCRED: c_int = 21;
 // end
@@ -48,18 +54,23 @@ pub const SO_GET_FILTER: c_int = SO_ATTACH_FILTER;
 pub const SO_PEERNAME: c_int = 28;
 cfg_if! {
     if #[cfg(linux_time_bits64)] {
+        const SO_TIMESTAMP_NEW: c_int = 63;
+        const SO_TIMESTAMPNS_NEW: c_int = 64;
+        const SO_TIMESTAMPING_NEW: c_int = 65;
+
         pub const SO_TIMESTAMP: c_int = SO_TIMESTAMP_NEW;
         pub const SO_TIMESTAMPNS: c_int = SO_TIMESTAMPNS_NEW;
         pub const SO_TIMESTAMPING: c_int = SO_TIMESTAMPING_NEW;
     } else {
+        const SO_TIMESTAMP_OLD: c_int = 29;
+        const SO_TIMESTAMPNS_OLD: c_int = 35;
+        const SO_TIMESTAMPING_OLD: c_int = 37;
+
         pub const SO_TIMESTAMP: c_int = SO_TIMESTAMP_OLD;
         pub const SO_TIMESTAMPNS: c_int = SO_TIMESTAMPNS_OLD;
         pub const SO_TIMESTAMPING: c_int = SO_TIMESTAMPING_OLD;
     }
 }
-const SO_TIMESTAMP_OLD: c_int = 29;
-const SO_TIMESTAMPNS_OLD: c_int = 35;
-const SO_TIMESTAMPING_OLD: c_int = 37;
 pub const SO_ACCEPTCONN: c_int = 30;
 pub const SO_PEERSEC: c_int = 31;
 pub const SO_SNDBUFFORCE: c_int = 32;
@@ -94,11 +105,6 @@ pub const SO_ZEROCOPY: c_int = 60;
 pub const SO_TXTIME: c_int = 61;
 pub const SCM_TXTIME: c_int = SO_TXTIME;
 pub const SO_BINDTOIFINDEX: c_int = 62;
-const SO_TIMESTAMP_NEW: c_int = 63;
-const SO_TIMESTAMPNS_NEW: c_int = 64;
-const SO_TIMESTAMPING_NEW: c_int = 65;
-const SO_RCVTIMEO_NEW: c_int = 66;
-const SO_SNDTIMEO_NEW: c_int = 67;
 // pub const SO_DETACH_REUSEPORT_BPF: c_int = 68;
 pub const SO_PREFER_BUSY_POLL: c_int = 69;
 pub const SO_BUSY_POLL_BUDGET: c_int = 70;

--- a/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
@@ -7,8 +7,6 @@ pub type wchar_t = c_int;
 
 pub type nlink_t = c_uint;
 pub type blksize_t = c_int;
-pub type fsblkcnt64_t = c_ulong;
-pub type fsfilcnt64_t = c_ulong;
 pub type __u64 = c_ulonglong;
 pub type __s64 = c_longlong;
 

--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -1,3 +1,6 @@
+// FIXME(ulibc): this module has definitions that are redundant with the parent
+#![allow(dead_code)]
+
 use crate::off64_t;
 use crate::prelude::*;
 

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -1258,14 +1258,6 @@ extern "C" {
     ) -> ssize_t;
     pub fn recvmsg(socket: c_int, msg: *mut msghdr, flags: c_int) -> ssize_t;
     pub fn sendmsg(socket: c_int, msg: *const msghdr, flags: c_int) -> ssize_t;
-    pub fn sendto(
-        socket: c_int,
-        buf: *const c_void,
-        len: size_t,
-        flags: c_int,
-        addr: *const crate::sockaddr,
-        addrlen: crate::socklen_t,
-    ) -> ssize_t;
 
     // sys/stat.h
     pub fn futimens(fd: c_int, times: *const crate::timespec) -> c_int;

--- a/src/unix/solarish/compat.rs
+++ b/src/unix/solarish/compat.rs
@@ -5,9 +5,6 @@ use core::cmp::min;
 use crate::unix::solarish::*;
 use crate::{c_char, c_int, size_t};
 
-const PTEM: &[u8] = b"ptem\0";
-const LDTERM: &[u8] = b"ldterm\0";
-
 pub unsafe fn cfmakeraw(termios: *mut crate::termios) {
     (*termios).c_iflag &=
         !(IMAXBEL | IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
@@ -41,6 +38,7 @@ pub unsafe fn cfsetspeed(termios: *mut crate::termios, speed: crate::speed_t) ->
     0
 }
 
+#[cfg(target_os = "illumos")]
 unsafe fn bail(fdm: c_int, fds: c_int) -> c_int {
     let e = *___errno();
     if fds >= 0 {
@@ -61,6 +59,9 @@ pub unsafe fn openpty(
     termp: *const termios,
     winp: *const crate::winsize,
 ) -> c_int {
+    const PTEM: &[u8] = b"ptem\0";
+    const LDTERM: &[u8] = b"ldterm\0";
+
     // Open the main pseudo-terminal device, making sure not to set it as the
     // controlling terminal for this process:
     let fdm = crate::posix_openpt(O_RDWR | O_NOCTTY);


### PR DESCRIPTION
lints: Warn rather than deny

We check with `-Dwarnings` in CI, so these still get checked. This
change serves to prevent failures to compile downstream if the lint
expectations are not met on untested targets.

---

lints: Remove `allow(dead_code)`

As discussed in [1], some changes to dead code warnings caused a lot of
code to be inaccurately reported as dead in `libc`. The change was
reverted and improved since then, so we no longer need to skip this
check.

[1]: https://github.com/rust-lang/libc/issues/3740

---

lints: Remove `allow(redundant_semicolons)`