### PR TITLE
NetBSD: add ptsname_r

### DIFF
--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2473,6 +2473,8 @@ extern "C" {
         winp: *mut crate::winsize,
     ) -> crate::pid_t;
 
+    pub fn ptsname_r(fd: c_int, buf: *mut c_char, buflen: size_t) -> c_int;
+
     #[link_name = "__lutimes50"]
     pub fn lutimes(file: *const c_char, times: *const crate::timeval) -> c_int;
     #[link_name = "__gettimeofday50"]


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

This adds NetBSD support for `ptsname_r`. The function was added in NetBSD 7.

# Sources

https://github.com/NetBSD/src/blob/0b011669be2b100a2339b1818db4629981dcdbf0/include/stdlib.h#L326

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
  - haven't done this since I don't know what 'mytarget' is and 'netbsd' didn't work.
 
<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

-->

I based this on the FreeBSD version, I'm not sure what the sort order in the file is supposed to be though.

@rustbot label +stable-nominated
