### PR TITLE
Revert of mut api breaking userspace users on AIX

### DIFF
--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -3246,7 +3246,7 @@ extern "C" {
     #[link_name = "nsendmsg"]
     pub fn sendmsg(sockfd: c_int, msg: *const msghdr, flags: c_int) -> ssize_t;
     pub fn setcontext(ucp: *const ucontext_t) -> c_int;
-    pub fn setdomainname(name: *mut c_char, len: c_int) -> c_int;
+    pub fn setdomainname(name: *const c_char, len: c_int) -> c_int;
     pub fn setgroups(ngroups: c_int, ptr: *mut crate::gid_t) -> c_int;
     pub fn setgrent();
     pub fn setmntent(filename: *const c_char, ty: *const c_char) -> *mut crate::FILE;
@@ -3254,7 +3254,7 @@ extern "C" {
     pub fn setpwent();
     pub fn setrlimit(resource: c_int, rlim: *const crate::rlimit) -> c_int;
     pub fn setrlimit64(resource: c_int, rlim: *const rlimit64) -> c_int;
-    pub fn settimeofday(tv: *mut crate::timeval, tz: *mut crate::timezone) -> c_int;
+    pub fn settimeofday(tv: *const crate::timeval, tz: *mut crate::timezone) -> c_int;
     pub fn setitimer(
         which: c_int,
         new_value: *const crate::itimerval,
@@ -3306,8 +3306,8 @@ extern "C" {
     pub fn strptime(s: *const c_char, format: *const c_char, tm: *mut crate::tm) -> *mut c_char;
     pub fn strsep(string: *mut *mut c_char, delim: *const c_char) -> *mut c_char;
     pub fn swapcontext(uocp: *mut ucontext_t, ucp: *const ucontext_t) -> c_int;
-    pub fn swapoff(puath: *mut c_char) -> c_int;
-    pub fn swapon(path: *mut c_char) -> c_int;
+    pub fn swapoff(puath: *const c_char) -> c_int;
+    pub fn swapon(path: *const c_char) -> c_int;
     pub fn sync();
     pub fn telldir(dirp: *mut crate::DIR) -> c_long;
     pub fn timer_create(
@@ -3328,7 +3328,7 @@ extern "C" {
     pub fn uname(buf: *mut crate::utsname) -> c_int;
     pub fn updwtmp(file: *const c_char, u: *const utmp);
     pub fn uselocale(loc: crate::locale_t) -> crate::locale_t;
-    pub fn utmpname(file: *mut c_char) -> c_int;
+    pub fn utmpname(file: *const c_char) -> c_int;
     pub fn utimensat(
         dirfd: c_int,
         path: *const c_char,

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -3281,10 +3281,10 @@ extern "C" {
     pub fn srand48(seed: c_long);
     pub fn stat64(path: *const c_char, buf: *mut stat64) -> c_int;
     pub fn stat64at(dirfd: c_int, path: *const c_char, buf: *mut stat64, flags: c_int) -> c_int;
-    pub fn statfs(path: *mut c_char, buf: *mut statfs) -> c_int;
-    pub fn statfs64(path: *mut c_char, buf: *mut statfs64) -> c_int;
+    pub fn statfs(path: *const c_char, buf: *mut statfs) -> c_int;
+    pub fn statfs64(path: *const c_char, buf: *mut statfs64) -> c_int;
     pub fn statvfs64(path: *const c_char, buf: *mut statvfs64) -> c_int;
-    pub fn statx(path: *mut c_char, buf: *mut stat, length: c_int, command: c_int) -> c_int;
+    pub fn statx(path: *const c_char, buf: *mut stat, length: c_int, command: c_int) -> c_int;
     pub fn strcasecmp_l(
         string1: *const c_char,
         string2: *const c_char,


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Reverted C api changes introduced by commit c192a5cae31dd84ad17dc3c2dd0a3deaacae452a

IBM AIX does not define pointer constness traditionally in their headers. Some commit changed const pointers to mutable ones, those breaking many userspace libraries, as those in rust libc are usually defined on other posix platforms as const.

Some older commit (mainly c192a5cae31dd84ad17dc3c2dd0a3deaacae452a) changed the api.
I reverted fstat, swapon apis, to expose path variable pointer as const again.
<!-- Add a short description about what this change does -->

# Sources

https://www.ibm.com/docs/en/aix/7.2.0?topic=s-stat-fstat-lstat-statx-fstatx-statxat-fstatat-fullstat-ffullstat-stat64-fstat64-lstat64-stat64x-fstat64x-lstat64x-stat64xat-subroutine)


<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:


-->
@rustbot label +stable-nominated
