### PR TITLE
musl: powerpc64: Fix definition of EDEADLK

### DIFF
--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -641,8 +641,8 @@ pub const SYS_process_mrelease: c_long = 448;
 pub const SYS_futex_waitv: c_long = 449;
 pub const SYS_set_mempolicy_home_node: c_long = 450;
 
-pub const EDEADLK: c_int = 58;
-pub const EDEADLOCK: c_int = EDEADLK;
+pub const EDEADLK: c_int = 35;
+pub const EDEADLOCK: c_int = 58;
 
 pub const EXTPROC: crate::tcflag_t = 0x10000000;
 pub const VEOL: usize = 6;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

musl defines EDEADLK to be 35 on powerpc64 and EDEADLOCK to be 58.

This has always been the case since the introduction of powerpc64 support in musl.

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

https://git.musl-libc.org/cgit/musl/tree/arch/powerpc64/bits/errno.h#n35
 https://git.musl-libc.org/cgit/musl/tree/arch/powerpc64/bits/errno.h#n58

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
