### PR TITLE
ctest-next: miscellaneous filtering bug fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
               # Remove `-Dwarnings` at the MSRV since lints may be different
               export RUSTFLAGS=""
               # Remove `ctest-next` which uses the 2024 edition
-              perl -i -ne 'print unless /"ctest-(next|test)",/' Cargo.toml
+              perl -i -ne 'print unless /"ctest-(next|test)",/ || /"libc-test",/' Cargo.toml
           fi
 
           ./ci/verify-build.sh
@@ -320,7 +320,7 @@ jobs:
     - name: Install Rust
       run: rustup update "$MSRV" --no-self-update && rustup default "$MSRV"
     - name: Remove edition 2024 crates
-      run: perl -i -ne 'print unless /"ctest-(next|test)",/' Cargo.toml
+      run: perl -i -ne 'print unless /"ctest-(next|test)",/ || /"libc-test",/' Cargo.toml
     - uses: Swatinem/rust-cache@v2
     - run: cargo build -p ctest
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.1",
  "ctest",
+ "ctest-next",
  "glob",
  "libc 1.0.0-alpha.1",
  "proc-macro2",

--- a/ctest-next/src/ast/union.rs
+++ b/ctest-next/src/ast/union.rs
@@ -3,7 +3,6 @@ use crate::{BoxStr, Field};
 /// Represents a union defined in Rust.
 #[derive(Debug, Clone)]
 pub struct Union {
-    #[expect(unused)]
     pub(crate) public: bool,
     pub(crate) ident: BoxStr,
     pub(crate) fields: Vec<Field>,

--- a/ctest-next/src/tests.rs
+++ b/ctest-next/src/tests.rs
@@ -127,3 +127,11 @@ fn test_translate_helper_array_1d_2d() {
     assert_r2cdecl("[u8; 10]", "uint8_t foo[10]");
     assert_r2cdecl("[[u8; 64]; 32]", "uint8_t foo[32][64]");
 }
+
+#[test]
+fn test_translate_expr_literal_types() {
+    assert_eq!(
+        r2cdecl("[u8; 10usize]", "foo").unwrap(),
+        "uint8_t foo[(size_t)10]"
+    );
+}

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -21,6 +21,7 @@ annotate-snippets = { version = "0.11.5", features = ["testing-colors"] }
 [build-dependencies]
 cc = "1.2.29"
 ctest = { path = "../ctest" }
+ctest-next = { path = "../ctest-next" }
 regex = "1.11.1"
 
 [features]
@@ -31,6 +32,11 @@ extra_traits = ["libc/extra_traits"]
 [[test]]
 name = "ctest"
 path = "test/ctest.rs"
+harness = false
+
+[[test]]
+name = "ctest_next"
+path = "test/ctest_next.rs"
 harness = false
 
 [[test]]

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -77,6 +77,11 @@ fn ctest_cfg() -> ctest::TestGenerator {
     ctest::TestGenerator::new()
 }
 
+#[expect(unused)]
+fn ctest_next_cfg() -> ctest_next::TestGenerator {
+    ctest_next::TestGenerator::new()
+}
+
 fn do_semver() {
     let mut out = PathBuf::from(env::var("OUT_DIR").unwrap());
     out.push("semver.rs");
@@ -163,6 +168,14 @@ fn main() {
     // FIXME(ctest): ctest cannot parse `crate::` in paths, so replace them with `::`
     let re = regex::bytes::Regex::new(r"(?-u:\b)crate::").unwrap();
     copy_dir_hotfix(Path::new("../src"), &hotfix_dir, &re, b"::");
+
+    // FIXME(ctest): Only needed until ctest-next supports all tests.
+    // Provide a default for targets that don't yet use `ctest-next`.
+    std::fs::write(
+        format!("{}/main_next.rs", std::env::var("OUT_DIR").unwrap()),
+        "\nfn main() { println!(\"test result: ok\"); }\n",
+    )
+    .unwrap();
 
     do_cc();
     do_ctest();

--- a/libc-test/test/ctest_next.rs
+++ b/libc-test/test/ctest_next.rs
@@ -1,0 +1,5 @@
+#[allow(deprecated)]
+#[allow(unused_imports)]
+use libc::*;
+
+include!(concat!(env!("OUT_DIR"), "/main_next.rs"));


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
Prepares for porting `libc-test` platforms to use `ctest-next` by fixing numerous bugs. rust-lang/libc#4600 and rust-lang/libc#4610 both depend on this PR, so this should be merged first.

Fixes:
- Excludes libc-test from MSRV checks since it will use `ctest-next` in the future, which is a edition 2024 crate.
- Modify `translate_expr` to support translating `[ty; 3usize]` properly.
- Adds a new test that for now always passes, but will be gradually used as the test for `ctest-next` backed platforms.
- Moves filtering `ffi_items` to the `TranslateHelper` since `template.rs` does the test filtering for consistency.
- Fixes a bug where unions were not being skipped properly.
- Fixes a bug where structs that were skipped for testing were not recognized as structs when testing a different item with that same struct as a field that shouldn't be skipped.
- A bug where sometimes pointers to structs would be translated as `struct const StructName*`, and sometimes the struct label would not be applied at all.
<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
