### PR TITLE
Fix CI on FreeBSD 15

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2572,7 +2572,7 @@ fn test_freebsd(target: &str) {
             "TDF_CANSWAP" | "TDF_SWAPINREQ" => true,
 
             // Unaccessible in FreeBSD 15
-            "TDI_SWAPPED" | "P_SWAPPINGOUT" | "P_SWAPPINGIN" => true,
+            "TDI_SWAPPED" | "P_SWAPPINGOUT" | "P_SWAPPINGIN" | "P_UNUSED3" => true,
 
             // Removed in FreeBSD 14 (git a6b55ee6be1)
             "IFF_KNOWSEPOCH" => true,
@@ -2981,6 +2981,8 @@ fn test_freebsd(target: &str) {
             // `tcp_snd_wscale` and `tcp_rcv_wscale` are bitfields
             ("tcp_info", "tcp_snd_wscale") => true,
             ("tcp_info", "tcp_rcv_wscale") => true,
+            // mc_spare can change in size between OS releases.  It's a spare field, after all.
+            ("__mcontext", "mc_spare") => true,
 
             _ => false,
         }

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -4114,7 +4114,9 @@ pub const TDI_IWAIT: c_int = 0x0010;
 pub const P_ADVLOCK: c_int = 0x00000001;
 pub const P_CONTROLT: c_int = 0x00000002;
 pub const P_KPROC: c_int = 0x00000004;
+#[deprecated(since="1.0", note="Replaced in FreeBSD 15 by P_IDLEPROC")]
 pub const P_UNUSED3: c_int = 0x00000008;
+pub const P_IDLEPROC: c_int = 0x00000008;
 pub const P_PPWAIT: c_int = 0x00000010;
 pub const P_PROFIL: c_int = 0x00000020;
 pub const P_STOPPROF: c_int = 0x00000040;

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -137,7 +137,8 @@ s_no_extra_traits! {
         pub mc_gsbase: register_t,
         pub mc_xfpustate: register_t,
         pub mc_xfpustate_len: register_t,
-        pub mc_spare: [c_long; 4],
+        pub mc_tlsbase: register_t,
+        pub mc_spare: [c_long; 3],
     }
 }
 


### PR DESCRIPTION
A recent change has replaced an unused preprocessor symbol: P_UNUSED3

https://github.com/freebsd/freebsd-src/commit/33be1632047c05dbfcc139476e05f49c3a86d560

Another recent change has changed the size of a spare field: mc_spare

https://github.com/freebsd/freebsd-src/commit/eea3e4dd9703a252509d75814049aa8da5007ebb

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
