### PR TITLE
ctest: add tests for field size, offset, and field ptr

### DIFF
--- a/ctest-next/src/ast/field.rs
+++ b/ctest-next/src/ast/field.rs
@@ -3,7 +3,6 @@ use crate::BoxStr;
 /// Represents a field in a struct or union defined in Rust.
 #[derive(Debug, Clone)]
 pub struct Field {
-    #[expect(unused)]
     pub(crate) public: bool,
     pub(crate) ident: BoxStr,
     pub(crate) ty: syn::Type,

--- a/ctest-next/src/ast/structure.rs
+++ b/ctest-next/src/ast/structure.rs
@@ -5,7 +5,6 @@ use crate::{BoxStr, Field};
 pub struct Struct {
     pub(crate) public: bool,
     pub(crate) ident: BoxStr,
-    #[expect(unused)]
     pub(crate) fields: Vec<Field>,
 }
 

--- a/ctest-next/src/ast/union.rs
+++ b/ctest-next/src/ast/union.rs
@@ -6,7 +6,6 @@ pub struct Union {
     #[expect(unused)]
     pub(crate) public: bool,
     pub(crate) ident: BoxStr,
-    #[expect(unused)]
     pub(crate) fields: Vec<Field>,
 }
 

--- a/ctest-next/src/generator.rs
+++ b/ctest-next/src/generator.rs
@@ -38,9 +38,9 @@ pub struct TestGenerator {
     pub(crate) defines: Vec<(String, Option<String>)>,
     cfg: Vec<(String, Option<String>)>,
     mapped_names: Vec<MappedName>,
-    skips: Vec<Skip>,
+    pub(crate) skips: Vec<Skip>,
     verbose_skip: bool,
-    volatile_items: Vec<VolatileItem>,
+    pub(crate) volatile_items: Vec<VolatileItem>,
     array_arg: Option<ArrayArg>,
     skip_private: bool,
     skip_roundtrip: Option<SkipTest>,
@@ -872,7 +872,6 @@ impl TestGenerator {
         let mut ffi_items = FfiItems::new();
         ffi_items.visit_file(&ast);
 
-        // FIXME(ctest): Does not filter out tests for fields.
         self.filter_ffi_items(&mut ffi_items);
 
         let output_directory = self
@@ -945,7 +944,7 @@ impl TestGenerator {
     }
 
     /// Maps Rust identifiers or types to C counterparts, or defaults to the original name.
-    pub(crate) fn map<'a>(&self, item: impl Into<MapInput<'a>>) -> String {
+    pub(crate) fn rty_to_cty<'a>(&self, item: impl Into<MapInput<'a>>) -> String {
         let item = item.into();
         if let Some(mapped) = self.mapped_names.iter().find_map(|f| f(&item)) {
             return mapped;

--- a/ctest-next/src/lib.rs
+++ b/ctest-next/src/lib.rs
@@ -56,9 +56,7 @@ pub(crate) enum MapInput<'a> {
     Struct(&'a Struct),
     Union(&'a Union),
     Fn(&'a crate::Fn),
-    #[expect(unused)]
     StructField(&'a Struct, &'a Field),
-    #[expect(unused)]
     UnionField(&'a Union, &'a Field),
     Alias(&'a Type),
     Const(&'a Const),
@@ -67,9 +65,7 @@ pub(crate) enum MapInput<'a> {
     /// This variant is used for renaming the struct type.
     StructType(&'a str),
     UnionType(&'a str),
-    #[expect(unused)]
     StructFieldType(&'a Struct, &'a Field),
-    #[expect(unused)]
     UnionFieldType(&'a Union, &'a Field),
 }
 

--- a/ctest-next/templates/test.c
+++ b/ctest-next/templates/test.c
@@ -53,3 +53,28 @@ uint32_t ctest_signededness_of__{{ alias.id }}(void) {
     return all_ones < 0;
 }
 {%- endfor +%}
+
+{%- for item in ctx.field_size_offset_tests +%}
+
+// Return the offset of a struct/union field.
+uint64_t ctest_offset_of__{{ item.id }}__{{ item.field.ident() }}(void) {
+    return offsetof({{ item.c_ty }}, {{ item.c_field }});
+}
+
+// Return the size of a struct/union field.
+uint64_t ctest_size_of__{{ item.id }}__{{ item.field.ident() }}(void) {
+    return sizeof((({{ item.c_ty }}){}).{{ item.c_field }});
+}
+{%- endfor +%}
+
+{%- for item in ctx.field_ptr_tests +%}
+
+// Return a pointer to a struct/union field.
+// This field can have a normal data type, or it could be a function pointer or an array, which
+// have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
+typedef {{ item.volatile_keyword }}{{ item.field_return_type }};
+ctest_field_ty__{{ item.id }}__{{ item.field.ident() }}
+ctest_field_ptr__{{ item.id }}__{{ item.field.ident() }}({{ item.c_ty }} *b) {
+    return &b->{{ item.c_field }};
+}
+{%- endfor +%}

--- a/ctest-next/tests/input/hierarchy.out.rs
+++ b/ctest-next/tests/input/hierarchy.out.rs
@@ -11,6 +11,8 @@ mod generated_tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[allow(unused_imports)]
     use std::{mem, ptr, slice};
+    #[allow(unused_imports)]
+    use std::mem::{MaybeUninit, offset_of};
 
     use super::*;
 

--- a/ctest-next/tests/input/macro.out.c
+++ b/ctest-next/tests/input/macro.out.c
@@ -18,3 +18,79 @@ uint64_t ctest_size_of__VecU16(void) { return sizeof(struct VecU16); }
 
 // Return the alignment of a type.
 uint64_t ctest_align_of__VecU16(void) { return _Alignof(struct VecU16); }
+
+// Return the offset of a struct/union field.
+uint64_t ctest_offset_of__VecU8__x(void) {
+    return offsetof(struct VecU8, x);
+}
+
+// Return the size of a struct/union field.
+uint64_t ctest_size_of__VecU8__x(void) {
+    return sizeof(((struct VecU8){}).x);
+}
+
+// Return the offset of a struct/union field.
+uint64_t ctest_offset_of__VecU8__y(void) {
+    return offsetof(struct VecU8, y);
+}
+
+// Return the size of a struct/union field.
+uint64_t ctest_size_of__VecU8__y(void) {
+    return sizeof(((struct VecU8){}).y);
+}
+
+// Return the offset of a struct/union field.
+uint64_t ctest_offset_of__VecU16__x(void) {
+    return offsetof(struct VecU16, x);
+}
+
+// Return the size of a struct/union field.
+uint64_t ctest_size_of__VecU16__x(void) {
+    return sizeof(((struct VecU16){}).x);
+}
+
+// Return the offset of a struct/union field.
+uint64_t ctest_offset_of__VecU16__y(void) {
+    return offsetof(struct VecU16, y);
+}
+
+// Return the size of a struct/union field.
+uint64_t ctest_size_of__VecU16__y(void) {
+    return sizeof(((struct VecU16){}).y);
+}
+
+// Return a pointer to a struct/union field.
+// This field can have a normal data type, or it could be a function pointer or an array, which
+// have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
+typedef uint8_t* ctest_field_ty__VecU8__x;
+ctest_field_ty__VecU8__x
+ctest_field_ptr__VecU8__x(struct VecU8 *b) {
+    return &b->x;
+}
+
+// Return a pointer to a struct/union field.
+// This field can have a normal data type, or it could be a function pointer or an array, which
+// have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
+typedef uint8_t* ctest_field_ty__VecU8__y;
+ctest_field_ty__VecU8__y
+ctest_field_ptr__VecU8__y(struct VecU8 *b) {
+    return &b->y;
+}
+
+// Return a pointer to a struct/union field.
+// This field can have a normal data type, or it could be a function pointer or an array, which
+// have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
+typedef uint16_t* ctest_field_ty__VecU16__x;
+ctest_field_ty__VecU16__x
+ctest_field_ptr__VecU16__x(struct VecU16 *b) {
+    return &b->x;
+}
+
+// Return a pointer to a struct/union field.
+// This field can have a normal data type, or it could be a function pointer or an array, which
+// have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
+typedef uint16_t* ctest_field_ty__VecU16__y;
+ctest_field_ty__VecU16__y
+ctest_field_ptr__VecU16__y(struct VecU16 *b) {
+    return &b->y;
+}

--- a/ctest-next/tests/input/macro.out.rs
+++ b/ctest-next/tests/input/macro.out.rs
@@ -11,6 +11,8 @@ mod generated_tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[allow(unused_imports)]
     use std::{mem, ptr, slice};
+    #[allow(unused_imports)]
+    use std::mem::{MaybeUninit, offset_of};
 
     use super::*;
 
@@ -75,6 +77,182 @@ mod generated_tests {
         check_same(rust_size, c_size, "VecU16 size");
         check_same(rust_align, c_align, "VecU16 align");
     }
+
+    /// Make sure that the offset and size of a field in a struct/union is the same.
+    pub fn ctest_field_size_offset_VecU8_x() {
+        extern "C" {
+            fn ctest_offset_of__VecU8__x() -> u64;
+            fn ctest_size_of__VecU8__x() -> u64;
+        }
+
+        let uninit_ty = MaybeUninit::<VecU8>::zeroed();
+        let uninit_ty = uninit_ty.as_ptr();
+
+        // SAFETY: we assume the field access doesn't wrap
+        let ty_ptr = unsafe { &raw const (*uninit_ty).x   };
+        // SAFETY: we assume that all zeros is a valid bitpattern for `ty_ptr`, otherwise the
+        // test should be skipped.
+        let val = unsafe { ty_ptr.read_unaligned() };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_offset = unsafe { ctest_offset_of__VecU8__x() };
+        check_same(offset_of!(VecU8, x) as u64, ctest_field_offset,
+            "field offset x of VecU8");
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_size = unsafe { ctest_size_of__VecU8__x() };
+        check_same(size_of_val(&val) as u64, ctest_field_size,
+            "field size x of VecU8");
+    }
+
+    /// Make sure that the offset and size of a field in a struct/union is the same.
+    pub fn ctest_field_size_offset_VecU8_y() {
+        extern "C" {
+            fn ctest_offset_of__VecU8__y() -> u64;
+            fn ctest_size_of__VecU8__y() -> u64;
+        }
+
+        let uninit_ty = MaybeUninit::<VecU8>::zeroed();
+        let uninit_ty = uninit_ty.as_ptr();
+
+        // SAFETY: we assume the field access doesn't wrap
+        let ty_ptr = unsafe { &raw const (*uninit_ty).y   };
+        // SAFETY: we assume that all zeros is a valid bitpattern for `ty_ptr`, otherwise the
+        // test should be skipped.
+        let val = unsafe { ty_ptr.read_unaligned() };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_offset = unsafe { ctest_offset_of__VecU8__y() };
+        check_same(offset_of!(VecU8, y) as u64, ctest_field_offset,
+            "field offset y of VecU8");
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_size = unsafe { ctest_size_of__VecU8__y() };
+        check_same(size_of_val(&val) as u64, ctest_field_size,
+            "field size y of VecU8");
+    }
+
+    /// Make sure that the offset and size of a field in a struct/union is the same.
+    pub fn ctest_field_size_offset_VecU16_x() {
+        extern "C" {
+            fn ctest_offset_of__VecU16__x() -> u64;
+            fn ctest_size_of__VecU16__x() -> u64;
+        }
+
+        let uninit_ty = MaybeUninit::<VecU16>::zeroed();
+        let uninit_ty = uninit_ty.as_ptr();
+
+        // SAFETY: we assume the field access doesn't wrap
+        let ty_ptr = unsafe { &raw const (*uninit_ty).x   };
+        // SAFETY: we assume that all zeros is a valid bitpattern for `ty_ptr`, otherwise the
+        // test should be skipped.
+        let val = unsafe { ty_ptr.read_unaligned() };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_offset = unsafe { ctest_offset_of__VecU16__x() };
+        check_same(offset_of!(VecU16, x) as u64, ctest_field_offset,
+            "field offset x of VecU16");
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_size = unsafe { ctest_size_of__VecU16__x() };
+        check_same(size_of_val(&val) as u64, ctest_field_size,
+            "field size x of VecU16");
+    }
+
+    /// Make sure that the offset and size of a field in a struct/union is the same.
+    pub fn ctest_field_size_offset_VecU16_y() {
+        extern "C" {
+            fn ctest_offset_of__VecU16__y() -> u64;
+            fn ctest_size_of__VecU16__y() -> u64;
+        }
+
+        let uninit_ty = MaybeUninit::<VecU16>::zeroed();
+        let uninit_ty = uninit_ty.as_ptr();
+
+        // SAFETY: we assume the field access doesn't wrap
+        let ty_ptr = unsafe { &raw const (*uninit_ty).y   };
+        // SAFETY: we assume that all zeros is a valid bitpattern for `ty_ptr`, otherwise the
+        // test should be skipped.
+        let val = unsafe { ty_ptr.read_unaligned() };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_offset = unsafe { ctest_offset_of__VecU16__y() };
+        check_same(offset_of!(VecU16, y) as u64, ctest_field_offset,
+            "field offset y of VecU16");
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_size = unsafe { ctest_size_of__VecU16__y() };
+        check_same(size_of_val(&val) as u64, ctest_field_size,
+            "field size y of VecU16");
+    }
+
+    /// Tests if the pointer to the field is the same in Rust and C.
+    pub fn ctest_field_ptr_VecU8_x() {
+        extern "C" {
+            fn ctest_field_ptr__VecU8__x(a: *const VecU8) -> *mut u8;
+        }
+
+        let uninit_ty = MaybeUninit::<VecU8>::zeroed();
+        let ty_ptr = uninit_ty.as_ptr();
+        // SAFETY: We don't read `field_ptr`, only compare the pointer itself.
+        // The assumption is made that this does not wrap the address space.
+        let field_ptr = unsafe { &raw const ((*ty_ptr).x) };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_ptr = unsafe { ctest_field_ptr__VecU8__x(ty_ptr) };
+        check_same(field_ptr.cast(), ctest_field_ptr,
+            "field type x of VecU8");
+    }
+
+    /// Tests if the pointer to the field is the same in Rust and C.
+    pub fn ctest_field_ptr_VecU8_y() {
+        extern "C" {
+            fn ctest_field_ptr__VecU8__y(a: *const VecU8) -> *mut u8;
+        }
+
+        let uninit_ty = MaybeUninit::<VecU8>::zeroed();
+        let ty_ptr = uninit_ty.as_ptr();
+        // SAFETY: We don't read `field_ptr`, only compare the pointer itself.
+        // The assumption is made that this does not wrap the address space.
+        let field_ptr = unsafe { &raw const ((*ty_ptr).y) };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_ptr = unsafe { ctest_field_ptr__VecU8__y(ty_ptr) };
+        check_same(field_ptr.cast(), ctest_field_ptr,
+            "field type y of VecU8");
+    }
+
+    /// Tests if the pointer to the field is the same in Rust and C.
+    pub fn ctest_field_ptr_VecU16_x() {
+        extern "C" {
+            fn ctest_field_ptr__VecU16__x(a: *const VecU16) -> *mut u8;
+        }
+
+        let uninit_ty = MaybeUninit::<VecU16>::zeroed();
+        let ty_ptr = uninit_ty.as_ptr();
+        // SAFETY: We don't read `field_ptr`, only compare the pointer itself.
+        // The assumption is made that this does not wrap the address space.
+        let field_ptr = unsafe { &raw const ((*ty_ptr).x) };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_ptr = unsafe { ctest_field_ptr__VecU16__x(ty_ptr) };
+        check_same(field_ptr.cast(), ctest_field_ptr,
+            "field type x of VecU16");
+    }
+
+    /// Tests if the pointer to the field is the same in Rust and C.
+    pub fn ctest_field_ptr_VecU16_y() {
+        extern "C" {
+            fn ctest_field_ptr__VecU16__y(a: *const VecU16) -> *mut u8;
+        }
+
+        let uninit_ty = MaybeUninit::<VecU16>::zeroed();
+        let ty_ptr = uninit_ty.as_ptr();
+        // SAFETY: We don't read `field_ptr`, only compare the pointer itself.
+        // The assumption is made that this does not wrap the address space.
+        let field_ptr = unsafe { &raw const ((*ty_ptr).y) };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_ptr = unsafe { ctest_field_ptr__VecU16__y(ty_ptr) };
+        check_same(field_ptr.cast(), ctest_field_ptr,
+            "field type y of VecU16");
+    }
 }
 
 use generated_tests::*;
@@ -96,4 +274,12 @@ fn main() {
 fn run_all() {
     ctest_size_align_VecU8();
     ctest_size_align_VecU16();
+    ctest_field_size_offset_VecU8_x();
+    ctest_field_size_offset_VecU8_y();
+    ctest_field_size_offset_VecU16_x();
+    ctest_field_size_offset_VecU16_y();
+    ctest_field_ptr_VecU8_x();
+    ctest_field_ptr_VecU8_y();
+    ctest_field_ptr_VecU16_x();
+    ctest_field_ptr_VecU16_y();
 }

--- a/ctest-next/tests/input/macro.rs
+++ b/ctest-next/tests/input/macro.rs
@@ -2,8 +2,8 @@ macro_rules! vector {
     ($name:ident, $ty:ty) => {
         #[repr(C)]
         struct $name {
-            x: $ty,
-            y: $ty,
+            pub x: $ty,
+            pub y: $ty,
         }
     };
 }

--- a/ctest-next/tests/input/simple.h
+++ b/ctest-next/tests/input/simple.h
@@ -6,6 +6,7 @@ struct Person
 {
     const char *name;
     uint8_t age;
+    void (*job)(uint8_t, const char *);
 };
 
 union Word

--- a/ctest-next/tests/input/simple.out.with-renames.c
+++ b/ctest-next/tests/input/simple.out.with-renames.c
@@ -47,3 +47,98 @@ uint32_t ctest_signededness_of__Byte(void) {
     Byte all_ones = (Byte) -1;
     return all_ones < 0;
 }
+
+// Return the offset of a struct/union field.
+uint64_t ctest_offset_of__Person__name(void) {
+    return offsetof(struct Person, name);
+}
+
+// Return the size of a struct/union field.
+uint64_t ctest_size_of__Person__name(void) {
+    return sizeof(((struct Person){}).name);
+}
+
+// Return the offset of a struct/union field.
+uint64_t ctest_offset_of__Person__age(void) {
+    return offsetof(struct Person, age);
+}
+
+// Return the size of a struct/union field.
+uint64_t ctest_size_of__Person__age(void) {
+    return sizeof(((struct Person){}).age);
+}
+
+// Return the offset of a struct/union field.
+uint64_t ctest_offset_of__Person__job(void) {
+    return offsetof(struct Person, job);
+}
+
+// Return the size of a struct/union field.
+uint64_t ctest_size_of__Person__job(void) {
+    return sizeof(((struct Person){}).job);
+}
+
+// Return the offset of a struct/union field.
+uint64_t ctest_offset_of__Word__word(void) {
+    return offsetof(union Word, word);
+}
+
+// Return the size of a struct/union field.
+uint64_t ctest_size_of__Word__word(void) {
+    return sizeof(((union Word){}).word);
+}
+
+// Return the offset of a struct/union field.
+uint64_t ctest_offset_of__Word__byte(void) {
+    return offsetof(union Word, byte);
+}
+
+// Return the size of a struct/union field.
+uint64_t ctest_size_of__Word__byte(void) {
+    return sizeof(((union Word){}).byte);
+}
+
+// Return a pointer to a struct/union field.
+// This field can have a normal data type, or it could be a function pointer or an array, which
+// have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
+typedef char const* *ctest_field_ty__Person__name;
+ctest_field_ty__Person__name
+ctest_field_ptr__Person__name(struct Person *b) {
+    return &b->name;
+}
+
+// Return a pointer to a struct/union field.
+// This field can have a normal data type, or it could be a function pointer or an array, which
+// have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
+typedef uint8_t* ctest_field_ty__Person__age;
+ctest_field_ty__Person__age
+ctest_field_ptr__Person__age(struct Person *b) {
+    return &b->age;
+}
+
+// Return a pointer to a struct/union field.
+// This field can have a normal data type, or it could be a function pointer or an array, which
+// have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
+typedef void (**ctest_field_ty__Person__job)(uint8_t, char const*);
+ctest_field_ty__Person__job
+ctest_field_ptr__Person__job(struct Person *b) {
+    return &b->job;
+}
+
+// Return a pointer to a struct/union field.
+// This field can have a normal data type, or it could be a function pointer or an array, which
+// have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
+typedef uint16_t* ctest_field_ty__Word__word;
+ctest_field_ty__Word__word
+ctest_field_ptr__Word__word(union Word *b) {
+    return &b->word;
+}
+
+// Return a pointer to a struct/union field.
+// This field can have a normal data type, or it could be a function pointer or an array, which
+// have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
+typedef Byte (*ctest_field_ty__Word__byte)[2];
+ctest_field_ty__Word__byte
+ctest_field_ptr__Word__byte(union Word *b) {
+    return &b->byte;
+}

--- a/ctest-next/tests/input/simple.out.with-renames.rs
+++ b/ctest-next/tests/input/simple.out.with-renames.rs
@@ -11,6 +11,8 @@ mod generated_tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[allow(unused_imports)]
     use std::{mem, ptr, slice};
+    #[allow(unused_imports)]
+    use std::mem::{MaybeUninit, offset_of};
 
     use super::*;
 
@@ -154,6 +156,226 @@ mod generated_tests {
 
         check_same((all_ones < all_zeros) as u32, c_is_signed, "Byte signed");
     }
+
+    /// Make sure that the offset and size of a field in a struct/union is the same.
+    pub fn ctest_field_size_offset_Person_name() {
+        extern "C" {
+            fn ctest_offset_of__Person__name() -> u64;
+            fn ctest_size_of__Person__name() -> u64;
+        }
+
+        let uninit_ty = MaybeUninit::<Person>::zeroed();
+        let uninit_ty = uninit_ty.as_ptr();
+
+        // SAFETY: we assume the field access doesn't wrap
+        let ty_ptr = unsafe { &raw const (*uninit_ty).name   };
+        // SAFETY: we assume that all zeros is a valid bitpattern for `ty_ptr`, otherwise the
+        // test should be skipped.
+        let val = unsafe { ty_ptr.read_unaligned() };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_offset = unsafe { ctest_offset_of__Person__name() };
+        check_same(offset_of!(Person, name) as u64, ctest_field_offset,
+            "field offset name of Person");
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_size = unsafe { ctest_size_of__Person__name() };
+        check_same(size_of_val(&val) as u64, ctest_field_size,
+            "field size name of Person");
+    }
+
+    /// Make sure that the offset and size of a field in a struct/union is the same.
+    pub fn ctest_field_size_offset_Person_age() {
+        extern "C" {
+            fn ctest_offset_of__Person__age() -> u64;
+            fn ctest_size_of__Person__age() -> u64;
+        }
+
+        let uninit_ty = MaybeUninit::<Person>::zeroed();
+        let uninit_ty = uninit_ty.as_ptr();
+
+        // SAFETY: we assume the field access doesn't wrap
+        let ty_ptr = unsafe { &raw const (*uninit_ty).age   };
+        // SAFETY: we assume that all zeros is a valid bitpattern for `ty_ptr`, otherwise the
+        // test should be skipped.
+        let val = unsafe { ty_ptr.read_unaligned() };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_offset = unsafe { ctest_offset_of__Person__age() };
+        check_same(offset_of!(Person, age) as u64, ctest_field_offset,
+            "field offset age of Person");
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_size = unsafe { ctest_size_of__Person__age() };
+        check_same(size_of_val(&val) as u64, ctest_field_size,
+            "field size age of Person");
+    }
+
+    /// Make sure that the offset and size of a field in a struct/union is the same.
+    pub fn ctest_field_size_offset_Person_job() {
+        extern "C" {
+            fn ctest_offset_of__Person__job() -> u64;
+            fn ctest_size_of__Person__job() -> u64;
+        }
+
+        let uninit_ty = MaybeUninit::<Person>::zeroed();
+        let uninit_ty = uninit_ty.as_ptr();
+
+        // SAFETY: we assume the field access doesn't wrap
+        let ty_ptr = unsafe { &raw const (*uninit_ty).job   };
+        // SAFETY: we assume that all zeros is a valid bitpattern for `ty_ptr`, otherwise the
+        // test should be skipped.
+        let val = unsafe { ty_ptr.read_unaligned() };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_offset = unsafe { ctest_offset_of__Person__job() };
+        check_same(offset_of!(Person, job) as u64, ctest_field_offset,
+            "field offset job of Person");
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_size = unsafe { ctest_size_of__Person__job() };
+        check_same(size_of_val(&val) as u64, ctest_field_size,
+            "field size job of Person");
+    }
+
+    /// Make sure that the offset and size of a field in a struct/union is the same.
+    pub fn ctest_field_size_offset_Word_word() {
+        extern "C" {
+            fn ctest_offset_of__Word__word() -> u64;
+            fn ctest_size_of__Word__word() -> u64;
+        }
+
+        let uninit_ty = MaybeUninit::<Word>::zeroed();
+        let uninit_ty = uninit_ty.as_ptr();
+
+        // SAFETY: we assume the field access doesn't wrap
+        let ty_ptr = unsafe { &raw const (*uninit_ty).word   };
+        // SAFETY: we assume that all zeros is a valid bitpattern for `ty_ptr`, otherwise the
+        // test should be skipped.
+        let val = unsafe { ty_ptr.read_unaligned() };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_offset = unsafe { ctest_offset_of__Word__word() };
+        check_same(offset_of!(Word, word) as u64, ctest_field_offset,
+            "field offset word of Word");
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_size = unsafe { ctest_size_of__Word__word() };
+        check_same(size_of_val(&val) as u64, ctest_field_size,
+            "field size word of Word");
+    }
+
+    /// Make sure that the offset and size of a field in a struct/union is the same.
+    pub fn ctest_field_size_offset_Word_byte() {
+        extern "C" {
+            fn ctest_offset_of__Word__byte() -> u64;
+            fn ctest_size_of__Word__byte() -> u64;
+        }
+
+        let uninit_ty = MaybeUninit::<Word>::zeroed();
+        let uninit_ty = uninit_ty.as_ptr();
+
+        // SAFETY: we assume the field access doesn't wrap
+        let ty_ptr = unsafe { &raw const (*uninit_ty).byte   };
+        // SAFETY: we assume that all zeros is a valid bitpattern for `ty_ptr`, otherwise the
+        // test should be skipped.
+        let val = unsafe { ty_ptr.read_unaligned() };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_offset = unsafe { ctest_offset_of__Word__byte() };
+        check_same(offset_of!(Word, byte) as u64, ctest_field_offset,
+            "field offset byte of Word");
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_size = unsafe { ctest_size_of__Word__byte() };
+        check_same(size_of_val(&val) as u64, ctest_field_size,
+            "field size byte of Word");
+    }
+
+    /// Tests if the pointer to the field is the same in Rust and C.
+    pub fn ctest_field_ptr_Person_name() {
+        extern "C" {
+            fn ctest_field_ptr__Person__name(a: *const Person) -> *mut u8;
+        }
+
+        let uninit_ty = MaybeUninit::<Person>::zeroed();
+        let ty_ptr = uninit_ty.as_ptr();
+        // SAFETY: We don't read `field_ptr`, only compare the pointer itself.
+        // The assumption is made that this does not wrap the address space.
+        let field_ptr = unsafe { &raw const ((*ty_ptr).name) };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_ptr = unsafe { ctest_field_ptr__Person__name(ty_ptr) };
+        check_same(field_ptr.cast(), ctest_field_ptr,
+            "field type name of Person");
+    }
+
+    /// Tests if the pointer to the field is the same in Rust and C.
+    pub fn ctest_field_ptr_Person_age() {
+        extern "C" {
+            fn ctest_field_ptr__Person__age(a: *const Person) -> *mut u8;
+        }
+
+        let uninit_ty = MaybeUninit::<Person>::zeroed();
+        let ty_ptr = uninit_ty.as_ptr();
+        // SAFETY: We don't read `field_ptr`, only compare the pointer itself.
+        // The assumption is made that this does not wrap the address space.
+        let field_ptr = unsafe { &raw const ((*ty_ptr).age) };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_ptr = unsafe { ctest_field_ptr__Person__age(ty_ptr) };
+        check_same(field_ptr.cast(), ctest_field_ptr,
+            "field type age of Person");
+    }
+
+    /// Tests if the pointer to the field is the same in Rust and C.
+    pub fn ctest_field_ptr_Person_job() {
+        extern "C" {
+            fn ctest_field_ptr__Person__job(a: *const Person) -> *mut u8;
+        }
+
+        let uninit_ty = MaybeUninit::<Person>::zeroed();
+        let ty_ptr = uninit_ty.as_ptr();
+        // SAFETY: We don't read `field_ptr`, only compare the pointer itself.
+        // The assumption is made that this does not wrap the address space.
+        let field_ptr = unsafe { &raw const ((*ty_ptr).job) };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_ptr = unsafe { ctest_field_ptr__Person__job(ty_ptr) };
+        check_same(field_ptr.cast(), ctest_field_ptr,
+            "field type job of Person");
+    }
+
+    /// Tests if the pointer to the field is the same in Rust and C.
+    pub fn ctest_field_ptr_Word_word() {
+        extern "C" {
+            fn ctest_field_ptr__Word__word(a: *const Word) -> *mut u8;
+        }
+
+        let uninit_ty = MaybeUninit::<Word>::zeroed();
+        let ty_ptr = uninit_ty.as_ptr();
+        // SAFETY: We don't read `field_ptr`, only compare the pointer itself.
+        // The assumption is made that this does not wrap the address space.
+        let field_ptr = unsafe { &raw const ((*ty_ptr).word) };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_ptr = unsafe { ctest_field_ptr__Word__word(ty_ptr) };
+        check_same(field_ptr.cast(), ctest_field_ptr,
+            "field type word of Word");
+    }
+
+    /// Tests if the pointer to the field is the same in Rust and C.
+    pub fn ctest_field_ptr_Word_byte() {
+        extern "C" {
+            fn ctest_field_ptr__Word__byte(a: *const Word) -> *mut u8;
+        }
+
+        let uninit_ty = MaybeUninit::<Word>::zeroed();
+        let ty_ptr = uninit_ty.as_ptr();
+        // SAFETY: We don't read `field_ptr`, only compare the pointer itself.
+        // The assumption is made that this does not wrap the address space.
+        let field_ptr = unsafe { &raw const ((*ty_ptr).byte) };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_ptr = unsafe { ctest_field_ptr__Word__byte(ty_ptr) };
+        check_same(field_ptr.cast(), ctest_field_ptr,
+            "field type byte of Word");
+    }
 }
 
 use generated_tests::*;
@@ -179,4 +401,14 @@ fn run_all() {
     ctest_size_align_Person();
     ctest_size_align_Word();
     ctest_signededness_Byte();
+    ctest_field_size_offset_Person_name();
+    ctest_field_size_offset_Person_age();
+    ctest_field_size_offset_Person_job();
+    ctest_field_size_offset_Word_word();
+    ctest_field_size_offset_Word_byte();
+    ctest_field_ptr_Person_name();
+    ctest_field_ptr_Person_age();
+    ctest_field_ptr_Person_job();
+    ctest_field_ptr_Word_word();
+    ctest_field_ptr_Word_byte();
 }

--- a/ctest-next/tests/input/simple.out.with-skips.c
+++ b/ctest-next/tests/input/simple.out.with-skips.c
@@ -39,3 +39,98 @@ uint32_t ctest_signededness_of__Byte(void) {
     Byte all_ones = (Byte) -1;
     return all_ones < 0;
 }
+
+// Return the offset of a struct/union field.
+uint64_t ctest_offset_of__Person__name(void) {
+    return offsetof(struct Person, name);
+}
+
+// Return the size of a struct/union field.
+uint64_t ctest_size_of__Person__name(void) {
+    return sizeof(((struct Person){}).name);
+}
+
+// Return the offset of a struct/union field.
+uint64_t ctest_offset_of__Person__age(void) {
+    return offsetof(struct Person, age);
+}
+
+// Return the size of a struct/union field.
+uint64_t ctest_size_of__Person__age(void) {
+    return sizeof(((struct Person){}).age);
+}
+
+// Return the offset of a struct/union field.
+uint64_t ctest_offset_of__Person__job(void) {
+    return offsetof(struct Person, job);
+}
+
+// Return the size of a struct/union field.
+uint64_t ctest_size_of__Person__job(void) {
+    return sizeof(((struct Person){}).job);
+}
+
+// Return the offset of a struct/union field.
+uint64_t ctest_offset_of__Word__word(void) {
+    return offsetof(union Word, word);
+}
+
+// Return the size of a struct/union field.
+uint64_t ctest_size_of__Word__word(void) {
+    return sizeof(((union Word){}).word);
+}
+
+// Return the offset of a struct/union field.
+uint64_t ctest_offset_of__Word__byte(void) {
+    return offsetof(union Word, byte);
+}
+
+// Return the size of a struct/union field.
+uint64_t ctest_size_of__Word__byte(void) {
+    return sizeof(((union Word){}).byte);
+}
+
+// Return a pointer to a struct/union field.
+// This field can have a normal data type, or it could be a function pointer or an array, which
+// have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
+typedef char const* *ctest_field_ty__Person__name;
+ctest_field_ty__Person__name
+ctest_field_ptr__Person__name(struct Person *b) {
+    return &b->name;
+}
+
+// Return a pointer to a struct/union field.
+// This field can have a normal data type, or it could be a function pointer or an array, which
+// have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
+typedef uint8_t* ctest_field_ty__Person__age;
+ctest_field_ty__Person__age
+ctest_field_ptr__Person__age(struct Person *b) {
+    return &b->age;
+}
+
+// Return a pointer to a struct/union field.
+// This field can have a normal data type, or it could be a function pointer or an array, which
+// have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
+typedef void (**ctest_field_ty__Person__job)(uint8_t, char const*);
+ctest_field_ty__Person__job
+ctest_field_ptr__Person__job(struct Person *b) {
+    return &b->job;
+}
+
+// Return a pointer to a struct/union field.
+// This field can have a normal data type, or it could be a function pointer or an array, which
+// have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
+typedef uint16_t* ctest_field_ty__Word__word;
+ctest_field_ty__Word__word
+ctest_field_ptr__Word__word(union Word *b) {
+    return &b->word;
+}
+
+// Return a pointer to a struct/union field.
+// This field can have a normal data type, or it could be a function pointer or an array, which
+// have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
+typedef Byte (*ctest_field_ty__Word__byte)[2];
+ctest_field_ty__Word__byte
+ctest_field_ptr__Word__byte(union Word *b) {
+    return &b->byte;
+}

--- a/ctest-next/tests/input/simple.out.with-skips.rs
+++ b/ctest-next/tests/input/simple.out.with-skips.rs
@@ -11,6 +11,8 @@ mod generated_tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[allow(unused_imports)]
     use std::{mem, ptr, slice};
+    #[allow(unused_imports)]
+    use std::mem::{MaybeUninit, offset_of};
 
     use super::*;
 
@@ -131,6 +133,226 @@ mod generated_tests {
 
         check_same((all_ones < all_zeros) as u32, c_is_signed, "Byte signed");
     }
+
+    /// Make sure that the offset and size of a field in a struct/union is the same.
+    pub fn ctest_field_size_offset_Person_name() {
+        extern "C" {
+            fn ctest_offset_of__Person__name() -> u64;
+            fn ctest_size_of__Person__name() -> u64;
+        }
+
+        let uninit_ty = MaybeUninit::<Person>::zeroed();
+        let uninit_ty = uninit_ty.as_ptr();
+
+        // SAFETY: we assume the field access doesn't wrap
+        let ty_ptr = unsafe { &raw const (*uninit_ty).name   };
+        // SAFETY: we assume that all zeros is a valid bitpattern for `ty_ptr`, otherwise the
+        // test should be skipped.
+        let val = unsafe { ty_ptr.read_unaligned() };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_offset = unsafe { ctest_offset_of__Person__name() };
+        check_same(offset_of!(Person, name) as u64, ctest_field_offset,
+            "field offset name of Person");
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_size = unsafe { ctest_size_of__Person__name() };
+        check_same(size_of_val(&val) as u64, ctest_field_size,
+            "field size name of Person");
+    }
+
+    /// Make sure that the offset and size of a field in a struct/union is the same.
+    pub fn ctest_field_size_offset_Person_age() {
+        extern "C" {
+            fn ctest_offset_of__Person__age() -> u64;
+            fn ctest_size_of__Person__age() -> u64;
+        }
+
+        let uninit_ty = MaybeUninit::<Person>::zeroed();
+        let uninit_ty = uninit_ty.as_ptr();
+
+        // SAFETY: we assume the field access doesn't wrap
+        let ty_ptr = unsafe { &raw const (*uninit_ty).age   };
+        // SAFETY: we assume that all zeros is a valid bitpattern for `ty_ptr`, otherwise the
+        // test should be skipped.
+        let val = unsafe { ty_ptr.read_unaligned() };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_offset = unsafe { ctest_offset_of__Person__age() };
+        check_same(offset_of!(Person, age) as u64, ctest_field_offset,
+            "field offset age of Person");
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_size = unsafe { ctest_size_of__Person__age() };
+        check_same(size_of_val(&val) as u64, ctest_field_size,
+            "field size age of Person");
+    }
+
+    /// Make sure that the offset and size of a field in a struct/union is the same.
+    pub fn ctest_field_size_offset_Person_job() {
+        extern "C" {
+            fn ctest_offset_of__Person__job() -> u64;
+            fn ctest_size_of__Person__job() -> u64;
+        }
+
+        let uninit_ty = MaybeUninit::<Person>::zeroed();
+        let uninit_ty = uninit_ty.as_ptr();
+
+        // SAFETY: we assume the field access doesn't wrap
+        let ty_ptr = unsafe { &raw const (*uninit_ty).job   };
+        // SAFETY: we assume that all zeros is a valid bitpattern for `ty_ptr`, otherwise the
+        // test should be skipped.
+        let val = unsafe { ty_ptr.read_unaligned() };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_offset = unsafe { ctest_offset_of__Person__job() };
+        check_same(offset_of!(Person, job) as u64, ctest_field_offset,
+            "field offset job of Person");
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_size = unsafe { ctest_size_of__Person__job() };
+        check_same(size_of_val(&val) as u64, ctest_field_size,
+            "field size job of Person");
+    }
+
+    /// Make sure that the offset and size of a field in a struct/union is the same.
+    pub fn ctest_field_size_offset_Word_word() {
+        extern "C" {
+            fn ctest_offset_of__Word__word() -> u64;
+            fn ctest_size_of__Word__word() -> u64;
+        }
+
+        let uninit_ty = MaybeUninit::<Word>::zeroed();
+        let uninit_ty = uninit_ty.as_ptr();
+
+        // SAFETY: we assume the field access doesn't wrap
+        let ty_ptr = unsafe { &raw const (*uninit_ty).word   };
+        // SAFETY: we assume that all zeros is a valid bitpattern for `ty_ptr`, otherwise the
+        // test should be skipped.
+        let val = unsafe { ty_ptr.read_unaligned() };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_offset = unsafe { ctest_offset_of__Word__word() };
+        check_same(offset_of!(Word, word) as u64, ctest_field_offset,
+            "field offset word of Word");
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_size = unsafe { ctest_size_of__Word__word() };
+        check_same(size_of_val(&val) as u64, ctest_field_size,
+            "field size word of Word");
+    }
+
+    /// Make sure that the offset and size of a field in a struct/union is the same.
+    pub fn ctest_field_size_offset_Word_byte() {
+        extern "C" {
+            fn ctest_offset_of__Word__byte() -> u64;
+            fn ctest_size_of__Word__byte() -> u64;
+        }
+
+        let uninit_ty = MaybeUninit::<Word>::zeroed();
+        let uninit_ty = uninit_ty.as_ptr();
+
+        // SAFETY: we assume the field access doesn't wrap
+        let ty_ptr = unsafe { &raw const (*uninit_ty).byte   };
+        // SAFETY: we assume that all zeros is a valid bitpattern for `ty_ptr`, otherwise the
+        // test should be skipped.
+        let val = unsafe { ty_ptr.read_unaligned() };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_offset = unsafe { ctest_offset_of__Word__byte() };
+        check_same(offset_of!(Word, byte) as u64, ctest_field_offset,
+            "field offset byte of Word");
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_size = unsafe { ctest_size_of__Word__byte() };
+        check_same(size_of_val(&val) as u64, ctest_field_size,
+            "field size byte of Word");
+    }
+
+    /// Tests if the pointer to the field is the same in Rust and C.
+    pub fn ctest_field_ptr_Person_name() {
+        extern "C" {
+            fn ctest_field_ptr__Person__name(a: *const Person) -> *mut u8;
+        }
+
+        let uninit_ty = MaybeUninit::<Person>::zeroed();
+        let ty_ptr = uninit_ty.as_ptr();
+        // SAFETY: We don't read `field_ptr`, only compare the pointer itself.
+        // The assumption is made that this does not wrap the address space.
+        let field_ptr = unsafe { &raw const ((*ty_ptr).name) };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_ptr = unsafe { ctest_field_ptr__Person__name(ty_ptr) };
+        check_same(field_ptr.cast(), ctest_field_ptr,
+            "field type name of Person");
+    }
+
+    /// Tests if the pointer to the field is the same in Rust and C.
+    pub fn ctest_field_ptr_Person_age() {
+        extern "C" {
+            fn ctest_field_ptr__Person__age(a: *const Person) -> *mut u8;
+        }
+
+        let uninit_ty = MaybeUninit::<Person>::zeroed();
+        let ty_ptr = uninit_ty.as_ptr();
+        // SAFETY: We don't read `field_ptr`, only compare the pointer itself.
+        // The assumption is made that this does not wrap the address space.
+        let field_ptr = unsafe { &raw const ((*ty_ptr).age) };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_ptr = unsafe { ctest_field_ptr__Person__age(ty_ptr) };
+        check_same(field_ptr.cast(), ctest_field_ptr,
+            "field type age of Person");
+    }
+
+    /// Tests if the pointer to the field is the same in Rust and C.
+    pub fn ctest_field_ptr_Person_job() {
+        extern "C" {
+            fn ctest_field_ptr__Person__job(a: *const Person) -> *mut u8;
+        }
+
+        let uninit_ty = MaybeUninit::<Person>::zeroed();
+        let ty_ptr = uninit_ty.as_ptr();
+        // SAFETY: We don't read `field_ptr`, only compare the pointer itself.
+        // The assumption is made that this does not wrap the address space.
+        let field_ptr = unsafe { &raw const ((*ty_ptr).job) };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_ptr = unsafe { ctest_field_ptr__Person__job(ty_ptr) };
+        check_same(field_ptr.cast(), ctest_field_ptr,
+            "field type job of Person");
+    }
+
+    /// Tests if the pointer to the field is the same in Rust and C.
+    pub fn ctest_field_ptr_Word_word() {
+        extern "C" {
+            fn ctest_field_ptr__Word__word(a: *const Word) -> *mut u8;
+        }
+
+        let uninit_ty = MaybeUninit::<Word>::zeroed();
+        let ty_ptr = uninit_ty.as_ptr();
+        // SAFETY: We don't read `field_ptr`, only compare the pointer itself.
+        // The assumption is made that this does not wrap the address space.
+        let field_ptr = unsafe { &raw const ((*ty_ptr).word) };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_ptr = unsafe { ctest_field_ptr__Word__word(ty_ptr) };
+        check_same(field_ptr.cast(), ctest_field_ptr,
+            "field type word of Word");
+    }
+
+    /// Tests if the pointer to the field is the same in Rust and C.
+    pub fn ctest_field_ptr_Word_byte() {
+        extern "C" {
+            fn ctest_field_ptr__Word__byte(a: *const Word) -> *mut u8;
+        }
+
+        let uninit_ty = MaybeUninit::<Word>::zeroed();
+        let ty_ptr = uninit_ty.as_ptr();
+        // SAFETY: We don't read `field_ptr`, only compare the pointer itself.
+        // The assumption is made that this does not wrap the address space.
+        let field_ptr = unsafe { &raw const ((*ty_ptr).byte) };
+
+        // SAFETY: FFI call with no preconditions
+        let ctest_field_ptr = unsafe { ctest_field_ptr__Word__byte(ty_ptr) };
+        check_same(field_ptr.cast(), ctest_field_ptr,
+            "field type byte of Word");
+    }
 }
 
 use generated_tests::*;
@@ -155,4 +377,14 @@ fn run_all() {
     ctest_size_align_Person();
     ctest_size_align_Word();
     ctest_signededness_Byte();
+    ctest_field_size_offset_Person_name();
+    ctest_field_size_offset_Person_age();
+    ctest_field_size_offset_Person_job();
+    ctest_field_size_offset_Word_word();
+    ctest_field_size_offset_Word_byte();
+    ctest_field_ptr_Person_name();
+    ctest_field_ptr_Person_age();
+    ctest_field_ptr_Person_job();
+    ctest_field_ptr_Word_word();
+    ctest_field_ptr_Word_byte();
 }

--- a/ctest-next/tests/input/simple.rs
+++ b/ctest-next/tests/input/simple.rs
@@ -4,14 +4,15 @@ pub type Byte = u8;
 
 #[repr(C)]
 pub struct Person {
-    name: *const c_char,
-    age: u8,
+    pub name: *const c_char,
+    pub age: u8,
+    pub job: extern "C" fn(u8, *const c_char),
 }
 
 #[repr(C)]
 pub union Word {
-    word: u16,
-    byte: [Byte; 2],
+    pub word: u16,
+    pub byte: [Byte; 2],
 }
 
 const A: *const c_char = c"abc".as_ptr();

--- a/ctest-test/tests/all.rs
+++ b/ctest-test/tests/all.rs
@@ -155,16 +155,16 @@ fn t2_next() {
         "bad T2Bar align",
         "bad T2Bar signed",
         "bad T2Baz size",
-        // "bad field offset a of T2Baz",
-        // "bad field type a of T2Baz",
-        // "bad field offset b of T2Baz",
-        // "bad field type b of T2Baz",
+        "bad field offset a of T2Baz",
+        "bad field type a of T2Baz",
+        "bad field offset b of T2Baz",
+        "bad field type b of T2Baz",
         // "bad T2a function pointer",
         "bad T2C value at byte 0",
         "bad const T2S string",
         "bad T2Union size",
-        // "bad field type b of T2Union",
-        // "bad field offset b of T2Union",
+        "bad field type b of T2Union",
+        "bad field offset b of T2Union",
     ];
     let mut errors = errors.iter().cloned().collect::<HashSet<_>>();
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
Adds tests for checking if the size and offset of a field is the same in Rust and C, as well as the pointer to that field.

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
