### PR TITLE
libc: add padding struct

### DIFF
--- a/libc-test/test/check_style.rs
+++ b/libc-test/test/check_style.rs
@@ -20,7 +20,7 @@ use style::{Result, StyleChecker};
 const SKIP_PREFIXES: &[&str] = &[
     // Don't run the style checker on the reorganized portion of the crate while we figure
     // out what style we want.
-    "new/",
+    "new/", "types.rs",
 ];
 
 #[test]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -64,6 +64,8 @@ macro_rules! cfg_if {
 /// Create an internal crate prelude with `core` reexports and common types.
 macro_rules! prelude {
     () => {
+        mod types;
+
         /// Frequently-used types that are available on all platforms
         ///
         /// We need to reexport the core types so this works with `rust-dep-of-std`.
@@ -72,14 +74,20 @@ macro_rules! prelude {
             #[allow(unused_imports)]
             pub(crate) use ::core::clone::Clone;
             #[allow(unused_imports)]
+            pub(crate) use ::core::default::Default;
+            #[allow(unused_imports)]
             pub(crate) use ::core::marker::{Copy, Send, Sync};
             #[allow(unused_imports)]
             pub(crate) use ::core::option::Option;
+            #[allow(unused_imports)]
+            pub(crate) use ::core::prelude::v1::derive;
             #[allow(unused_imports)]
             pub(crate) use ::core::{fmt, hash, iter, mem};
             #[allow(unused_imports)]
             pub(crate) use mem::{align_of, align_of_val, size_of, size_of_val};
 
+            #[allow(unused_imports)]
+            pub(crate) use crate::types::Padding;
             // Commonly used types defined in this crate
             #[allow(unused_imports)]
             pub(crate) use crate::{

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,18 @@
+//! Platform-agnostic support types.
+
+use core::mem::MaybeUninit;
+
+use crate::prelude::*;
+
+/// A transparent wrapper over `MaybeUninit<T>` to represent uninitialized padding
+/// while providing `Default`.
+#[allow(unused)]
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub(crate) struct Padding<T: Copy>(MaybeUninit<T>);
+
+impl<T: Copy> Default for Padding<T> {
+    fn default() -> Self {
+        Self(MaybeUninit::zeroed())
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
Adds a struct for padding types.
<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
