### PR TITLE
Add extraction of relevant types.

### DIFF
--- a/ctest-next/src/ast/constant.rs
+++ b/ctest-next/src/ast/constant.rs
@@ -1,0 +1,41 @@
+/// Represents a constant variable defined in Rust.
+pub struct Const {
+    public: bool,
+    ident: syn::Ident,
+    ty: syn::Type,
+    expr: syn::Expr,
+}
+
+impl Const {
+    /// Creates a new constant.
+    pub fn new(public: bool, ident: syn::Ident, ty: syn::Type, expr: syn::Expr) -> Self {
+        Self {
+            public,
+            ident,
+            ty,
+            expr,
+        }
+    }
+
+    /// Return whether the constant is visible to other crates.
+    pub fn public(&self) -> bool {
+        self.public
+    }
+
+    /// Return the identifier of the constant as a string.
+    pub fn ident(&self) -> String {
+        self.ident.to_string()
+    }
+
+    /// Return the type of the constant.
+    #[expect(unused)]
+    pub(crate) fn ty(&self) -> &syn::Type {
+        &self.ty
+    }
+
+    /// Return the expression stored as a constant.
+    #[expect(unused)]
+    pub(crate) fn expr(&self) -> &syn::Expr {
+        &self.expr
+    }
+}

--- a/ctest-next/src/ast/field.rs
+++ b/ctest-next/src/ast/field.rs
@@ -1,0 +1,29 @@
+/// Represents a field in a struct or union defined in Rust.
+pub struct Field {
+    public: bool,
+    ident: Option<syn::Ident>,
+    ty: syn::Type,
+}
+
+impl Field {
+    /// Creates a new field.
+    pub fn new(public: bool, ident: Option<syn::Ident>, ty: syn::Type) -> Self {
+        Self { public, ident, ty }
+    }
+
+    /// Return whether the field is visible to other crates.
+    pub fn public(&self) -> bool {
+        self.public
+    }
+
+    /// Return the identifier of the field as a string if it exists.
+    pub fn ident(&self) -> Option<String> {
+        self.ident.as_ref().map(|i| i.to_string())
+    }
+
+    /// Return the type of the field.
+    #[expect(unused)]
+    pub(crate) fn ty(&self) -> &syn::Type {
+        &self.ty
+    }
+}

--- a/ctest-next/src/ast/function.rs
+++ b/ctest-next/src/ast/function.rs
@@ -1,0 +1,49 @@
+use crate::Parameter;
+
+/// Represents a function signature defined in Rust.
+///
+/// This structure is only used for parsing functions in extern blocks.
+pub struct Fn {
+    public: bool,
+    ident: syn::Ident,
+    parameters: Vec<Parameter>,
+    return_type: Option<syn::Type>,
+}
+
+impl Fn {
+    /// Creates a new function.
+    pub fn new(
+        public: bool,
+        ident: syn::Ident,
+        parameters: Vec<Parameter>,
+        return_type: Option<syn::Type>,
+    ) -> Self {
+        Self {
+            public,
+            ident,
+            parameters,
+            return_type,
+        }
+    }
+
+    /// Return whether the function is visible to other crates.
+    pub fn public(&self) -> bool {
+        self.public
+    }
+
+    /// Return the identifier of the function as a string.
+    pub fn ident(&self) -> String {
+        self.ident.to_string()
+    }
+
+    /// Return the parameters of the function.
+    pub fn parameters(&self) -> &Vec<Parameter> {
+        &self.parameters
+    }
+
+    /// Return the return type of the function.
+    #[expect(unused)]
+    pub(crate) fn return_type(&self) -> &Option<syn::Type> {
+        &self.return_type
+    }
+}

--- a/ctest-next/src/ast/item.rs
+++ b/ctest-next/src/ast/item.rs
@@ -1,0 +1,20 @@
+use crate::{Const, Fn, Static, Struct, Type, Union};
+
+/// Things that can appear directly inside of a module or scope.
+///
+/// This is not an exhaustive list and only contains variants directly useful
+/// for our purposes.
+pub enum Item {
+    /// Represents a constant defined in Rust.
+    Const(Const),
+    /// Represents a function defined in Rust.
+    Fn(Fn),
+    /// Represents a static variable defined in Rust.
+    Static(Static),
+    /// Represents a type alias defined in Rust.
+    Type(Type),
+    /// Represents a struct defined in Rust.
+    Struct(Struct),
+    /// Represents a union defined in Rust.
+    Union(Union),
+}

