### PR TITLE
Move keyctl to new/linux_uapi

### DIFF
--- a/src/new/linux_uapi/linux/keyctl.rs
+++ b/src/new/linux_uapi/linux/keyctl.rs
@@ -1,0 +1,70 @@
+//! Header: `uapi/linux/keyctl.h`
+
+// linux/keyctl.h
+pub const KEY_SPEC_THREAD_KEYRING: i32 = -1;
+pub const KEY_SPEC_PROCESS_KEYRING: i32 = -2;
+pub const KEY_SPEC_SESSION_KEYRING: i32 = -3;
+pub const KEY_SPEC_USER_KEYRING: i32 = -4;
+pub const KEY_SPEC_USER_SESSION_KEYRING: i32 = -5;
+pub const KEY_SPEC_GROUP_KEYRING: i32 = -6;
+pub const KEY_SPEC_REQKEY_AUTH_KEY: i32 = -7;
+pub const KEY_SPEC_REQUESTOR_KEYRING: i32 = -8;
+
+pub const KEY_REQKEY_DEFL_NO_CHANGE: i32 = -1;
+pub const KEY_REQKEY_DEFL_DEFAULT: i32 = 0;
+pub const KEY_REQKEY_DEFL_THREAD_KEYRING: i32 = 1;
+pub const KEY_REQKEY_DEFL_PROCESS_KEYRING: i32 = 2;
+pub const KEY_REQKEY_DEFL_SESSION_KEYRING: i32 = 3;
+pub const KEY_REQKEY_DEFL_USER_KEYRING: i32 = 4;
+pub const KEY_REQKEY_DEFL_USER_SESSION_KEYRING: i32 = 5;
+pub const KEY_REQKEY_DEFL_GROUP_KEYRING: i32 = 6;
+pub const KEY_REQKEY_DEFL_REQUESTOR_KEYRING: i32 = 7;
+
+pub const KEYCTL_GET_KEYRING_ID: u32 = 0;
+pub const KEYCTL_JOIN_SESSION_KEYRING: u32 = 1;
+pub const KEYCTL_UPDATE: u32 = 2;
+pub const KEYCTL_REVOKE: u32 = 3;
+pub const KEYCTL_CHOWN: u32 = 4;
+pub const KEYCTL_SETPERM: u32 = 5;
+pub const KEYCTL_DESCRIBE: u32 = 6;
+pub const KEYCTL_CLEAR: u32 = 7;
+pub const KEYCTL_LINK: u32 = 8;
+pub const KEYCTL_UNLINK: u32 = 9;
+pub const KEYCTL_SEARCH: u32 = 10;
+pub const KEYCTL_READ: u32 = 11;
+pub const KEYCTL_INSTANTIATE: u32 = 12;
+pub const KEYCTL_NEGATE: u32 = 13;
+pub const KEYCTL_SET_REQKEY_KEYRING: u32 = 14;
+pub const KEYCTL_SET_TIMEOUT: u32 = 15;
+pub const KEYCTL_ASSUME_AUTHORITY: u32 = 16;
+pub const KEYCTL_GET_SECURITY: u32 = 17;
+pub const KEYCTL_SESSION_TO_PARENT: u32 = 18;
+pub const KEYCTL_REJECT: u32 = 19;
+pub const KEYCTL_INSTANTIATE_IOV: u32 = 20;
+pub const KEYCTL_INVALIDATE: u32 = 21;
+pub const KEYCTL_GET_PERSISTENT: u32 = 22;
+pub const KEYCTL_DH_COMPUTE: u32 = 23;
+pub const KEYCTL_PKEY_QUERY: u32 = 24;
+pub const KEYCTL_PKEY_ENCRYPT: u32 = 25;
+pub const KEYCTL_PKEY_DECRYPT: u32 = 26;
+pub const KEYCTL_PKEY_SIGN: u32 = 27;
+pub const KEYCTL_PKEY_VERIFY: u32 = 28;
+pub const KEYCTL_RESTRICT_KEYRING: u32 = 29;
+pub const KEYCTL_MOVE: u32 = 30;
+pub const KEYCTL_CAPABILITIES: u32 = 31;
+
+pub const KEYCTL_SUPPORTS_ENCRYPT: u32 = 0x01;
+pub const KEYCTL_SUPPORTS_DECRYPT: u32 = 0x02;
+pub const KEYCTL_SUPPORTS_SIGN: u32 = 0x04;
+pub const KEYCTL_SUPPORTS_VERIFY: u32 = 0x08;
+
+pub const KEYCTL_CAPS0_CAPABILITIES: u32 = 0x01;
+pub const KEYCTL_CAPS0_PERSISTENT_KEYRINGS: u32 = 0x02;
+pub const KEYCTL_CAPS0_DIFFIE_HELLMAN: u32 = 0x04;
+pub const KEYCTL_CAPS0_PUBLIC_KEY: u32 = 0x08;
+pub const KEYCTL_CAPS0_BIG_KEY: u32 = 0x10;
+pub const KEYCTL_CAPS0_INVALIDATE: u32 = 0x20;
+pub const KEYCTL_CAPS0_RESTRICT_KEYRING: u32 = 0x40;
+pub const KEYCTL_CAPS0_MOVE: u32 = 0x80;
+pub const KEYCTL_CAPS1_NS_KEYRING_NAME: u32 = 0x01;
+pub const KEYCTL_CAPS1_NS_KEY_TAG: u32 = 0x02;

