### PR TITLE
ci: Only build `core` with `-Zbuild-std`

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -51,7 +51,7 @@ if [ -n "${QEMU:-}" ]; then
     cargo build \
         --manifest-path libc-test/Cargo.toml \
         --target "$target" \
-        --test main ${LIBC_CI_ZBUILD_STD+"-Zbuild-std"}
+        --test main ${LIBC_CI_ZBUILD_STD+"-Zbuild-std=core"}
     rm "${CARGO_TARGET_DIR}/${target}"/debug/main-*.d
     cp "${CARGO_TARGET_DIR}/${target}"/debug/main-* "${tmpdir}"/mount/libc-test
     # shellcheck disable=SC2016

--- a/ci/verify-build.sh
+++ b/ci/verify-build.sh
@@ -48,7 +48,7 @@ test_target() {
 
     if [ "${no_dist}" != "0" ]; then
         # If we can't download a `core`, we need to build it
-        cmd="$cmd -Zbuild-std=core,alloc"
+        cmd="$cmd -Zbuild-std=core"
 
         # FIXME: With `build-std` feature, `compiler_builtins` emits a lof of lint warnings.
         RUSTFLAGS="${RUSTFLAGS:-} -Aimproper_ctypes_definitions"


### PR DESCRIPTION
We don't need alloc or std, so save some CI time by only building `core`.