### PR TITLE
musl: mips64: Use special MIPS definition of stack_t

### DIFF
--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -56,6 +56,12 @@ s! {
         __pad5: [c_int; 14],
     }
 
+    pub struct stack_t {
+        pub ss_sp: *mut c_void,
+        pub ss_size: size_t,
+        pub ss_flags: c_int,
+    }
+
     pub struct ipc_perm {
         #[cfg(musl_v1_2_3)]
         pub __key: crate::key_t,

--- a/src/unix/linux_like/linux/musl/b64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/mod.rs
@@ -3,6 +3,8 @@ use crate::prelude::*;
 pub type regoff_t = c_long;
 
 s! {
+    // MIPS implementation is special, see the subfolder.
+    #[cfg(not(target_arch = "mips64"))]
     pub struct stack_t {
         pub ss_sp: *mut c_void,
         pub ss_flags: c_int,


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

stack_t is sigaltstack, which in musl has a special definition for MIPS that switches around ss_size and ss_flags.

The 32-bit definition was already correct.

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

https://git.musl-libc.org/cgit/musl/tree/arch/mips64/bits/signal.h#n67

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
