### PR TITLE
unix: make `struct timespec` non-exhaustive.

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -338,6 +338,7 @@ s! {
 
     // linux x32 compatibility
     // See https://sourceware.org/bugzilla/show_bug.cgi?id=16437
+    #[non_exhaustive]
     pub struct timespec {
         pub tv_sec: time_t,
         #[cfg(all(gnu_time_bits64, target_endian = "big"))]

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -68,6 +68,7 @@ s! {
 
     // linux x32 compatibility
     // See https://sourceware.org/bugzilla/show_bug.cgi?id=16437
+    #[non_exhaustive]
     #[cfg(not(target_env = "gnu"))]
     pub struct timespec {
         pub tv_sec: time_t,


### PR DESCRIPTION
# Description

As discussed in rust-lang/libc#4463 time64 changes on both GNU and Musl libcs add padding fields to timespec. This can cause compilation failures when using time64 when regular 64-bit compiles fine. Add `non_exhaustive` to force people to use e.g. `..Default::default()` when initializing to prevent sudden errors appearing when using time64.

# Sources

Not applicable.

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

Note: this is a breaking change.