### PR TITLE
Add `backtrace_symbols(_fd)()` functions

### DIFF
--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -582,6 +582,8 @@ aio_write
 aiocb
 asctime_r
 backtrace
+backtrace_symbols
+backtrace_symbols_fd
 clock_adjtime
 close_range
 copy_file_range

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1192,6 +1192,8 @@ extern "C" {
 
     pub fn ctermid(s: *mut c_char) -> *mut c_char;
     pub fn backtrace(buf: *mut *mut c_void, sz: c_int) -> c_int;
+    pub fn backtrace_symbols(buffer: *const *mut c_void, len: c_int) -> *mut *mut c_char;
+    pub fn backtrace_symbols_fd(buffer: *const *mut c_void, len: c_int, fd: c_int);
     #[cfg_attr(gnu_time_bits64, link_name = "__glob64_time64")]
     pub fn glob64(
         pattern: *const c_char,


### PR DESCRIPTION
# Description
Add `backtrace_symbols()` and `backtrace_symbols_fd()` for linux gnu.
Fixes https://github.com/rust-lang/libc/issues/4667

# Sources
https://github.com/bminor/glibc/blob/6f999af332c91035350390ef8af96388b8f4fd2c/debug/execinfo.h

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
