### PR TITLE
ctest: add tests for size and alignment of structs, unions, and aliases, and signededness of aliases.

### DIFF
--- a/ctest-next/src/ast/type_alias.rs
+++ b/ctest-next/src/ast/type_alias.rs
@@ -5,7 +5,6 @@ use crate::BoxStr;
 pub struct Type {
     pub(crate) public: bool,
     pub(crate) ident: BoxStr,
-    #[expect(unused)]
     pub(crate) ty: syn::Type,
 }
 

--- a/ctest-next/src/ffi_items.rs
+++ b/ctest-next/src/ffi_items.rs
@@ -37,7 +37,6 @@ impl FfiItems {
     }
 
     /// Return a list of all type aliases found.
-    #[cfg_attr(not(test), expect(unused))]
     pub(crate) fn aliases(&self) -> &Vec<Type> {
         &self.aliases
     }

--- a/ctest-next/src/generator.rs
+++ b/ctest-next/src/generator.rs
@@ -44,6 +44,7 @@ pub struct TestGenerator {
     array_arg: Option<ArrayArg>,
     skip_private: bool,
     skip_roundtrip: Option<SkipTest>,
+    pub(crate) skip_signededness: Option<SkipTest>,
 }
 
 #[derive(Debug, Error)]
@@ -829,6 +830,28 @@ impl TestGenerator {
     /// ```
     pub fn skip_roundtrip(&mut self, f: impl Fn(&str) -> bool + 'static) -> &mut Self {
         self.skip_roundtrip = Some(Box::new(f));
+        self
+    }
+
+    /// Configures whether a type's signededness is tested or not.
+    ///
+    /// The closure is given the name of a Rust type, and returns whether the
+    /// type should be tested as having the right sign (positive or negative).
+    ///
+    /// By default all signededness checks are performed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ctest_next::TestGenerator;
+    ///
+    /// let mut cfg = TestGenerator::new();
+    /// cfg.skip_signededness(|s| {
+    ///     s.starts_with("foo_")
+    /// });
+    /// ```
+    pub fn skip_signededness(&mut self, f: impl Fn(&str) -> bool + 'static) -> &mut Self {
+        self.skip_signededness = Some(Box::new(f));
         self
     }
 

--- a/ctest-next/templates/test.c
+++ b/ctest-next/templates/test.c
@@ -34,3 +34,22 @@ static {{ constant.c_ty }} ctest_const_{{ constant.id }}_val_static = {{ constan
     return &ctest_const_{{ constant.id }}_val_static;
 }
 {%- endfor +%}
+
+{%- for item in ctx.size_align_tests +%}
+
+// Return the size of a type.
+uint64_t ctest_size_of__{{ item.id }}(void) { return sizeof({{ item.c_ty }}); }
+
+// Return the alignment of a type.
+uint64_t ctest_align_of__{{ item.id }}(void) { return _Alignof({{ item.c_ty }}); }
+{%- endfor +%}
+
+{%- for alias in ctx.signededness_tests +%}
+
+// Return `1` if the type is signed, otherwise return `0`.
+// Casting -1 to the aliased type if signed evaluates to `-1 < 0`, if unsigned to `MAX_VALUE < 0`
+uint32_t ctest_signededness_of__{{ alias.id }}(void) {
+    {{ alias.c_ty }} all_ones = ({{ alias.c_ty }}) -1;
+    return all_ones < 0;
+}
+{%- endfor +%}

--- a/ctest-next/tests/input/hierarchy.out.c
+++ b/ctest-next/tests/input/hierarchy.out.c
@@ -14,3 +14,16 @@ static bool ctest_const_ON_val_static = ON;
 bool *ctest_const__ON(void) {
     return &ctest_const_ON_val_static;
 }
+
+// Return the size of a type.
+uint64_t ctest_size_of__in6_addr(void) { return sizeof(in6_addr); }
+
+// Return the alignment of a type.
+uint64_t ctest_align_of__in6_addr(void) { return _Alignof(in6_addr); }
+
+// Return `1` if the type is signed, otherwise return `0`.
+// Casting -1 to the aliased type if signed evaluates to `-1 < 0`, if unsigned to `MAX_VALUE < 0`
+uint32_t ctest_signededness_of__in6_addr(void) {
+    in6_addr all_ones = (in6_addr) -1;
+    return all_ones < 0;
+}

--- a/ctest-next/tests/input/hierarchy.out.rs
+++ b/ctest-next/tests/input/hierarchy.out.rs
@@ -66,6 +66,39 @@ mod generated_tests {
             check_same_hex(b1, b2, &format!("ON value at byte {}", i));
         }
     }
+
+    /// Compare the size and alignment of the type in Rust and C, making sure they are the same.
+    pub fn ctest_size_align_in6_addr() {
+        extern "C" {
+            fn ctest_size_of__in6_addr() -> u64;
+            fn ctest_align_of__in6_addr() -> u64;
+        }
+
+        let rust_size = size_of::<in6_addr>() as u64;
+        let c_size = unsafe { ctest_size_of__in6_addr() };
+
+        let rust_align = align_of::<in6_addr>() as u64;
+        let c_align = unsafe { ctest_align_of__in6_addr() };
+
+        check_same(rust_size, c_size, "in6_addr size");
+        check_same(rust_align, c_align, "in6_addr align");
+    }
+
+    /// Make sure that the signededness of a type alias in Rust and C is the same.
+    ///
+    /// This is done by casting 0 to that type and flipping all of its bits. For unsigned types,
+    /// this would result in a value larger than zero. For signed types, this results in a value
+    /// smaller than 0.
+    pub fn ctest_signededness_in6_addr() {
+         extern "C" {
+            fn ctest_signededness_of__in6_addr() -> u32;
+        }
+        let all_ones = !(0 as in6_addr);
+        let all_zeros = 0 as in6_addr;
+        let c_is_signed = unsafe { ctest_signededness_of__in6_addr() };
+
+        check_same((all_ones < all_zeros) as u32, c_is_signed, "in6_addr signed");
+    }
 }
 
 use generated_tests::*;
