### PR TITLE
libc: fix reg32 on 32 bit freebsd

### DIFF
--- a/ctest/src/generator.rs
+++ b/ctest/src/generator.rs
@@ -14,7 +14,7 @@ use crate::template::{CTestTemplate, RustTestTemplate};
 use crate::translator::translate_primitive_type;
 use crate::{
     Const, Field, MapInput, Parameter, Result, Static, Struct, TranslationError, Type, Union,
-    VolatileItemKind, expand,
+    VolatileItemKind, expand, get_build_target,
 };
 
 /// A function that takes a mappable input and returns its mapping as `Some`, otherwise
@@ -961,7 +961,7 @@ impl TestGenerator {
         crate_path: impl AsRef<Path>,
         output_file_path: impl AsRef<Path>,
     ) -> Result<PathBuf, GenerationError> {
-        let expanded = expand(&crate_path, &self.cfg).map_err(|e| {
+        let expanded = expand(&crate_path, &self.cfg, get_build_target(self)?).map_err(|e| {
             GenerationError::MacroExpansion(crate_path.as_ref().to_path_buf(), e.to_string())
         })?;
         let ast = syn::parse_file(&expanded)

--- a/ctest/src/macro_expansion.rs
+++ b/ctest/src/macro_expansion.rs
@@ -6,7 +6,11 @@ use std::process::Command;
 use crate::{EDITION, Result};
 
 /// Use rustc to expand all macros and pretty print the crate into a single file.
-pub fn expand<P: AsRef<Path>>(crate_path: P, cfg: &[(String, Option<String>)]) -> Result<String> {
+pub fn expand<P: AsRef<Path>>(
+    crate_path: P,
+    cfg: &[(String, Option<String>)],
+    target: String,
+) -> Result<String> {
     let rustc = env::var("RUSTC").unwrap_or_else(|_| String::from("rustc"));
 
     let mut cmd = Command::new(rustc);
@@ -15,6 +19,10 @@ pub fn expand<P: AsRef<Path>>(crate_path: P, cfg: &[(String, Option<String>)]) -
         .arg("--edition")
         .arg(EDITION) // By default, -Zunpretty=expanded uses 2015 edition.
         .arg(canonicalize(crate_path)?);
+
+    if !target.is_empty() {
+        cmd.arg("--target").arg(target);
+    }
 
     // `libc` uses non standard cfg flags as well, which have to be manually expanded.
     for (k, v) in cfg {

--- a/ctest/src/runner.rs
+++ b/ctest/src/runner.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::generator::GenerationError;
-use crate::{EDITION, Result, TestGenerator};
+use crate::{EDITION, Result, TestGenerator, get_build_target};
 
 /// Generate all tests for the given crate and output the Rust side to a file.
 #[doc(hidden)]
@@ -18,17 +18,7 @@ pub fn generate_test(
 ) -> Result<PathBuf, GenerationError> {
     let output_file_path = generator.generate_files(crate_path, output_file_path)?;
 
-    // Search for the target and host to build for if specified manually
-    // (generator.target, generator.host),
-    // via build script (TARGET, HOST), or for internal testing (TARGET_PLATFORM, HOST_PLATFORM).
-    let target = generator
-        .target
-        .clone()
-        .or_else(|| env::var("TARGET").ok())
-        .or_else(|| env::var("TARGET_PLATFORM").ok())
-        .ok_or(GenerationError::EnvVarNotFound(
-            "TARGET, TARGET_PLATFORM".to_string(),
-        ))?;
+    let target = get_build_target(generator)?;
     let host = env::var("HOST")
         .or_else(|_| env::var("HOST_PLATFORM"))
         .map_err(|_| GenerationError::EnvVarNotFound("HOST, HOST_PLATFORM".to_string()))?;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
Attempts to fix errors in freebsd i686 by making sure that the correct build target is used when expanding macros.

<!-- Add a short description about what this change does -->

# Sources
https://cgit.freebsd.org/src/tree/sys/x86/include/reg.h?h=releng/13.1
<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
