### PR TITLE
include cfmakeraw definition for target_os = nto

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1841,11 +1841,28 @@ cfg_if! {
     if #[cfg(any(target_os = "aix", target_os = "nto"))] {
         extern "C" {
             pub fn cfmakeraw(termios: *mut crate::termios) -> c_int;
-            pub fn cfsetspeed(termios: *mut crate::termios, speed: crate::speed_t) -> c_int;
         }
     } else if #[cfg(not(any(target_os = "solaris", target_os = "illumos",)))] {
         extern "C" {
             pub fn cfmakeraw(termios: *mut crate::termios);
+        }
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(
+        target_os = "aix",
+        all(target_os = "nto", target_env = "nto80")
+    ))] {
+        extern "C" {
+            pub fn cfsetspeed(termios: *mut crate::termios, speed: crate::speed_t) -> c_int;
+        }
+    } else if #[cfg(not(any(
+        target_os = "solaris",
+        target_os = "illumos",
+        target_os = "nto"
+    )))] {
+        extern "C" {
             pub fn cfsetspeed(termios: *mut crate::termios, speed: crate::speed_t) -> c_int;
         }
     }


### PR DESCRIPTION
Hi,
apparently cfmakeraw was not included for target_os = "nto".

Definition of cfmakeraw for nto-qnx:
https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.lib_ref/topic/c/cfmakeraw.html
https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.lib_ref/topic/c/cfmakeraw.html