### PR TITLE
ctest: add foreign static test

### DIFF
--- a/ctest-next/src/ffi_items.rs
+++ b/ctest-next/src/ffi_items.rs
@@ -62,7 +62,6 @@ impl FfiItems {
     }
 
     /// Return a list of all foreign statics found mapped by their ABI.
-    #[cfg_attr(not(test), expect(unused))]
     pub(crate) fn foreign_statics(&self) -> &Vec<Static> {
         &self.foreign_statics
     }

--- a/ctest-next/templates/test.c
+++ b/ctest-next/templates/test.c
@@ -137,3 +137,12 @@ ctest_void_func ctest_foreign_fn__{{ item.id }}(void) {
 #ifdef _MSC_VER
 #  pragma warning(default:4191)
 #endif
+
+{%- for static_ in ctx.foreign_static_tests +%}
+
+// Return a pointer to the static variable content.
+void *ctest_static__{{ static_.id }}(void) {
+    // FIXME(ctest): Not correct due to casting the function to a data pointer.
+    return (void *)&{{ static_.c_val }};
+}
+{%- endfor +%}

--- a/ctest-next/templates/test.rs
+++ b/ctest-next/templates/test.rs
@@ -10,7 +10,7 @@ mod generated_tests {
     #![allow(non_snake_case)]
     #![deny(improper_ctypes_definitions)]
     #[allow(unused_imports)]
-    use std::ffi::{CStr, c_int, c_char};
+    use std::ffi::{CStr, c_int, c_char, c_uint};
     use std::fmt::{Debug, LowerHex};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[allow(unused_imports)]
@@ -325,6 +325,21 @@ mod generated_tests {
         let actual = unsafe { ctest_foreign_fn__{{ item.id }}() } as u64;
         let expected = {{ item.id }} as u64;
         check_same(actual, expected, "{{ item.id }} function pointer");
+    }
+{%- endfor +%}
+
+{%- for static_ in ctx.foreign_static_tests +%}
+
+    // Tests if the pointer to the static variable matches in both Rust and C.
+    pub fn {{ static_.test_name }}() {
+        extern "C" {
+            fn ctest_static__{{ static_.id }}() -> *const {{ static_.rust_ty }};
+        }
+        let actual = (&raw const {{ static_.id }}).addr();
+        let expected = unsafe {
+            ctest_static__{{ static_.id }}().addr()
+        };
+        check_same(actual, expected, "{{ static_.id }} static");
     }
 {%- endfor +%}
 }

--- a/ctest-next/tests/input/hierarchy.out.c
+++ b/ctest-next/tests/input/hierarchy.out.c
@@ -80,3 +80,9 @@ ctest_void_func ctest_foreign_fn__malloc(void) {
 #ifdef _MSC_VER
 #  pragma warning(default:4191)
 #endif
+
+// Return a pointer to the static variable content.
+void *ctest_static__in6addr_any(void) {
+    // FIXME(ctest): Not correct due to casting the function to a data pointer.
+    return (void *)&in6addr_any;
+}

--- a/ctest-next/tests/input/hierarchy.out.rs
+++ b/ctest-next/tests/input/hierarchy.out.rs
@@ -7,7 +7,7 @@ mod generated_tests {
     #![allow(non_snake_case)]
     #![deny(improper_ctypes_definitions)]
     #[allow(unused_imports)]
-    use std::ffi::{CStr, c_int, c_char};
+    use std::ffi::{CStr, c_int, c_char, c_uint};
     use std::fmt::{Debug, LowerHex};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[allow(unused_imports)]
@@ -223,6 +223,18 @@ mod generated_tests {
         let expected = malloc as u64;
         check_same(actual, expected, "malloc function pointer");
     }
+
+    // Tests if the pointer to the static variable matches in both Rust and C.
+    pub fn ctest_static_in6addr_any() {
+        extern "C" {
+            fn ctest_static__in6addr_any() -> *const in6_addr;
+        }
+        let actual = (&raw const in6addr_any).addr();
+        let expected = unsafe {
+            ctest_static__in6addr_any().addr()
+        };
+        check_same(actual, expected, "in6addr_any static");
+    }
 }
 
 use generated_tests::*;
@@ -247,4 +259,5 @@ fn run_all() {
     ctest_signededness_in6_addr();
     ctest_roundtrip_in6_addr();
     ctest_foreign_fn_malloc();
+    ctest_static_in6addr_any();
 }

--- a/ctest-next/tests/input/hierarchy/foo.rs
+++ b/ctest-next/tests/input/hierarchy/foo.rs
@@ -6,5 +6,5 @@ pub const ON: bool = true;
 unsafe extern "C" {
     pub fn malloc(size: usize) -> *mut c_void;
 
-    static in6addr_any: in6_addr;
+    pub static in6addr_any: in6_addr;
 }

--- a/ctest-next/tests/input/macro.out.rs
+++ b/ctest-next/tests/input/macro.out.rs
@@ -7,7 +7,7 @@ mod generated_tests {
     #![allow(non_snake_case)]
     #![deny(improper_ctypes_definitions)]
     #[allow(unused_imports)]
-    use std::ffi::{CStr, c_int, c_char};
+    use std::ffi::{CStr, c_int, c_char, c_uint};
     use std::fmt::{Debug, LowerHex};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[allow(unused_imports)]

--- a/ctest-next/tests/input/simple.out.with-renames.rs
+++ b/ctest-next/tests/input/simple.out.with-renames.rs
@@ -7,7 +7,7 @@ mod generated_tests {
     #![allow(non_snake_case)]
     #![deny(improper_ctypes_definitions)]
     #[allow(unused_imports)]
-    use std::ffi::{CStr, c_int, c_char};
+    use std::ffi::{CStr, c_int, c_char, c_uint};
     use std::fmt::{Debug, LowerHex};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[allow(unused_imports)]

--- a/ctest-next/tests/input/simple.out.with-skips.rs
+++ b/ctest-next/tests/input/simple.out.with-skips.rs
@@ -7,7 +7,7 @@ mod generated_tests {
     #![allow(non_snake_case)]
     #![deny(improper_ctypes_definitions)]
     #[allow(unused_imports)]
-    use std::ffi::{CStr, c_int, c_char};
+    use std::ffi::{CStr, c_int, c_char, c_uint};
     use std::fmt::{Debug, LowerHex};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[allow(unused_imports)]

--- a/ctest-test/build.rs
+++ b/ctest-test/build.rs
@@ -99,6 +99,7 @@ fn test_ctest_next() {
         .include("src")
         .skip_private(true)
         .rename_fn(|f| f.link_name().unwrap_or(f.ident()).to_string().into())
+        .rename_static(|s| s.link_name().unwrap_or(s.ident()).to_string().into())
         .rename_union_ty(|ty| (ty == "T1Union").then_some(ty.to_string()))
         .rename_struct_ty(|ty| (ty == "Transparent").then_some(ty.to_string()))
         .volatile_struct_field(|s, f| s.ident() == "V" && f.ident() == "v")


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
Adds support for testing extern statics.

Also adds support for parsing any dimensional array in `make_cdecl`, and makes it easier to extract ffi safe types from `Option`.

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
