### PR TITLE
freebsd15: Add ki_uerrmsg to struct kinfo_proc

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
@@ -50,6 +50,7 @@ s! {
         _priv: [c_ulong; 8],
     }
 
+    #[non_exhaustive]
     pub struct kinfo_proc {
         /// Size of this structure.
         pub ki_structsize: c_int,


### PR DESCRIPTION

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

During the development of FreeBSD 15, a field was added to `kinfo_proc`. With this PR and https://github.com/rust-lang/libc/pull/4552, the `libc-test` suite passes on FreeBSD 15 on ppc64.

# Sources

Upstream commit: https://github.com/freebsd/freebsd-src/commit/7212b37345936899e979c63d0b054e114576faa0

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
