### PR TITLE
musl: add semid_ds and seminfo

### DIFF
--- a/libc-test/semver/linux-musl.txt
+++ b/libc-test/semver/linux-musl.txt
@@ -85,6 +85,8 @@ pututxline
 pwritev2
 pwritev64
 reallocarray
+semid_ds
+seminfo
 setutxent
 tcp_info
 timex

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -121,6 +121,26 @@ s! {
         shm_ctime: crate::time_t,
     }
 
+    pub struct semid_ds {
+        pub sem_perm: crate::ipc_perm,
+        __sem_otime_lo: crate::c_ulong,
+        __sem_otime_hi: crate::c_ulong,
+        __sem_ctime_lo: crate::c_ulong,
+        __sem_ctime_hi: crate::c_ulong,
+        #[cfg(target_endian = "little")]
+        pub sem_nsems: crate::c_ushort,
+        #[cfg(target_endian = "little")]
+        __sem_nsems_pad: crate::c_char,
+        #[cfg(target_endian = "big")]
+        __sem_nsems_pad: crate::c_char,
+        #[cfg(target_endian = "big")]
+        pub sem_nsems: crate::c_ushort,
+        __unused3: crate::c_long,
+        __unused4: crate::c_long,
+        pub sem_otime: crate::time_t,
+        pub sem_ctime: crate::time_t,
+    }
+
     pub struct msqid_ds {
         pub msg_perm: crate::ipc_perm,
 

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -80,6 +80,24 @@ s! {
         __unused2: Padding<c_long>,
     }
 
+    pub struct semid_ds {
+        pub sem_perm: crate::ipc_perm,
+        __sem_otime_lo: crate::c_ulong,
+        __sem_ctime_lo: crate::c_ulong,
+        #[cfg(target_endian = "little")]
+        pub sem_nsems: crate::c_ulong,
+        #[cfg(target_endian = "little")]
+        __sem_nsems_pad: crate::c_char,
+        #[cfg(target_endian = "big")]
+        __sem_nsems_pad: crate::c_char,
+        #[cfg(target_endian = "big")]
+        pub sem_nsems: crate::c_ulong,
+        __sem_otime_hi: crate::c_ulong,
+        __sem_ctime_hi: crate::c_ulong,
+        pub sem_otime: crate::time_t,
+        pub sem_ctime: crate::time_t,
+    }
+
     pub struct shmid_ds {
         pub shm_perm: crate::ipc_perm,
         pub shm_segsz: size_t,

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -136,6 +136,20 @@ s! {
         pub shm_ctime: crate::time_t,
     }
 
+    pub struct semid_ds {
+        pub sem_perm: crate::ipc_perm,
+        __sem_otime_hi: crate::c_ulong,
+        __sem_otime_lo: crate::c_ulong,
+        __sem_ctime_hi: crate::c_ulong,
+        __sem_ctime_lo: crate::c_ulong,
+        __sem_nsems_pad: crate::c_ushort,
+        pub sem_nsems: crate::c_ushort,
+        __unused3: crate::c_long,
+        __unused4: crate::c_long,
+        pub sem_otime: crate::time_t,
+        pub sem_ctime: crate::time_t,
+    }
+
     pub struct msqid_ds {
         pub msg_perm: crate::ipc_perm,
 

--- a/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
@@ -78,6 +78,26 @@ s! {
         __unused6: Padding<c_ulong>,
     }
 
+    pub struct semid_ds {
+        pub sem_perm: crate::ipc_perm,
+        __sem_otime_lo: crate::c_ulong,
+        __sem_otime_hi: crate::c_ulong,
+        __sem_ctime_lo: crate::c_ulong,
+        __sem_ctime_hi: crate::c_ulong,
+        #[cfg(target_endian = "little")]
+        pub sem_nsems: crate::c_ushort,
+        #[cfg(target_endian = "little")]
+        __sem_nsems_pad: crate::c_char,
+        #[cfg(target_endian = "big")]
+        __sem_nsems_pad: crate::c_char,
+        #[cfg(target_endian = "big")]
+        pub sem_nsems: crate::c_ushort,
+        __unused3: crate::c_long,
+        __unused4: crate::c_long,
+        pub sem_otime: crate::time_t,
+        pub sem_ctime: crate::time_t,
+    }
+
     pub struct msqid_ds {
         pub msg_perm: crate::ipc_perm,
         pub msg_stime: crate::time_t,

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -125,6 +125,18 @@ s! {
         shm_ctime: crate::time_t,
     }
 
+    pub struct semid_ds {
+        pub sem_perm: crate::ipc_perm,
+        pub sem_otime: crate::time_t,
+        __unused1: crate::c_longlong,
+        pub sem_ctime: crate::time_t,
+        __unused2: crate::c_longlong,
+        pub sem_nsems: crate::c_ushort,
+        __sem_nsems_pad: crate::c_char,
+        __unused3: crate::c_longlong,
+        __unused4: crate::c_longlong,
+    }
+
     pub struct msqid_ds {
         pub msg_perm: crate::ipc_perm,
 

--- a/src/unix/linux_like/linux/musl/b64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/mod.rs
@@ -34,6 +34,26 @@ s! {
         __pad2: Padding<c_ulong>,
     }
 
+    pub struct semid_ds {
+        pub sem_perm: crate::ipc_perm,
+        pub sem_otime: crate::time_t,
+        #[cfg(any(target_arch = "x86_64"))]
+        __unused1: crate::c_long,
+        pub sem_ctime: crate::time_t,
+        #[cfg(any(target_arch = "x86_64"))]
+        __unused2: crate::c_long,
+        #[cfg(target_endian = "little")]
+        pub sem_nsems: crate::c_ushort,
+        #[cfg(target_endian = "little")]
+        __sem_nsems_pad: crate::c_char,
+        #[cfg(target_endian = "big")]
+        __sem_nsems_pad: crate::c_char,
+        #[cfg(target_endian = "big")]
+        pub sem_nsems: crate::c_ushort,
+        __unused3: crate::c_long,
+        __unused4: crate::c_long,
+    }
+
     pub struct msqid_ds {
         pub msg_perm: crate::ipc_perm,
         pub msg_stime: crate::time_t,

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -287,6 +287,19 @@ s! {
         pub ch_addralign: crate::Elf32_Word,
     }
 
+    pub struct seminfo {
+        pub semmap: c_int,
+        pub semmni: c_int,
+        pub semmns: c_int,
+        pub semmnu: c_int,
+        pub semmsl: c_int,
+        pub semopm: c_int,
+        pub semume: c_int,
+        pub semusz: c_int,
+        pub semvmx: c_int,
+        pub semaem: c_int,
+    }
+
     pub struct timex {
         pub modes: c_uint,
         pub offset: c_long,


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Adds the semid_ds and seminfo structs to musl. These exist in the musl C library, but are not wrapped in the libc crate yet.

<!-- Add a short description about what this change does -->

# Sources

* semid_ds: https://github.com/bminor/musl/blob/8fd5d031876345e42ae3d11cc07b962f8625bc3b/arch/generic/bits/sem.h
* seminfo: https://github.com/bminor/musl/blob/8fd5d031876345e42ae3d11cc07b962f8625bc3b/include/sys/sem.h

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:
-->
@rustbot label +stable-nominated