@@ -86,4 +119,6 @@ fn main() {
 // Run all tests by calling the functions that define them.
 fn run_all() {
     ctest_const_ON();
+    ctest_size_align_in6_addr();
+    ctest_signededness_in6_addr();
 }

--- a/ctest-next/tests/input/macro.out.c
+++ b/ctest-next/tests/input/macro.out.c
@@ -6,3 +6,15 @@
 #include <stdio.h>
 
 #include <macro.h>
+
+// Return the size of a type.
+uint64_t ctest_size_of__VecU8(void) { return sizeof(struct VecU8); }
+
+// Return the alignment of a type.
+uint64_t ctest_align_of__VecU8(void) { return _Alignof(struct VecU8); }
+
+// Return the size of a type.
+uint64_t ctest_size_of__VecU16(void) { return sizeof(struct VecU16); }
+
+// Return the alignment of a type.
+uint64_t ctest_align_of__VecU16(void) { return _Alignof(struct VecU16); }

--- a/ctest-next/tests/input/macro.out.rs
+++ b/ctest-next/tests/input/macro.out.rs
@@ -40,6 +40,40 @@ mod generated_tests {
             NTESTS.fetch_add(1, Ordering::Relaxed);
         }
     }
+
+    /// Compare the size and alignment of the type in Rust and C, making sure they are the same.
+    pub fn ctest_size_align_VecU8() {
+        extern "C" {
+            fn ctest_size_of__VecU8() -> u64;
+            fn ctest_align_of__VecU8() -> u64;
+        }
+
+        let rust_size = size_of::<VecU8>() as u64;
+        let c_size = unsafe { ctest_size_of__VecU8() };
+
+        let rust_align = align_of::<VecU8>() as u64;
+        let c_align = unsafe { ctest_align_of__VecU8() };
+
+        check_same(rust_size, c_size, "VecU8 size");
+        check_same(rust_align, c_align, "VecU8 align");
+    }
+
+    /// Compare the size and alignment of the type in Rust and C, making sure they are the same.
+    pub fn ctest_size_align_VecU16() {
+        extern "C" {
+            fn ctest_size_of__VecU16() -> u64;
+            fn ctest_align_of__VecU16() -> u64;
+        }
+
+        let rust_size = size_of::<VecU16>() as u64;
+        let c_size = unsafe { ctest_size_of__VecU16() };
+
+        let rust_align = align_of::<VecU16>() as u64;
+        let c_align = unsafe { ctest_align_of__VecU16() };
+
+        check_same(rust_size, c_size, "VecU16 size");
+        check_same(rust_align, c_align, "VecU16 align");
+    }
 }
 
 use generated_tests::*;
