### PR TITLE
musl: Clarify reason for CPU_SETSIZE value

### DIFF
--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -685,6 +685,7 @@ pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
 pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: usize = 8;
 pub const __SIZEOF_PTHREAD_BARRIERATTR_T: usize = 4;
 
+// FIXME(musl): Value is 1024 for all architectures since 1.2.4
 #[cfg(not(target_arch = "loongarch64"))]
 pub const CPU_SETSIZE: c_int = 128;
 #[cfg(target_arch = "loongarch64")]


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

This value was set to 1024 for all targets in the following commit: https://git.musl-libc.org/cgit/musl/commit/?id=bc695a5ac1d7929e5c1ad5297eb47e146cccd157

Since loongarch64 requires musl 1.2.5, the expected value there is different than the other targets, which still target an earlier musl.

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
