### PR TITLE
ci/docs: Build and check powerpc64le-unknown-linux-musl

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,6 +188,7 @@ jobs:
           - loongarch64-unknown-linux-musl
           - powerpc64-unknown-linux-gnu
           - powerpc64le-unknown-linux-gnu
+          - powerpc64le-unknown-linux-musl
           - riscv64gc-unknown-linux-gnu
           - s390x-unknown-linux-gnu
           - wasm32-unknown-emscripten
@@ -220,6 +221,9 @@ jobs:
             env:
               RUST_LIBC_UNSTABLE_MUSL_V1_2_3: 1
           - target: loongarch64-unknown-linux-musl
+            env:
+              RUST_LIBC_UNSTABLE_MUSL_V1_2_3: 1
+          - target: powerpc64le-unknown-linux-musl
             env:
               RUST_LIBC_UNSTABLE_MUSL_V1_2_3: 1
           # FIXME(ppc): SIGILL running tests, see

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ targets = [
     "powerpc64-unknown-linux-gnu",
     "powerpc64-wrs-vxworks",
     "powerpc64le-unknown-linux-gnu",
+    "powerpc64le-unknown-linux-musl",
     "riscv32gc-unknown-linux-gnu",
     "riscv32i-unknown-none-elf",
     "riscv32imac-unknown-none-elf",

--- a/ci/docker/powerpc64le-unknown-linux-musl/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-musl/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:24.10
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  gcc make libc6-dev git curl ca-certificates \
+  gcc-powerpc64le-linux-gnu qemu-user xz-utils patch rsync
+
+COPY install-musl.sh /
+RUN /install-musl.sh powerpc64le
+
+# FIXME: shouldn't need the `-lgcc` here, shouldn't that be in std?
+ENV PATH=$PATH:/musl-powerpc64/bin:/rust/bin \
+    CC_powerpc64le_unknown_linux_musl=musl-gcc \
+    RUSTFLAGS='-Clink-args=-lgcc -L /musl-powerpc64/lib' \
+    CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
+    CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_MUSL_RUNNER="qemu-ppc64le -L /musl-powerpc64"

--- a/ci/install-musl.sh
+++ b/ci/install-musl.sh
@@ -68,6 +68,13 @@ case ${1} in
           ./configure --prefix="/musl-${musl_arch}" --enable-wrapper=yes
         make install -j4
         ;;
+    powerpc64*)
+        musl_arch=powerpc64
+        kernel_arch=powerpc
+        CC="${1}-linux-gnu-gcc" CFLAGS="-mlong-double-64" \
+          ./configure --prefix="/musl-${musl_arch}" --enable-wrapper=yes
+        make install -j4
+        ;;
     *)
         echo "Unknown target arch: \"${1}\""
         exit 1

--- a/ci/verify-build.sh
+++ b/ci/verify-build.sh
@@ -161,11 +161,14 @@ x86_64-unknown-linux-musl \
 x86_64-unknown-netbsd \
 "
 
+# FIXME(powerpc64le): powerpc64le-unknown-linux-musl is tier 2 since 1.85 and
+# can be moved to rust_linux_targets once MSRV is increased
 rust_nightly_linux_targets="\
 aarch64-unknown-fuchsia \
 armv5te-unknown-linux-gnueabi \
 armv5te-unknown-linux-musleabi \
 i686-pc-windows-gnu \
+powerpc64le-unknown-linux-musl \
 riscv64gc-unknown-linux-gnu \
 x86_64-fortanix-unknown-sgx \
 x86_64-pc-solaris \


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

Now that all of the issues with powerpc64 + musl are resolved, let's make sure it won't regress in the future and also build the documentation for it.

This is a tier 2 target for a few months now and requires musl 1.2.3 as a baseline.

The big-endian target isn't tier 2 yet, I'm still working towards that, so we can't test it at the moment.

This obviously depends on all the remaining open pull requests with the fixes.

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-2-with-host-tools

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
