### PR TITLE
libc: use more accurate type of sighandler_t on windows

### DIFF
--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -10,7 +10,7 @@ pub type ptrdiff_t = isize;
 pub type intptr_t = isize;
 pub type uintptr_t = usize;
 pub type ssize_t = isize;
-pub type sighandler_t = usize;
+pub type sighandler_t = *const c_void;
 
 pub type wchar_t = u16;
 
@@ -237,11 +237,11 @@ pub const SIGABRT: c_int = 22;
 pub const NSIG: c_int = 23;
 
 pub const SIG_ERR: c_int = -1;
-pub const SIG_DFL: crate::sighandler_t = 0;
-pub const SIG_IGN: crate::sighandler_t = 1;
-pub const SIG_GET: crate::sighandler_t = 2;
-pub const SIG_SGE: crate::sighandler_t = 3;
-pub const SIG_ACK: crate::sighandler_t = 4;
+pub const SIG_DFL: crate::sighandler_t = 0 as sighandler_t;
+pub const SIG_IGN: crate::sighandler_t = 1 as sighandler_t;
+pub const SIG_GET: crate::sighandler_t = 2 as sighandler_t;
+pub const SIG_SGE: crate::sighandler_t = 3 as sighandler_t;
+pub const SIG_ACK: crate::sighandler_t = 4 as sighandler_t;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum FILE {}


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
Changes the type of `sighandler_t` on windows from `usize` to `*const c_void` as per #1637 to more accurately represent the fact that it is a pointer to a function (since the value of the address is also sometimes matched without dereferencing it).

A better type would be `Option<extern fn ...>` however because of the dual use of `sighandler_t` as a constant, it would be undefined behavior to construct that type from something like `5`.
<!-- Add a short description about what this change does -->

# Sources
https://github.com/msys2/msys2-runtime/blob/23a25d49e3b8c18f12ce588869d4cb24de9f2454/newlib/libc/machine/cris/sys/signal.h#L23
<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
