### PR TITLE
add `pthread_cond_timedwait_relative_np`

### DIFF
--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -2090,6 +2090,7 @@ pthread_attr_setschedpolicy
 pthread_attr_setscope
 pthread_attr_setstackaddr
 pthread_cancel
+pthread_cond_timedwait_relative_np
 pthread_condattr_getpshared
 pthread_condattr_setpshared
 pthread_cpu_number_np

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -5179,6 +5179,11 @@ extern "C" {
         newp: *mut c_void,
         newlen: size_t,
     ) -> c_int;
+    pub fn pthread_cond_timedwait_relative_np(
+        cond: *mut pthread_cond_t,
+        lock: *mut pthread_mutex_t,
+        timeout: *const crate::timespec,
+    ) -> c_int;
     pub fn pthread_once(
         once_control: *mut crate::pthread_once_t,
         init_routine: Option<unsafe extern "C" fn()>,


### PR DESCRIPTION
# Description

This PR adds bindings for the non-standard, Apple-specific function `pthread_cond_timedwait_relative_np`, which allows waiting on a condvar with a relative timeout. It was added in Mac OS X 10.4 and iOS 2.0.

# Sources

* [`pthread.h`](https://github.com/apple-oss-distributions/libpthread/blob/1ebf56b3a702df53213c2996e5e128a535d2577e/include/pthread/pthread.h#L555-L559)

@rustbot label +stable-nominated