### PR TITLE
linux-musl-s390x: Add __psw_t/fprefset_t/*context_t

### DIFF
--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -84,6 +84,31 @@ s! {
         pub f_flags: c_uint,
         pub f_spare: [c_uint; 4],
     }
+
+    pub struct __psw_t {
+        pub mask: c_ulong,
+        pub addr: c_ulong,
+    }
+
+    pub struct fpregset_t {
+        pub fpc: c_uint,
+        pub fprs: [fpreg_t; 16],
+    }
+
+    pub struct mcontext_t {
+        pub psw: __psw_t,
+        pub gregs: [c_ulong; 16],
+        pub aregs: [c_uint; 16],
+        pub fpregs: fpregset_t,
+    }
+
+    pub struct ucontext_t {
+        pub uc_flags: c_ulong,
+        pub uc_link: *mut ucontext_t,
+        pub uc_stack: crate::stack_t,
+        pub uc_mcontext: mcontext_t,
+        pub uc_sigmask: crate::sigset_t,
+    }
 }
 
 s_no_extra_traits! {


### PR DESCRIPTION


<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Define signal-related structs according to musl-libc. These structs are already mentioned in libc-test/semver/linux-s390x.txt, so it makes sense to define the for musl, not just for glibc.

# Sources

https://elixir.bootlin.com/musl/v1.2.5/source/arch/s390x/bits/signal.h

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] ~~Relevant tests in `libc-test/semver` have been updated~~ no change
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
