### PR TITLE
Add musl and glibc bindings for getdents{,64}

### DIFF
--- a/libc-test/semver/dragonfly.txt
+++ b/libc-test/semver/dragonfly.txt
@@ -1348,6 +1348,7 @@ freezero
 fsid_t
 fstatfs
 futimes
+getdents
 getdomainname
 getdtablesize
 getentropy

--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -1984,6 +1984,7 @@ fsid_t
 fstatfs
 ftok
 futimes
+getdents
 getdomainname
 getdtablesize
 getgrent

--- a/libc-test/semver/hurd.txt
+++ b/libc-test/semver/hurd.txt
@@ -1,0 +1,1 @@
+getdents64

--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -604,6 +604,7 @@ fgetpwent_r
 fgetspent_r
 futimes
 getauxval
+getdents64
 getentropy
 getgrent_r
 getloadavg

--- a/libc-test/semver/linux-musl.txt
+++ b/libc-test/semver/linux-musl.txt
@@ -74,8 +74,6 @@ getutxline
 lio_listio
 ntptimeval
 open_wmemstream
-posix_dent
-posix_getdents
 posix_spawn_file_actions_addchdir_np
 posix_spawn_file_actions_addfchdir_np
 preadv2

--- a/libc-test/semver/linux-musl.txt
+++ b/libc-test/semver/linux-musl.txt
@@ -65,6 +65,8 @@ euidaccess
 explicit_bzero
 futimes
 getauxval
+getdents
+getdents64
 getloadavg
 getutxent
 getutxid
@@ -72,6 +74,8 @@ getutxline
 lio_listio
 ntptimeval
 open_wmemstream
+posix_dent
+posix_getdents
 posix_spawn_file_actions_addchdir_np
 posix_spawn_file_actions_addfchdir_np
 preadv2

--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -1340,6 +1340,7 @@ ftok
 futimes
 getbootfile
 getbyteorder
+getdents
 getdiskrawname
 getdistcookedname
 getdomainname

--- a/libc-test/semver/openbsd.txt
+++ b/libc-test/semver/openbsd.txt
@@ -1113,6 +1113,7 @@ ftok
 fusefs_args
 futex
 futimes
+getdents
 getdomainname
 getdtablesize
 getentropy

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1586,6 +1586,8 @@ extern "C" {
     ) -> c_int;
 
     pub fn closefrom(lowfd: c_int) -> c_int;
