### PR TITLE
openbsd: Fix some clippy warnings to use `pointer::cast`.

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -630,7 +630,7 @@ impl siginfo_t {
             _pad: [c_int; SI_PAD],
             _pid: crate::pid_t,
         }
-        (*(self as *const siginfo_t as *const siginfo_timer))._pid
+        (*(self as *const siginfo_t).cast::<siginfo_timer>())._pid
     }
 
     pub unsafe fn si_uid(&self) -> crate::uid_t {
@@ -643,7 +643,7 @@ impl siginfo_t {
             _pid: crate::pid_t,
             _uid: crate::uid_t,
         }
-        (*(self as *const siginfo_t as *const siginfo_timer))._uid
+        (*(self as *const siginfo_t).cast::<siginfo_timer>())._uid
     }
 
     pub unsafe fn si_value(&self) -> crate::sigval {
@@ -657,7 +657,7 @@ impl siginfo_t {
             _uid: crate::uid_t,
             value: crate::sigval,
         }
-        (*(self as *const siginfo_t as *const siginfo_timer)).value
+        (*(self as *const siginfo_t).cast::<siginfo_timer>()).value
     }
 }
 


### PR DESCRIPTION
This change just fixes some `clippy` warnings that are found on OpenBSD like:
```
warning: `as` casting between raw pointers without changing their constness
   --> src/unix/bsd/netbsdlike/openbsd/mod.rs:633:11
    |
633 |         (*(self as *const siginfo_t as *const siginfo_timer))._pid
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast`, a safer alternative: `(self as *const siginfo_t).cast::<siginfo_timer>()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_as_ptr
    = note: requested on the command line with `-W clippy::ptr-as-ptr`
```

@rustbot label +stable-nominated