### PR TITLE
Add `core::mem::{size_of, align_of}` to the prelude

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -3250,20 +3250,20 @@ cfg_if! {
 f! {
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
         return;
     }
@@ -3281,21 +3281,21 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] |= 1 << offset;
         ()
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] &= !(1 << offset);
         ()
     }
 
     pub fn CPU_ISSET(cpu: usize, cpuset: &cpu_set_t) -> bool {
-        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]);
+        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]);
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         0 != (cpuset.bits[idx] & (1 << offset))
     }
@@ -3309,9 +3309,9 @@ f! {
     }
 
     pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        if ((*cmsg).cmsg_len as size_t) < mem::size_of::<cmsghdr>() {
+        if ((*cmsg).cmsg_len as size_t) < size_of::<cmsghdr>() {
             core::ptr::null_mut::<cmsghdr>()
-        } else if __CMSG_NEXT(cmsg).add(mem::size_of::<cmsghdr>()) >= __MHDR_END(mhdr) {
+        } else if __CMSG_NEXT(cmsg).add(size_of::<cmsghdr>()) >= __MHDR_END(mhdr) {
             core::ptr::null_mut::<cmsghdr>()
         } else {
             __CMSG_NEXT(cmsg).cast()
@@ -3319,7 +3319,7 @@ f! {
     }
 
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as size_t >= mem::size_of::<cmsghdr>() {
+        if (*mhdr).msg_controllen as size_t >= size_of::<cmsghdr>() {
             (*mhdr).msg_control.cast()
         } else {
             core::ptr::null_mut::<cmsghdr>()
@@ -3327,15 +3327,15 @@ f! {
     }
 
     pub {const} fn CMSG_ALIGN(len: size_t) -> size_t {
-        (len + mem::size_of::<size_t>() - 1) & !(mem::size_of::<size_t>() - 1)
+        (len + size_of::<size_t>() - 1) & !(size_of::<size_t>() - 1)
     }
 
     pub {const} fn CMSG_SPACE(len: c_uint) -> c_uint {
-        (CMSG_ALIGN(len as size_t) + CMSG_ALIGN(mem::size_of::<cmsghdr>())) as c_uint
+        (CMSG_ALIGN(len as size_t) + CMSG_ALIGN(size_of::<cmsghdr>())) as c_uint
     }
 
     pub {const} fn CMSG_LEN(len: c_uint) -> c_uint {
-        (CMSG_ALIGN(mem::size_of::<cmsghdr>()) + len as size_t) as c_uint
+        (CMSG_ALIGN(size_of::<cmsghdr>()) + len as size_t) as c_uint
     }
 }
 
@@ -3403,8 +3403,8 @@ safe_f! {
 }
 
 fn __CMSG_LEN(cmsg: *const cmsghdr) -> ssize_t {
-    ((unsafe { (*cmsg).cmsg_len as size_t } + mem::size_of::<c_long>() - 1)
-        & !(mem::size_of::<c_long>() - 1)) as ssize_t
+    ((unsafe { (*cmsg).cmsg_len as size_t } + size_of::<c_long>() - 1) & !(size_of::<c_long>() - 1))
+        as ssize_t
 }
 
 fn __CMSG_NEXT(cmsg: *const cmsghdr) -> *mut c_uchar {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -77,6 +77,8 @@ macro_rules! prelude {
             pub(crate) use ::core::option::Option;
             #[allow(unused_imports)]
             pub(crate) use ::core::{fmt, hash, iter, mem};
+            #[allow(unused_imports)]
+            pub(crate) use mem::{align_of, align_of_val, size_of, size_of_val};
 
             // Commonly used types defined in this crate
             #[allow(unused_imports)]

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -160,17 +160,17 @@ cfg_if! {
         // // catch the fact that llvm and gcc disagree on how x64 __int128
         // // is actually *passed* on the stack (clang underaligns it for
         // // the same reason that rustc *never* properly aligns it).
-        // static_assert_eq!(core::mem::size_of::<__int128>(), _SIZE_128);
-        // static_assert_eq!(core::mem::align_of::<__int128>(), _ALIGN_128);
+        // static_assert_eq!(size_of::<__int128>(), _SIZE_128);
+        // static_assert_eq!(align_of::<__int128>(), _ALIGN_128);
 
-        // static_assert_eq!(core::mem::size_of::<__uint128>(), _SIZE_128);
-        // static_assert_eq!(core::mem::align_of::<__uint128>(), _ALIGN_128);
+        // static_assert_eq!(size_of::<__uint128>(), _SIZE_128);
+        // static_assert_eq!(align_of::<__uint128>(), _ALIGN_128);
 
-        // static_assert_eq!(core::mem::size_of::<__int128_t>(), _SIZE_128);
-        // static_assert_eq!(core::mem::align_of::<__int128_t>(), _ALIGN_128);
+        // static_assert_eq!(size_of::<__int128_t>(), _SIZE_128);
+        // static_assert_eq!(align_of::<__int128_t>(), _ALIGN_128);
 
-        // static_assert_eq!(core::mem::size_of::<__uint128_t>(), _SIZE_128);
-        // static_assert_eq!(core::mem::align_of::<__uint128_t>(), _ALIGN_128);
+        // static_assert_eq!(size_of::<__uint128_t>(), _SIZE_128);
+        // static_assert_eq!(align_of::<__uint128_t>(), _ALIGN_128);
     } else if #[cfg(all(
         target_arch = "aarch64",
         any(

--- a/src/teeos/mod.rs
+++ b/src/teeos/mod.rs
@@ -99,7 +99,7 @@ pub struct pthread_attr_t {
 
 #[repr(C)]
 pub struct cpu_set_t {
-    bits: [c_ulong; 128 / core::mem::size_of::<c_ulong>()],
+    bits: [c_ulong; 128 / size_of::<c_ulong>()],
 }
 
 #[repr(C)]
@@ -137,7 +137,7 @@ pub struct mbstate_t {
 
 #[repr(C)]
 pub struct sem_t {
-    pub __val: [c_int; 4 * core::mem::size_of::<c_long>() / core::mem::size_of::<c_int>()],
+    pub __val: [c_int; 4 * size_of::<c_long>() / size_of::<c_int>()],
 }
 
 #[repr(C)]
@@ -1342,7 +1342,7 @@ pub fn errno() -> c_int {
 
 pub fn CPU_COUNT_S(size: usize, cpuset: &cpu_set_t) -> c_int {
     let mut s: u32 = 0;
-    let size_of_mask = core::mem::size_of_val(&cpuset.bits[0]);
+    let size_of_mask = size_of_val(&cpuset.bits[0]);
 
     for i in cpuset.bits[..(size / size_of_mask)].iter() {
         s += i.count_ones();
@@ -1351,5 +1351,5 @@ pub fn CPU_COUNT_S(size: usize, cpuset: &cpu_set_t) -> c_int {
 }
 
 pub fn CPU_COUNT(cpuset: &cpu_set_t) -> c_int {
-    CPU_COUNT_S(core::mem::size_of::<cpu_set_t>(), cpuset)
+    CPU_COUNT_S(size_of::<cpu_set_t>(), cpuset)
 }

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -2433,7 +2433,7 @@ pub const ACCOUNTING: c_short = 9;
 
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= mem::size_of::<cmsghdr>() {
+        if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
             (*mhdr).msg_control as *mut cmsghdr
         } else {
             core::ptr::null_mut::<cmsghdr>()
@@ -2444,7 +2444,7 @@ f! {
         if cmsg.is_null() {
             CMSG_FIRSTHDR(mhdr)
         } else {
-            if (cmsg as usize + (*cmsg).cmsg_len as usize + mem::size_of::<cmsghdr>())
+            if (cmsg as usize + (*cmsg).cmsg_len as usize + size_of::<cmsghdr>())
                 > ((*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize)
             {
                 core::ptr::null_mut::<cmsghdr>()
@@ -2456,15 +2456,15 @@ f! {
     }
 
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(mem::size_of::<cmsghdr>() as isize)
+        (cmsg as *mut c_uchar).offset(size_of::<cmsghdr>() as isize)
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        mem::size_of::<cmsghdr>() as c_uint + length
+        size_of::<cmsghdr>() as c_uint + length
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        mem::size_of::<cmsghdr>() as c_uint + length
+        size_of::<cmsghdr>() as c_uint + length
     }
 
     pub fn FD_ZERO(set: *mut fd_set) -> () {
@@ -2474,21 +2474,21 @@ f! {
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
-        let bits = mem::size_of::<c_long>() * 8;
+        let bits = size_of::<c_long>() * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] |= 1 << (fd % bits);
         return;
     }
 
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
-        let bits = mem::size_of::<c_long>() * 8;
+        let bits = size_of::<c_long>() * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] &= !(1 << (fd % bits));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
-        let bits = mem::size_of::<c_long>() * 8;
+        let bits = size_of::<c_long>() * 8;
         let fd = fd as usize;
         return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0;
     }

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -4470,7 +4470,7 @@ pub const PROC_PIDVNODEPATHINFO: c_int = 9;
 pub const PROC_PIDPATHINFO_MAXSIZE: c_int = 4096;
 
 pub const PROC_PIDLISTFDS: c_int = 1;
-pub const PROC_PIDLISTFD_SIZE: c_int = mem::size_of::<proc_fdinfo>() as c_int;
+pub const PROC_PIDLISTFD_SIZE: c_int = size_of::<proc_fdinfo>() as c_int;
 pub const PROX_FDTYPE_ATALK: c_int = 0;
 pub const PROX_FDTYPE_VNODE: c_int = 1;
 pub const PROX_FDTYPE_SOCKET: c_int = 2;
@@ -4956,48 +4956,42 @@ pub const VMADDR_CID_HOST: c_uint = 2;
 pub const VMADDR_PORT_ANY: c_uint = 0xFFFFFFFF;
 
 const fn __DARWIN_ALIGN32(p: usize) -> usize {
-    const __DARWIN_ALIGNBYTES32: usize = mem::size_of::<u32>() - 1;
+    const __DARWIN_ALIGNBYTES32: usize = size_of::<u32>() - 1;
     (p + __DARWIN_ALIGNBYTES32) & !__DARWIN_ALIGNBYTES32
 }
 
 pub const THREAD_EXTENDED_POLICY_COUNT: mach_msg_type_number_t =
-    (mem::size_of::<thread_extended_policy_data_t>() / mem::size_of::<integer_t>())
-        as mach_msg_type_number_t;
+    (size_of::<thread_extended_policy_data_t>() / size_of::<integer_t>()) as mach_msg_type_number_t;
 pub const THREAD_TIME_CONSTRAINT_POLICY_COUNT: mach_msg_type_number_t =
-    (mem::size_of::<thread_time_constraint_policy_data_t>() / mem::size_of::<integer_t>())
+    (size_of::<thread_time_constraint_policy_data_t>() / size_of::<integer_t>())
         as mach_msg_type_number_t;
 pub const THREAD_PRECEDENCE_POLICY_COUNT: mach_msg_type_number_t =
-    (mem::size_of::<thread_precedence_policy_data_t>() / mem::size_of::<integer_t>())
+    (size_of::<thread_precedence_policy_data_t>() / size_of::<integer_t>())
         as mach_msg_type_number_t;
 pub const THREAD_AFFINITY_POLICY_COUNT: mach_msg_type_number_t =
-    (mem::size_of::<thread_affinity_policy_data_t>() / mem::size_of::<integer_t>())
-        as mach_msg_type_number_t;
+    (size_of::<thread_affinity_policy_data_t>() / size_of::<integer_t>()) as mach_msg_type_number_t;
 pub const THREAD_BACKGROUND_POLICY_COUNT: mach_msg_type_number_t =
-    (mem::size_of::<thread_background_policy_data_t>() / mem::size_of::<integer_t>())
+    (size_of::<thread_background_policy_data_t>() / size_of::<integer_t>())
         as mach_msg_type_number_t;
 pub const THREAD_LATENCY_QOS_POLICY_COUNT: mach_msg_type_number_t =
-    (mem::size_of::<thread_latency_qos_policy_data_t>() / mem::size_of::<integer_t>())
+    (size_of::<thread_latency_qos_policy_data_t>() / size_of::<integer_t>())
         as mach_msg_type_number_t;
 pub const THREAD_THROUGHPUT_QOS_POLICY_COUNT: mach_msg_type_number_t =
-    (mem::size_of::<thread_throughput_qos_policy_data_t>() / mem::size_of::<integer_t>())
+    (size_of::<thread_throughput_qos_policy_data_t>() / size_of::<integer_t>())
         as mach_msg_type_number_t;
 pub const THREAD_BASIC_INFO_COUNT: mach_msg_type_number_t =
-    (mem::size_of::<thread_basic_info_data_t>() / mem::size_of::<integer_t>())
-        as mach_msg_type_number_t;
+    (size_of::<thread_basic_info_data_t>() / size_of::<integer_t>()) as mach_msg_type_number_t;
 pub const THREAD_IDENTIFIER_INFO_COUNT: mach_msg_type_number_t =
-    (mem::size_of::<thread_identifier_info_data_t>() / mem::size_of::<integer_t>())
-        as mach_msg_type_number_t;
+    (size_of::<thread_identifier_info_data_t>() / size_of::<integer_t>()) as mach_msg_type_number_t;
 pub const THREAD_EXTENDED_INFO_COUNT: mach_msg_type_number_t =
-    (mem::size_of::<thread_extended_info_data_t>() / mem::size_of::<integer_t>())
-        as mach_msg_type_number_t;
+    (size_of::<thread_extended_info_data_t>() / size_of::<integer_t>()) as mach_msg_type_number_t;
 
 pub const TASK_THREAD_TIMES_INFO_COUNT: u32 =
-    (mem::size_of::<task_thread_times_info_data_t>() / mem::size_of::<natural_t>()) as u32;
+    (size_of::<task_thread_times_info_data_t>() / size_of::<natural_t>()) as u32;
 pub const MACH_TASK_BASIC_INFO_COUNT: u32 =
-    (mem::size_of::<mach_task_basic_info_data_t>() / mem::size_of::<natural_t>()) as u32;
-pub const HOST_VM_INFO64_COUNT: mach_msg_type_number_t = (mem::size_of::<vm_statistics64_data_t>()
-    / mem::size_of::<integer_t>())
-    as mach_msg_type_number_t;
+    (size_of::<mach_task_basic_info_data_t>() / size_of::<natural_t>()) as u32;
+pub const HOST_VM_INFO64_COUNT: mach_msg_type_number_t =
+    (size_of::<vm_statistics64_data_t>() / size_of::<integer_t>()) as mach_msg_type_number_t;
 
 // bsd/net/if_mib.h
 /// Non-interface-specific
@@ -5036,7 +5030,7 @@ f! {
         let cmsg_len = (*cmsg).cmsg_len as usize;
         let next = cmsg as usize + __DARWIN_ALIGN32(cmsg_len);
         let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
-        if next + __DARWIN_ALIGN32(mem::size_of::<cmsghdr>()) > max {
+        if next + __DARWIN_ALIGN32(size_of::<cmsghdr>()) > max {
             core::ptr::null_mut()
         } else {
             next as *mut cmsghdr
@@ -5044,15 +5038,15 @@ f! {
     }
 
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).add(__DARWIN_ALIGN32(mem::size_of::<cmsghdr>()))
+        (cmsg as *mut c_uchar).add(__DARWIN_ALIGN32(size_of::<cmsghdr>()))
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (__DARWIN_ALIGN32(mem::size_of::<cmsghdr>()) + __DARWIN_ALIGN32(length as usize)) as c_uint
+        (__DARWIN_ALIGN32(size_of::<cmsghdr>()) + __DARWIN_ALIGN32(length as usize)) as c_uint
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        (__DARWIN_ALIGN32(mem::size_of::<cmsghdr>()) + length as usize) as c_uint
+        (__DARWIN_ALIGN32(size_of::<cmsghdr>()) + length as usize) as c_uint
     }
 
     pub {const} fn VM_MAKE_TAG(id: u8) -> u32 {

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -949,7 +949,7 @@ pub const CPUCTL_MSRSBIT: c_int = 0xc0106305;
 pub const CPUCTL_MSRCBIT: c_int = 0xc0106306;
 pub const CPUCTL_CPUID_COUNT: c_int = 0xc0106307;
 
-pub const CPU_SETSIZE: size_t = mem::size_of::<crate::cpumask_t>() * 8;
+pub const CPU_SETSIZE: size_t = size_of::<crate::cpumask_t>() * 8;
 
 pub const EVFILT_READ: i16 = -1;
 pub const EVFILT_WRITE: i16 = -2;
@@ -1421,23 +1421,23 @@ pub const RTAX_MAX: c_int = 11;
 
 const_fn! {
     {const} fn _CMSG_ALIGN(n: usize) -> usize {
-        (n + (mem::size_of::<c_long>() - 1)) & !(mem::size_of::<c_long>() - 1)
+        (n + (size_of::<c_long>() - 1)) & !(size_of::<c_long>() - 1)
     }
 }
 
 f! {
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(_CMSG_ALIGN(mem::size_of::<cmsghdr>()) as isize)
+        (cmsg as *mut c_uchar).offset(_CMSG_ALIGN(size_of::<cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        (_CMSG_ALIGN(mem::size_of::<cmsghdr>()) + length as usize) as c_uint
+        (_CMSG_ALIGN(size_of::<cmsghdr>()) + length as usize) as c_uint
     }
 
     pub fn CMSG_NXTHDR(mhdr: *const crate::msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         let next = cmsg as usize
             + _CMSG_ALIGN((*cmsg).cmsg_len as usize)
-            + _CMSG_ALIGN(mem::size_of::<cmsghdr>());
+            + _CMSG_ALIGN(size_of::<cmsghdr>());
         let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next <= max {
             (cmsg as usize + _CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr
@@ -1447,7 +1447,7 @@ f! {
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (_CMSG_ALIGN(mem::size_of::<cmsghdr>()) + _CMSG_ALIGN(length as usize)) as c_uint
+        (_CMSG_ALIGN(size_of::<cmsghdr>()) + _CMSG_ALIGN(length as usize)) as c_uint
     }
 
     pub fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {

--- a/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
@@ -33,7 +33,7 @@ s_no_extra_traits! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_longlong>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_longlong>() - 1;
 
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {

--- a/src/unix/bsd/freebsdlike/freebsd/arm.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/arm.rs
@@ -43,7 +43,7 @@ cfg_if! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_int>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_int>() - 1;
 
 pub const BIOCSRTIMEOUT: c_ulong = 0x8010426d;
 pub const BIOCGRTIMEOUT: c_ulong = 0x4010426e;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -4700,19 +4700,18 @@ const_fn! {
 
 f! {
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).add(_ALIGN(mem::size_of::<cmsghdr>()))
+        (cmsg as *mut c_uchar).add(_ALIGN(size_of::<cmsghdr>()))
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        _ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
+        _ALIGN(size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub fn CMSG_NXTHDR(mhdr: *const crate::msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         if cmsg.is_null() {
             return crate::CMSG_FIRSTHDR(mhdr);
         }
-        let next =
-            cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize) + _ALIGN(mem::size_of::<cmsghdr>());
+        let next = cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize) + _ALIGN(size_of::<cmsghdr>());
         let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next > max {
             core::ptr::null_mut::<cmsghdr>()
@@ -4722,7 +4721,7 @@ f! {
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (_ALIGN(mem::size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
+        (_ALIGN(size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
     }
 
     pub fn MALLOCX_ALIGN(lg: c_uint) -> c_int {
@@ -4739,7 +4738,7 @@ f! {
 
     pub fn SOCKCREDSIZE(ngrps: usize) -> usize {
         let ngrps = if ngrps > 0 { ngrps - 1 } else { 0 };
-        mem::size_of::<sockcred>() + mem::size_of::<crate::gid_t>() * ngrps
+        size_of::<sockcred>() + size_of::<crate::gid_t>() * ngrps
     }
 
     pub fn uname(buf: *mut crate::utsname) -> c_int {
@@ -4759,27 +4758,27 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpuset_t) -> () {
-        let bitset_bits = 8 * mem::size_of::<c_long>();
+        let bitset_bits = 8 * size_of::<c_long>();
         let (idx, offset) = (cpu / bitset_bits, cpu % bitset_bits);
         cpuset.__bits[idx] |= 1 << offset;
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpuset_t) -> () {
-        let bitset_bits = 8 * mem::size_of::<c_long>();
+        let bitset_bits = 8 * size_of::<c_long>();
         let (idx, offset) = (cpu / bitset_bits, cpu % bitset_bits);
         cpuset.__bits[idx] &= !(1 << offset);
     }
 
     pub fn CPU_ISSET(cpu: usize, cpuset: &cpuset_t) -> bool {
-        let bitset_bits = 8 * mem::size_of::<c_long>();
+        let bitset_bits = 8 * size_of::<c_long>();
         let (idx, offset) = (cpu / bitset_bits, cpu % bitset_bits);
         0 != cpuset.__bits[idx] & (1 << offset)
     }
 
     pub fn CPU_COUNT(cpuset: &cpuset_t) -> c_int {
         let mut s: u32 = 0;
-        let cpuset_size = mem::size_of::<cpuset_t>();
-        let bitset_size = mem::size_of::<c_long>();
+        let cpuset_size = size_of::<cpuset_t>();
+        let bitset_size = size_of::<c_long>();
 
         for i in cpuset.__bits[..(cpuset_size / bitset_size)].iter() {
             s += i.count_ones();
@@ -4789,7 +4788,7 @@ f! {
 
     pub fn SOCKCRED2SIZE(ngrps: usize) -> usize {
         let ngrps = if ngrps > 0 { ngrps - 1 } else { 0 };
-        mem::size_of::<sockcred2>() + mem::size_of::<crate::gid_t>() * ngrps
+        size_of::<sockcred2>() + size_of::<crate::gid_t>() * ngrps
     }
 
     pub fn PROT_MAX(x: c_int) -> c_int {

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
@@ -53,7 +53,7 @@ cfg_if! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_int>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_int>() - 1;
 
 pub const BIOCSRTIMEOUT: c_ulong = 0x8010426d;
 pub const BIOCGRTIMEOUT: c_ulong = 0x4010426e;

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
@@ -53,7 +53,7 @@ cfg_if! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
 
 pub const BIOCSRTIMEOUT: c_ulong = 0x8010426d;
 pub const BIOCGRTIMEOUT: c_ulong = 0x4010426e;

--- a/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
@@ -107,7 +107,7 @@ cfg_if! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_longlong>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_longlong>() - 1;
 
 pub const BIOCSRTIMEOUT: c_ulong = 0x8010426d;
 pub const BIOCGRTIMEOUT: c_ulong = 0x4010426e;

--- a/src/unix/bsd/freebsdlike/freebsd/x86.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86.rs
@@ -42,7 +42,7 @@ s_no_extra_traits! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
 
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -317,7 +317,7 @@ cfg_if! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
 
 pub const BIOCSRTIMEOUT: c_ulong = 0x8010426d;
 pub const BIOCGRTIMEOUT: c_ulong = 0x4010426e;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -427,7 +427,7 @@ cfg_if! {
 }
 
 // Non-public helper constant
-const SIZEOF_LONG: usize = mem::size_of::<c_long>();
+const SIZEOF_LONG: usize = size_of::<c_long>();
 
 #[deprecated(
     since = "0.2.64",

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -573,7 +573,7 @@ pub const RTAX_BRD: c_int = 7;
 
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const crate::msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= mem::size_of::<cmsghdr>() {
+        if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
             (*mhdr).msg_control.cast::<cmsghdr>()
         } else {
             core::ptr::null_mut()
@@ -581,20 +581,20 @@ f! {
     }
 
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
-        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] &= !(1 << (fd % bits));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
-        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
-        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] |= 1 << (fd % bits);
         return;

--- a/src/unix/bsd/netbsdlike/netbsd/aarch64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/aarch64.rs
@@ -65,7 +65,7 @@ cfg_if! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_int>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_int>() - 1;
 
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 0;
 pub const PT_SETREGS: c_int = PT_FIRSTMACH + 1;

--- a/src/unix/bsd/netbsdlike/netbsd/arm.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/arm.rs
@@ -3,7 +3,7 @@ use crate::PT_FIRSTMACH;
 
 pub type __cpu_simple_lock_nv_t = c_int;
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_longlong>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_longlong>() - 1;
 
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 1;
 pub const PT_SETREGS: c_int = PT_FIRSTMACH + 2;

--- a/src/unix/bsd/netbsdlike/netbsd/mips.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mips.rs
@@ -3,7 +3,7 @@ use crate::PT_FIRSTMACH;
 
 pub type __cpu_simple_lock_nv_t = c_int;
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_longlong>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_longlong>() - 1;
 
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 1;
 pub const PT_SETREGS: c_int = PT_FIRSTMACH + 2;

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2285,19 +2285,18 @@ const_fn! {
 
 f! {
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).add(_ALIGN(mem::size_of::<cmsghdr>()))
+        (cmsg as *mut c_uchar).add(_ALIGN(size_of::<cmsghdr>()))
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        _ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
+        _ALIGN(size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub fn CMSG_NXTHDR(mhdr: *const crate::msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         if cmsg.is_null() {
             return crate::CMSG_FIRSTHDR(mhdr);
         }
-        let next =
-            cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize) + _ALIGN(mem::size_of::<cmsghdr>());
+        let next = cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize) + _ALIGN(size_of::<cmsghdr>());
         let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next > max {
             core::ptr::null_mut::<cmsghdr>()
@@ -2307,7 +2306,7 @@ f! {
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (_ALIGN(mem::size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
+        (_ALIGN(size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
     }
 
     // dirfd() is a macro on netbsd to access
@@ -2319,7 +2318,7 @@ f! {
 
     pub fn SOCKCREDSIZE(ngrps: usize) -> usize {
         let ngrps = if ngrps > 0 { ngrps - 1 } else { 0 };
-        mem::size_of::<sockcred>() + mem::size_of::<crate::gid_t>() * ngrps
+        size_of::<sockcred>() + size_of::<crate::gid_t>() * ngrps
     }
 
     pub fn PROT_MPROTECT(x: c_int) -> c_int {

--- a/src/unix/bsd/netbsdlike/netbsd/powerpc.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/powerpc.rs
@@ -3,7 +3,7 @@ use crate::PT_FIRSTMACH;
 
 pub type __cpu_simple_lock_nv_t = c_int;
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_double>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_double>() - 1;
 
 pub const PT_STEP: c_int = PT_FIRSTMACH + 0;
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 1;

--- a/src/unix/bsd/netbsdlike/netbsd/riscv64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/riscv64.rs
@@ -22,7 +22,7 @@ s_no_extra_traits! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
 
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 0;
 pub const PT_SETREGS: c_int = PT_FIRSTMACH + 1;

--- a/src/unix/bsd/netbsdlike/netbsd/x86.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/x86.rs
@@ -2,4 +2,4 @@ use crate::prelude::*;
 
 pub type __cpu_simple_lock_nv_t = c_uchar;
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_int>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_int>() - 1;

--- a/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
@@ -20,7 +20,7 @@ s! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
 
 pub const PT_STEP: c_int = PT_FIRSTMACH + 0;
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 1;

--- a/src/unix/bsd/netbsdlike/openbsd/aarch64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/aarch64.rs
@@ -15,6 +15,6 @@ s! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
 
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/arm.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/arm.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_double>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_double>() - 1;
 
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1616,7 +1616,7 @@ pub const NTFS_MFLAG_ALLNAMES: c_int = 0x2;
 pub const TMPFS_ARGS_VERSION: c_int = 1;
 
 const SI_MAXSZ: size_t = 128;
-const SI_PAD: size_t = (SI_MAXSZ / mem::size_of::<c_int>()) - 3;
+const SI_PAD: size_t = (SI_MAXSZ / size_of::<c_int>()) - 3;
 
 pub const MAP_STACK: c_int = 0x4000;
 pub const MAP_CONCEAL: c_int = 0x8000;
@@ -1842,19 +1842,18 @@ const_fn! {
 
 f! {
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(_ALIGN(mem::size_of::<cmsghdr>()) as isize)
+        (cmsg as *mut c_uchar).offset(_ALIGN(size_of::<cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        _ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
+        _ALIGN(size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub fn CMSG_NXTHDR(mhdr: *const crate::msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         if cmsg.is_null() {
             return crate::CMSG_FIRSTHDR(mhdr);
         }
-        let next =
-            cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize) + _ALIGN(mem::size_of::<cmsghdr>());
+        let next = cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize) + _ALIGN(size_of::<cmsghdr>());
         let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next > max {
             core::ptr::null_mut::<cmsghdr>()
@@ -1864,7 +1863,7 @@ f! {
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (_ALIGN(mem::size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
+        (_ALIGN(size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
     }
 }
 

--- a/src/unix/bsd/netbsdlike/openbsd/powerpc.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/powerpc.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_double>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_double>() - 1;
 
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/powerpc64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/powerpc64.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
 
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/riscv64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/riscv64.rs
@@ -20,6 +20,6 @@ s! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
 
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/x86.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/x86.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_int>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_int>() - 1;
 
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/x86_64.rs
@@ -98,7 +98,7 @@ cfg_if! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = mem::size_of::<c_long>() - 1;
+pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
 
 pub const _MAX_PAGE_SHIFT: u32 = 12;
 

--- a/src/unix/cygwin/mod.rs
+++ b/src/unix/cygwin/mod.rs
@@ -272,7 +272,7 @@ s! {
     }
 
     pub struct fd_set {
-        fds_bits: [fd_mask; FD_SETSIZE / core::mem::size_of::<c_ulong>() / 8],
+        fds_bits: [fd_mask; FD_SETSIZE / size_of::<c_ulong>() / 8],
     }
 
     pub struct _uc_fpxreg {
@@ -1774,19 +1774,19 @@ pub const FALLOC_FL_KEEP_SIZE: c_int = 0x1000;
 f! {
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = core::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
-        let size = core::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = core::mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
     }
 
@@ -1798,13 +1798,13 @@ f! {
 
     pub fn CPU_ALLOC_SIZE(count: c_int) -> size_t {
         let _dummy: cpu_set_t = cpu_set_t { bits: [0; 16] };
-        let size_in_bits = 8 * core::mem::size_of_val(&_dummy.bits[0]);
+        let size_in_bits = 8 * size_of_val(&_dummy.bits[0]);
         ((count as size_t + size_in_bits - 1) / 8) as size_t
     }
 
     pub fn CPU_COUNT_S(size: usize, cpuset: &cpu_set_t) -> c_int {
         let mut s: u32 = 0;
-        let size_of_mask = core::mem::size_of_val(&cpuset.bits[0]);
+        let size_of_mask = size_of_val(&cpuset.bits[0]);
         for i in cpuset.bits[..(size / size_of_mask)].iter() {
             s += i.count_ones();
         }
@@ -1817,7 +1817,7 @@ f! {
         }
     }
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * core::mem::size_of_val(&cpuset.bits[0]);
+        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]);
         if cpu < size_in_bits {
             let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
             cpuset.bits[idx] |= 1 << offset;
@@ -1825,7 +1825,7 @@ f! {
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * core::mem::size_of_val(&cpuset.bits[0]);
+        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]);
         if cpu < size_in_bits {
             let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
             cpuset.bits[idx] &= !(1 << offset);
@@ -1833,7 +1833,7 @@ f! {
     }
 
     pub fn CPU_ISSET(cpu: usize, cpuset: &cpu_set_t) -> bool {
-        let size_in_bits = 8 * core::mem::size_of_val(&cpuset.bits[0]);
+        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]);
         if cpu < size_in_bits {
             let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
             0 != (cpuset.bits[idx] & (1 << offset))
@@ -1843,7 +1843,7 @@ f! {
     }
 
     pub fn CPU_COUNT(cpuset: &cpu_set_t) -> c_int {
-        CPU_COUNT_S(::core::mem::size_of::<cpu_set_t>(), cpuset)
+        CPU_COUNT_S(size_of::<cpu_set_t>(), cpuset)
     }
 
     pub fn CPU_EQUAL(set1: &cpu_set_t, set2: &cpu_set_t) -> bool {
@@ -1851,15 +1851,15 @@ f! {
     }
 
     pub fn CMSG_LEN(length: c_uint) -> c_uint {
-        CMSG_ALIGN(::core::mem::size_of::<cmsghdr>()) as c_uint + length
+        CMSG_ALIGN(size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(::core::mem::size_of::<cmsghdr>())) as c_uint
+        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(size_of::<cmsghdr>())) as c_uint
     }
 
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= core::mem::size_of::<cmsghdr>() {
+        if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
             (*mhdr).msg_control.cast()
         } else {
             core::ptr::null_mut()
@@ -1869,7 +1869,7 @@ f! {
     pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         let next = (cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr;
         let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
-        if next as usize + CMSG_ALIGN(::core::mem::size_of::<cmsghdr>()) as usize > max {
+        if next as usize + CMSG_ALIGN(size_of::<cmsghdr>()) as usize > max {
             core::ptr::null_mut()
         } else {
             next
@@ -1931,7 +1931,7 @@ safe_f! {
 
 const_fn! {
     {const} fn CMSG_ALIGN(len: usize) -> usize {
-        len + core::mem::size_of::<usize>() - 1 & !(::core::mem::size_of::<usize>() - 1)
+        len + size_of::<usize>() - 1 & !(size_of::<usize>() - 1)
     }
 }
 

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -1503,13 +1503,13 @@ pub const POSIX_SPAWN_SETSID: c_short = 0x40;
 
 const_fn! {
     {const} fn CMSG_ALIGN(len: usize) -> usize {
-        len + mem::size_of::<usize>() - 1 & !(mem::size_of::<usize>() - 1)
+        len + size_of::<usize>() - 1 & !(size_of::<usize>() - 1)
     }
 }
 
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= mem::size_of::<cmsghdr>() {
+        if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
             (*mhdr).msg_control as *mut cmsghdr
         } else {
             core::ptr::null_mut::<cmsghdr>()
@@ -1517,15 +1517,15 @@ f! {
     }
 
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(CMSG_ALIGN(mem::size_of::<cmsghdr>()) as isize)
+        (cmsg as *mut c_uchar).offset(CMSG_ALIGN(size_of::<cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(mem::size_of::<cmsghdr>())) as c_uint
+        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(size_of::<cmsghdr>())) as c_uint
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        CMSG_ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
+        CMSG_ALIGN(size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
@@ -1534,7 +1534,7 @@ f! {
         }
         let next = cmsg as usize
             + CMSG_ALIGN((*cmsg).cmsg_len as usize)
-            + CMSG_ALIGN(mem::size_of::<cmsghdr>());
+            + CMSG_ALIGN(size_of::<cmsghdr>());
         let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next > max {
             core::ptr::null_mut::<cmsghdr>()
@@ -1545,20 +1545,20 @@ f! {
 
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
         return;
     }

--- a/src/unix/haiku/native.rs
+++ b/src/unix/haiku/native.rs
@@ -1298,17 +1298,12 @@ extern "C" {
 // The following functions are defined as macros in C/C++
 #[inline]
 pub unsafe fn get_cpu_info(firstCPU: u32, cpuCount: u32, info: *mut cpu_info) -> status_t {
-    _get_cpu_info_etc(
-        firstCPU,
-        cpuCount,
-        info,
-        core::mem::size_of::<cpu_info>() as size_t,
-    )
+    _get_cpu_info_etc(firstCPU, cpuCount, info, size_of::<cpu_info>() as size_t)
 }
 
 #[inline]
 pub unsafe fn get_area_info(id: area_id, info: *mut area_info) -> status_t {
-    _get_area_info(id, info, core::mem::size_of::<area_info>() as usize)
+    _get_area_info(id, info, size_of::<area_info>() as usize)
 }
 
 #[inline]
@@ -1317,17 +1312,12 @@ pub unsafe fn get_next_area_info(
     cookie: *mut isize,
     info: *mut area_info,
 ) -> status_t {
-    _get_next_area_info(
-        team,
-        cookie,
-        info,
-        core::mem::size_of::<area_info>() as usize,
-    )
+    _get_next_area_info(team, cookie, info, size_of::<area_info>() as usize)
 }
 
 #[inline]
 pub unsafe fn get_port_info(port: port_id, buf: *mut port_info) -> status_t {
-    _get_port_info(port, buf, core::mem::size_of::<port_info>() as size_t)
+    _get_port_info(port, buf, size_of::<port_info>() as size_t)
 }
 
 #[inline]
@@ -1336,12 +1326,7 @@ pub unsafe fn get_next_port_info(
     cookie: *mut i32,
     portInfo: *mut port_info,
 ) -> status_t {
-    _get_next_port_info(
-        port,
-        cookie,
-        portInfo,
-        core::mem::size_of::<port_info>() as size_t,
-    )
+    _get_next_port_info(port, cookie, portInfo, size_of::<port_info>() as size_t)
 }
 
 #[inline]
@@ -1354,7 +1339,7 @@ pub unsafe fn get_port_message_info_etc(
     _get_port_message_info_etc(
         port,
         info,
-        core::mem::size_of::<port_message_info>() as size_t,
+        size_of::<port_message_info>() as size_t,
         flags,
         timeout,
     )
@@ -1362,42 +1347,32 @@ pub unsafe fn get_port_message_info_etc(
 
 #[inline]
 pub unsafe fn get_sem_info(id: sem_id, info: *mut sem_info) -> status_t {
-    _get_sem_info(id, info, core::mem::size_of::<sem_info>() as size_t)
+    _get_sem_info(id, info, size_of::<sem_info>() as size_t)
 }
 
 #[inline]
 pub unsafe fn get_next_sem_info(team: team_id, cookie: *mut i32, info: *mut sem_info) -> status_t {
-    _get_next_sem_info(
-        team,
-        cookie,
-        info,
-        core::mem::size_of::<sem_info>() as size_t,
-    )
+    _get_next_sem_info(team, cookie, info, size_of::<sem_info>() as size_t)
 }
 
 #[inline]
 pub unsafe fn get_team_info(team: team_id, info: *mut team_info) -> status_t {
-    _get_team_info(team, info, core::mem::size_of::<team_info>() as size_t)
+    _get_team_info(team, info, size_of::<team_info>() as size_t)
 }
 
 #[inline]
 pub unsafe fn get_next_team_info(cookie: *mut i32, info: *mut team_info) -> status_t {
-    _get_next_team_info(cookie, info, core::mem::size_of::<team_info>() as size_t)
+    _get_next_team_info(cookie, info, size_of::<team_info>() as size_t)
 }
 
 #[inline]
 pub unsafe fn get_team_usage_info(team: team_id, who: i32, info: *mut team_usage_info) -> status_t {
-    _get_team_usage_info(
-        team,
-        who,
-        info,
-        core::mem::size_of::<team_usage_info>() as size_t,
-    )
+    _get_team_usage_info(team, who, info, size_of::<team_usage_info>() as size_t)
 }
 
 #[inline]
 pub unsafe fn get_thread_info(id: thread_id, info: *mut thread_info) -> status_t {
-    _get_thread_info(id, info, core::mem::size_of::<thread_info>() as size_t)
+    _get_thread_info(id, info, size_of::<thread_info>() as size_t)
 }
 
 #[inline]
@@ -1406,18 +1381,13 @@ pub unsafe fn get_next_thread_info(
     cookie: *mut i32,
     info: *mut thread_info,
 ) -> status_t {
-    _get_next_thread_info(
-        team,
-        cookie,
-        info,
-        core::mem::size_of::<thread_info>() as size_t,
-    )
+    _get_next_thread_info(team, cookie, info, size_of::<thread_info>() as size_t)
 }
 
 // kernel/image.h
 #[inline]
 pub unsafe fn get_image_info(image: image_id, info: *mut image_info) -> status_t {
-    _get_image_info(image, info, core::mem::size_of::<image_info>() as size_t)
+    _get_image_info(image, info, size_of::<image_info>() as size_t)
 }
 
 #[inline]
@@ -1426,10 +1396,5 @@ pub unsafe fn get_next_image_info(
     cookie: *mut i32,
     info: *mut image_info,
 ) -> status_t {
-    _get_next_image_info(
-        team,
-        cookie,
-        info,
-        core::mem::size_of::<image_info>() as size_t,
-    )
+    _get_next_image_info(team, cookie, info, size_of::<image_info>() as size_t)
 }

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -3416,14 +3416,14 @@ const _UTSNAME_LENGTH: usize = 1024;
 
 const_fn! {
     {const} fn CMSG_ALIGN(len: usize) -> usize {
-        (len + mem::size_of::<usize>() - 1) & !(mem::size_of::<usize>() - 1)
+        (len + size_of::<usize>() - 1) & !(size_of::<usize>() - 1)
     }
 }
 
 // functions
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= mem::size_of::<cmsghdr>() {
+        if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
             (*mhdr).msg_control.cast::<cmsghdr>()
         } else {
             core::ptr::null_mut::<cmsghdr>()
@@ -3431,19 +3431,19 @@ f! {
     }
 
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(CMSG_ALIGN(mem::size_of::<cmsghdr>()) as isize)
+        (cmsg as *mut c_uchar).offset(CMSG_ALIGN(size_of::<cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(mem::size_of::<cmsghdr>())) as c_uint
+        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(size_of::<cmsghdr>())) as c_uint
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        CMSG_ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
+        CMSG_ALIGN(size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        if ((*cmsg).cmsg_len as usize) < mem::size_of::<cmsghdr>() {
+        if ((*cmsg).cmsg_len as usize) < size_of::<cmsghdr>() {
             return core::ptr::null_mut::<cmsghdr>();
         }
         let next = (cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr;
@@ -3459,7 +3459,7 @@ f! {
 
     pub fn CPU_ALLOC_SIZE(count: c_int) -> size_t {
         let _dummy: cpu_set_t = mem::zeroed();
-        let size_in_bits = 8 * mem::size_of_val(&_dummy.bits[0]);
+        let size_in_bits = 8 * size_of_val(&_dummy.bits[0]);
         ((count as size_t + size_in_bits - 1) / 8) as size_t
     }
 
@@ -3470,26 +3470,26 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] |= 1 << offset;
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] &= !(1 << offset);
     }
 
     pub fn CPU_ISSET(cpu: usize, cpuset: &cpu_set_t) -> bool {
-        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]);
+        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]);
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         0 != (cpuset.bits[idx] & (1 << offset))
     }
 
     pub fn CPU_COUNT_S(size: usize, cpuset: &cpu_set_t) -> c_int {
         let mut s: u32 = 0;
-        let size_of_mask = mem::size_of_val(&cpuset.bits[0]);
+        let size_of_mask = size_of_val(&cpuset.bits[0]);
         for i in cpuset.bits[..(size / size_of_mask)].iter() {
             s += i.count_ones();
         }
@@ -3497,7 +3497,7 @@ f! {
     }
 
     pub fn CPU_COUNT(cpuset: &cpu_set_t) -> c_int {
-        CPU_COUNT_S(mem::size_of::<cpu_set_t>(), cpuset)
+        CPU_COUNT_S(size_of::<cpu_set_t>(), cpuset)
     }
 
     pub fn CPU_EQUAL(set1: &cpu_set_t, set2: &cpu_set_t) -> bool {
@@ -3514,20 +3514,20 @@ f! {
 
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
         return;
     }

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -3369,7 +3369,7 @@ f! {
 
     pub fn CPU_ALLOC_SIZE(count: c_int) -> size_t {
         let _dummy: cpu_set_t = mem::zeroed();
-        let size_in_bits = 8 * mem::size_of_val(&_dummy.__bits[0]);
+        let size_in_bits = 8 * size_of_val(&_dummy.__bits[0]);
         ((count as size_t + size_in_bits - 1) / 8) as size_t
     }
 
@@ -3380,28 +3380,28 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * mem::size_of_val(&cpuset.__bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * size_of_val(&cpuset.__bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.__bits[idx] |= 1 << offset;
         ()
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * mem::size_of_val(&cpuset.__bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * size_of_val(&cpuset.__bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.__bits[idx] &= !(1 << offset);
         ()
     }
 
     pub fn CPU_ISSET(cpu: usize, cpuset: &cpu_set_t) -> bool {
-        let size_in_bits = 8 * mem::size_of_val(&cpuset.__bits[0]);
+        let size_in_bits = 8 * size_of_val(&cpuset.__bits[0]);
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         0 != (cpuset.__bits[idx] & (1 << offset))
     }
 
     pub fn CPU_COUNT_S(size: usize, cpuset: &cpu_set_t) -> c_int {
         let mut s: u32 = 0;
-        let size_of_mask = mem::size_of_val(&cpuset.__bits[0]);
+        let size_of_mask = size_of_val(&cpuset.__bits[0]);
         for i in cpuset.__bits[..(size / size_of_mask)].iter() {
             s += i.count_ones();
         }
@@ -3409,7 +3409,7 @@ f! {
     }
 
     pub fn CPU_COUNT(cpuset: &cpu_set_t) -> c_int {
-        CPU_COUNT_S(mem::size_of::<cpu_set_t>(), cpuset)
+        CPU_COUNT_S(size_of::<cpu_set_t>(), cpuset)
     }
 
     pub fn CPU_EQUAL(set1: &cpu_set_t, set2: &cpu_set_t) -> bool {

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1365,7 +1365,7 @@ pub const SOMAXCONN: c_int = 128;
 
 f! {
     pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        if ((*cmsg).cmsg_len as usize) < mem::size_of::<cmsghdr>() {
+        if ((*cmsg).cmsg_len as usize) < size_of::<cmsghdr>() {
             return core::ptr::null_mut::<cmsghdr>();
         }
         let next = (cmsg as usize + super::CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr;
@@ -1384,21 +1384,21 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] |= 1 << offset;
         ()
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] &= !(1 << offset);
         ()
     }
 
     pub fn CPU_ISSET(cpu: usize, cpuset: &cpu_set_t) -> bool {
-        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]);
+        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]);
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         0 != (cpuset.bits[idx] & (1 << offset))
     }

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1,7 +1,5 @@
 //! Linux-specific definitions for linux-like values
 
-use core::mem::size_of;
-
 use crate::prelude::*;
 use crate::{sock_filter, _IO, _IOR, _IOW, _IOWR};
 
@@ -5929,7 +5927,7 @@ f! {
 
     pub fn CPU_ALLOC_SIZE(count: c_int) -> size_t {
         let _dummy: cpu_set_t = mem::zeroed();
-        let size_in_bits = 8 * mem::size_of_val(&_dummy.bits[0]);
+        let size_in_bits = 8 * size_of_val(&_dummy.bits[0]);
         ((count as size_t + size_in_bits - 1) / 8) as size_t
     }
 
@@ -5940,26 +5938,26 @@ f! {
     }
 
     pub fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] |= 1 << offset;
     }
 
     pub fn CPU_CLR(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         cpuset.bits[idx] &= !(1 << offset);
     }
 
     pub fn CPU_ISSET(cpu: usize, cpuset: &cpu_set_t) -> bool {
-        let size_in_bits = 8 * mem::size_of_val(&cpuset.bits[0]);
+        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]);
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
         0 != (cpuset.bits[idx] & (1 << offset))
     }
 
     pub fn CPU_COUNT_S(size: usize, cpuset: &cpu_set_t) -> c_int {
         let mut s: u32 = 0;
-        let size_of_mask = mem::size_of_val(&cpuset.bits[0]);
+        let size_of_mask = size_of_val(&cpuset.bits[0]);
         for i in &cpuset.bits[..(size / size_of_mask)] {
             s += i.count_ones();
         }

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -95,8 +95,11 @@ s! {
 }
 
 pub const MADV_SOFT_OFFLINE: c_int = 101;
-#[deprecated(since = "0.2.175", note = "Linux does not define MAP_32BIT on any architectures \
-    other than x86 and x86_64, this constant will be removed in the future")]
+#[deprecated(
+    since = "0.2.175",
+    note = "Linux does not define MAP_32BIT on any architectures \
+    other than x86 and x86_64, this constant will be removed in the future"
+)]
 pub const MAP_32BIT: c_int = 0x0040;
 pub const O_APPEND: c_int = 1024;
 pub const O_DIRECT: c_int = 0x20000;

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -422,7 +422,7 @@ s_no_extra_traits! {
         pub aio_offset: off_t,
         __next: *mut c_void,
         __prev: *mut c_void,
-        // FIXME(ctest): length should be `32 - 2 * core::mem::size_of::<*const ()>()`
+        // FIXME(ctest): length should be `32 - 2 * size_of::<*const ()>()`
         #[cfg(target_pointer_width = "32")]
         __dummy4: [c_char; 24],
         #[cfg(target_pointer_width = "64")]

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1764,17 +1764,17 @@ cfg_if! {
 
         /// Build an ioctl number for an read-only ioctl.
         pub const fn _IOR<T>(ty: u32, nr: u32) -> Ioctl {
-            _IOC(_IOC_READ, ty, nr, mem::size_of::<T>())
+            _IOC(_IOC_READ, ty, nr, size_of::<T>())
         }
 
         /// Build an ioctl number for an write-only ioctl.
         pub const fn _IOW<T>(ty: u32, nr: u32) -> Ioctl {
-            _IOC(_IOC_WRITE, ty, nr, mem::size_of::<T>())
+            _IOC(_IOC_WRITE, ty, nr, size_of::<T>())
         }
 
         /// Build an ioctl number for a read-write ioctl.
         pub const fn _IOWR<T>(ty: u32, nr: u32) -> Ioctl {
-            _IOC(_IOC_READ | _IOC_WRITE, ty, nr, mem::size_of::<T>())
+            _IOC(_IOC_READ | _IOC_WRITE, ty, nr, size_of::<T>())
         }
 
         extern "C" {
@@ -1786,13 +1786,13 @@ cfg_if! {
 
 const_fn! {
     {const} fn CMSG_ALIGN(len: usize) -> usize {
-        (len + mem::size_of::<usize>() - 1) & !(mem::size_of::<usize>() - 1)
+        (len + size_of::<usize>() - 1) & !(size_of::<usize>() - 1)
     }
 }
 
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= mem::size_of::<cmsghdr>() {
+        if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
             (*mhdr).msg_control.cast::<cmsghdr>()
         } else {
             core::ptr::null_mut::<cmsghdr>()
@@ -1804,29 +1804,29 @@ f! {
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(mem::size_of::<cmsghdr>())) as c_uint
+        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(size_of::<cmsghdr>())) as c_uint
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        CMSG_ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
+        CMSG_ALIGN(size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
         return;
     }

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -836,20 +836,20 @@ pub const PRIO_USER: c_int = 2;
 
 f! {
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
-        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] &= !(1 << (fd % bits));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
-        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
-        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] |= 1 << (fd % bits);
         return;

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -2309,7 +2309,7 @@ pub const BIOCSHDRCMPLT: c_int = -2147204491;
 pub const BIOCSRTIMEOUT: c_int = -2146418067;
 pub const BIOCVERSION: c_int = 1074020977;
 
-pub const BPF_ALIGNMENT: usize = mem::size_of::<c_long>();
+pub const BPF_ALIGNMENT: usize = size_of::<c_long>();
 pub const CHAR_BIT: usize = 8;
 pub const CODESET: crate::nl_item = 1;
 pub const CRNCYSTR: crate::nl_item = 55;
@@ -2480,7 +2480,7 @@ pub const SIGEV_NONE: c_int = 0;
 pub const SIGEV_SIGNAL: c_int = 129;
 pub const SIGEV_THREAD: c_int = 135;
 pub const SO_USELOOPBACK: c_int = 0x0040;
-pub const _SS_ALIGNSIZE: usize = mem::size_of::<i64>();
+pub const _SS_ALIGNSIZE: usize = size_of::<i64>();
 pub const _SS_MAXSIZE: usize = 128;
 pub const _SS_PAD1SIZE: usize = _SS_ALIGNSIZE - 2;
 pub const _SS_PAD2SIZE: usize = _SS_MAXSIZE - 2 - _SS_PAD1SIZE - _SS_ALIGNSIZE;
@@ -2608,7 +2608,7 @@ pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
 
 const_fn! {
     {const} fn _CMSG_ALIGN(len: usize) -> usize {
-        len + mem::size_of::<usize>() - 1 & !(mem::size_of::<usize>() - 1)
+        len + size_of::<usize>() - 1 & !(size_of::<usize>() - 1)
     }
 
     {const} fn _ALIGN(p: usize, b: usize) -> usize {
@@ -2618,7 +2618,7 @@ const_fn! {
 
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= mem::size_of::<cmsghdr>() {
+        if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
             (*mhdr).msg_control as *mut cmsghdr
         } else {
             core::ptr::null_mut::<cmsghdr>()
@@ -2627,7 +2627,7 @@ f! {
 
     pub fn CMSG_NXTHDR(mhdr: *const crate::msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         let msg = _CMSG_ALIGN((*cmsg).cmsg_len as usize);
-        let next = cmsg as usize + msg + _CMSG_ALIGN(mem::size_of::<cmsghdr>());
+        let next = cmsg as usize + msg + _CMSG_ALIGN(size_of::<cmsghdr>());
         if next > (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize {
             core::ptr::null_mut::<cmsghdr>()
         } else {
@@ -2636,33 +2636,33 @@ f! {
     }
 
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(_CMSG_ALIGN(mem::size_of::<cmsghdr>()) as isize)
+        (cmsg as *mut c_uchar).offset(_CMSG_ALIGN(size_of::<cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        _CMSG_ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
+        _CMSG_ALIGN(size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (_CMSG_ALIGN(mem::size_of::<cmsghdr>()) + _CMSG_ALIGN(length as usize)) as c_uint
+        (_CMSG_ALIGN(size_of::<cmsghdr>()) + _CMSG_ALIGN(length as usize)) as c_uint
     }
 
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
         return;
     }
@@ -2681,7 +2681,7 @@ f! {
     }
 
     pub fn _DEXTRA_VALID(_x: *const crate::dirent_extra, _d: *const dirent) -> bool {
-        let sz = _x as usize - _d as usize + mem::size_of::<crate::dirent_extra>();
+        let sz = _x as usize - _d as usize + size_of::<crate::dirent_extra>();
         let rsz = (*_d).d_reclen as usize;
 
         if sz > rsz || sz + (*_x).d_datalen as usize > rsz {
@@ -2693,14 +2693,14 @@ f! {
 
     pub fn _DEXTRA_NEXT(_x: *const crate::dirent_extra) -> *mut crate::dirent_extra {
         _ALIGN(
-            _x as usize + mem::size_of::<crate::dirent_extra>() + (*_x).d_datalen as usize,
+            _x as usize + size_of::<crate::dirent_extra>() + (*_x).d_datalen as usize,
             8,
         ) as *mut crate::dirent_extra
     }
 
     pub fn SOCKCREDSIZE(ngrps: usize) -> usize {
         let ngrps = if ngrps > 0 { ngrps - 1 } else { 0 };
-        mem::size_of::<sockcred>() + mem::size_of::<crate::gid_t>() * ngrps
+        size_of::<sockcred>() + size_of::<crate::gid_t>() * ngrps
     }
 }
 

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -67,7 +67,7 @@ s_no_extra_traits! {
 
     pub struct sockaddr_storage {
         pub ss_family: crate::sa_family_t,
-        __ss_padding: [u8; 128 - mem::size_of::<sa_family_t>() - mem::size_of::<c_ulong>()],
+        __ss_padding: [u8; 128 - size_of::<sa_family_t>() - size_of::<c_ulong>()],
         __ss_align: c_ulong,
     }
 }
@@ -1020,32 +1020,32 @@ pub const PRIO_USER: c_int = 2;
 f! {
     //sys/socket.h
     pub {const} fn CMSG_ALIGN(len: size_t) -> size_t {
-        (len + mem::size_of::<size_t>() - 1) & !(mem::size_of::<size_t>() - 1)
+        (len + size_of::<size_t>() - 1) & !(size_of::<size_t>() - 1)
     }
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        (CMSG_ALIGN(mem::size_of::<cmsghdr>()) + length as usize) as c_uint
+        (CMSG_ALIGN(size_of::<cmsghdr>()) + length as usize) as c_uint
     }
     pub {const} fn CMSG_SPACE(len: c_uint) -> c_uint {
-        (CMSG_ALIGN(len as size_t) + CMSG_ALIGN(mem::size_of::<cmsghdr>())) as c_uint
+        (CMSG_ALIGN(len as size_t) + CMSG_ALIGN(size_of::<cmsghdr>())) as c_uint
     }
 
     // wait.h
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] &= !(1 << (fd % size));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
-        let size = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let size = size_of_val(&(*set).fds_bits[0]) * 8;
         (*set).fds_bits[fd / size] |= 1 << (fd % size);
         return;
     }

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -1,5 +1,3 @@
-use core::mem::size_of;
-
 use crate::prelude::*;
 
 pub type caddr_t = *mut c_char;
@@ -2408,7 +2406,7 @@ f! {
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        _CMSG_DATA_ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
+        _CMSG_DATA_ALIGN(size_of::<cmsghdr>()) as c_uint + length
     }
 
     pub fn CMSG_FIRSTHDR(mhdr: *const crate::msghdr) -> *mut cmsghdr {
@@ -2438,20 +2436,20 @@ f! {
     }
 
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
-        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] &= !(1 << (fd % bits));
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
-        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
-        let bits = mem::size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;
         (*set).fds_bits[fd / bits] |= 1 << (fd % bits);
         return;

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -1,6 +1,5 @@
 //! Interface to VxWorks C library
 
-use core::mem::size_of;
 use core::ptr::null_mut;
 
 use crate::prelude::*;
@@ -1085,13 +1084,13 @@ impl Clone for fpos_t {
 
 f! {
     pub {const} fn CMSG_ALIGN(len: usize) -> usize {
-        len + mem::size_of::<usize>() - 1 & !(mem::size_of::<usize>() - 1)
+        len + size_of::<usize>() - 1 & !(size_of::<usize>() - 1)
     }
 
     pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         let next = cmsg as usize
             + CMSG_ALIGN((*cmsg).cmsg_len as usize)
-            + CMSG_ALIGN(mem::size_of::<cmsghdr>());
+            + CMSG_ALIGN(size_of::<cmsghdr>());
         let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
         if next <= max {
             (cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr
@@ -1109,15 +1108,15 @@ f! {
     }
 
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(CMSG_ALIGN(mem::size_of::<cmsghdr>()) as isize)
+        (cmsg as *mut c_uchar).offset(CMSG_ALIGN(size_of::<cmsghdr>()) as isize)
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(mem::size_of::<cmsghdr>())) as c_uint
+        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(size_of::<cmsghdr>())) as c_uint
     }
 
     pub {const} fn CMSG_LEN(length: c_uint) -> c_uint {
-        CMSG_ALIGN(mem::size_of::<cmsghdr>()) as c_uint + length
+        CMSG_ALIGN(size_of::<cmsghdr>()) as c_uint + length
     }
 }
 


### PR DESCRIPTION
Since 1.80 these, along with their `_val` versions, are in the default `core` prelude so they don't need to be imported. 1.80 exceeds our MSRV so we can't use it from there, but we can add it to our prelude for now.