### PR TITLE
Map madvise() to posix_madvise() for AIX

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -5711,6 +5711,10 @@ fn test_aix(target: &str) {
             "setdomainname" | "settimeofday" | "statfs" | "statfs64" | "statx" | "swapoff"
             | "swapon" | "utmpname" | "setgroups" => true,
 
+            // The AIX signature of 'madvise' differs from the POSIX version.
+            // It is mapped to 'posix_madvise' in 'src/unix/aix.rs'.
+            "madvise" => true,
+
             _ => false,
         }
     });

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -3017,7 +3017,9 @@ extern "C" {
     ) -> *mut c_void;
     pub fn lseek64(fd: c_int, offset: off64_t, whence: c_int) -> off64_t;
     pub fn lstat64(path: *const c_char, buf: *mut stat64) -> c_int;
-    pub fn madvise(addr: caddr_t, len: size_t, advice: c_int) -> c_int;
+    // Map madvise() to posix_madvise(), which takes 'void *' as the type of the 'addr' argument.
+    #[link_name = "posix_madvise"]
+    pub fn madvise(addr: *mut c_void, len: size_t, advice: c_int) -> c_int;
     pub fn makecontext(ucp: *mut crate::ucontext_t, func: extern "C" fn(), argc: c_int, ...);
     pub fn mallinfo() -> crate::mallinfo;
     pub fn mallopt(param: c_int, value: c_int) -> c_int;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
The AIX signature of `madvise()` differs from the POSIX specification, which expects `void *` as the type of the `addr` argument, whereas AIX uses `caddr_t` (i.e., `char *`). This patch updates the `madvise()` signature and maps it to `posix_madvise()` to be consistent with other platforms.

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
