### PR TITLE
Always implement `Debug`

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -80,7 +80,7 @@ pub type rlim_t = c_ulonglong;
 
 // FIXME(fuchsia): why are these uninhabited types? that seems... wrong?
 // Presumably these should be `()` or an `extern type` (when that stabilizes).
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum timezone {}
 impl Copy for timezone {}
 impl Clone for timezone {
@@ -88,7 +88,7 @@ impl Clone for timezone {
         *self
     }
 }
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum DIR {}
 impl Copy for DIR {}
 impl Clone for DIR {
@@ -97,7 +97,7 @@ impl Clone for DIR {
     }
 }
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum fpos64_t {} // FIXME(fuchsia): fill this out with a struct
 impl Copy for fpos64_t {}
 impl Clone for fpos64_t {
@@ -3469,7 +3469,7 @@ fn __MHDR_END(mhdr: *const msghdr) -> *mut c_uchar {
 #[link(name = "fdio")]
 extern "C" {}
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum FILE {}
 impl Copy for FILE {}
 impl Clone for FILE {
@@ -3477,7 +3477,7 @@ impl Clone for FILE {
         *self
     }
 }
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum fpos_t {} // FIXME(fuchsia): fill this out with a struct
 impl Copy for fpos_t {}
 impl Clone for fpos_t {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,6 @@
 // Attributes needed when building as part of the standard library
 #![cfg_attr(feature = "rustc-dep-of-std", feature(link_cfg, no_core))]
 #![cfg_attr(feature = "rustc-dep-of-std", allow(internal_features))]
-// Enable extra lints:
-#![cfg_attr(feature = "extra_traits", warn(missing_debug_implementations))]
 #![warn(missing_copy_implementations, safe_packed_borrows)]
 #![cfg_attr(not(feature = "rustc-dep-of-std"), no_std)]
 #![cfg_attr(feature = "rustc-dep-of-std", no_core)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -72,17 +72,20 @@ macro_rules! prelude {
         mod prelude {
             // Exports from `core`
             #[allow(unused_imports)]
-            pub(crate) use ::core::clone::Clone;
+            pub(crate) use core::clone::Clone;
             #[allow(unused_imports)]
-            pub(crate) use ::core::default::Default;
+            pub(crate) use core::default::Default;
             #[allow(unused_imports)]
-            pub(crate) use ::core::marker::{Copy, Send, Sync};
+            pub(crate) use core::marker::{Copy, Send, Sync};
             #[allow(unused_imports)]
-            pub(crate) use ::core::option::Option;
+            pub(crate) use core::option::Option;
             #[allow(unused_imports)]
-            pub(crate) use ::core::prelude::v1::derive;
+            pub(crate) use core::prelude::v1::derive;
             #[allow(unused_imports)]
-            pub(crate) use ::core::{fmt, hash, iter, mem, ptr};
+            pub(crate) use core::{fmt, hash, iter, mem, ptr};
+
+            #[allow(unused_imports)]
+            pub(crate) use fmt::Debug;
             #[allow(unused_imports)]
             pub(crate) use mem::{align_of, align_of_val, size_of, size_of_val};
 
@@ -120,9 +123,13 @@ macro_rules! s {
             #[repr(C)]
             #[cfg_attr(
                 feature = "extra_traits",
-                ::core::prelude::v1::derive(Debug, Eq, Hash, PartialEq)
+                ::core::prelude::v1::derive(Eq, Hash, PartialEq)
             )]
-            #[::core::prelude::v1::derive(::core::clone::Clone, ::core::marker::Copy)]
+            #[::core::prelude::v1::derive(
+                ::core::clone::Clone,
+                ::core::marker::Copy,
+                ::core::fmt::Debug,
+            )]
             #[allow(deprecated)]
             $(#[$attr])*
             pub struct $i { $($field)* }
@@ -142,17 +149,21 @@ macro_rules! s_paren {
         __item! {
             #[cfg_attr(
                 feature = "extra_traits",
-                ::core::prelude::v1::derive(Debug, Eq, Hash, PartialEq)
+                ::core::prelude::v1::derive(Eq, Hash, PartialEq)
             )]
-            #[::core::prelude::v1::derive(::core::clone::Clone, ::core::marker::Copy)]
+            #[::core::prelude::v1::derive(
+                ::core::clone::Clone,
+                ::core::marker::Copy,
+                ::core::fmt::Debug,
+            )]
             $(#[$attr])*
             pub struct $i ( $($field)* );
         }
     )*);
 }
 
