### PR TITLE
Restore 'struct ld_info' and related types for AIX

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -5625,6 +5625,18 @@ fn test_aix(target: &str) {
             // allow type 'double' to be used in signal contexts.
             "fpreg_t" => true,
 
+            // This type is defined for a union used within `struct ld_info`.
+            // The AIX header does not declare a separate standalone union
+            // type for it.
+            "__ld_info_file" => true,
+
+            // This is a simplified version of the AIX union `_simple_lock`.
+            "_kernel_simple_lock" => true,
+
+            // These structures are guarded by the `_KERNEL` macro in the AIX
+            // header.
+            "fileops_t" | "file" => true,
+
             _ => false,
         }
     });
@@ -5641,6 +5653,11 @@ fn test_aix(target: &str) {
 
             // The _ALL_SOURCE type of 'f_fsid' differs from POSIX's on AIX.
             ("statvfs", "f_fsid") => true,
+
+            // The type of `_file` is `__ld_info_file`, which is defined
+            // specifically for the union inside `struct ld_info`. The AIX
+            // header does not define a separate standalone union type for it.
+            ("ld_info", "_file") => true,
 
             _ => false,
         }

--- a/libc-test/semver/aix.txt
+++ b/libc-test/semver/aix.txt
@@ -1791,12 +1791,14 @@ _W_STOPPED
 _W_STRC
 __context64
 __extctx_t
+__ld_info_file
 __pollfd_ext_u
 __tm_context_t
 __vmx_context_t
 __vmxreg_t
 __vsx_context_t
 _exit
+_kernel_simple_lock
 abort
 accept
 access
@@ -1915,7 +1917,9 @@ fgetpos
 fgetpos64
 fgetpwent
 fgets
+file
 fileno
+fileops_t
 flock
 flock64
 fnmatch
@@ -2079,6 +2083,7 @@ kill
 lchown
 lcong48
 lconv
+ld_info
 lfind
 linger
 link
@@ -2090,6 +2095,7 @@ locale_t
 localeconv
 localtime
 localtime_r
+lock_data_instrumented
 lpar_get_info
 lpar_set_resources
 lrand48


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
`struct ld_info` and related types are used by the AIX system call `loadquery()`. This patch reintroduces them with adjustments to pass CI.

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
