### PR TITLE
ci: Don't run ctest self tests on loongarch

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -22,9 +22,11 @@ case "$target" in
     *) cmd="$cmd --workspace" ;;
 esac
 
-# garando_errors only compiles on `cfg(any(unix, windows))`
 case "$target" in
+    # garando_errors only compiles on `cfg(any(unix, windows))`
     *wasm*) cmd="$cmd --exclude ctest --exclude ctest-test --exclude ctest-next" ;;
+    # https://github.com/bytecodealliance/rustix/issues/1496
+    *loongarch*) cmd="$cmd --exclude ctest --exclude ctest-test --exclude ctest-next" ;;
 esac
 
 if [ "$target" = "s390x-unknown-linux-gnu" ]; then


### PR DESCRIPTION
Currently rustix doesn't compile due to a new conflicting import with rustix. Resolve this by excluding the crates that need `rustix` (via `tempfile`) as a dependency.

See https://github.com/bytecodealliance/rustix/issues/1496