### PR TITLE
Add missing timespec.tv_nsec for gnux32

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -344,6 +344,8 @@ s! {
         __pad: i32,
         #[cfg(not(all(target_arch = "x86_64", target_pointer_width = "32")))]
         pub tv_nsec: c_long,
+        #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
+        pub tv_nsec: i64,
         #[cfg(all(gnu_time_bits64, target_endian = "little"))]
         __pad: i32,
     }


### PR DESCRIPTION
Add missing timespec.tv_nsec for gnux32

The tv_nsec field was removed by mistake for gnux32 in bbaa0173daa4 ("gnu: Update struct timespec for GNU _TIME_BITS=64").

Fixes rust-lang/libc#4495

Link: https://github.com/bminor/glibc/blob/d1b27eeda3d92f33314e93537437cab11ddf4777/time/bits/types/struct_timespec.h#L11-L31

[ add referenced commit summary and link to the message - Trevor ]