### PR TITLE
riscv32: Define plain syscalls as their time64 variants

### DIFF
--- a/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
@@ -633,3 +633,23 @@ pub const SYS_faccessat2: c_long = 439;
 pub const SYS_process_madvise: c_long = 440;
 pub const SYS_epoll_pwait2: c_long = 441;
 pub const SYS_mount_setattr: c_long = 442;
+
+// Plain syscalls aliased to their time64 variants
+pub const SYS_clock_gettime: c_long = SYS_clock_gettime64;
+pub const SYS_clock_settime: c_long = SYS_clock_settime64;
+pub const SYS_clock_adjtime: c_long = SYS_clock_adjtime64;
+pub const SYS_clock_getres: c_long = SYS_clock_getres_time64;
+pub const SYS_clock_nanosleep: c_long = SYS_clock_nanosleep_time64;
+pub const SYS_timer_gettime: c_long = SYS_timer_gettime64;
+pub const SYS_timer_settime: c_long = SYS_timer_settime64;
+pub const SYS_timerfd_gettime: c_long = SYS_timerfd_gettime64;
+pub const SYS_timerfd_settime: c_long = SYS_timerfd_settime64;
+pub const SYS_utimensat: c_long = SYS_utimensat_time64;
+pub const SYS_pselect6: c_long = SYS_pselect6_time64;
+pub const SYS_ppoll: c_long = SYS_ppoll_time64;
+pub const SYS_recvmmsg: c_long = SYS_recvmmsg_time64;
+pub const SYS_mq_timedsend: c_long = SYS_mq_timedsend_time64;
+pub const SYS_mq_timedreceive: c_long = SYS_mq_timedreceive_time64;
+pub const SYS_rt_sigtimedwait: c_long = SYS_rt_sigtimedwait_time64;
+pub const SYS_futex: c_long = SYS_futex_time64;
+pub const SYS_sched_rr_get_interval: c_long = SYS_sched_rr_get_interval_time64;


### PR DESCRIPTION
RISCV32 is "time64-only" from the beginning on the kernel side.

Based on musl change [1]

[1] https://git.musl-libc.org/cgit/musl/commit/?id=4bbd7baea7c8538b3fb8e30f7b022a1eee071450

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
