### PR TITLE
libc: make structs non_exhaustive by default.

### DIFF
--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -798,7 +798,6 @@ s! {
     }
 
     // linux/openat2.h
-    #[non_exhaustive]
     pub struct open_how {
         pub flags: crate::__u64,
         pub mode: crate::__u64,
@@ -1329,7 +1328,6 @@ s! {
 
     // linux/pidfd.h
 
-    #[non_exhaustive]
     pub struct pidfd_info {
         pub mask: crate::__u64,
         pub cgroupid: crate::__u64,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -149,6 +149,7 @@ s! {
         pub h_addr_list: *mut *mut c_char,
     }
 
+    #[@not_non_exhaustive]
     pub struct iovec {
         pub iov_base: *mut c_void,
         pub iov_len: size_t,


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
By default all structs that use the `s` and `s_no_extra_traits` macros are now `non_exhaustive`. Structs can opt out of this if their first attribute is `#[@not_non_exhaustive]`.

The `@` was necessary so that Rust could differentiate between a normal attribute (which cannot have an `@`) and this. Another possible syntax that we could use instead is `#[@not(non_exhaustive)]`.

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
