### PR TITLE
ctest: test ctest-next in ctest-test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
               # Remove `-Dwarnings` at the MSRV since lints may be different
               export RUSTFLAGS=""
               # Remove `ctest-next` which uses the 2024 edition
-              perl -i -ne 'print unless /"ctest-next",/' Cargo.toml
+              perl -i -ne 'print unless /"ctest-(next|test)",/' Cargo.toml
           fi
 
           ./ci/verify-build.sh
@@ -320,7 +320,7 @@ jobs:
     - name: Install Rust
       run: rustup update "$MSRV" --no-self-update && rustup default "$MSRV"
     - name: Remove edition 2024 crates
-      run: perl -i -ne 'print unless /"ctest-next",/' Cargo.toml
+      run: perl -i -ne 'print unless /"ctest-(next|test)",/' Cargo.toml
     - uses: Swatinem/rust-cache@v2
     - run: cargo build -p ctest
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.1",
  "ctest",
+ "ctest-next",
  "libc 1.0.0-alpha.1",
 ]
 

--- a/ctest-next/src/ast/function.rs
+++ b/ctest-next/src/ast/function.rs
@@ -9,6 +9,7 @@ pub struct Fn {
     #[expect(unused)]
     pub(crate) abi: Abi,
     pub(crate) ident: BoxStr,
+    pub(crate) link_name: Option<BoxStr>,
     #[expect(unused)]
     pub(crate) parameters: Vec<Parameter>,
     #[expect(unused)]
@@ -19,5 +20,10 @@ impl Fn {
     /// Return the identifier of the function as a string.
     pub fn ident(&self) -> &str {
         &self.ident
+    }
+
+    /// Return the name of the function to be linked C side with.
+    pub fn link_name(&self) -> Option<&str> {
+        self.link_name.as_deref()
     }
 }

--- a/ctest-next/src/ast/static_variable.rs
+++ b/ctest-next/src/ast/static_variable.rs
@@ -10,6 +10,7 @@ pub struct Static {
     #[expect(unused)]
     pub(crate) abi: Abi,
     pub(crate) ident: BoxStr,
+    pub(crate) link_name: Option<BoxStr>,
     pub(crate) ty: syn::Type,
 }
 
@@ -17,5 +18,10 @@ impl Static {
     /// Return the identifier of the static variable as a string.
     pub fn ident(&self) -> &str {
         &self.ident
+    }
+
+    /// Return the name of the function to be linked C side with.
+    pub fn link_name(&self) -> Option<&str> {
+        self.link_name.as_deref()
     }
 }

--- a/ctest-next/templates/test.rs
+++ b/ctest-next/templates/test.rs
@@ -9,9 +9,10 @@
 mod generated_tests {
     #![allow(non_snake_case)]
     #![deny(improper_ctypes_definitions)]
-    use std::ffi::CStr;
+    use std::ffi::{CStr, c_char};
     use std::fmt::{Debug, LowerHex};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    #[allow(unused_imports)]
     use std::{mem, ptr, slice};
 
     use super::*;
@@ -62,7 +63,7 @@ mod generated_tests {
 
         // SAFETY: FFI call returns a valid C string.
         let c_val = unsafe {
-            let c_ptr: *const c_char = unsafe { ctest_const_cstr__{{ const_cstr.id }}()  };
+            let c_ptr: *const c_char = ctest_const_cstr__{{ const_cstr.id }}();
             CStr::from_ptr(c_ptr)
         };
 
@@ -89,7 +90,7 @@ mod generated_tests {
         };
 
         let c_bytes = unsafe {
-            let c_ptr: *const T = unsafe { ctest_const__{{ constant.id }}() };
+            let c_ptr: *const T = ctest_const__{{ constant.id }}();
             slice::from_raw_parts(c_ptr.cast::<u8>(), size_of::<T>())
         };
 

--- a/ctest-next/tests/input/hierarchy.out.rs
+++ b/ctest-next/tests/input/hierarchy.out.rs
@@ -6,9 +6,10 @@
 mod generated_tests {
     #![allow(non_snake_case)]
     #![deny(improper_ctypes_definitions)]
-    use std::ffi::CStr;
+    use std::ffi::{CStr, c_char};
     use std::fmt::{Debug, LowerHex};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    #[allow(unused_imports)]
     use std::{mem, ptr, slice};
 
     use super::*;
@@ -58,7 +59,7 @@ mod generated_tests {
         };
 
         let c_bytes = unsafe {
-            let c_ptr: *const T = unsafe { ctest_const__ON() };
+            let c_ptr: *const T = ctest_const__ON();
             slice::from_raw_parts(c_ptr.cast::<u8>(), size_of::<T>())
         };
 

--- a/ctest-next/tests/input/macro.out.rs
+++ b/ctest-next/tests/input/macro.out.rs
@@ -6,9 +6,10 @@
 mod generated_tests {
     #![allow(non_snake_case)]
     #![deny(improper_ctypes_definitions)]
-    use std::ffi::CStr;
+    use std::ffi::{CStr, c_char};
     use std::fmt::{Debug, LowerHex};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    #[allow(unused_imports)]
     use std::{mem, ptr, slice};
 
     use super::*;

--- a/ctest-next/tests/input/simple.out.with-renames.rs
+++ b/ctest-next/tests/input/simple.out.with-renames.rs
@@ -6,9 +6,10 @@
 mod generated_tests {
     #![allow(non_snake_case)]
     #![deny(improper_ctypes_definitions)]
-    use std::ffi::CStr;
+    use std::ffi::{CStr, c_char};
     use std::fmt::{Debug, LowerHex};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    #[allow(unused_imports)]
     use std::{mem, ptr, slice};
 
     use super::*;
@@ -57,7 +58,7 @@ mod generated_tests {
 
         // SAFETY: FFI call returns a valid C string.
         let c_val = unsafe {
-            let c_ptr: *const c_char = unsafe { ctest_const_cstr__A()  };
+            let c_ptr: *const c_char = ctest_const_cstr__A();
             CStr::from_ptr(c_ptr)
         };
 
@@ -80,7 +81,7 @@ mod generated_tests {
 
         // SAFETY: FFI call returns a valid C string.
         let c_val = unsafe {
-            let c_ptr: *const c_char = unsafe { ctest_const_cstr__B()  };
+            let c_ptr: *const c_char = ctest_const_cstr__B();
             CStr::from_ptr(c_ptr)
         };
 

--- a/ctest-next/tests/input/simple.out.with-skips.rs
+++ b/ctest-next/tests/input/simple.out.with-skips.rs
@@ -6,9 +6,10 @@
 mod generated_tests {
     #![allow(non_snake_case)]
     #![deny(improper_ctypes_definitions)]
-    use std::ffi::CStr;
+    use std::ffi::{CStr, c_char};
     use std::fmt::{Debug, LowerHex};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    #[allow(unused_imports)]
     use std::{mem, ptr, slice};
 
     use super::*;
@@ -57,7 +58,7 @@ mod generated_tests {
 
         // SAFETY: FFI call returns a valid C string.
         let c_val = unsafe {
-            let c_ptr: *const c_char = unsafe { ctest_const_cstr__A()  };
+            let c_ptr: *const c_char = ctest_const_cstr__A();
             CStr::from_ptr(c_ptr)
         };
 

--- a/ctest-test/Cargo.toml
+++ b/ctest-test/Cargo.toml
@@ -7,10 +7,12 @@ edition = "2021"
 
 [build-dependencies]
 ctest = { path = "../ctest" }
+ctest-next = { path = "../ctest-next" }
 cc = "1.2"
 
 [dev-dependencies]
 ctest = { path = "../ctest" }
+ctest-next = { path = "../ctest-next" }
 
 [dependencies]
 cfg-if = "1.0.1"
@@ -22,6 +24,14 @@ test = false
 
 [[bin]]
 name = "t2"
+test = false
+
+[[bin]]
+name = "t1_next"
+test = false
+
+[[bin]]
+name = "t2_next"
 test = false
 
 [[bin]]

--- a/ctest-test/build.rs
+++ b/ctest-test/build.rs
@@ -10,19 +10,14 @@ fn main() {
     if profile == "release" || opt_level >= 2 {
         println!("cargo:rustc-cfg=optimized");
     }
-    cc::Build::new()
-        .include("src")
-        .warnings(false)
-        .file("src/t1.c")
-        .compile("libt1.a");
-    println!("cargo:rerun-if-changed=src/t1.c");
-    println!("cargo:rerun-if-changed=src/t1.h");
-    cc::Build::new()
-        .warnings(false)
-        .file("src/t2.c")
-        .compile("libt2.a");
-    println!("cargo:rerun-if-changed=src/t2.c");
-    println!("cargo:rerun-if-changed=src/t2.h");
+
+    do_cc();
+    test_ctest_c();
+    test_ctest_cpp();
+    test_ctest_next();
+}
+
+fn test_ctest_c() {
     ctest::TestGenerator::new()
         .header("t1.h")
         .include("src")
@@ -37,10 +32,13 @@ fn main() {
         .volatile_item(t1_volatile)
         .array_arg(t1_arrays)
         .skip_roundtrip(|n| n == "Arr")
+        .skip_const(|name| name == "T1S")
         .generate("src/t1.rs", "t1gen.rs");
+
     ctest::TestGenerator::new()
         .header("t2.h")
         .include("src")
+        .skip_const(|name| name == "T2S")
         .type_name(move |ty, is_struct, is_union| match ty {
             "T2Union" => ty.to_string(),
             t if is_struct => format!("struct {t}"),
@@ -49,7 +47,9 @@ fn main() {
         })
         .skip_roundtrip(|_| true)
         .generate("src/t2.rs", "t2gen.rs");
+}
 
+fn test_ctest_cpp() {
     println!("cargo::rustc-check-cfg=cfg(has_cxx)");
     if !cfg!(unix) || Command::new("c++").arg("v").output().is_ok() {
         // A C compiler is always available, but these are only run if a C++ compiler is
@@ -68,14 +68,17 @@ fn main() {
                 t if is_union => format!("union {t}"),
                 t => t.to_string(),
             })
+            .skip_const(|name| name == "T1S")
             .volatile_item(t1_volatile)
             .array_arg(t1_arrays)
             .skip_roundtrip(|n| n == "Arr")
             .generate("src/t1.rs", "t1gen_cxx.rs");
+
         ctest::TestGenerator::new()
             .header("t2.h")
             .language(ctest::Lang::CXX)
             .include("src")
+            .skip_const(|name| name == "T2S")
             .type_name(move |ty, is_struct, is_union| match ty {
                 "T2Union" => ty.to_string(),
                 t if is_struct => format!("struct {t}"),
@@ -87,6 +90,54 @@ fn main() {
     } else {
         println!("cargo::warning=skipping C++ tests");
     }
+}
+
+fn test_ctest_next() {
+    let mut t1gen = ctest_next::TestGenerator::new();
+    t1gen
+        .header("t1.h")
+        .include("src")
+        .skip_private(true)
+        .rename_fn(|f| f.link_name().unwrap_or(f.ident()).to_string().into())
+        .rename_union_ty(|ty| (ty == "T1Union").then_some(ty.to_string()))
+        .rename_struct_ty(|ty| (ty == "Transparent").then_some(ty.to_string()))
+        .volatile_struct_field(|s, f| s.ident() == "V" && f.ident() == "v")
+        .volatile_static(|s| s.ident() == "vol_ptr")
+        .volatile_static(|s| s.ident() == "T1_fn_ptr_vol")
+        .volatile_fn_arg(|f, p| f.ident() == "T1_vol0" && p.ident() == "arg0")
+        .volatile_fn_arg(|f, p| f.ident() == "T1_vol2" && p.ident() == "arg1")
+        .volatile_fn_return_type(|f| f.ident() == "T1_vol1")
+        .volatile_fn_return_type(|f| f.ident() == "T1_vol2")
+        // The parameter `a` of the functions `T1r`, `T1s`, `T1t`, `T1v` is an array.
+        .array_arg(|f, p| matches!(f.ident(), "T1r" | "T1s" | "T1t" | "T1v") && p.ident() == "a")
+        .skip_roundtrip(|n| n == "Arr");
+    ctest_next::generate_test(&mut t1gen, "src/t1.rs", "t1nextgen.rs").unwrap();
+
+    let mut t2gen = ctest_next::TestGenerator::new();
+    t2gen
+        .header("t2.h")
+        .include("src")
+        // public C typedefs have to manually be specified because they are identical to normal
+        // structs on the Rust side.
+        .rename_union_ty(|ty| (ty == "T2Union").then_some(ty.to_string()))
+        .skip_roundtrip(|_| true);
+    ctest_next::generate_test(&mut t2gen, "src/t2.rs", "t2nextgen.rs").unwrap();
+}
+
+fn do_cc() {
+    cc::Build::new()
+        .include("src")
+        .warnings(false)
+        .file("src/t1.c")
+        .compile("libt1.a");
+    println!("cargo:rerun-if-changed=src/t1.c");
+    println!("cargo:rerun-if-changed=src/t1.h");
+    cc::Build::new()
+        .warnings(false)
+        .file("src/t2.c")
+        .compile("libt2.a");
+    println!("cargo:rerun-if-changed=src/t2.c");
+    println!("cargo:rerun-if-changed=src/t2.h");
 }
 
 fn t1_volatile(i: ctest::VolatileItemKind) -> bool {

--- a/ctest-test/src/bin/t1.rs
+++ b/ctest-test/src/bin/t1.rs
@@ -1,7 +1,8 @@
 #![cfg(not(test))]
 #![deny(warnings)]
 
+use std::ffi::c_uint;
+
 use ctest_test::t1::*;
-use libc::*;
 
 include!(concat!(env!("OUT_DIR"), "/t1gen.rs"));

--- a/ctest-test/src/bin/t1_cxx.rs
+++ b/ctest-test/src/bin/t1_cxx.rs
@@ -3,7 +3,7 @@
 cfg_if::cfg_if! {
     if #[cfg(has_cxx)] {
         use ctest_test::t1::*;
-        use libc::*;
+        use std::ffi::c_uint;
 
         include!(concat!(env!("OUT_DIR"), "/t1gen_cxx.rs"));
     } else {

--- a/ctest-test/src/bin/t1_next.rs
+++ b/ctest-test/src/bin/t1_next.rs
@@ -1,0 +1,6 @@
+#![cfg(not(test))]
+#![deny(warnings)]
+
+use ctest_test::t1::*;
+
+include!(concat!(env!("OUT_DIR"), "/t1nextgen.rs"));

--- a/ctest-test/src/bin/t2_next.rs
+++ b/ctest-test/src/bin/t2_next.rs
@@ -1,0 +1,6 @@
+#![cfg(not(test))]
+#![deny(warnings)]
+
+use ctest_test::t2::*;
+
+include!(concat!(env!("OUT_DIR"), "/t2nextgen.rs"));

--- a/ctest-test/src/t1.rs
+++ b/ctest-test/src/t1.rs
@@ -1,9 +1,9 @@
 #![allow(dead_code)]
 
-use libc::*;
+use std::ffi::{c_char, c_double, c_int, c_long, c_uint, c_void};
 
 pub type T1Foo = i32;
-pub const T1S: &str = "foo";
+pub const T1S: *const c_char = b"foo\0".as_ptr().cast();
 
 pub const T1N: i32 = 5;
 

--- a/ctest-test/src/t2.h
+++ b/ctest-test/src/t2.h
@@ -17,7 +17,8 @@ typedef struct {
   int64_t b;
 } T2Union;
 
-static void T2a(void) {}
+// FIXME(ctest): Cannot be uncommented until tests for functions are implemented in ctest-next.
+// static void T2a(void) {}
 
 #define T2C 4
 #define T2S "a"

--- a/ctest-test/src/t2.rs
+++ b/ctest-test/src/t2.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::{c_char, c_int};
 
 pub type T2Foo = u32;
 pub type T2Bar = u32;
@@ -28,9 +28,10 @@ pub union T2Union {
 pub const T2C: i32 = 5;
 
 i! {
-    pub const T2S: &str = "b";
+    pub const T2S: *const c_char = b"b\0".as_ptr().cast();
 }
 
-extern "C" {
-    pub fn T2a();
-}
+// FIXME(ctest): Cannot be uncommented until tests for functions are implemented in ctest-next.
+// extern "C" {
+//     pub fn T2a();
+// }


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
- Adds support for testing `ctest-next` using the same test crate as `ctest`.
- Additionally fixes some bugs in the template (unnecessary unsafe, and missing `c_char` import).
- Removes tests for `&str`, they can be added back in with separate constants that are skipped by `ctest-next` if needed.
- Adds `link_name` support for functions and statics, which goes unused right now but will be used when tests for functions and statics are implemented.
- Removes the dependency on `libc`, as `ctest-next` cannot resolve it (can be fixed later, although it isn't really necessary anywhere)
<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
