### PR TITLE
Warn on missing debug implementations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,11 @@
     unused_macros,
     unused_macro_rules,
 )]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    safe_packed_borrows
+)]
 // Prepare for a future upgrade
 #![warn(rust_2024_compatibility)]
 // Things missing for 2024 that are blocked on MSRV or breakage
@@ -22,7 +27,6 @@
 // Attributes needed when building as part of the standard library
 #![cfg_attr(feature = "rustc-dep-of-std", feature(link_cfg, no_core))]
 #![cfg_attr(feature = "rustc-dep-of-std", allow(internal_features))]
-#![warn(missing_copy_implementations, safe_packed_borrows)]
 #![cfg_attr(not(feature = "rustc-dep-of-std"), no_std)]
 #![cfg_attr(feature = "rustc-dep-of-std", no_core)]
 


### PR DESCRIPTION
This was removed by accident; only the `feature = "rustc-dep-of-std"` gate should have been removed.

Fixes: a6e75638ce4e ("Always implement `Debug`")

@rustbot label +stable-nominated