### PR TITLE
Cast to `c_char` rather than `i8`

### DIFF
--- a/ctest-next/templates/test.rs
+++ b/ctest-next/templates/test.rs
@@ -56,7 +56,7 @@ mod generated_tests {
         let val = {{ ident }};
         unsafe {
             let ptr = *__test_const_{{ ident }}();
-            let val = unsafe {CStr::from_ptr(ptr)};
+            let val = CStr::from_ptr(ptr as _);
             let val = val.to_str().expect("const {{ ident }} not utf8");
             let c = ::std::ffi::CStr::from_ptr(ptr as *const _);
             let c = c.to_str().expect("const {{ ident }} not utf8");

--- a/ctest-next/templates/test.rs
+++ b/ctest-next/templates/test.rs
@@ -56,7 +56,7 @@ mod generated_tests {
         let val = {{ ident }};
         unsafe {
             let ptr = *__test_const_{{ ident }}();
-            let val = CStr::from_ptr(ptr as _);
+            let val = CStr::from_ptr(ptr.cast::<c_char>());
             let val = val.to_str().expect("const {{ ident }} not utf8");
             let c = ::std::ffi::CStr::from_ptr(ptr as *const _);
             let c = c.to_str().expect("const {{ ident }} not utf8");

--- a/ctest-next/templates/test.rs
+++ b/ctest-next/templates/test.rs
@@ -56,8 +56,7 @@ mod generated_tests {
         let val = {{ ident }};
         unsafe {
             let ptr = *__test_const_{{ ident }}();
-            // c_char can be i8 or u8, so just cast to i8.
-            let val = CStr::from_ptr(ptr.cast::<i8>());
+            let val = unsafe {CStr::from_ptr(ptr)};
             let val = val.to_str().expect("const {{ ident }} not utf8");
             let c = ::std::ffi::CStr::from_ptr(ptr as *const _);
             let c = c.to_str().expect("const {{ ident }} not utf8");

--- a/ctest-next/tests/input/simple.out.rs
+++ b/ctest-next/tests/input/simple.out.rs
@@ -49,7 +49,7 @@ mod generated_tests {
         let val = A;
         unsafe {
             let ptr = *__test_const_A();
-            let val = CStr::from_ptr(ptr as _);
+            let val = CStr::from_ptr(ptr.cast::<c_char>());
             let val = val.to_str().expect("const A not utf8");
             let c = ::std::ffi::CStr::from_ptr(ptr as *const _);
             let c = c.to_str().expect("const A not utf8");

--- a/ctest-next/tests/input/simple.out.rs
+++ b/ctest-next/tests/input/simple.out.rs
@@ -49,8 +49,7 @@ mod generated_tests {
         let val = A;
         unsafe {
             let ptr = *__test_const_A();
-            // c_char can be i8 or u8, so just cast to i8.
-            let val = CStr::from_ptr(ptr.cast::<i8>());
+            let val = unsafe {CStr::from_ptr(ptr)};
             let val = val.to_str().expect("const A not utf8");
             let c = ::std::ffi::CStr::from_ptr(ptr as *const _);
             let c = c.to_str().expect("const A not utf8");

--- a/ctest-next/tests/input/simple.out.rs
+++ b/ctest-next/tests/input/simple.out.rs
@@ -49,7 +49,7 @@ mod generated_tests {
         let val = A;
         unsafe {
             let ptr = *__test_const_A();
-            let val = unsafe {CStr::from_ptr(ptr)};
+            let val = CStr::from_ptr(ptr as _);
             let val = val.to_str().expect("const A not utf8");
             let c = ::std::ffi::CStr::from_ptr(ptr as *const _);
             let c = c.to_str().expect("const A not utf8");


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
The AIX CI failed with the following error because `c_char` is `u8` on AIX and casting to `i8` causes type mismatch. This PR changes to use `cast::<c_char>())` to cast `ptr`.
```
thread 'test_entrypoint_simple' panicked at ctest-next/tests/basic.rs:75:78:
called `Result::unwrap()` on an `Err` value: "error[E0308]: mismatched types\n  --> /tmp/.tmpL9FroM/simple.out.rs:53:38\n
        |\n
     53 |             let val = CStr::from_ptr(ptr.cast::<i8>());\n
        |                       -------------- ^^^^^^^^^^^^^^^^ expected `*const u8`, found `*const i8`\n
        |\n
```
<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
