### PR TITLE
make pidfd_info fields pub

### DIFF
--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1366,21 +1366,22 @@ s! {
 
     // linux/pidfd.h
 
+    #[non_exhaustive]
     pub struct pidfd_info {
-        mask: crate::__u64,
-        cgroupid: crate::__u64,
-        pid: crate::__u32,
-        tgid: crate::__u32,
-        ppid: crate::__u32,
-        ruid: crate::__u32,
-        rgid: crate::__u32,
-        euid: crate::__u32,
-        egid: crate::__u32,
-        suid: crate::__u32,
-        sgid: crate::__u32,
-        fsuid: crate::__u32,
-        fsgid: crate::__u32,
-        exit_code: crate::__s32,
+        pub mask: crate::__u64,
+        pub cgroupid: crate::__u64,
+        pub pid: crate::__u32,
+        pub tgid: crate::__u32,
+        pub ppid: crate::__u32,
+        pub ruid: crate::__u32,
+        pub rgid: crate::__u32,
+        pub euid: crate::__u32,
+        pub egid: crate::__u32,
+        pub suid: crate::__u32,
+        pub sgid: crate::__u32,
+        pub fsuid: crate::__u32,
+        pub fsgid: crate::__u32,
+        pub exit_code: crate::__s32,
     }
 
     // linux/uio.h


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

This marks the fields of `pidfd_info` pub.
This seems to have been an oversight, most of the other fields in module are also pub. I also mark it as non_exhaustive since the struct is extensible, new fields have been added recently.

<!-- Add a short description about what this change does -->

# Sources

https://github.com/torvalds/linux/blob/19272b37aa4f83ca52bdf9c16d5d81bdd1354494/include/uapi/linux/pidfd.h#L109-L110

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI


@rustbot label +stable-nominated
