### PR TITLE
Add additional fields to statx

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -5227,6 +5227,17 @@ fn test_linux(target: &str) {
             ("file_handle", "f_handle") if musl || uclibc => true,
             // FIXME(ctest): ctest does not translate the rust code which computes the padding size
             ("pthread_cond_t", "__padding") if l4re => true,
+            (
+                "statx",
+                "stx_subvol"
+                | "stx_atomic_write_unit_min"
+                | "stx_atomic_write_unit_max"
+                | "stx_atomic_write_segments_max"
+                | "stx_dio_read_offset_align"
+                | "stx_atomic_write_unit_max_opt"
+                | "__statx_pad2"
+                | "__statx_pad3",
+            ) if gnu && versions.glibc.unwrap() < (2, 43) => true,
             _ => false,
         }
     });

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -292,6 +292,25 @@ cfg_if! {
                 pub stx_mnt_id: crate::__u64,
                 pub stx_dio_mem_align: crate::__u32,
                 pub stx_dio_offset_align: crate::__u32,
+                // The following fields are not available on Android as of
+                // 2026-06.
+                #[cfg(target_os = "linux")]
+                pub stx_subvol: crate::__u64,
+                #[cfg(target_os = "linux")]
+                pub stx_atomic_write_unit_min: crate::__u32,
+                #[cfg(target_os = "linux")]
+                pub stx_atomic_write_unit_max: crate::__u32,
+                #[cfg(target_os = "linux")]
+                pub stx_atomic_write_segments_max: crate::__u32,
+                #[cfg(target_os = "linux")]
+                pub stx_dio_read_offset_align: crate::__u32,
+                #[cfg(target_os = "linux")]
+                pub stx_atomic_write_unit_max_opt: crate::__u32,
+                #[cfg(target_os = "linux")]
+                __statx_pad2: Padding<[crate::__u32; 1]>,
+                #[cfg(target_os = "linux")]
+                __statx_pad3: Padding<[crate::__u64; 8]>,
+                #[cfg(not(target_os = "linux"))]
                 __statx_pad3: Padding<[crate::__u64; 12]>,
             }
 


### PR DESCRIPTION
# Description

Updates statx to include all fields as of Linux v6.16.

# Sources

* Linux: https://github.com/torvalds/linux/blob/038d61fd642278bab63ee8ef722c50d10ab01e8f/include/uapi/linux/stat.h#L99-L193
* glibc: https://sourceware.org/git/?p=glibc.git;a=blob;f=io/bits/types/struct_statx.h;h=f8ecc53768e0980d9ef3c737c2141ae769f80e4f;hb=f762ccf84f122d1354f103a151cba8bde797d521#l55-l62

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
