### PR TITLE
FreeBSD: update gating of `mcontext_t.mc_tlsbase`

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -98,7 +98,7 @@ s_no_extra_traits! {
     }
 
     #[repr(align(16))]
-    #[non_exhaustive]
+    #[cfg_attr(not(any(freebsd11, freebsd12, freebsd13, freebsd14)), non_exhaustive)]
     pub struct mcontext_t {
         pub mc_onstack: register_t,
         pub mc_rdi: register_t,
@@ -137,11 +137,13 @@ s_no_extra_traits! {
         pub mc_gsbase: register_t,
         pub mc_xfpustate: register_t,
         pub mc_xfpustate_len: register_t,
-        #[cfg(any(freebsd12, freebsd13, freebsd14))]
+        // freebsd < 15
+        #[cfg(any(freebsd11, freebsd12, freebsd13, freebsd14))]
         pub mc_spare: [c_long; 4],
-        #[cfg(freebsd15)]
+        // freebsd >= 15
+        #[cfg(not(any(freebsd11, freebsd12, freebsd13, freebsd14)))]
         pub mc_tlsbase: register_t,
-        #[cfg(freebsd15)]
+        #[cfg(not(any(freebsd11, freebsd12, freebsd13, freebsd14)))]
         pub mc_spare: [c_long; 3],
     }
 }


### PR DESCRIPTION
freebsd11 wasn't covered, meaning test failures on the 0.2 branch. Add freebsd11 to the pattern, and use `cfg(not(...))` rather than `cfg(freebsd15)`. (Ideally this would instead be encoded as something like `cfg(freebsd_least_15)`.)

Fixes: 3d93bf589413 ("freebsd: Limit mcontext_t::mc_tlsbase to FreeBSD 15")