### PR TITLE
ci: Run a daily cron job to populate the CI cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,11 @@ on:
   merge_group:
   pull_request:
     types: [opened, synchronize, reopened]
+  schedule:
+    # Run CI on `main` daily so there is a cache available for merge queues.
+    # See <https://github.com/orgs/community/discussions/66430>
+    - cron: "0 8 * * *"
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
The merge queue doesn't have a cache available because CI runs before the push to `main` happens, and cache can only be retrieved from branches that the testing commit is derived from. Work around this by adding a daily CI run on `main` so there will be something in the cache usable to PRs. It can also be run manually with `workflow_dispatch`.

Link: https://github.com/orgs/community/discussions/66430