### PR TITLE
Simplify rustc-check-cfg emission in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -145,19 +145,11 @@ fn main() {
     // avoid warnings.
     if rustc_minor_ver >= 80 {
         for cfg in ALLOWED_CFGS {
-            if rustc_minor_ver >= 75 {
-                println!("cargo:rustc-check-cfg=cfg({cfg})");
-            } else {
-                println!("cargo:rustc-check-cfg=values({cfg})");
-            }
+            println!("cargo:rustc-check-cfg=cfg({cfg})");
         }
         for &(name, values) in CHECK_CFG_EXTRA {
             let values = values.join("\",\"");
-            if rustc_minor_ver >= 75 {
-                println!("cargo:rustc-check-cfg=cfg({name},values(\"{values}\"))");
-            } else {
-                println!("cargo:rustc-check-cfg=values({name},\"{values}\")");
-            }
+            println!("cargo:rustc-check-cfg=cfg({name},values(\"{values}\"))");
         }
     }
 }


### PR DESCRIPTION
# Description

Simplify rustc-check-cfg emission in build.rs

# Sources

N/A

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI