### PR TITLE
adding dlvsym support for linux/GNU, freebsd, dragonflybsd and netbsd.

### DIFF
--- a/libc-test/semver/dragonfly.txt
+++ b/libc-test/semver/dragonfly.txt
@@ -1317,6 +1317,7 @@ dirfd
 dirname
 dl_iterate_phdr
 dl_phdr_info
+dlvsym
 drand48
 duplocale
 eaccess

--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -1928,6 +1928,7 @@ dirfd
 dirname
 dl_iterate_phdr
 dl_phdr_info
+dlvsym
 drand48
 dup3
 duplocale

--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -590,6 +590,7 @@ ctime_r
 dirname
 dlinfo
 dlmopen
+dlvsym
 eaccess
 endutxent
 epoll_pwait2

--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -1282,6 +1282,7 @@ dirfd
 dirname
 dl_iterate_phdr
 dl_phdr_info
+dlvsym
 dqblk
 drand48
 dup3

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -5275,6 +5275,11 @@ extern "C" {
         idx1: c_ulong,
         idx2: c_ulong,
     ) -> c_int;
+    pub fn dlvsym(
+        handle: *mut c_void,
+        symbol: *const c_char,
+        version: *const c_char,
+    ) -> *mut c_void;
 }
 
 #[link(name = "memstat")]

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2686,6 +2686,11 @@ extern "C" {
         new_value: *const crate::itimerspec,
         old_value: *mut crate::itimerspec,
     ) -> c_int;
+    pub fn dlvsym(
+        handle: *mut c_void,
+        symbol: *const c_char,
+        version: *const c_char,
+    ) -> *mut c_void;
 
     // Added in `NetBSD` 7.0
     pub fn explicit_memset(b: *mut c_void, c: c_int, len: size_t);

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1285,6 +1285,11 @@ extern "C" {
         extra_info: *mut *mut c_void,
         flags: c_int,
     ) -> c_int;
+    pub fn dlvsym(
+        handle: *mut c_void,
+        symbol: *const c_char,
+        version: *const c_char,
+    ) -> *mut c_void;
     pub fn malloc_trim(__pad: size_t) -> c_int;
     pub fn gnu_get_libc_release() -> *const c_char;
     pub fn gnu_get_libc_version() -> *const c_char;


### PR DESCRIPTION
ref: https://linux.die.net/man/3/dlvsym
ref: https://man.freebsd.org/cgi/man.cgi?query=dlvsym
ref: https://github.com/DragonFlyBSD/DragonFlyBSD/blob/088552723935447397400336f5ddb7aa5f5de660/include/dlfcn.h#L126
ref: https://man.netbsd.org/dlfcn.3
