### PR TITLE
Add strerror_r function to nuttx system (version 0.2.174)

### DIFF
--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -566,6 +566,7 @@ pub const IP_ADD_MEMBERSHIP: i32 = 0x14;
 pub const IP_DROP_MEMBERSHIP: i32 = 0x15;
 
 extern "C" {
+    pub fn strerror_r(errnum: i32, buf: *mut c_char, buflen: usize) -> i32;
     pub fn bind(sockfd: i32, addr: *const sockaddr, addrlen: socklen_t) -> i32;
     pub fn ioctl(fd: i32, request: i32, ...) -> i32;
     pub fn dirfd(dirp: *mut DIR) -> i32;


### PR DESCRIPTION
# Description

Line 69 of nuttx/include/string.h file:

 ```c
int        strerror_r(int, FAR char *, size_t);
```

not exposed in libc, causing rustix compilation exception.

# Sources

https://github.com/apache/nuttx/blob/0f73f92ffce74f349aecbe2a20adc69f2d84c601/include/string.h#L69

# Checklist

This  PR is not a breaking change.
