### PR TITLE
On FreeBSD, set the ELF symbol version for readdir_r

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1758,6 +1758,10 @@ cfg_if! {
                 all(target_os = "freebsd", any(freebsd11, freebsd10)),
                 link_name = "readdir_r@FBSD_1.0"
             )]
+            #[cfg_attr(
+                all(target_os = "freebsd", not(any(freebsd11, freebsd10))),
+                link_name = "readdir_r@FBSD_1.5"
+            )]
             #[allow(non_autolinks)] // FIXME(docs): `<>` breaks line length limit.
             /// The 64-bit libc on Solaris and illumos only has readdir_r. If a
             /// 32-bit Solaris or illumos target is ever created, it should use


### PR DESCRIPTION
This function will probably be removed in FreeBSD 16.  But the old symbol will remain, for backwards-compatibility.  Set the symbol version now, so that the current version of libc will still be able to compile on future versions of FreeBSD.

If and when the `readdir_r` function does get removed, libc's CI will start to fail.  But the crate itself will continue to build, thanks to this PR.

# Sources
https://github.com/freebsd/freebsd-src/blob/455426da078cbbea8160bf4232b3fd1ae56e2ff5/lib/libc/gen/Symbol.map#L421

# Checklist

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
