### PR TITLE
Restore some non-POSIX functions for AIX

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -5738,6 +5738,14 @@ fn test_aix(target: &str) {
             "setdomainname" | "settimeofday" | "statfs" | "statfs64" | "statx" | "swapoff"
             | "swapon" | "utmpname" | "setgroups" => true,
 
+            // These non-POSIX functions are guarded by the _KERNEL macro in the AIX headers.
+            "recvmmsg" | "sendmmsg" | "sctp_opt_info" | "sctp_peeloff" | "sethostid"
+            | "sethostname" | "splice" => true,
+
+            // 'mount' is available in the system's libc.a and has a man page, but it is
+            // not declared in the AIX headers."
+            "mount" => true,
+
             _ => false,
         }
     });

--- a/libc-test/semver/aix.txt
+++ b/libc-test/semver/aix.txt
@@ -2133,6 +2133,7 @@ mmap
 mmsghdr
 mntent
 mode_t
+mount
 mprotect
 mq_attr
 mq_close
@@ -2363,6 +2364,7 @@ realloc
 realpath
 recv
 recvfrom
+recvmmsg
 recvmsg
 regcomp
 regerror
@@ -2393,6 +2395,8 @@ sched_rr_get_interval
 sched_setparam
 sched_setscheduler
 sched_yield
+sctp_opt_info
+sctp_peeloff
 seed48
 seekdir
 select
@@ -2413,6 +2417,7 @@ semget
 semop
 send
 send_file
+sendmmsg
 sendmsg
 sendto
 servent
@@ -2425,6 +2430,8 @@ seteuid
 setgid
 setgrent
 setgroups
+sethostid
+sethostname
 setitimer
 setlocale
 setlogmask
@@ -2484,6 +2491,7 @@ socket
 socketpair
 socklen_t
 speed_t
+splice
 sprintf
 srand
 srand48

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -3027,6 +3027,7 @@ extern "C" {
     pub fn mincore(addr: caddr_t, len: size_t, vec: *mut c_char) -> c_int;
     pub fn mkfifoat(dirfd: c_int, pathname: *const c_char, mode: mode_t) -> c_int;
     pub fn mknodat(dirfd: c_int, pathname: *const c_char, mode: mode_t, dev: dev_t) -> c_int;
+    pub fn mount(device: *const c_char, path: *const c_char, flags: c_int) -> c_int;
     pub fn mprotect(addr: *mut c_void, len: size_t, prot: c_int) -> c_int;
     pub fn mq_close(mqd: crate::mqd_t) -> c_int;
     pub fn mq_getattr(mqd: crate::mqd_t, attr: *mut crate::mq_attr) -> c_int;
@@ -3196,6 +3197,13 @@ extern "C" {
         addr: *mut crate::sockaddr,
         addrlen: *mut crate::socklen_t,
     ) -> ssize_t;
+    pub fn recvmmsg(
+        sockfd: c_int,
+        msgvec: *mut crate::mmsghdr,
+        vlen: c_uint,
+        flags: c_int,
+        timeout: *mut crate::timespec,
+    ) -> c_int;
     // AIX header socket.h maps recvmsg() to nrecvmsg().
     #[link_name = "nrecvmsg"]
     pub fn recvmsg(sockfd: c_int, msg: *mut msghdr, flags: c_int) -> ssize_t;
@@ -3226,6 +3234,14 @@ extern "C" {
         policy: c_int,
         param: *const crate::sched_param,
     ) -> c_int;
+    pub fn sctp_opt_info(
+        sd: c_int,
+        id: c_uint,
+        opt: c_int,
+        arg_size: *mut c_void,
+        size: *mut size_t,
+    ) -> c_int;
+    pub fn sctp_peeloff(s: c_int, id: *mut c_uint) -> c_int;
     pub fn seed48(xseed: *mut c_ushort) -> *mut c_ushort;
     pub fn seekdir(dirp: *mut crate::DIR, loc: c_long);
     pub fn sem_close(sem: *mut sem_t) -> c_int;
@@ -3239,6 +3255,7 @@ extern "C" {
     pub fn semget(key: crate::key_t, nsems: c_int, semflag: c_int) -> c_int;
     pub fn semop(semid: c_int, sops: *mut sembuf, nsops: size_t) -> c_int;
     pub fn send_file(socket: *mut c_int, iobuf: *mut sf_parms, flags: c_uint) -> ssize_t;
+    pub fn sendmmsg(sockfd: c_int, msgvec: *mut mmsghdr, vlen: c_uint, flags: c_int) -> c_int;
     // AIX header socket.h maps sendmsg() to nsendmsg().
     #[link_name = "nsendmsg"]
     pub fn sendmsg(sockfd: c_int, msg: *const msghdr, flags: c_int) -> ssize_t;
@@ -3246,6 +3263,8 @@ extern "C" {
     pub fn setdomainname(name: *const c_char, len: c_int) -> c_int;
     pub fn setgroups(ngroups: c_int, ptr: *const crate::gid_t) -> c_int;
     pub fn setgrent();
+    pub fn sethostid(hostid: c_int) -> c_int;
+    pub fn sethostname(name: *const c_char, len: c_int) -> c_int;
     pub fn setmntent(filename: *const c_char, ty: *const c_char) -> *mut crate::FILE;
     pub fn setpriority(which: c_int, who: id_t, priority: c_int) -> c_int;
     pub fn setpwent();
@@ -3274,6 +3293,7 @@ extern "C" {
     pub fn shmget(key: key_t, size: size_t, shmflg: c_int) -> c_int;
     pub fn shm_open(name: *const c_char, oflag: c_int, mode: mode_t) -> c_int;
     pub fn shm_unlink(name: *const c_char) -> c_int;
+    pub fn splice(socket1: c_int, socket2: c_int, flags: c_int) -> c_int;
     pub fn srand(seed: c_uint);
     pub fn srand48(seed: c_long);
     pub fn stat64(path: *const c_char, buf: *mut stat64) -> c_int;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
These non-POSIX functions were previously removed because they are guarded by the `_KERNEL` macro in AIX headers. After discussion, we concluded they might be useful, so this patch restores them with necessary fixes.

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