@@ -59,4 +93,6 @@ fn main() {
 
 // Run all tests by calling the functions that define them.
 fn run_all() {
+    ctest_size_align_VecU8();
+    ctest_size_align_VecU16();
 }

--- a/ctest-next/tests/input/simple.out.with-renames.c
+++ b/ctest-next/tests/input/simple.out.with-renames.c
@@ -22,3 +22,28 @@ static char *ctest_const_B_val_static = C_B;
 char *ctest_const_cstr__B(void) {
     return ctest_const_B_val_static;
 }
+
+// Return the size of a type.
+uint64_t ctest_size_of__Byte(void) { return sizeof(Byte); }
+
+// Return the alignment of a type.
+uint64_t ctest_align_of__Byte(void) { return _Alignof(Byte); }
+
+// Return the size of a type.
+uint64_t ctest_size_of__Person(void) { return sizeof(struct Person); }
+
+// Return the alignment of a type.
+uint64_t ctest_align_of__Person(void) { return _Alignof(struct Person); }
+
+// Return the size of a type.
+uint64_t ctest_size_of__Word(void) { return sizeof(union Word); }
+
+// Return the alignment of a type.
+uint64_t ctest_align_of__Word(void) { return _Alignof(union Word); }
+
+// Return `1` if the type is signed, otherwise return `0`.
+// Casting -1 to the aliased type if signed evaluates to `-1 < 0`, if unsigned to `MAX_VALUE < 0`
+uint32_t ctest_signededness_of__Byte(void) {
+    Byte all_ones = (Byte) -1;
+    return all_ones < 0;
+}

--- a/ctest-next/tests/input/simple.out.with-renames.rs
+++ b/ctest-next/tests/input/simple.out.with-renames.rs
@@ -86,6 +86,73 @@ mod generated_tests {
 
         check_same(r_val, c_val, "const B string");
     }
+
+    /// Compare the size and alignment of the type in Rust and C, making sure they are the same.
+    pub fn ctest_size_align_Byte() {
+        extern "C" {
+            fn ctest_size_of__Byte() -> u64;
+            fn ctest_align_of__Byte() -> u64;
+        }
+
+        let rust_size = size_of::<Byte>() as u64;
+        let c_size = unsafe { ctest_size_of__Byte() };
+
+        let rust_align = align_of::<Byte>() as u64;
+        let c_align = unsafe { ctest_align_of__Byte() };
+
+        check_same(rust_size, c_size, "Byte size");
+        check_same(rust_align, c_align, "Byte align");
+    }
+
+    /// Compare the size and alignment of the type in Rust and C, making sure they are the same.
+    pub fn ctest_size_align_Person() {
+        extern "C" {
+            fn ctest_size_of__Person() -> u64;
+            fn ctest_align_of__Person() -> u64;
+        }
+
+        let rust_size = size_of::<Person>() as u64;
+        let c_size = unsafe { ctest_size_of__Person() };
+
+        let rust_align = align_of::<Person>() as u64;
+        let c_align = unsafe { ctest_align_of__Person() };
+
+        check_same(rust_size, c_size, "Person size");
+        check_same(rust_align, c_align, "Person align");
+    }
+
+    /// Compare the size and alignment of the type in Rust and C, making sure they are the same.
+    pub fn ctest_size_align_Word() {
+        extern "C" {
+            fn ctest_size_of__Word() -> u64;
+            fn ctest_align_of__Word() -> u64;
+        }
+
+        let rust_size = size_of::<Word>() as u64;
+        let c_size = unsafe { ctest_size_of__Word() };
+
+        let rust_align = align_of::<Word>() as u64;
+        let c_align = unsafe { ctest_align_of__Word() };
+
+        check_same(rust_size, c_size, "Word size");
+        check_same(rust_align, c_align, "Word align");
+    }
+
+    /// Make sure that the signededness of a type alias in Rust and C is the same.
+    ///
+    /// This is done by casting 0 to that type and flipping all of its bits. For unsigned types,
+    /// this would result in a value larger than zero. For signed types, this results in a value
+    /// smaller than 0.
+    pub fn ctest_signededness_Byte() {
+         extern "C" {
+            fn ctest_signededness_of__Byte() -> u32;
+        }
+        let all_ones = !(0 as Byte);
+        let all_zeros = 0 as Byte;
+        let c_is_signed = unsafe { ctest_signededness_of__Byte() };
+
+        check_same((all_ones < all_zeros) as u32, c_is_signed, "Byte signed");
+    }
 }
 
 use generated_tests::*;
