### PR TITLE
Remove duplicate constant definitions for AIX

### DIFF
--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -1160,10 +1160,6 @@ pub const NFSMNT_ACDIRMAX: c_int = 0x0800;
 // rpcsvc/rstat.h
 pub const CPUSTATES: c_int = 4;
 
-// search.h
-pub const FIND: c_int = 0;
-pub const ENTER: c_int = 1;
-
 // semaphore.h
 pub const SEM_FAILED: *mut sem_t = -1isize as *mut crate::sem_t;
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
Remove duplicate constant definitions in `src/unix/aix/mod.rs`, which is exposed by commit a541bf4f6dc50b399e60e8220a1793b8493fb438.

```
c_enum! {
   #[repr(u32)]
    pub enum ACTION {
        FIND = 0,
        ENTER,
    }
}
...
// search.h
pub const FIND: c_int = 0;
pub const ENTER: c_int = 1;
```


<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
