### PR TITLE
test: Start using automatic test detection

### DIFF
--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -64,11 +64,6 @@ path = "test/linux_termios.rs"
 harness = false
 
 [[test]]
-name = "cmsg"
-path = "test/cmsg.rs"
-harness = true
-
-[[test]]
 name = "makedev"
 path = "test/makedev.rs"
 harness = true


### PR DESCRIPTION
Move the `cmsg` test from `test/` to `tests/`, which is the directory for autodetection. This means that we can drop the corresponding `[[test]]` entry in `libc-test/Cargo.toml`.