+
+    pub fn getdents(fd: c_int, buf: *mut c_char, nbytes: c_int) -> c_int;
 }
 
 #[link(name = "rt")]

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -4819,6 +4819,10 @@ cfg_if! {
 }
 
 extern "C" {
+    pub fn getdents(fd: c_int, buf: *mut c_char, nbytes: usize) -> isize;
+}
+
+extern "C" {
     #[cfg_attr(doc, doc(alias = "__errno_location"))]
     #[cfg_attr(doc, doc(alias = "errno"))]
     pub fn __error() -> *mut c_int;

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2957,6 +2957,8 @@ extern "C" {
     pub fn flags_to_string(flags: c_ulong, def: *const c_char) -> c_int;
 
     pub fn kinfo_getvmmap(pid: crate::pid_t, cntp: *mut size_t) -> *mut kinfo_vmentry;
+
+    pub fn getdents(fd: c_int, buf: *mut c_char, nbytes: usize) -> c_int;
 }
 
 #[link(name = "execinfo")]

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -2074,6 +2074,8 @@ extern "C" {
     pub fn fstatfs(fd: c_int, buf: *mut statfs) -> c_int;
     pub fn getmntinfo(mntbufp: *mut *mut crate::statfs, flags: c_int) -> c_int;
     pub fn getfsstat(buf: *mut statfs, bufsize: size_t, flags: c_int) -> c_int;
+
+    pub fn getdents(fd: c_int, buf: *mut c_void, nbytes: usize) -> c_int;
 }
 
 #[link(name = "execinfo")]

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -4282,6 +4282,8 @@ extern "C" {
     pub fn seekdir(dirp: *mut crate::DIR, loc: c_long);
     pub fn telldir(dirp: *mut crate::DIR) -> c_long;
 
+    pub fn getdents64(fd: c_int, buf: *mut c_void, nbytes: usize) -> isize;
+
     pub fn dirfd(dirp: *mut crate::DIR) -> c_int;
 
     #[link_name = "__xpg_strerror_r"]

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1346,6 +1346,13 @@ extern "C" {
     pub fn mempcpy(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
 }
 
+extern "C" {
+    // There is no glibc wrapper for the getdents system call, and getdents64() is only available
+    // from 2.30 onwards.
+    /// `buffer` points to a buffer of [`crate::dirent64`] structs.
+    pub fn getdents64(fd: c_int, buffer: *mut c_void, nbytes: usize) -> isize;
+}
+
 cfg_if! {
     if #[cfg(any(
         target_arch = "x86",

--- a/src/unix/linux_like/linux/musl/lfs64.rs
+++ b/src/unix/linux_like/linux/musl/lfs64.rs
@@ -199,6 +199,11 @@ pub unsafe extern "C" fn readdir64_r(
 }
 
 #[inline]
+pub unsafe extern "C" fn getdents64(fd: c_int, buf: *mut crate::dirent64, len: usize) -> c_int {
+    crate::getdents(fd, buf as *mut _, len)
+}
+
+#[inline]
 pub unsafe extern "C" fn sendfile64(
     out_fd: c_int,
     in_fd: c_int,

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -37,13 +37,15 @@ cfg_if! {
     }
 }
 
-#[repr(C)]
-pub struct posix_dent {
-    pub d_ino: ino_t,
-    pub d_off: off_t,
-    pub d_reclen: c_ushort,
-    pub d_type: c_uchar,
-    pub d_name: *mut c_char,
+s_no_extra_traits! {
+    #[repr(C)]
+    pub struct posix_dent {
+        pub d_ino: ino_t,
+        pub d_off: off_t,
+        pub d_reclen: c_ushort,
+        pub d_type: c_uchar,
+        pub d_name: *mut c_char,
+    }
 }
 
 impl siginfo_t {

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -37,6 +37,15 @@ cfg_if! {
     }
 }
 
+#[repr(C)]
+pub struct posix_dent {
+    pub d_ino: ino_t,
+    pub d_off: off_t,
+    pub d_reclen: c_ushort,
+    pub d_type: c_uchar,
+    pub d_name: *mut c_char,
+}
+
 impl siginfo_t {
     pub unsafe fn si_addr(&self) -> *mut c_void {
         #[repr(C)]
@@ -969,6 +978,12 @@ extern "C" {
         note = "musl provides `utmp` as stubs and an alternative should be preferred; see https://wiki.musl-libc.org/faq.html"
     )]
     pub fn utmpxname(file: *const c_char) -> c_int;
+}
+
+extern "C" {
+    pub fn posix_getdents(fd: c_int, buf: *mut c_void, len: usize, flags: c_int) -> isize;
+
+    pub fn getdents(fd: c_int, buf: *mut crate::dirent, len: usize) -> c_int;
 }
 
 // Alias <foo> to <foo>64 to mimic glibc's LFS64 support

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -37,17 +37,6 @@ cfg_if! {
     }
 }
 
-s_no_extra_traits! {
-    #[repr(C)]
-    pub struct posix_dent {
-        pub d_ino: ino_t,
-        pub d_off: off_t,
-        pub d_reclen: c_ushort,
-        pub d_type: c_uchar,
-        pub d_name: *mut c_char,
-    }
-}
-
 impl siginfo_t {
     pub unsafe fn si_addr(&self) -> *mut c_void {
         #[repr(C)]
@@ -983,8 +972,6 @@ extern "C" {
 }
 
 extern "C" {
-    pub fn posix_getdents(fd: c_int, buf: *mut c_void, len: usize, flags: c_int) -> isize;
-
     pub fn getdents(fd: c_int, buf: *mut crate::dirent, len: usize) -> c_int;
 }
 


### PR DESCRIPTION
# Description

The method [`posix_getdents()`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/posix_getdents.html) has recently been added in POSIX issue 8 (from 2024). This method offers a standard interface to retrieve multiple directory entries at once into a preallocated buffer. This typically translates directly to a syscall using the existing `SYS_getdents{,64}` key.

However, as `posix_getdents()` is so new, it has not been universally implemented yet. musl added it immediately last year, but glibc does not yet have it. Instead, glibc >= 2.30 has the method `getdents64()`, which is Linux-only.

While musl appears to implement `posix_getdents()` for all supported platforms, it appears that the version of musl rust pulls in is not from the local machine, but from its own bundled copy. This copy does not have `posix_getdents()`, but instead simply has `getdents64()` to match glibc on linux, as well as a `getdents()` macro for compatibility with the BSD standard.

The extant BSDs just name their version of this method `getdents()`, without any `64`  extension, and expose this as a libc method call instead of a syscall.

Surprisingly, macOS does *not* support any form of the `getdents*()` method. I mentioned this in passing to an Apple engineer a few weeks ago.

I have been in contact with a glibc developer who plans to support this, but cannot make any timeline guarantees. Since it appears that the BSDs also have yet to add support for the POSIX standardized `posix_getdents()` too, it does not seem terribly pressing to block this PR until upstream Rust pulls in a more recent version of musl. Instead, a followup PR should be able to triumphantly add `posix_getdents()` to all the POSIX platforms at once! ^_^ :D

# Sources

- musl (`posix_getdents()`): https://github.com/bminor/musl/blob/86373b4999bfd9a9379bc4a3ca877b1c80a2a340/src/dirent/posix_getdents.c#L6
- musl (`getdents()`): https://github.com/bminor/musl/blob/86373b4999bfd9a9379bc4a3ca877b1c80a2a340/src/linux/getdents.c#L6
- musl (`getdents64()`): https://github.com/bminor/musl/blob/86373b4999bfd9a9379bc4a3ca877b1c80a2a340/include/dirent.h#L80
- glibc (`getdents64()`): https://github.com/bminor/glibc/blob/7eed691cc2b6c5dbb6066ee1251606a744c7f05c/sysdeps/unix/sysv/linux/bits/dirent_ext.h#L29
- freebsd (`getdents()`): https://man.freebsd.org/cgi/man.cgi?query=getdents&sektion=2&manpath=freebsd-release-ports
- netbsd (`getdents()`): https://man.netbsd.org/getdents.2
- openbsd (`getdents()`): https://man.openbsd.org/getdents.2
- dragonflybsd (`getdents()`): https://man.dragonflybsd.org/?command=getdents&section=ANY

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated