### PR TITLE
ctest: Better error propagation when subprocesses fail

### DIFF
--- a/ctest-next/src/macro_expansion.rs
+++ b/ctest-next/src/macro_expansion.rs
@@ -27,8 +27,8 @@ pub fn expand<P: AsRef<Path>>(crate_path: P, cfg: &[(String, Option<String>)]) -
     let output = cmd.output()?;
 
     if !output.status.success() {
-        let error = std::str::from_utf8(&output.stderr)?;
-        return Err(error.into());
+        let stderr = std::str::from_utf8(&output.stderr)?;
+        return Err(format!("macro expansion failed with {}: {}", output.status, stderr).into());
     }
 
     let expanded = std::str::from_utf8(&output.stdout)?.to_string();

--- a/ctest-next/src/runner.rs
+++ b/ctest-next/src/runner.rs
@@ -146,7 +146,8 @@ pub fn __compile_test(
 
     let output = cmd.output()?;
     if !output.status.success() {
-        return Err(std::str::from_utf8(&output.stderr)?.into());
+        let stderr = std::str::from_utf8(&output.stderr)?;
+        return Err(format!("compile test failed with {}: {}", output.status, stderr).into());
     }
 
     Ok(binary_path)
@@ -171,7 +172,8 @@ pub fn __run_test<P: AsRef<Path>>(test_binary: P) -> Result<String> {
     let output = cmd.output()?;
 
     if !output.status.success() {
-        return Err(std::str::from_utf8(&output.stderr)?.into());
+        let stderr = std::str::from_utf8(&output.stderr)?;
+        return Err(format!("run test failed with {}: {}", output.status, stderr).into());
     }
 
     Ok(std::str::from_utf8(&output.stdout)?.to_string())


### PR DESCRIPTION
# Description

When a process fails, it can be useful to know the termination reason in addition to the stderr output, especially when a process is terminated with a fatal signal such as SIGSEGV.

# Sources

_not applicable_

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] ~~Relevant tests in `libc-test/semver` have been updated~~
- [ ] ~~No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))~~
- [ ] ~~Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI~~

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
