### PR TITLE
linux/musl: Make time_t and suseconds_t 64-bit on all musl platforms

### DIFF
--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -12,8 +12,8 @@ pub type clock_t = c_long;
                 See #1848 for more info."
     )
 )]
-pub type time_t = c_long;
-pub type suseconds_t = c_long;
+pub type time_t = i64;
+pub type suseconds_t = i64;
 pub type ino_t = u64;
 pub type off_t = i64;
 pub type blkcnt_t = i64;


### PR DESCRIPTION
time_t and suseconds_t are defined as 64-bit quanity on musl systems regardless of 32bit or 64bit CPU word length

grep "_Int64" in musl tree shows this

arch/aarch64/bits/alltypes.h.in:#define _Int64 long arch/arm/bits/alltypes.h.in:#define _Int64 long long arch/i386/bits/alltypes.h.in:#define _Int64 long long arch/loongarch64/bits/alltypes.h.in:#define _Int64 long arch/m68k/bits/alltypes.h.in:#define _Int64 long long arch/microblaze/bits/alltypes.h.in:#define _Int64 long long arch/mips/bits/alltypes.h.in:#define _Int64 long long arch/mips64/bits/alltypes.h.in:#define _Int64 long arch/mipsn32/bits/alltypes.h.in:#define _Int64 long long arch/or1k/bits/alltypes.h.in:#define _Int64 long long arch/powerpc/bits/alltypes.h.in:#define _Int64 long long arch/powerpc64/bits/alltypes.h.in:#define _Int64 long arch/riscv32/bits/alltypes.h.in:#define _Int64 long long arch/riscv64/bits/alltypes.h.in:#define _Int64 long arch/s390x/bits/alltypes.h.in:#define _Int64 long
arch/sh/bits/alltypes.h.in:#define _Int64 long long arch/x32/bits/alltypes.h.in:#define _Int64 long long arch/x86_64/bits/alltypes.h.in:#define _Int64 long include/alltypes.h.in:TYPEDEF _Int64 time_t;
include/alltypes.h.in:TYPEDEF _Int64 suseconds_t;

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