--- a/src/new/linux_uapi/linux/mod.rs
+++ b/src/new/linux_uapi/linux/mod.rs
@@ -2,3 +2,5 @@
 
 pub(crate) mod can;
 pub use can::*;
+pub(crate) mod keyctl;
+pub use keyctl::*;

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -889,42 +889,6 @@ pub const GENL_ID_PMCRAID: c_int = crate::NLMSG_MIN_TYPE + 2;
 
 pub const ELFOSABI_ARM_AEABI: u8 = 64;
 
-// linux/keyctl.h
-pub const KEYCTL_DH_COMPUTE: u32 = 23;
-pub const KEYCTL_PKEY_QUERY: u32 = 24;
-pub const KEYCTL_PKEY_ENCRYPT: u32 = 25;
-pub const KEYCTL_PKEY_DECRYPT: u32 = 26;
-pub const KEYCTL_PKEY_SIGN: u32 = 27;
-pub const KEYCTL_PKEY_VERIFY: u32 = 28;
-pub const KEYCTL_RESTRICT_KEYRING: u32 = 29;
-
-pub const KEYCTL_SUPPORTS_ENCRYPT: u32 = 0x01;
-pub const KEYCTL_SUPPORTS_DECRYPT: u32 = 0x02;
-pub const KEYCTL_SUPPORTS_SIGN: u32 = 0x04;
-pub const KEYCTL_SUPPORTS_VERIFY: u32 = 0x08;
-cfg_if! {
-    if #[cfg(not(any(
-        target_arch = "mips",
-        target_arch = "mips32r6",
-        target_arch = "mips64",
-        target_arch = "mips64r6"
-    )))] {
-        pub const KEYCTL_MOVE: u32 = 30;
-        pub const KEYCTL_CAPABILITIES: u32 = 31;
-
-        pub const KEYCTL_CAPS0_CAPABILITIES: u32 = 0x01;
-        pub const KEYCTL_CAPS0_PERSISTENT_KEYRINGS: u32 = 0x02;
-        pub const KEYCTL_CAPS0_DIFFIE_HELLMAN: u32 = 0x04;
-        pub const KEYCTL_CAPS0_PUBLIC_KEY: u32 = 0x08;
-        pub const KEYCTL_CAPS0_BIG_KEY: u32 = 0x10;
-        pub const KEYCTL_CAPS0_INVALIDATE: u32 = 0x20;
-        pub const KEYCTL_CAPS0_RESTRICT_KEYRING: u32 = 0x40;
-        pub const KEYCTL_CAPS0_MOVE: u32 = 0x80;
-        pub const KEYCTL_CAPS1_NS_KEYRING_NAME: u32 = 0x01;
-        pub const KEYCTL_CAPS1_NS_KEY_TAG: u32 = 0x02;
-    }
-}
-
 pub const M_MXFAST: c_int = 1;
 pub const M_NLBLKS: c_int = 2;
 pub const M_GRAIN: c_int = 3;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -4791,50 +4791,6 @@ const fn issecure_mask(x: c_int) -> c_int {
     1 << x
 }
 
