### PR TITLE
cleanup: Remove `allow(missing_debug_implementations)`

### DIFF
--- a/src/unix/bsd/apple/b32/mod.rs
+++ b/src/unix/bsd/apple/b32/mod.rs
@@ -60,7 +60,6 @@ s_no_extra_traits! {
         __opaque: [c_char; crate::__PTHREAD_ONCE_SIZE__],
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [f64; 2],

--- a/src/unix/bsd/apple/b64/aarch64/mod.rs
+++ b/src/unix/bsd/apple/b64/aarch64/mod.rs
@@ -47,7 +47,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     pub struct max_align_t {
         priv_: f64,
     }

--- a/src/unix/bsd/apple/b64/x86_64/mod.rs
+++ b/src/unix/bsd/apple/b64/x86_64/mod.rs
@@ -170,7 +170,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [f64; 2],

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -92,7 +92,6 @@ s_no_extra_traits! {
         pub a_un: __c_anonymous_elf64_auxv_union,
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [f64; 4],

--- a/src/unix/cygwin/mod.rs
+++ b/src/unix/cygwin/mod.rs
@@ -453,7 +453,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [f64; 4],

--- a/src/unix/linux_like/android/b32/x86/mod.rs
+++ b/src/unix/linux_like/android/b32/x86/mod.rs
@@ -51,7 +51,6 @@ s_no_extra_traits! {
         __fpregs_mem: _libc_fpstate,
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
         priv_: [f64; 2],

--- a/src/unix/linux_like/android/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/android/b64/aarch64/mod.rs
@@ -85,7 +85,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [f32; 8],

--- a/src/unix/linux_like/android/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/android/b64/riscv64/mod.rs
@@ -55,7 +55,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [f32; 8],

--- a/src/unix/linux_like/android/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/android/b64/x86_64/mod.rs
@@ -112,7 +112,6 @@ s_no_extra_traits! {
         uc_sigmask64: crate::sigset64_t,
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [f64; 4],

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -596,7 +596,6 @@ s_no_extra_traits! {
         pub absflat: [crate::__s32; ABS_CNT],
     }
 
-    #[allow(missing_debug_implementations)]
     pub struct af_alg_iv {
         pub ivlen: u32,
         pub iv: [c_uchar; 0],

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -315,7 +315,6 @@ s! {
         pub ha: [c_uchar; crate::MAX_ADDR_LEN],
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(4))]
     pub struct pthread_mutex_t {
         size: [u8; crate::__SIZEOF_PTHREAD_MUTEX_T],
@@ -382,7 +381,6 @@ s_no_extra_traits! {
         size: [u8; crate::__SIZEOF_PTHREAD_COND_T],
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
         priv_: [f64; 3],

--- a/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
@@ -232,13 +232,11 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
         priv_: [i64; 2],
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct ucontext_t {
         pub uc_flags: c_ulong,

--- a/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
@@ -168,7 +168,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
         priv_: [i64; 2],

--- a/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
@@ -161,7 +161,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(2))]
     pub struct max_align_t {
         priv_: [i8; 20],

--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -252,7 +252,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
         priv_: [f32; 4],

--- a/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
@@ -197,7 +197,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     pub struct ucontext_t {
         pub __uc_flags: c_ulong,
         pub uc_link: *mut ucontext_t,
@@ -206,7 +205,6 @@ s_no_extra_traits! {
         pub uc_mcontext: mcontext_t,
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct mcontext_t {
         pub __gregs: [c_ulong; 32],
@@ -219,19 +217,16 @@ s_no_extra_traits! {
         pub __q: __riscv_mc_q_ext_state,
     }
 
-    #[allow(missing_debug_implementations)]
     pub struct __riscv_mc_f_ext_state {
         pub __f: [c_uint; 32],
         pub __fcsr: c_uint,
     }
 
-    #[allow(missing_debug_implementations)]
     pub struct __riscv_mc_d_ext_state {
         pub __f: [c_ulonglong; 32],
         pub __fcsr: c_uint,
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct __riscv_mc_q_ext_state {
         pub __f: [c_ulonglong; 64],

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -198,7 +198,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
         priv_: [i64; 3],

--- a/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
@@ -287,7 +287,6 @@ s_no_extra_traits! {
         __ssp: [c_ulong; 4],
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [f64; 6],

--- a/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
@@ -242,7 +242,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [f32; 8],

--- a/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
@@ -237,7 +237,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [f64; 4],

--- a/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
@@ -187,7 +187,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [f64; 4],

--- a/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
@@ -194,7 +194,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [i64; 4],

--- a/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
@@ -247,7 +247,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     pub struct ucontext_t {
         pub __uc_flags: c_ulong,
         pub uc_link: *mut ucontext_t,
@@ -256,7 +255,6 @@ s_no_extra_traits! {
         pub uc_mcontext: mcontext_t,
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct mcontext_t {
         pub __gregs: [c_ulong; 32],
@@ -269,19 +267,16 @@ s_no_extra_traits! {
         pub __q: __riscv_mc_q_ext_state,
     }
 
-    #[allow(missing_debug_implementations)]
     pub struct __riscv_mc_f_ext_state {
         pub __f: [c_uint; 32],
         pub __fcsr: c_uint,
     }
 
-    #[allow(missing_debug_implementations)]
     pub struct __riscv_mc_d_ext_state {
         pub __f: [c_ulonglong; 32],
         pub __fcsr: c_uint,
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct __riscv_mc_q_ext_state {
         pub __f: [c_ulonglong; 64],

--- a/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
@@ -197,7 +197,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [i64; 4],

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -317,7 +317,6 @@ s_no_extra_traits! {
         // __ssp: [c_ulonglong; 4],
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [f64; 4],

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1476,7 +1476,6 @@ s_no_extra_traits! {
         pub absflat: [__s32; ABS_CNT],
     }
 
-    #[allow(missing_debug_implementations)]
     pub struct af_alg_iv {
         pub ivlen: u32,
         pub iv: [c_uchar; 0],
@@ -1568,18 +1567,15 @@ s_no_extra_traits! {
         pub sched_period: crate::__u64,
     }
 
-    #[allow(missing_debug_implementations)]
     pub union tpacket_req_u {
         pub req: crate::tpacket_req,
         pub req3: crate::tpacket_req3,
     }
 
-    #[allow(missing_debug_implementations)]
     pub union tpacket_bd_header_u {
         pub bh1: crate::tpacket_hdr_v1,
     }
 
-    #[allow(missing_debug_implementations)]
     pub struct tpacket_block_desc {
         pub version: __u32,
         pub offset_to_priv: __u32,
@@ -1740,7 +1736,6 @@ s_no_extra_traits! {
     }
 
     // linux/net_tstamp.h
-    #[allow(missing_debug_implementations)]
     pub struct sock_txtime {
         pub clockid: crate::clockid_t,
         pub flags: __u32,
@@ -1748,7 +1743,6 @@ s_no_extra_traits! {
 
     // linux/can.h
     #[repr(align(8))]
-    #[allow(missing_debug_implementations)]
     pub struct can_frame {
         pub can_id: canid_t,
         // FIXME(1.0): this field was renamed to `len` in Linux 5.11
@@ -1760,7 +1754,6 @@ s_no_extra_traits! {
     }
 
     #[repr(align(8))]
-    #[allow(missing_debug_implementations)]
     pub struct canfd_frame {
         pub can_id: canid_t,
         pub len: u8,
@@ -1771,7 +1764,6 @@ s_no_extra_traits! {
     }
 
     #[repr(align(8))]
-    #[allow(missing_debug_implementations)]
     pub struct canxl_frame {
         pub prio: canid_t,
         pub flags: u8,
@@ -1781,13 +1773,11 @@ s_no_extra_traits! {
         pub data: [u8; CANXL_MAX_DLEN],
     }
 
-    #[allow(missing_debug_implementations)]
     pub union __c_anonymous_sockaddr_can_can_addr {
         pub tp: __c_anonymous_sockaddr_can_tp,
         pub j1939: __c_anonymous_sockaddr_can_j1939,
     }
 
-    #[allow(missing_debug_implementations)]
     pub struct sockaddr_can {
         pub can_family: crate::sa_family_t,
         pub can_ifindex: c_int,
@@ -1842,7 +1832,6 @@ s_no_extra_traits! {
         pub rsv: [c_uint; 4],
     }
 
-    #[allow(missing_debug_implementations)]
     pub struct ptp_perout_request {
         pub anonymous_1: __c_anonymous_ptp_perout_request_1,
         pub period: ptp_clock_time,
@@ -1852,7 +1841,6 @@ s_no_extra_traits! {
     }
 
     // linux/if_xdp.h
-    #[allow(missing_debug_implementations)]
     pub struct xsk_tx_metadata {
         pub flags: crate::__u64,
         pub xsk_tx_metadata_union: __c_anonymous_xsk_tx_metadata_union,

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -133,7 +133,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     pub struct ucontext_t {
         pub uc_flags: c_ulong,
         pub uc_link: *mut ucontext_t,
@@ -143,7 +142,6 @@ s_no_extra_traits! {
         pub uc_regspace: [c_ulonglong; 64],
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
         priv_: (i64, i64),

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -147,7 +147,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
         priv_: [f32; 4],

--- a/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
@@ -102,7 +102,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
         priv_: (i64, f64),

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -138,7 +138,6 @@ s_no_extra_traits! {
         __private: [u8; 112],
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(8))]
     pub struct max_align_t {
         priv_: [f64; 3],

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -129,7 +129,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [f32; 8],

--- a/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
@@ -114,7 +114,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [f64; 4],

--- a/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
@@ -86,7 +86,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     pub struct ucontext_t {
         pub __uc_flags: c_ulong,
         pub uc_link: *mut ucontext_t,
@@ -95,7 +94,6 @@ s_no_extra_traits! {
         pub uc_mcontext: mcontext_t,
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct mcontext_t {
         pub __gregs: [c_ulong; 32],
@@ -108,19 +106,16 @@ s_no_extra_traits! {
         pub __q: __riscv_mc_q_ext_state,
     }
 
-    #[allow(missing_debug_implementations)]
     pub struct __riscv_mc_f_ext_state {
         pub __f: [c_uint; 32],
         pub __fcsr: c_uint,
     }
 
-    #[allow(missing_debug_implementations)]
     pub struct __riscv_mc_d_ext_state {
         pub __f: [c_ulonglong; 32],
         pub __fcsr: c_uint,
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct __riscv_mc_q_ext_state {
         pub __f: [c_ulonglong; 64],

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -171,7 +171,6 @@ s_no_extra_traits! {
         __private: [u8; 512],
     }
 
-    #[allow(missing_debug_implementations)]
     #[repr(align(16))]
     pub struct max_align_t {
         priv_: [f64; 4],

--- a/src/unix/linux_like/linux/uclibc/x86_64/l4re.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/l4re.rs
@@ -28,7 +28,7 @@ s! {
     }
 }
 
-#[allow(missing_debug_implementations)]
+#[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub struct pthread_attr_t {
     pub __detachstate: c_int,
     pub __schedpolicy: c_int,

--- a/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
@@ -281,7 +281,6 @@ s! {
 }
 
 s_no_extra_traits! {
-    #[allow(missing_debug_implementations)]
     pub struct dirent {
         pub d_ino: crate::ino64_t,
         pub d_off: off64_t,

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -59,7 +59,6 @@ s! {
 
 s_no_extra_traits! {
     #[repr(packed)]
-    #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
     pub struct door_desc_t__d_data__d_desc {
         pub d_descriptor: c_int,
         pub d_id: crate::door_id_t,
@@ -70,13 +69,11 @@ s_no_extra_traits! {
         d_resv: [c_int; 5], /* Check out /usr/include/sys/door.h */
     }
 
-    #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
     pub struct door_desc_t {
         pub d_attributes: door_attr_t,
         pub d_data: door_desc_t__d_data,
     }
 
-    #[cfg_attr(feature = "extra_traits", allow(missing_debug_implementations))]
     pub struct door_arg_t {
         pub data_ptr: *const c_char,
         pub data_size: size_t,

--- a/src/wasi/mod.rs
+++ b/src/wasi/mod.rs
@@ -36,7 +36,6 @@ pub type locale_t = *mut __locale_struct;
 
 s_no_extra_traits! {
     #[repr(align(16))]
-    #[allow(missing_debug_implementations)]
     pub struct max_align_t {
         priv_: [f64; 4],
     }

--- a/src/windows/gnu/mod.rs
+++ b/src/windows/gnu/mod.rs
@@ -3,7 +3,6 @@ use crate::prelude::*;
 cfg_if! {
     if #[cfg(target_pointer_width = "64")] {
         s_no_extra_traits! {
-            #[allow(missing_debug_implementations)]
             #[repr(align(16))]
             pub struct max_align_t {
                 priv_: [f64; 4],
@@ -11,7 +10,6 @@ cfg_if! {
         }
     } else if #[cfg(target_pointer_width = "32")] {
         s_no_extra_traits! {
-            #[allow(missing_debug_implementations)]
             #[repr(align(16))]
             pub struct max_align_t {
                 priv_: [i64; 6],


### PR DESCRIPTION
Since the macros now create a `Debug` implementation for all types, there isn't any need to allow this lint anywhere.