### PR TITLE
Add function getpeereid for AIX

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -5668,6 +5668,9 @@ fn test_aix(target: &str) {
             // https://github.com/gnzlbg/ctest/issues/68.
             "lio_listio" => true,
 
+            // The function is only available under macro _KERNEL in 'proto_uipc.h'.
+            "getpeereid" => true,
+
             _ => false,
         }
     });

--- a/libc-test/semver/aix.txt
+++ b/libc-test/semver/aix.txt
@@ -1987,6 +1987,7 @@ getmntent
 getnameinfo
 getopt
 getpagesize
+getpeereid
 getpeername
 getpgid
 getpgrp

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -2943,6 +2943,7 @@ extern "C" {
         flags: c_int,
     ) -> c_int;
     pub fn getpagesize() -> c_int;
+    pub fn getpeereid(socket: c_int, euid: *mut crate::uid_t, egid: *mut crate::gid_t) -> c_int;
     pub fn getpriority(which: c_int, who: crate::id_t) -> c_int;
     pub fn getpwent() -> *mut crate::passwd;
     #[link_name = "_posix_getpwnam_r"]


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
AIX provides `getpeereid` in `libc` even though it is not mandated by POSIX. Since the `tokio` crate has a dependency on this function, this PR makes it available in the libc crate.
<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