-// linux/keyctl.h
-pub const KEY_SPEC_THREAD_KEYRING: i32 = -1;
-pub const KEY_SPEC_PROCESS_KEYRING: i32 = -2;
-pub const KEY_SPEC_SESSION_KEYRING: i32 = -3;
-pub const KEY_SPEC_USER_KEYRING: i32 = -4;
-pub const KEY_SPEC_USER_SESSION_KEYRING: i32 = -5;
-pub const KEY_SPEC_GROUP_KEYRING: i32 = -6;
-pub const KEY_SPEC_REQKEY_AUTH_KEY: i32 = -7;
-pub const KEY_SPEC_REQUESTOR_KEYRING: i32 = -8;
-
-pub const KEY_REQKEY_DEFL_NO_CHANGE: i32 = -1;
-pub const KEY_REQKEY_DEFL_DEFAULT: i32 = 0;
-pub const KEY_REQKEY_DEFL_THREAD_KEYRING: i32 = 1;
-pub const KEY_REQKEY_DEFL_PROCESS_KEYRING: i32 = 2;
-pub const KEY_REQKEY_DEFL_SESSION_KEYRING: i32 = 3;
-pub const KEY_REQKEY_DEFL_USER_KEYRING: i32 = 4;
-pub const KEY_REQKEY_DEFL_USER_SESSION_KEYRING: i32 = 5;
-pub const KEY_REQKEY_DEFL_GROUP_KEYRING: i32 = 6;
-pub const KEY_REQKEY_DEFL_REQUESTOR_KEYRING: i32 = 7;
-
-pub const KEYCTL_GET_KEYRING_ID: u32 = 0;
-pub const KEYCTL_JOIN_SESSION_KEYRING: u32 = 1;
-pub const KEYCTL_UPDATE: u32 = 2;
-pub const KEYCTL_REVOKE: u32 = 3;
-pub const KEYCTL_CHOWN: u32 = 4;
-pub const KEYCTL_SETPERM: u32 = 5;
-pub const KEYCTL_DESCRIBE: u32 = 6;
-pub const KEYCTL_CLEAR: u32 = 7;
-pub const KEYCTL_LINK: u32 = 8;
-pub const KEYCTL_UNLINK: u32 = 9;
-pub const KEYCTL_SEARCH: u32 = 10;
-pub const KEYCTL_READ: u32 = 11;
-pub const KEYCTL_INSTANTIATE: u32 = 12;
-pub const KEYCTL_NEGATE: u32 = 13;
-pub const KEYCTL_SET_REQKEY_KEYRING: u32 = 14;
-pub const KEYCTL_SET_TIMEOUT: u32 = 15;
-pub const KEYCTL_ASSUME_AUTHORITY: u32 = 16;
-pub const KEYCTL_GET_SECURITY: u32 = 17;
-pub const KEYCTL_SESSION_TO_PARENT: u32 = 18;
-pub const KEYCTL_REJECT: u32 = 19;
-pub const KEYCTL_INSTANTIATE_IOV: u32 = 20;
-pub const KEYCTL_INVALIDATE: u32 = 21;
-pub const KEYCTL_GET_PERSISTENT: u32 = 22;
-
 pub const IN_MASK_CREATE: u32 = 0x1000_0000;
 pub const IN_MASK_ADD: u32 = 0x2000_0000;
 pub const IN_ISDIR: u32 = 0x4000_0000;


### PR DESCRIPTION
# Description

These constants are entirely defined in the Linux UAPI.

cc @tgross35 @Gelbpunkt 

# Sources

* https://elixir.bootlin.com/linux/v6.16.9/source/include/uapi/linux/keyctl.h

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] ~~Relevant tests in `libc-test/semver` have been updated~~ no change
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
