### PR TITLE
musl: powerpc64: Decommonize definition of shmid_ds

### DIFF
--- a/src/unix/linux_like/linux/musl/b64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/mod.rs
@@ -17,6 +17,8 @@ s! {
         __val: [c_ulong; 16],
     }
 
+    // PowerPC implementation is special, see the subfolder.
+    #[cfg(not(target_arch = "powerpc64"))]
     pub struct shmid_ds {
         pub shm_perm: crate::ipc_perm,
         pub shm_segsz: size_t,

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -50,6 +50,18 @@ s! {
         __reserved: [c_long; 3],
     }
 
+    pub struct shmid_ds {
+        pub shm_perm: crate::ipc_perm,
+        pub shm_atime: crate::time_t,
+        pub shm_dtime: crate::time_t,
+        pub shm_ctime: crate::time_t,
+        pub shm_segsz: size_t,
+        pub shm_cpid: crate::pid_t,
+        pub shm_lpid: crate::pid_t,
+        pub shm_nattch: c_ulong,
+        __unused: [c_ulong; 2],
+    }
+
     pub struct ipc_perm {
         #[cfg(musl_v1_2_3)]
         pub __key: crate::key_t,


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

powerpc64 is the only 64-bit target that doesn't use the generic definition for these in musl.

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->
https://git.musl-libc.org/cgit/musl/tree/arch/powerpc64/bits/shm.h#n3

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
