### PR TITLE
musl: mips64: Use special MIPS definition of statfs

### DIFF
--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -76,6 +76,36 @@ s! {
         __unused1: c_ulong,
         __unused2: c_ulong,
     }
+
+    pub struct statfs {
+        pub f_type: c_ulong,
+        pub f_bsize: c_ulong,
+        pub f_frsize: c_ulong,
+        pub f_blocks: crate::fsblkcnt_t,
+        pub f_bfree: crate::fsblkcnt_t,
+        pub f_files: crate::fsfilcnt_t,
+        pub f_ffree: crate::fsfilcnt_t,
+        pub f_bavail: crate::fsblkcnt_t,
+        pub f_fsid: crate::fsid_t,
+        pub f_namelen: c_ulong,
+        pub f_flags: c_ulong,
+        pub f_spare: [c_ulong; 5],
+    }
+
+    pub struct statfs64 {
+        pub f_type: c_ulong,
+        pub f_bsize: c_ulong,
+        pub f_frsize: c_ulong,
+        pub f_blocks: crate::fsblkcnt_t,
+        pub f_bfree: crate::fsblkcnt_t,
+        pub f_files: crate::fsfilcnt_t,
+        pub f_ffree: crate::fsfilcnt_t,
+        pub f_bavail: crate::fsblkcnt_t,
+        pub f_fsid: crate::fsid_t,
+        pub f_namelen: c_ulong,
+        pub f_flags: c_ulong,
+        pub f_spare: [c_ulong; 5],
+    }
 }
 
 pub const SIGSTKSZ: size_t = 8192;

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -373,7 +373,7 @@ s! {
     }
 
     // MIPS implementation is special (see mips arch folders)
-    #[cfg(not(target_arch = "mips"))]
+    #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
     pub struct statfs {
         pub f_type: c_ulong,
         pub f_bsize: c_ulong,
@@ -390,7 +390,7 @@ s! {
     }
 
     // MIPS implementation is special (see mips arch folders)
-    #[cfg(not(target_arch = "mips"))]
+    #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
     pub struct statfs64 {
         pub f_type: c_ulong,
         pub f_bsize: c_ulong,


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

64-bit MIPS has the same special definition as 32-bit MIPS in musl.

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

https://git.musl-libc.org/cgit/musl/tree/arch/mips64/bits/statfs.h

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
