### PR TITLE
Correct the definition of `sigval`

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -43,6 +43,27 @@ missing! {
 }
 pub type locale_t = *mut c_void;
 
+s_no_extra_traits! {
+    pub union sigval {
+        pub sival_ptr: *mut c_void,
+        pub sival_int: c_int,
+    }
+}
+
+impl hash::Hash for sigval {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        state.write_usize(unsafe { self.sival_ptr } as usize);
+    }
+}
+
+impl ::core::cmp::PartialEq for sigval {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { self.sival_ptr == other.sival_ptr }
+    }
+}
+
+impl ::core::cmp::Eq for sigval {}
+
 s! {
     pub struct group {
         pub gr_name: *mut c_char,


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Make the definition of [`sigval`](https://pubs.opengroup.org/onlinepubs/000095399/basedefs/signal.h.html#:~:text=The-,sigval,-union%20shall%20be) match libc, split from rust-lang/libc#4620 

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

https://github.com/bminor/glibc/blob/8543577b04ded6d979ffcc5a818930e4d74d0645/signal/bits/types/__sigval_t.h#L24-L28
https://github.com/bminor/musl/blob/8fd5d031876345e42ae3d11cc07b962f8625bc3b/include/signal.h#L94-L97
https://github.com/torvalds/linux/blob/8f5ae30d69d7543eee0d70083daf4de8fe15d585/include/uapi/asm-generic/siginfo.h#L8-L11

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
