### PR TITLE
ctest: add defines for specific headers and language selection

### DIFF
--- a/ctest/src/lib.rs
+++ b/ctest/src/lib.rs
@@ -78,6 +78,27 @@ pub(crate) enum MapInput<'a> {
     UnionFieldType(&'a Union, &'a Field),
 }
 
+/// The language used to generate the tests.
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub enum Language {
+    /// The C Programming Language.
+    #[default]
+    C,
+    /// The C++ Programming Language.
+    CXX,
+}
+
+impl Language {
+    /// Return the file extension of the programming language.
+    pub(crate) fn extension(&self) -> &str {
+        match self {
+            Self::C => "c",
+            Self::CXX => "cpp",
+        }
+    }
+}
+
 /// Search for the target to build for, specified manually or through an environment variable.
 ///
 /// This function will check the following places for the target name:

--- a/ctest/src/template.rs
+++ b/ctest/src/template.rs
@@ -35,7 +35,7 @@ impl RustTestTemplate {
 #[template(path = "test.c")]
 pub(crate) struct CTestTemplate {
     pub template: TestTemplate,
-    pub headers: Vec<String>,
+    pub headers: Vec<(BoxStr, Vec<BoxStr>)>,
 }
 
 impl CTestTemplate {

--- a/ctest/tests/input/hierarchy.h
+++ b/ctest/tests/input/hierarchy.h
@@ -1,6 +1,10 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+#ifdef SUPPRESS_ERROR
+#error Expected SUPPRESS_ERROR to not be defined (testing per-file defines)
+#endif
+
 typedef unsigned int in6_addr;
 
 #define ON true

--- a/ctest/tests/input/hierarchy.out.c
+++ b/ctest/tests/input/hierarchy.out.c
@@ -4,8 +4,15 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-
 #include <hierarchy.h>
+
+#if defined(__cplusplus)
+    #define CTEST_ALIGNOF(T) alignof(T)
+    #define CTEST_EXTERN extern "C" 
+#else
+    #define CTEST_ALIGNOF(T) _Alignof(T)
+    #define CTEST_EXTERN
+#endif
 
 typedef void (*ctest_void_func)(void);
 
@@ -13,19 +20,19 @@ static bool ctest_const_ON_val_static = ON;
 
 // Define a function that returns a pointer to the value of the constant to test.
 // This will later be called on the Rust side via FFI.
-bool *ctest_const__ON(void) {
+CTEST_EXTERN bool *ctest_const__ON(void) {
     return &ctest_const_ON_val_static;
 }
 
 // Return the size of a type.
-uint64_t ctest_size_of__in6_addr(void) { return sizeof(in6_addr); }
+CTEST_EXTERN uint64_t ctest_size_of__in6_addr(void) { return sizeof(in6_addr); }
 
 // Return the alignment of a type.
-uint64_t ctest_align_of__in6_addr(void) { return _Alignof(in6_addr); }
+CTEST_EXTERN uint64_t ctest_align_of__in6_addr(void) { return CTEST_ALIGNOF(in6_addr); }
 
 // Return `1` if the type is signed, otherwise return `0`.
 // Casting -1 to the aliased type if signed evaluates to `-1 < 0`, if unsigned to `MAX_VALUE < 0`
-uint32_t ctest_signededness_of__in6_addr(void) {
+CTEST_EXTERN uint32_t ctest_signededness_of__in6_addr(void) {
     in6_addr all_ones = (in6_addr) -1;
     return all_ones < 0;
 }
@@ -39,7 +46,7 @@ uint32_t ctest_signededness_of__in6_addr(void) {
 // Tests whether the struct/union/alias `x` when passed by value to C and back to Rust
 // remains unchanged.
 // It checks if the size is the same as well as if the padding bytes are all in the correct place.
-in6_addr ctest_roundtrip__in6_addr(
+CTEST_EXTERN in6_addr ctest_roundtrip__in6_addr(
     in6_addr value,
     const uint8_t is_padding_byte[sizeof(in6_addr)],
     uint8_t value_bytes[sizeof(in6_addr)]
@@ -73,7 +80,8 @@ in6_addr ctest_roundtrip__in6_addr(
 #  pragma warning(disable:4191)
 #endif
 
-ctest_void_func ctest_foreign_fn__malloc(void) {
+// Return a function pointer.
+CTEST_EXTERN ctest_void_func ctest_foreign_fn__malloc(void) {
     return (ctest_void_func)malloc;
 }
 
@@ -82,7 +90,7 @@ ctest_void_func ctest_foreign_fn__malloc(void) {
 #endif
 
 // Return a pointer to the static variable content.
-void *ctest_static__in6addr_any(void) {
+CTEST_EXTERN void *ctest_static__in6addr_any(void) {
     // FIXME(ctest): Not correct due to casting the function to a data pointer.
     return (void *)&in6addr_any;
 }

--- a/ctest/tests/input/macro.h
+++ b/ctest/tests/input/macro.h
@@ -1,5 +1,9 @@
 #include <stdint.h>
 
+#ifndef SUPPRESS_ERROR
+#error Expected SUPPRESS_ERROR to be defined (testing per-file defines)
+#endif
+
 struct VecU8
 {
     uint8_t x;

--- a/ctest/tests/input/macro.out.c
+++ b/ctest/tests/input/macro.out.c
@@ -5,59 +5,69 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#define SUPPRESS_ERROR
 #include <macro.h>
+#undef SUPPRESS_ERROR
+
+#if defined(__cplusplus)
+    #define CTEST_ALIGNOF(T) alignof(T)
+    #define CTEST_EXTERN extern "C" 
+#else
+    #define CTEST_ALIGNOF(T) _Alignof(T)
+    #define CTEST_EXTERN
+#endif
 
 typedef void (*ctest_void_func)(void);
 
 // Return the size of a type.
-uint64_t ctest_size_of__VecU8(void) { return sizeof(struct VecU8); }
+CTEST_EXTERN uint64_t ctest_size_of__VecU8(void) { return sizeof(struct VecU8); }
 
 // Return the alignment of a type.
-uint64_t ctest_align_of__VecU8(void) { return _Alignof(struct VecU8); }
+CTEST_EXTERN uint64_t ctest_align_of__VecU8(void) { return CTEST_ALIGNOF(struct VecU8); }
 
 // Return the size of a type.
-uint64_t ctest_size_of__VecU16(void) { return sizeof(struct VecU16); }
+CTEST_EXTERN uint64_t ctest_size_of__VecU16(void) { return sizeof(struct VecU16); }
 
 // Return the alignment of a type.
-uint64_t ctest_align_of__VecU16(void) { return _Alignof(struct VecU16); }
+CTEST_EXTERN uint64_t ctest_align_of__VecU16(void) { return CTEST_ALIGNOF(struct VecU16); }
 
 // Return the offset of a struct/union field.
-uint64_t ctest_offset_of__VecU8__x(void) {
+CTEST_EXTERN uint64_t ctest_offset_of__VecU8__x(void) {
     return offsetof(struct VecU8, x);
 }
 
 // Return the size of a struct/union field.
-uint64_t ctest_size_of__VecU8__x(void) {
+CTEST_EXTERN uint64_t ctest_size_of__VecU8__x(void) {
     return sizeof(((struct VecU8){}).x);
 }
 
 // Return the offset of a struct/union field.
-uint64_t ctest_offset_of__VecU8__y(void) {
+CTEST_EXTERN uint64_t ctest_offset_of__VecU8__y(void) {
     return offsetof(struct VecU8, y);
 }
 
 // Return the size of a struct/union field.
-uint64_t ctest_size_of__VecU8__y(void) {
+CTEST_EXTERN uint64_t ctest_size_of__VecU8__y(void) {
     return sizeof(((struct VecU8){}).y);
 }
 
 // Return the offset of a struct/union field.
-uint64_t ctest_offset_of__VecU16__x(void) {
+CTEST_EXTERN uint64_t ctest_offset_of__VecU16__x(void) {
     return offsetof(struct VecU16, x);
 }
 
 // Return the size of a struct/union field.
-uint64_t ctest_size_of__VecU16__x(void) {
+CTEST_EXTERN uint64_t ctest_size_of__VecU16__x(void) {
     return sizeof(((struct VecU16){}).x);
 }
 
 // Return the offset of a struct/union field.
-uint64_t ctest_offset_of__VecU16__y(void) {
+CTEST_EXTERN uint64_t ctest_offset_of__VecU16__y(void) {
     return offsetof(struct VecU16, y);
 }
 
 // Return the size of a struct/union field.
-uint64_t ctest_size_of__VecU16__y(void) {
+CTEST_EXTERN uint64_t ctest_size_of__VecU16__y(void) {
     return sizeof(((struct VecU16){}).y);
 }
 
@@ -65,7 +75,7 @@ uint64_t ctest_size_of__VecU16__y(void) {
 // This field can have a normal data type, or it could be a function pointer or an array, which
 // have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
 typedef uint8_t *ctest_field_ty__VecU8__x;
-ctest_field_ty__VecU8__x
+CTEST_EXTERN ctest_field_ty__VecU8__x
 ctest_field_ptr__VecU8__x(struct VecU8 *b) {
     return &b->x;
 }
@@ -74,7 +84,7 @@ ctest_field_ptr__VecU8__x(struct VecU8 *b) {
 // This field can have a normal data type, or it could be a function pointer or an array, which
 // have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
 typedef uint8_t *ctest_field_ty__VecU8__y;
-ctest_field_ty__VecU8__y
+CTEST_EXTERN ctest_field_ty__VecU8__y
 ctest_field_ptr__VecU8__y(struct VecU8 *b) {
     return &b->y;
 }
@@ -83,7 +93,7 @@ ctest_field_ptr__VecU8__y(struct VecU8 *b) {
 // This field can have a normal data type, or it could be a function pointer or an array, which
 // have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
 typedef uint16_t *ctest_field_ty__VecU16__x;
-ctest_field_ty__VecU16__x
+CTEST_EXTERN ctest_field_ty__VecU16__x
 ctest_field_ptr__VecU16__x(struct VecU16 *b) {
     return &b->x;
 }
@@ -92,7 +102,7 @@ ctest_field_ptr__VecU16__x(struct VecU16 *b) {
 // This field can have a normal data type, or it could be a function pointer or an array, which
 // have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
 typedef uint16_t *ctest_field_ty__VecU16__y;
-ctest_field_ty__VecU16__y
+CTEST_EXTERN ctest_field_ty__VecU16__y
 ctest_field_ptr__VecU16__y(struct VecU16 *b) {
     return &b->y;
 }
@@ -106,7 +116,7 @@ ctest_field_ptr__VecU16__y(struct VecU16 *b) {
 // Tests whether the struct/union/alias `x` when passed by value to C and back to Rust
 // remains unchanged.
 // It checks if the size is the same as well as if the padding bytes are all in the correct place.
-struct VecU8 ctest_roundtrip__VecU8(
+CTEST_EXTERN struct VecU8 ctest_roundtrip__VecU8(
     struct VecU8 value,
     const uint8_t is_padding_byte[sizeof(struct VecU8)],
     uint8_t value_bytes[sizeof(struct VecU8)]
@@ -133,7 +143,7 @@ struct VecU8 ctest_roundtrip__VecU8(
 // Tests whether the struct/union/alias `x` when passed by value to C and back to Rust
 // remains unchanged.
 // It checks if the size is the same as well as if the padding bytes are all in the correct place.
-struct VecU16 ctest_roundtrip__VecU16(
+CTEST_EXTERN struct VecU16 ctest_roundtrip__VecU16(
     struct VecU16 value,
     const uint8_t is_padding_byte[sizeof(struct VecU16)],
     uint8_t value_bytes[sizeof(struct VecU16)]

--- a/ctest/tests/input/simple.out.with-renames.c
+++ b/ctest/tests/input/simple.out.with-renames.c
@@ -4,8 +4,15 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-
 #include <simple.h>
+
+#if defined(__cplusplus)
+    #define CTEST_ALIGNOF(T) alignof(T)
+    #define CTEST_EXTERN extern "C" 
+#else
+    #define CTEST_ALIGNOF(T) _Alignof(T)
+    #define CTEST_EXTERN
+#endif
 
 typedef void (*ctest_void_func)(void);
 
@@ -13,7 +20,7 @@ static char *ctest_const_A_val_static = A;
 
 // Define a function that returns a pointer to the value of the constant to test.
 // This will later be called on the Rust side via FFI.
-char *ctest_const_cstr__A(void) {
+CTEST_EXTERN char *ctest_const_cstr__A(void) {
     return ctest_const_A_val_static;
 }
 
@@ -21,7 +28,7 @@ static char *ctest_const_B_val_static = C_B;
 
 // Define a function that returns a pointer to the value of the constant to test.
 // This will later be called on the Rust side via FFI.
-char *ctest_const_cstr__B(void) {
+CTEST_EXTERN char *ctest_const_cstr__B(void) {
     return ctest_const_B_val_static;
 }
 
@@ -29,7 +36,7 @@ static enum Color ctest_const_RED_val_static = RED;
 
 // Define a function that returns a pointer to the value of the constant to test.
 // This will later be called on the Rust side via FFI.
-enum Color *ctest_const__RED(void) {
+CTEST_EXTERN enum Color *ctest_const__RED(void) {
     return &ctest_const_RED_val_static;
 }
 
@@ -37,7 +44,7 @@ static enum Color ctest_const_BLUE_val_static = BLUE;
 
 // Define a function that returns a pointer to the value of the constant to test.
 // This will later be called on the Rust side via FFI.
-enum Color *ctest_const__BLUE(void) {
+CTEST_EXTERN enum Color *ctest_const__BLUE(void) {
     return &ctest_const_BLUE_val_static;
 }
 
@@ -45,88 +52,88 @@ static enum Color ctest_const_GREEN_val_static = GREEN;
 
 // Define a function that returns a pointer to the value of the constant to test.
 // This will later be called on the Rust side via FFI.
-enum Color *ctest_const__GREEN(void) {
+CTEST_EXTERN enum Color *ctest_const__GREEN(void) {
     return &ctest_const_GREEN_val_static;
 }
 
 // Return the size of a type.
-uint64_t ctest_size_of__Byte(void) { return sizeof(Byte); }
+CTEST_EXTERN uint64_t ctest_size_of__Byte(void) { return sizeof(Byte); }
 
 // Return the alignment of a type.
-uint64_t ctest_align_of__Byte(void) { return _Alignof(Byte); }
+CTEST_EXTERN uint64_t ctest_align_of__Byte(void) { return CTEST_ALIGNOF(Byte); }
 
 // Return the size of a type.
-uint64_t ctest_size_of__Color(void) { return sizeof(enum Color); }
+CTEST_EXTERN uint64_t ctest_size_of__Color(void) { return sizeof(enum Color); }
 
 // Return the alignment of a type.
-uint64_t ctest_align_of__Color(void) { return _Alignof(enum Color); }
+CTEST_EXTERN uint64_t ctest_align_of__Color(void) { return CTEST_ALIGNOF(enum Color); }
 
 // Return the size of a type.
-uint64_t ctest_size_of__Person(void) { return sizeof(struct Person); }
+CTEST_EXTERN uint64_t ctest_size_of__Person(void) { return sizeof(struct Person); }
 
 // Return the alignment of a type.
-uint64_t ctest_align_of__Person(void) { return _Alignof(struct Person); }
+CTEST_EXTERN uint64_t ctest_align_of__Person(void) { return CTEST_ALIGNOF(struct Person); }
 
 // Return the size of a type.
-uint64_t ctest_size_of__Word(void) { return sizeof(union Word); }
+CTEST_EXTERN uint64_t ctest_size_of__Word(void) { return sizeof(union Word); }
 
 // Return the alignment of a type.
-uint64_t ctest_align_of__Word(void) { return _Alignof(union Word); }
+CTEST_EXTERN uint64_t ctest_align_of__Word(void) { return CTEST_ALIGNOF(union Word); }
 
 // Return `1` if the type is signed, otherwise return `0`.
 // Casting -1 to the aliased type if signed evaluates to `-1 < 0`, if unsigned to `MAX_VALUE < 0`
-uint32_t ctest_signededness_of__Byte(void) {
+CTEST_EXTERN uint32_t ctest_signededness_of__Byte(void) {
     Byte all_ones = (Byte) -1;
     return all_ones < 0;
 }
 
 // Return the offset of a struct/union field.
-uint64_t ctest_offset_of__Person__name(void) {
+CTEST_EXTERN uint64_t ctest_offset_of__Person__name(void) {
     return offsetof(struct Person, name);
 }
 
 // Return the size of a struct/union field.
-uint64_t ctest_size_of__Person__name(void) {
+CTEST_EXTERN uint64_t ctest_size_of__Person__name(void) {
     return sizeof(((struct Person){}).name);
 }
 
 // Return the offset of a struct/union field.
-uint64_t ctest_offset_of__Person__age(void) {
+CTEST_EXTERN uint64_t ctest_offset_of__Person__age(void) {
     return offsetof(struct Person, age);
 }
 
 // Return the size of a struct/union field.
-uint64_t ctest_size_of__Person__age(void) {
+CTEST_EXTERN uint64_t ctest_size_of__Person__age(void) {
     return sizeof(((struct Person){}).age);
 }
 
 // Return the offset of a struct/union field.
-uint64_t ctest_offset_of__Person__job(void) {
+CTEST_EXTERN uint64_t ctest_offset_of__Person__job(void) {
     return offsetof(struct Person, job);
 }
 
 // Return the size of a struct/union field.
-uint64_t ctest_size_of__Person__job(void) {
+CTEST_EXTERN uint64_t ctest_size_of__Person__job(void) {
     return sizeof(((struct Person){}).job);
 }
 
 // Return the offset of a struct/union field.
-uint64_t ctest_offset_of__Word__word(void) {
+CTEST_EXTERN uint64_t ctest_offset_of__Word__word(void) {
     return offsetof(union Word, word);
 }
 
 // Return the size of a struct/union field.
-uint64_t ctest_size_of__Word__word(void) {
+CTEST_EXTERN uint64_t ctest_size_of__Word__word(void) {
     return sizeof(((union Word){}).word);
 }
 
 // Return the offset of a struct/union field.
-uint64_t ctest_offset_of__Word__byte(void) {
+CTEST_EXTERN uint64_t ctest_offset_of__Word__byte(void) {
     return offsetof(union Word, byte);
 }
 
 // Return the size of a struct/union field.
-uint64_t ctest_size_of__Word__byte(void) {
+CTEST_EXTERN uint64_t ctest_size_of__Word__byte(void) {
     return sizeof(((union Word){}).byte);
 }
 
@@ -134,7 +141,7 @@ uint64_t ctest_size_of__Word__byte(void) {
 // This field can have a normal data type, or it could be a function pointer or an array, which
 // have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
 typedef const char **ctest_field_ty__Person__name;
-ctest_field_ty__Person__name
+CTEST_EXTERN ctest_field_ty__Person__name
 ctest_field_ptr__Person__name(struct Person *b) {
     return &b->name;
 }
@@ -143,7 +150,7 @@ ctest_field_ptr__Person__name(struct Person *b) {
 // This field can have a normal data type, or it could be a function pointer or an array, which
 // have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
 typedef uint8_t *ctest_field_ty__Person__age;
-ctest_field_ty__Person__age
+CTEST_EXTERN ctest_field_ty__Person__age
 ctest_field_ptr__Person__age(struct Person *b) {
     return &b->age;
 }
@@ -152,7 +159,7 @@ ctest_field_ptr__Person__age(struct Person *b) {
 // This field can have a normal data type, or it could be a function pointer or an array, which
 // have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
 typedef void (**ctest_field_ty__Person__job)(uint8_t, const char *);
-ctest_field_ty__Person__job
+CTEST_EXTERN ctest_field_ty__Person__job
 ctest_field_ptr__Person__job(struct Person *b) {
     return &b->job;
 }
@@ -161,7 +168,7 @@ ctest_field_ptr__Person__job(struct Person *b) {
 // This field can have a normal data type, or it could be a function pointer or an array, which
 // have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
 typedef uint16_t *ctest_field_ty__Word__word;
-ctest_field_ty__Word__word
+CTEST_EXTERN ctest_field_ty__Word__word
 ctest_field_ptr__Word__word(union Word *b) {
     return &b->word;
 }
@@ -170,7 +177,7 @@ ctest_field_ptr__Word__word(union Word *b) {
 // This field can have a normal data type, or it could be a function pointer or an array, which
 // have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
 typedef Byte (*ctest_field_ty__Word__byte)[2];
-ctest_field_ty__Word__byte
+CTEST_EXTERN ctest_field_ty__Word__byte
 ctest_field_ptr__Word__byte(union Word *b) {
     return &b->byte;
 }
@@ -184,7 +191,7 @@ ctest_field_ptr__Word__byte(union Word *b) {
 // Tests whether the struct/union/alias `x` when passed by value to C and back to Rust
 // remains unchanged.
 // It checks if the size is the same as well as if the padding bytes are all in the correct place.
-Byte ctest_roundtrip__Byte(
+CTEST_EXTERN Byte ctest_roundtrip__Byte(
     Byte value,
     const uint8_t is_padding_byte[sizeof(Byte)],
     uint8_t value_bytes[sizeof(Byte)]
@@ -211,7 +218,7 @@ Byte ctest_roundtrip__Byte(
 // Tests whether the struct/union/alias `x` when passed by value to C and back to Rust
 // remains unchanged.
 // It checks if the size is the same as well as if the padding bytes are all in the correct place.
-enum Color ctest_roundtrip__Color(
+CTEST_EXTERN enum Color ctest_roundtrip__Color(
     enum Color value,
     const uint8_t is_padding_byte[sizeof(enum Color)],
     uint8_t value_bytes[sizeof(enum Color)]
@@ -238,7 +245,7 @@ enum Color ctest_roundtrip__Color(
 // Tests whether the struct/union/alias `x` when passed by value to C and back to Rust
 // remains unchanged.
 // It checks if the size is the same as well as if the padding bytes are all in the correct place.
-struct Person ctest_roundtrip__Person(
+CTEST_EXTERN struct Person ctest_roundtrip__Person(
     struct Person value,
     const uint8_t is_padding_byte[sizeof(struct Person)],
     uint8_t value_bytes[sizeof(struct Person)]
@@ -265,7 +272,7 @@ struct Person ctest_roundtrip__Person(
 // Tests whether the struct/union/alias `x` when passed by value to C and back to Rust
 // remains unchanged.
 // It checks if the size is the same as well as if the padding bytes are all in the correct place.
-union Word ctest_roundtrip__Word(
+CTEST_EXTERN union Word ctest_roundtrip__Word(
     union Word value,
     const uint8_t is_padding_byte[sizeof(union Word)],
     uint8_t value_bytes[sizeof(union Word)]
@@ -299,7 +306,8 @@ union Word ctest_roundtrip__Word(
 #  pragma warning(disable:4191)
 #endif
 
-ctest_void_func ctest_foreign_fn__calloc(void) {
+// Return a function pointer.
+CTEST_EXTERN ctest_void_func ctest_foreign_fn__calloc(void) {
     return (ctest_void_func)calloc;
 }
 
@@ -308,7 +316,7 @@ ctest_void_func ctest_foreign_fn__calloc(void) {
 #endif
 
 // Return a pointer to the static variable content.
-void *ctest_static__byte(void) {
+CTEST_EXTERN void *ctest_static__byte(void) {
     // FIXME(ctest): Not correct due to casting the function to a data pointer.
     return (void *)&byte;
 }

--- a/ctest/tests/input/simple.out.with-skips.c
+++ b/ctest/tests/input/simple.out.with-skips.c
@@ -4,8 +4,15 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-
 #include <simple.h>
+
+#if defined(__cplusplus)
+    #define CTEST_ALIGNOF(T) alignof(T)
+    #define CTEST_EXTERN extern "C" 
+#else
+    #define CTEST_ALIGNOF(T) _Alignof(T)
+    #define CTEST_EXTERN
+#endif
 
 typedef void (*ctest_void_func)(void);
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
Allows defining values only for certain headers, as well as choosing which language to use when generating tests.

Closes rust-lang/libc#4598
<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