@@ -107,4 +174,8 @@ fn main() {
 fn run_all() {
     ctest_const_cstr_A();
     ctest_const_cstr_B();
+    ctest_size_align_Byte();
+    ctest_size_align_Person();
+    ctest_size_align_Word();
+    ctest_signededness_Byte();
 }

--- a/ctest-next/tests/input/simple.out.with-skips.c
+++ b/ctest-next/tests/input/simple.out.with-skips.c
@@ -14,3 +14,28 @@ static char *ctest_const_A_val_static = A;
 char *ctest_const_cstr__A(void) {
     return ctest_const_A_val_static;
 }
+
+// Return the size of a type.
+uint64_t ctest_size_of__Byte(void) { return sizeof(Byte); }
+
+// Return the alignment of a type.
+uint64_t ctest_align_of__Byte(void) { return _Alignof(Byte); }
+
+// Return the size of a type.
+uint64_t ctest_size_of__Person(void) { return sizeof(struct Person); }
+
+// Return the alignment of a type.
+uint64_t ctest_align_of__Person(void) { return _Alignof(struct Person); }
+
+// Return the size of a type.
+uint64_t ctest_size_of__Word(void) { return sizeof(union Word); }
+
+// Return the alignment of a type.
+uint64_t ctest_align_of__Word(void) { return _Alignof(union Word); }
+
+// Return `1` if the type is signed, otherwise return `0`.
+// Casting -1 to the aliased type if signed evaluates to `-1 < 0`, if unsigned to `MAX_VALUE < 0`
+uint32_t ctest_signededness_of__Byte(void) {
+    Byte all_ones = (Byte) -1;
+    return all_ones < 0;
+}

--- a/ctest-next/tests/input/simple.out.with-skips.rs
+++ b/ctest-next/tests/input/simple.out.with-skips.rs
@@ -63,6 +63,73 @@ mod generated_tests {
 
         check_same(r_val, c_val, "const A string");
     }
+
+    /// Compare the size and alignment of the type in Rust and C, making sure they are the same.
+    pub fn ctest_size_align_Byte() {
+        extern "C" {
+            fn ctest_size_of__Byte() -> u64;
+            fn ctest_align_of__Byte() -> u64;
+        }
+
+        let rust_size = size_of::<Byte>() as u64;
+        let c_size = unsafe { ctest_size_of__Byte() };
+
+        let rust_align = align_of::<Byte>() as u64;
+        let c_align = unsafe { ctest_align_of__Byte() };
+
+        check_same(rust_size, c_size, "Byte size");
+        check_same(rust_align, c_align, "Byte align");
+    }
+
+    /// Compare the size and alignment of the type in Rust and C, making sure they are the same.
+    pub fn ctest_size_align_Person() {
+        extern "C" {
+            fn ctest_size_of__Person() -> u64;
+            fn ctest_align_of__Person() -> u64;
+        }
+
+        let rust_size = size_of::<Person>() as u64;
+        let c_size = unsafe { ctest_size_of__Person() };
+
+        let rust_align = align_of::<Person>() as u64;
+        let c_align = unsafe { ctest_align_of__Person() };
+
+        check_same(rust_size, c_size, "Person size");
+        check_same(rust_align, c_align, "Person align");
+    }
+
+    /// Compare the size and alignment of the type in Rust and C, making sure they are the same.
+    pub fn ctest_size_align_Word() {
+        extern "C" {
+            fn ctest_size_of__Word() -> u64;
+            fn ctest_align_of__Word() -> u64;
+        }
+
+        let rust_size = size_of::<Word>() as u64;
+        let c_size = unsafe { ctest_size_of__Word() };
+
+        let rust_align = align_of::<Word>() as u64;
+        let c_align = unsafe { ctest_align_of__Word() };
+
+        check_same(rust_size, c_size, "Word size");
+        check_same(rust_align, c_align, "Word align");
+    }
+
+    /// Make sure that the signededness of a type alias in Rust and C is the same.
+    ///
+    /// This is done by casting 0 to that type and flipping all of its bits. For unsigned types,
+    /// this would result in a value larger than zero. For signed types, this results in a value
+    /// smaller than 0.
+    pub fn ctest_signededness_Byte() {
+         extern "C" {
+            fn ctest_signededness_of__Byte() -> u32;
+        }
+        let all_ones = !(0 as Byte);
+        let all_zeros = 0 as Byte;
+        let c_is_signed = unsafe { ctest_signededness_of__Byte() };
+
+        check_same((all_ones < all_zeros) as u32, c_is_signed, "Byte signed");
+    }
 }
 
 use generated_tests::*;
@@ -83,4 +150,8 @@ fn main() {
 // Run all tests by calling the functions that define them.
 fn run_all() {
     ctest_const_cstr_A();
+    ctest_size_align_Byte();
+    ctest_size_align_Person();
+    ctest_size_align_Word();
+    ctest_signededness_Byte();
 }


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
This PR adds tests for verifying size and alignment of struct, union, and typedef types, as well as signededness of alias types (if they are signed).

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