--- a/ctest-next/src/ast/mod.rs
+++ b/ctest-next/src/ast/mod.rs
@@ -1,0 +1,19 @@
+mod constant;
+mod field;
+mod function;
+mod item;
+mod parameter;
+mod static_variable;
+mod structure;
+mod type_alias;
+mod union;
+
+pub use constant::Const;
+pub use field::Field;
+pub use function::Fn;
+pub use item::Item;
+pub use parameter::Parameter;
+pub use static_variable::Static;
+pub use structure::Struct;
+pub use type_alias::Type;
+pub use union::Union;

--- a/ctest-next/src/ast/parameter.rs
+++ b/ctest-next/src/ast/parameter.rs
@@ -1,0 +1,24 @@
+/// Represents a parameter in a function signature defined in Rust.
+pub struct Parameter {
+    pattern: syn::Pat,
+    ty: syn::Type,
+}
+
+impl Parameter {
+    /// Creates a new parameter.
+    pub fn new(pattern: syn::Pat, ty: syn::Type) -> Self {
+        Self { pattern, ty }
+    }
+
+    /// Return the pattern to match for the parameter.
+    #[expect(unused)]
+    pub(crate) fn pattern(&self) -> &syn::Pat {
+        &self.pattern
+    }
+
+    /// Return the type of the parameter.
+    #[expect(unused)]
+    pub(crate) fn ty(&self) -> &syn::Type {
+        &self.ty
+    }
+}

--- a/ctest-next/src/ast/static_variable.rs
+++ b/ctest-next/src/ast/static_variable.rs
@@ -1,0 +1,32 @@
+/// Represents a static variable in Rust.
+///
+/// This structure is only used for parsing statics in extern blocks,
+/// as a result it does not have a field for storing the expression.
+pub struct Static {
+    public: bool,
+    ident: syn::Ident,
+    ty: syn::Type,
+}
+
+impl Static {
+    /// Creates a new static variable.
+    pub fn new(public: bool, ident: syn::Ident, ty: syn::Type) -> Self {
+        Self { public, ident, ty }
+    }
+
+    /// Return whether the static variable is visible to other crates.
+    pub fn public(&self) -> bool {
+        self.public
+    }
+
+    /// Return the identifier of the static variable as a string.
+    pub fn ident(&self) -> String {
+        self.ident.to_string()
+    }
+
+    /// Return the type of the static variable.
+    #[expect(unused)]
+    pub(crate) fn ty(&self) -> &syn::Type {
+        &self.ty
+    }
+}

--- a/ctest-next/src/ast/structure.rs
+++ b/ctest-next/src/ast/structure.rs
@@ -1,0 +1,34 @@
+use crate::Field;
+
+/// Represents a struct defined in Rust.
+pub struct Struct {
+    public: bool,
+    ident: syn::Ident,
+    fields: Vec<Field>,
+}
+
+impl Struct {
+    /// Creates a new struct.
+    pub fn new(public: bool, ident: syn::Ident, fields: Vec<Field>) -> Self {
+        Self {
+            public,
+            ident,
+            fields,
+        }
+    }
+
+    /// Return whether the struct is visible to other crates.
+    pub fn public(&self) -> bool {
+        self.public
+    }
+
+    /// Return the identifier of the struct as a string.
+    pub fn ident(&self) -> String {
+        self.ident.to_string()
+    }
+
+    /// Return the fields of the struct.
+    pub fn fields(&self) -> &Vec<Field> {
+        &self.fields
+    }
+}

--- a/ctest-next/src/ast/type_alias.rs
+++ b/ctest-next/src/ast/type_alias.rs
@@ -1,0 +1,29 @@
+/// Represents a type alias defined in Rust.
+pub struct Type {
+    public: bool,
+    ident: syn::Ident,
+    ty: syn::Type,
+}
+
+impl Type {
+    /// Creates a new type alias.
+    pub fn new(public: bool, ident: syn::Ident, ty: syn::Type) -> Self {
+        Self { public, ident, ty }
+    }
+
+    /// Return whether the type alias is visible to other crates.
+    pub fn public(&self) -> bool {
+        self.public
+    }
+
+    /// Return the identifier of the type alias as a string.
+    pub fn ident(&self) -> String {
+        self.ident.to_string()
+    }
+
+    /// Return the type that the type alias aliases.
+    #[expect(unused)]
+    pub(crate) fn ty(&self) -> &syn::Type {
+        &self.ty
+    }
+}

