### PR TITLE
Fix redox MAP_FIXED

### DIFF
--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -761,7 +761,7 @@ pub const MAP_SHARED: c_int = 0x0001;
 pub const MAP_PRIVATE: c_int = 0x0002;
 pub const MAP_ANON: c_int = 0x0020;
 pub const MAP_ANONYMOUS: c_int = MAP_ANON;
-pub const MAP_FIXED: c_int = 0x0010;
+pub const MAP_FIXED: c_int = 0x0004;
 pub const MAP_FAILED: *mut c_void = !0 as _;
 
 pub const MS_ASYNC: c_int = 0x0001;


### PR DESCRIPTION
# Description

This PR Fixes MAP_FIXED constant that's actually used in Redox. I have checked other MAP_* constant is correct.

# Sources

+ [the constant in relibc](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/sys_mman/redox.rs#L8)
+ [the test case](https://gitlab.redox-os.org/redox-os/redox/-/issues/1721)

# Checklist

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
