### PR TITLE
ci: Update Debian s390x links

### DIFF
--- a/ci/linux-s390x.sh
+++ b/ci/linux-s390x.sh
@@ -6,8 +6,8 @@ mkdir -m 777 /qemu
 cd /qemu
 
 curl --retry 5 -LO https://github.com/qemu/qemu/raw/HEAD/pc-bios/s390-ccw.img
-curl --retry 5 -LO http://ftp.debian.org/debian/dists/testing/main/installer-s390x/20241227/images/generic/kernel.debian
-curl --retry 5 -LO http://ftp.debian.org/debian/dists/testing/main/installer-s390x/20241227/images/generic/initrd.debian
+curl --retry 5 -LO https://ftp.debian.org/debian/dists/testing/main/installer-s390x/20250803/images/generic/kernel.debian
+curl --retry 5 -LO https://ftp.debian.org/debian/dists/testing/main/installer-s390x/20250803/images/generic/initrd.debian
 
 mv kernel.debian kernel
 mv initrd.debian initrd.gz


### PR DESCRIPTION
Debian recently had a release, so we need to update our links.