### PR TITLE
Add the `enum` keyword to the `c_enum` macro

### DIFF
--- a/ci/style.sh
+++ b/ci/style.sh
@@ -26,7 +26,7 @@ while IFS= read -r file; do
 
     # Turn all braced macro `foo! { /* ... */ }` invocations into
     # `fn foo_fmt_tmp() { /* ... */ }`.
-    perl -pi -e 's/(?!macro_rules|c_enum)\b(\w+)!\s*\{/fn $1_fmt_tmp() {/g' "$file"
+    perl -pi -e 's/(?!macro_rules)\b(\w+)!\s*\{/fn $1_fmt_tmp() {/g' "$file"
 
     # Replace `if #[cfg(...)]` within `cfg_if` with `if cfg_tmp!([...])` which
     # `rustfmt` will format. We put brackets within the parens so it is easy to

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -223,7 +223,7 @@ macro_rules! e {
 macro_rules! c_enum {
     (
         $(#[repr($repr:ty)])?
-        $ty_name:ident {
+        enum $ty_name:ident {
             $($variant:ident $(= $value:literal)?,)+
         }
     ) => {
@@ -377,7 +377,7 @@ mod tests {
     fn c_enumbasic() {
         // By default, variants get sequential values.
         c_enum! {
-            e {
+            enum e {
                 VAR0,
                 VAR1,
                 VAR2,
@@ -394,7 +394,7 @@ mod tests {
         // By default, variants get sequential values.
         c_enum! {
             #[repr(u16)]
-            e {
+            enum e {
                 VAR0,
             }
         }
@@ -406,7 +406,7 @@ mod tests {
     fn c_enumset_value() {
         // Setting an explicit value resets the count.
         c_enum! {
-            e {
+            enum e {
                 VAR2 = 2,
                 VAR3,
                 VAR4,
@@ -423,7 +423,7 @@ mod tests {
         // C enums always take one more than the previous value, unless set to a specific
         // value. Duplicates are allowed.
         c_enum! {
-            e {
+            enum e {
                 VAR0,
                 VAR2_0 = 2,
                 VAR3_0,

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -39,7 +39,7 @@ pub type Elf64_Xword = u64;
 pub type iconv_t = *mut c_void;
 
 c_enum! {
-    fae_action {
+    enum fae_action {
         FAE_OPEN,
         FAE_DUP2,
         FAE_CLOSE,

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -86,7 +86,7 @@ cfg_if! {
 }
 
 c_enum! {
-    tpacket_versions {
+    enum tpacket_versions {
         TPACKET_V1,
         TPACKET_V2,
         TPACKET_V3,
@@ -94,7 +94,7 @@ c_enum! {
 }
 
 c_enum! {
-    pid_type {
+    enum pid_type {
         PIDTYPE_PID,
         PIDTYPE_TGID,
         PIDTYPE_PGID,
@@ -4528,14 +4528,14 @@ pub const RTNLGRP_STATS: c_uint = 0x24;
 
 // linux/cn_proc.h
 c_enum! {
-    proc_cn_mcast_op {
+    enum proc_cn_mcast_op {
         PROC_CN_MCAST_LISTEN = 1,
         PROC_CN_MCAST_IGNORE = 2,
     }
 }
 
 c_enum! {
-    proc_cn_event {
+    enum proc_cn_event {
         PROC_EVENT_NONE = 0x00000000,
         PROC_EVENT_FORK = 0x00000001,
         PROC_EVENT_EXEC = 0x00000002,


### PR DESCRIPTION
Our `style.sh` script can't handle these easily, and it seems like `ctest` may struggle with this macro. Add the `enum` keyword so the expanded code is valid Rust.