### PR TITLE
Enable the `rust_2024_compatibility` lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,15 @@
     unused_macros,
     unused_macro_rules,
 )]
+// Prepare for a future upgrade
+#![warn(rust_2024_compatibility)]
+// Things missing for 2024 that are blocked on MSRV or breakage
+#![allow(
+    missing_unsafe_on_extern,
+    edition_2024_expr_fragment_specifier,
+    // Allowed globally, the warning is enabled in individual modules as we work through them
+    unsafe_op_in_unsafe_fn
+)]
 #![cfg_attr(libc_deny_warnings, deny(warnings))]
 // Attributes needed when building as part of the standard library
 #![cfg_attr(feature = "rustc-dep-of-std", feature(link_cfg, no_core))]

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -1653,7 +1653,7 @@ impl siginfo_t {
             si_value: crate::sigval,
         }
 
-        (*(self as *const siginfo_t).cast::<siginfo_timer>()).si_value
+        unsafe { (*(self as *const siginfo_t).cast::<siginfo_timer>()).si_value }
     }
 
     pub unsafe fn si_pid(&self) -> crate::pid_t {
@@ -5025,11 +5025,11 @@ pub const MAX_KCTL_NAME: usize = 96;
 f! {
     pub fn CMSG_NXTHDR(mhdr: *const crate::msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
         if cmsg.is_null() {
-            return crate::CMSG_FIRSTHDR(mhdr);
+            return unsafe { crate::CMSG_FIRSTHDR(mhdr) };
         }
-        let cmsg_len = (*cmsg).cmsg_len as usize;
+        let cmsg_len = unsafe { (*cmsg).cmsg_len as usize };
         let next = cmsg as usize + __DARWIN_ALIGN32(cmsg_len);
-        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
+        let max = unsafe { (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize };
         if next + __DARWIN_ALIGN32(size_of::<cmsghdr>()) > max {
             core::ptr::null_mut()
         } else {
@@ -5038,7 +5038,7 @@ f! {
     }
 
     pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).add(__DARWIN_ALIGN32(size_of::<cmsghdr>()))
+        (cmsg as *mut c_uchar).wrapping_add(__DARWIN_ALIGN32(size_of::<cmsghdr>()))
     }
 
     pub {const} fn CMSG_SPACE(length: c_uint) -> c_uint {

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -1,3 +1,5 @@
+#![warn(unsafe_op_in_unsafe_fn)]
+
 use crate::prelude::*;
 
 pub type off_t = i64;
@@ -573,35 +575,40 @@ pub const RTAX_BRD: c_int = 7;
 
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const crate::msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
-            (*mhdr).msg_control.cast::<cmsghdr>()
+        let ctrl_len = unsafe { (*mhdr).msg_controllen } as usize;
+        if ctrl_len >= size_of::<cmsghdr>() {
+            let ptr = unsafe { (*mhdr).msg_control };
+            ptr.cast::<cmsghdr>()
         } else {
             core::ptr::null_mut()
         }
     }
 
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
-        let bits = size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = unsafe { size_of_val( &(*set).fds_bits[0] ) * 8 };
         let fd = fd as usize;
-        (*set).fds_bits[fd / bits] &= !(1 << (fd % bits));
+        let mask = !(1 << (fd % bits));
+        unsafe { (*set).fds_bits[fd / bits] &= mask };
         return;
     }
 
     pub fn FD_ISSET(fd: c_int, set: *const fd_set) -> bool {
-        let bits = size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = unsafe { size_of_val(&(*set).fds_bits[0]) * 8 };
         let fd = fd as usize;
-        return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0;
+        let bit = unsafe { (*set).fds_bits[fd / bits] };
+        return (bit & (1 << (fd % bits))) != 0;
     }
 
     pub fn FD_SET(fd: c_int, set: *mut fd_set) -> () {
-        let bits = size_of_val(&(*set).fds_bits[0]) * 8;
+        let bits = unsafe { size_of_val(&(*set).fds_bits[0]) * 8 };
         let fd = fd as usize;
-        (*set).fds_bits[fd / bits] |= 1 << (fd % bits);
+        unsafe { (*set).fds_bits[fd / bits] |= 1 << (fd % bits) };
         return;
     }
 
     pub fn FD_ZERO(set: *mut fd_set) -> () {
-        for slot in &mut (*set).fds_bits {
+        let mut bits = unsafe { (*set).fds_bits };
+        for slot in &mut bits {
             *slot = 0;
         }
     }


### PR DESCRIPTION
Enable this lint with the expectation that we will eventually be upgrading editions. There are some exceptions needed, and `unsafe_op_in_unsafe_fn` will take a while to go through.