### PR TITLE
linux: Use the input_event_X macros to access input_event members

### DIFF
--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -332,21 +332,18 @@ s! {
     }
 
     pub struct input_event {
-        // FIXME(1.0): Change to the commented variant, see https://github.com/rust-lang/libc/pull/4148#discussion_r1857511742
         #[cfg(any(target_pointer_width = "64", not(linux_time_bits64)))]
-        pub time: crate::timeval,
-        // #[cfg(any(target_pointer_width = "64", not(linux_time_bits64)))]
-        // pub input_event_sec: time_t,
-        // #[cfg(any(target_pointer_width = "64", not(linux_time_bits64)))]
-        // pub input_event_usec: suseconds_t,
-        // #[cfg(target_arch = "sparc64")]
-        // _pad1: c_int,
+        pub input_event_sec: crate::time_t,
         #[cfg(all(target_pointer_width = "32", linux_time_bits64))]
         pub input_event_sec: c_ulong,
 
+        #[cfg(any(target_pointer_width = "64", not(linux_time_bits64)))]
+        pub input_event_usec: crate::suseconds_t,
         #[cfg(all(target_pointer_width = "32", linux_time_bits64))]
         pub input_event_usec: c_ulong,
 
+        #[cfg(target_arch = "sparc64")]
+        _pad1: c_int,
         pub type_: __u16,
         pub code: __u16,
         pub value: __s32,


### PR DESCRIPTION
# Description

Use the `input_event_sec` and `input_event_usec` members (macros in C) on all platforms, no matter whether `time_t` is 32 or 64 bits. 
This means the same members are available in the struct no matter whether it is a 32 or 64 bit platform or the linux_time_bits64 config is set.

This is a breaking change.

# Sources

https://github.com/torvalds/linux/blob/0cc53520e68bea7fb80fdc6bdf8d226d1b6a98d9/include/uapi/linux/input.h#L28

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

This is a breaking change and should not be backported to the 0.2 branch.