-/// Implement `Clone` and `Copy` for a struct with no `extra_traits` feature, as well as `Debug`
-/// with `extra_traits` since that can always be derived.
+/// Implement `Clone`, `Copy`, and `Debug` since those can be derived, but exclude `PartialEq`,
+/// `Eq`, and `Hash`.
 ///
 /// Most items will prefer to use [`s`].
 macro_rules! s_no_extra_traits {
@@ -171,7 +182,6 @@ macro_rules! s_no_extra_traits {
             pub union $i { $($field)* }
         }
 
-        #[cfg(feature = "extra_traits")]
         impl ::core::fmt::Debug for $i {
             fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 f.debug_struct(::core::stringify!($i)).finish_non_exhaustive()
@@ -182,8 +192,11 @@ macro_rules! s_no_extra_traits {
     (it: $(#[$attr:meta])* pub struct $i:ident { $($field:tt)* }) => (
         __item! {
             #[repr(C)]
-            #[::core::prelude::v1::derive(::core::clone::Clone, ::core::marker::Copy)]
-            #[cfg_attr(feature = "extra_traits", ::core::prelude::v1::derive(Debug))]
+            #[::core::prelude::v1::derive(
+                ::core::clone::Clone,
+                ::core::marker::Copy,
+                ::core::fmt::Debug,
+            )]
             $(#[$attr])*
             pub struct $i { $($field)* }
         }

--- a/src/solid/mod.rs
+++ b/src/solid/mod.rs
@@ -395,7 +395,7 @@ pub const SIGUSR1: c_int = 30;
 pub const SIGUSR2: c_int = 31;
 pub const SIGPWR: c_int = 32;
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum FILE {}
 impl Copy for FILE {}
 impl Clone for FILE {
@@ -403,7 +403,7 @@ impl Clone for FILE {
         *self
     }
 }
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum fpos_t {}
 impl Copy for fpos_t {}
 impl Clone for fpos_t {

--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 
 // Define lock_data_instrumented as an empty enum
 missing! {
-    #[cfg_attr(feature = "extra_traits", derive(Debug))]
+    #[derive(Debug)]
     pub enum lock_data_instrumented {}
 }
 

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -175,7 +175,7 @@ pub type copyfile_callback_t = Option<
 pub type attrgroup_t = u32;
 pub type vol_capabilities_set_t = [u32; 4];
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum timezone {}
 impl Copy for timezone {}
 impl Clone for timezone {

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -45,7 +45,7 @@ pub type vm_map_entry_t = *mut vm_map_entry;
 
 pub type pmap = __c_anonymous_pmap;
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum sem {}
 impl Copy for sem {}
 impl Clone for sem {

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/b32.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/b32.rs
@@ -2,7 +2,8 @@ use crate::off_t;
 use crate::prelude::*;
 
 #[repr(C)]
-#[cfg_attr(feature = "extra_traits", derive(Debug, Eq, Hash, PartialEq))]
+#[derive(Debug)]
+#[cfg_attr(feature = "extra_traits", derive(Eq, Hash, PartialEq))]
 pub struct stat {
     pub st_dev: crate::dev_t,
     pub st_ino: crate::ino_t,

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/b64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/b64.rs
@@ -2,7 +2,8 @@ use crate::off_t;
 use crate::prelude::*;
 
 #[repr(C)]
-#[cfg_attr(feature = "extra_traits", derive(Debug, Eq, Hash, PartialEq))]
+#[derive(Debug)]
+#[cfg_attr(feature = "extra_traits", derive(Eq, Hash, PartialEq))]
 pub struct stat {
     pub st_dev: crate::dev_t,
     pub st_ino: crate::ino_t,

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -59,7 +59,7 @@ cfg_if! {
 
 // link.h
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum timezone {}
 impl Copy for timezone {}
 impl Clone for timezone {

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -16,7 +16,7 @@ pub type id_t = u32;
 pub type sem_t = *mut sem;
 pub type key_t = c_long;
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum timezone {}
 impl Copy for timezone {}
 impl Clone for timezone {
@@ -24,7 +24,7 @@ impl Clone for timezone {
         *self
     }
 }
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum sem {}
 impl Copy for sem {}
 impl Clone for sem {

--- a/src/unix/cygwin/mod.rs
+++ b/src/unix/cygwin/mod.rs
@@ -28,7 +28,7 @@ pub type nlink_t = c_ushort;
 pub type suseconds_t = c_long;
 pub type useconds_t = c_ulong;
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum timezone {}
 impl Copy for timezone {}
 impl Clone for timezone {
@@ -75,7 +75,7 @@ pub type nfds_t = c_uint;
 
 pub type sem_t = *mut sem;
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum sem {}
 impl Copy for sem {}
 impl Clone for sem {

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -80,7 +80,7 @@ pub type ACTION = c_int;
 pub type posix_spawnattr_t = *mut c_void;
 pub type posix_spawn_file_actions_t = *mut c_void;
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum timezone {}
 impl Copy for timezone {}
 impl Clone for timezone {

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -225,7 +225,7 @@ pub type nl_item = c_int;
 
 pub type iconv_t = *mut c_void;
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum fpos64_t {} // FIXME(hurd): fill this out with a struct
 impl Copy for fpos64_t {}
 impl Clone for fpos64_t {
@@ -234,7 +234,7 @@ impl Clone for fpos64_t {
     }
 }
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum timezone {}
 impl Copy for timezone {}
 impl Clone for timezone {

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -41,7 +41,7 @@ pub type statfs64 = crate::statfs;
 pub type statvfs64 = crate::statvfs;
 pub type dirent64 = crate::dirent;
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum fpos64_t {} // FIXME(emscripten): fill this out with a struct
 impl Copy for fpos64_t {}
 impl Clone for fpos64_t {

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -68,7 +68,7 @@ pub type eventfd_t = u64;
 cfg_if! {
     if #[cfg(not(target_env = "gnu"))] {
         missing! {
-            #[cfg_attr(feature = "extra_traits", derive(Debug))]
+            #[derive(Debug)]
             pub enum fpos64_t {} // FIXME(linux): fill this out with a struct
         }
     }

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -9,7 +9,7 @@ pub type key_t = c_int;
 pub type id_t = c_uint;
 
 missing! {
-    #[cfg_attr(feature = "extra_traits", derive(Debug))]
+    #[derive(Debug)]
     pub enum timezone {}
 }
 

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -38,7 +38,7 @@ cfg_if! {
 }
 
 missing! {
-    #[cfg_attr(feature = "extra_traits", derive(Debug))]
+    #[derive(Debug)]
     pub enum DIR {}
 }
 pub type locale_t = *mut c_void;
@@ -586,14 +586,14 @@ cfg_if! {
 cfg_if! {
     if #[cfg(not(all(target_os = "linux", target_env = "gnu")))] {
         missing! {
-            #[cfg_attr(feature = "extra_traits", derive(Debug))]
+            #[derive(Debug)]
             pub enum fpos_t {} // FIXME(unix): fill this out with a struct
         }
     }
 }
 
 missing! {
-    #[cfg_attr(feature = "extra_traits", derive(Debug))]
+    #[derive(Debug)]
     pub enum FILE {}
 }
 

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -72,7 +72,7 @@ pub type sem_t = sync_t;
 
 pub type nl_item = c_int;
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum timezone {}
 impl Copy for timezone {}
 impl Clone for timezone {

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -32,7 +32,7 @@ pub type pid_t = usize;
 pub type uid_t = c_int;
 pub type gid_t = c_int;
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum timezone {}
 impl Copy for timezone {}
 impl Clone for timezone {

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -55,7 +55,7 @@ pub type lgrp_view_t = c_uint;
 pub type posix_spawnattr_t = *mut c_void;
 pub type posix_spawn_file_actions_t = *mut c_void;
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum timezone {}
 impl Copy for timezone {}
 impl Clone for timezone {
@@ -64,7 +64,7 @@ impl Clone for timezone {
     }
 }
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum ucred_t {}
 impl Copy for ucred_t {}
 impl Clone for ucred_t {

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -4,7 +4,7 @@ use core::ptr::null_mut;
 
 use crate::prelude::*;
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum DIR {}
 impl Copy for DIR {}
 impl Clone for DIR {
@@ -95,7 +95,7 @@ pub type sa_family_t = c_uchar;
 // mqueue.h
 pub type mqd_t = c_int;
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum _Vx_semaphore {}
 impl Copy for _Vx_semaphore {}
 impl Clone for _Vx_semaphore {
@@ -1065,7 +1065,7 @@ pub const MAP_CONTIG: c_int = 0x0020;
 
 pub const MAP_FAILED: *mut c_void = !0 as *mut c_void;
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum FILE {}
 impl Copy for FILE {}
 impl Clone for FILE {
@@ -1073,7 +1073,7 @@ impl Clone for FILE {
         *self
     }
 }
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum fpos_t {} // FIXME(vxworks): fill this out with a struct
 impl Copy for fpos_t {}
 impl Clone for fpos_t {

--- a/src/wasi/mod.rs
+++ b/src/wasi/mod.rs
@@ -42,13 +42,13 @@ s_no_extra_traits! {
 }
 
 #[allow(missing_copy_implementations)]
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum FILE {}
 #[allow(missing_copy_implementations)]
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum DIR {}
 #[allow(missing_copy_implementations)]
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum __locale_struct {}
 
 s_paren! {
@@ -176,7 +176,7 @@ s! {
 // etc., since it contains a flexible array member with a dynamic size.
 #[repr(C)]
 #[allow(missing_copy_implementations)]
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub struct dirent {
     pub d_ino: ino_t,
     pub d_type: c_uchar,

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -29,7 +29,7 @@ cfg_if! {
 pub type off_t = i32;
 pub type dev_t = u32;
 pub type ino_t = u16;
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum timezone {}
 impl Copy for timezone {}
 impl Clone for timezone {
@@ -243,7 +243,7 @@ pub const SIG_GET: crate::sighandler_t = 2;
 pub const SIG_SGE: crate::sighandler_t = 3;
 pub const SIG_ACK: crate::sighandler_t = 4;
 
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum FILE {}
 impl Copy for FILE {}
 impl Clone for FILE {
@@ -251,7 +251,7 @@ impl Clone for FILE {
         *self
     }
 }
-#[cfg_attr(feature = "extra_traits", derive(Debug))]
+#[derive(Debug)]
 pub enum fpos_t {} // FIXME(windows): fill this out with a struct
 impl Copy for fpos_t {}
 impl Clone for fpos_t {


### PR DESCRIPTION
Currently `Debug` implementations are gated behind the `extra-traits` feature. My understanding is that historically, this was for two reasons:

1. `Debug` implementations for unions were unsound
2. Concerns about compile time

The first was resolved a while ago by adding a "manual derive" opaque implementation, in 6faa521f32fc ("fix: make Debug impl for unions opaque"). Regarding the second reason, compile times for the current `main` on my machine are (cleaning in between, with the 2025-08-06 nightly):

      $ cargo build -p libc
         Compiling libc v1.0.0-alpha.1 (~/rust-libc)
          Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.79s
      $ cargo build -p libc --release
         Compiling libc v1.0.0-alpha.1 (~/rust-libc)
          Finished `release` profile [optimized] target(s) in 0.64s
      $ cargo build -p libc --features extra_traits
         Compiling libc v1.0.0-alpha.1 (~/rust-libc)
          Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.08s
      $ cargo build -p libc --features extra_traits --release
         Compiling libc v1.0.0-alpha.1 (~/rust-libc)
          Finished `release` profile [optimized] target(s) in 0.85s

And with this patch applied:
    
      $ cargo build -p libc
         Compiling libc v1.0.0-alpha.1 (~/rust-libc)
          Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.89s
      $ cargo build -p libc --release
         Compiling libc v1.0.0-alpha.1 (~/rust-libc)
          Finished `release` profile [optimized] target(s) in 0.70s
      $ cargo build -p libc --features extra_traits
         Compiling libc v1.0.0-alpha.1 (~/rust-libc)
          Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.15s
      $ cargo build -p libc --features extra_traits --release
         Compiling libc v1.0.0-alpha.1 (~/rust-libc)
          Finished `release` profile [optimized] target(s) in 0.86s

That is a microbenchmark but it shows that there probably isn't anything to worry about.

Thus, remove the `Debug` implementation from the `feature = "extra_traitts"` gating.

Another advantage of doing this is that it should allow many crates to remove the enable for `extra_traits`, giving us a better idea of who wants `Debug` vs. who is actually using the `Eq`/`Hash` implementations.

Link: https://github.com/rust-lang/libc/issues/3880