### PR TITLE
Fix gid_t/uid_t types for redox.

### DIFF
--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -29,8 +29,8 @@ pub type tcflag_t = u32;
 pub type time_t = c_longlong;
 pub type id_t = c_uint;
 pub type pid_t = usize;
-pub type uid_t = u32;
-pub type gid_t = u32;
+pub type uid_t = c_int;
+pub type gid_t = c_int;
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum timezone {}


### PR DESCRIPTION
Closes rust-lang/libc#4678