--- a/ctest-next/src/ast/union.rs
+++ b/ctest-next/src/ast/union.rs
@@ -1,0 +1,34 @@
+use crate::Field;
+
+/// Represents a union defined in Rust.
+pub struct Union {
+    public: bool,
+    ident: syn::Ident,
+    fields: Vec<Field>,
+}
+
+impl Union {
+    /// Creates a new union.
+    pub fn new(public: bool, ident: syn::Ident, fields: Vec<Field>) -> Self {
+        Self {
+            public,
+            ident,
+            fields,
+        }
+    }
+
+    /// Return whether the union is visible to other crates.
+    pub fn public(&self) -> bool {
+        self.public
+    }
+
+    /// Return the identifier of the union as a string.
+    pub fn ident(&self) -> String {
+        self.ident.to_string()
+    }
+
+    /// Return the fields of the union.
+    pub fn fields(&self) -> &Vec<Field> {
+        &self.fields
+    }
+}

--- a/ctest-next/src/ffi_items.rs
+++ b/ctest-next/src/ffi_items.rs
@@ -1,0 +1,209 @@
+use std::{collections::HashMap, ops::Deref};
+
+use syn::{punctuated::Punctuated, visit::Visit};
+
+use crate::{Const, Field, Fn, Parameter, Static, Struct, Type, Union};
+
+/// The ABI as defined by the extern block.
+type Abi = String;
+
+/// Represents a collected set of top-level Rust items relevant to FFI generation or analysis.
+///
+/// Includes foreign functions/statics, type aliases, structs, unions, and constants.
+pub struct FfiItems {
+    aliases: Vec<Type>,
+    structs: Vec<Struct>,
+    unions: Vec<Union>,
+    constants: Vec<Const>,
+    foreign_functions: HashMap<Abi, Vec<Fn>>,
+    foreign_statics: HashMap<Abi, Vec<Static>>,
+}
+
+impl Default for FfiItems {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FfiItems {
+    /// Creates a new blank FfiItems.
+    pub fn new() -> Self {
+        Self {
+            aliases: Vec::new(),
+            structs: Vec::new(),
+            unions: Vec::new(),
+            constants: Vec::new(),
+            foreign_functions: HashMap::new(),
+            foreign_statics: HashMap::new(),
+        }
+    }
+
+    /// Return whether the type has parsed a struct with the given identifier.
+    pub fn contains_struct(&self, ident: &str) -> bool {
+        self.structs()
+            .iter()
+            .any(|structure| structure.ident() == ident)
+    }
+
+    /// Return whether the type has parsed a union with the given identifier.
+    pub fn contains_union(&self, ident: &str) -> bool {
+        self.unions().iter().any(|union| union.ident() == ident)
+    }
+
+    /// Return a list of all type aliases found.
+    pub fn aliases(&self) -> &Vec<Type> {
+        &self.aliases
+    }
+
+    /// Return a list of all structs found.
+    pub fn structs(&self) -> &Vec<Struct> {
+        &self.structs
+    }
+
+    /// Return a list of all unions found.
+    pub fn unions(&self) -> &Vec<Union> {
+        &self.unions
+    }
+
+    /// Return a list of all constants found.
+    pub fn constants(&self) -> &Vec<Const> {
+        &self.constants
+    }
+
+    /// Return a list of all foreign functions found mapped by their ABI.
+    pub fn foreign_functions(&self) -> &HashMap<Abi, Vec<Fn>> {
+        &self.foreign_functions
+    }
+
+    /// Return a list of all foreign statics found mapped by their ABI.
+    pub fn foreign_statics(&self) -> &HashMap<Abi, Vec<Static>> {
+        &self.foreign_statics
+    }
+}
+
+/// Determine whether an item is visible to other crates.
+///
+/// This function assumes that if the visibility is restricted then it is not
+/// meant to be accessed.
+fn is_visible(vis: &syn::Visibility) -> bool {
+    match vis {
+        syn::Visibility::Public(_) => true,
+        syn::Visibility::Inherited | syn::Visibility::Restricted(_) => false,
+    }
+}
+
+/// Collect fields in a syn grammar into ctest's equivalent structure.
+fn collect_fields(fields: &Punctuated<syn::Field, syn::Token![,]>) -> Vec<Field> {
+    fields
+        .iter()
+        .map(|field| {
+            Field::new(
+                is_visible(&field.vis),
+                field.ident.clone(),
+                field.ty.clone(),
+            )
+        })
+        .collect()
+}
+
+fn visit_foreign_item_fn(table: &mut FfiItems, i: &syn::ForeignItemFn, abi: &str) {
+    let public = is_visible(&i.vis);
+    let ident = i.sig.ident.clone();
+    let parameters = i
+        .sig
+        .inputs
+        .iter()
+        .map(|arg| match arg {
+            syn::FnArg::Typed(arg) => {
+                Parameter::new(arg.pat.deref().clone(), arg.ty.deref().clone())
+            }
+            syn::FnArg::Receiver(_) => {
+                unreachable!("Foreign functions can't have self/receiver parameters.")
+            }
+        })
+        .collect::<Vec<_>>();
+    let return_type = match &i.sig.output {
+        syn::ReturnType::Default => None,
+        syn::ReturnType::Type(_, ty) => Some(ty.deref().clone()),
+    };
+
+    table
+        .foreign_functions
+        .entry(abi.to_string())
+        .or_default()
+        .push(Fn::new(public, ident, parameters, return_type));
+}
+
+fn visit_foreign_item_static(table: &mut FfiItems, i: &syn::ForeignItemStatic, abi: &str) {
+    let public = is_visible(&i.vis);
+    let ident = i.ident.clone();
+    let ty = i.ty.deref().clone();
+
+    table
+        .foreign_statics
+        .entry(abi.to_string())
+        .or_default()
+        .push(Static::new(public, ident, ty));
+}
+
+impl<'ast> Visit<'ast> for FfiItems {
+    fn visit_item_type(&mut self, i: &'ast syn::ItemType) {
+        let public = is_visible(&i.vis);
+        let ty = i.ty.deref().clone();
+        let ident = i.ident.clone();
+
+        self.aliases.push(Type::new(public, ident, ty));
+    }
+
+    fn visit_item_struct(&mut self, i: &'ast syn::ItemStruct) {
+        let public = is_visible(&i.vis);
+        let ident = i.ident.clone();
+        let fields = match &i.fields {
+            syn::Fields::Named(fields) => collect_fields(&fields.named),
+            syn::Fields::Unnamed(fields) => collect_fields(&fields.unnamed),
+            syn::Fields::Unit => Vec::new(),
+        };
+
+        self.structs.push(Struct::new(public, ident, fields));
+    }
+
+    fn visit_item_union(&mut self, i: &'ast syn::ItemUnion) {
+        let public = is_visible(&i.vis);
+        let ident = i.ident.clone();
+        let fields = collect_fields(&i.fields.named);
+
+        self.unions.push(Union::new(public, ident, fields));
+    }
+
+    fn visit_item_const(&mut self, i: &'ast syn::ItemConst) {
+        let public = is_visible(&i.vis);
+        let ident = i.ident.clone();
+        let ty = i.ty.deref().clone();
+        let expr = i.expr.deref().clone();
+
+        self.constants.push(Const::new(public, ident, ty, expr));
+    }
+
+    fn visit_item_foreign_mod(&mut self, i: &'ast syn::ItemForeignMod) {
+        // Because we need to store the ABI we can't directly visit the foreign
+        // functions/statics.
+
+        // Since this is an extern block, assume extern "C" by default.
+        let abi = i
+            .abi
+            .name
+            .clone()
+            .map(|s| s.value())
+            .unwrap_or_else(|| "C".to_string());
+
+        for item in &i.items {
+            match item {
+                syn::ForeignItem::Fn(function) => visit_foreign_item_fn(self, function, &abi),
+                syn::ForeignItem::Static(static_variable) => {
+                    visit_foreign_item_static(self, static_variable, &abi)
+                }
+                _ => (),
+            }
+        }
+    }
+}

--- a/ctest-next/src/generator.rs
+++ b/ctest-next/src/generator.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
-use crate::{expand, Result};
+use syn::visit::Visit;
+
+use crate::{expand, FfiItems, Result};
 
 /// A builder used to generate a test suite.
 #[non_exhaustive]
@@ -20,7 +22,12 @@ impl TestGenerator {
 
     /// Generate all tests for the given crate and output the Rust side to a file.
     pub fn generate<P: AsRef<Path>>(&self, crate_path: P, _output_file_path: P) -> Result<()> {
-        let _expanded = expand(crate_path)?;
+        let expanded = expand(crate_path)?;
+        let ast = syn::parse_file(&expanded)?;
+
+        let mut ffi_items = FfiItems::new();
+        ffi_items.visit_file(&ast);
+
         Ok(())
     }
 }

--- a/ctest-next/src/lib.rs
+++ b/ctest-next/src/lib.rs
@@ -7,9 +7,13 @@
 //! project from the main repo to generate tests which can be used to validate
 //! FFI bindings in Rust against the headers from which they come from.
 
+mod ast;
+mod ffi_items;
 mod generator;
 mod macro_expansion;
 
+pub use ast::{Const, Field, Fn, Item, Parameter, Static, Struct, Type, Union};
+pub use ffi_items::FfiItems;
 pub use generator::TestGenerator;
 pub use macro_expansion::expand;
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Adds support for extracting relevant types (such as Structs, Unions, Aliases, etc.) from Rust code.
<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
