### PR TITLE
ctest: automatically skip roundtrip testing for aliases to arrays

### DIFF
--- a/ctest/src/generator.rs
+++ b/ctest/src/generator.rs
@@ -930,8 +930,6 @@ impl TestGenerator {
         self
     }
 
-    // FIXME(ctest): should arrays be handled differently?
-
     /// Configures whether the ABI roundtrip tests for a type are emitted.
     ///
     /// The closure is passed the name of a Rust type and returns whether the
@@ -939,7 +937,7 @@ impl TestGenerator {
     ///
     /// By default all types undergo ABI roundtrip tests. Arrays cannot undergo
     /// an ABI roundtrip because they cannot be returned by C functions, and
-    /// have to be manually skipped here.
+    /// are automatically skipped.
     ///
     /// # Examples
     /// ```no_run

--- a/ctest/src/template.rs
+++ b/ctest/src/template.rs
@@ -257,6 +257,10 @@ impl TestTemplate {
         helper: &TranslateHelper,
     ) -> Result<(), TranslationError> {
         for alias in helper.filtered_ffi_items.aliases() {
+            // Arrays cannot be roundtripped, and are automatically skipped.
+            if let syn::Type::Array(_) = alias.ty {
+                continue;
+            }
             let c_ty = helper.c_type(alias)?;
             self.add_roundtrip_test(helper, alias.ident(), &[], &c_ty, true);
         }

--- a/ctest/tests/basic.rs
+++ b/ctest/tests/basic.rs
@@ -101,7 +101,7 @@ fn test_skip_simple() {
     let (mut gen_, out_dir) = default_generator(1, Some("simple.h")).unwrap();
     gen_.skip_const(|c| c.ident() == "B" || c.ident() == "A")
         .skip_c_enum(|e| e == "Color")
-        .skip_alias(|a| a.ident() == "Byte")
+        .skip_alias(|a| a.ident() == "Byte" || a.ident() == "gregset_t")
         .skip_struct(|s| s.ident() == "Person")
         .skip_union(|u| u.ident() == "Word")
         .skip_fn(|f| f.ident() == "calloc")

--- a/ctest/tests/input/simple.h
+++ b/ctest/tests/input/simple.h
@@ -2,6 +2,8 @@
 
 typedef uint8_t Byte;
 
+typedef unsigned long gregset_t[32];
+
 Byte byte = 0x42;
 
 struct Person

--- a/ctest/tests/input/simple.out.with-renames.c
+++ b/ctest/tests/input/simple.out.with-renames.c
@@ -63,6 +63,12 @@ CTEST_EXTERN uint64_t ctest_size_of__Byte(void) { return sizeof(Byte); }
 CTEST_EXTERN uint64_t ctest_align_of__Byte(void) { return CTEST_ALIGNOF(Byte); }
 
 // Return the size of a type.
+CTEST_EXTERN uint64_t ctest_size_of__gregset_t(void) { return sizeof(gregset_t); }
+
+// Return the alignment of a type.
+CTEST_EXTERN uint64_t ctest_align_of__gregset_t(void) { return CTEST_ALIGNOF(gregset_t); }
+
+// Return the size of a type.
 CTEST_EXTERN uint64_t ctest_size_of__Color(void) { return sizeof(enum Color); }
 
 // Return the alignment of a type.

--- a/ctest/tests/input/simple.out.with-renames.rs
+++ b/ctest/tests/input/simple.out.with-renames.rs
@@ -187,6 +187,23 @@ mod generated_tests {
     }
 
     /// Compare the size and alignment of the type in Rust and C, making sure they are the same.
+    pub fn ctest_size_align_gregset_t() {
+        extern "C" {
+            fn ctest_size_of__gregset_t() -> u64;
+            fn ctest_align_of__gregset_t() -> u64;
+        }
+
+        let rust_size = size_of::<gregset_t>() as u64;
+        let c_size = unsafe { ctest_size_of__gregset_t() };
+
+        let rust_align = align_of::<gregset_t>() as u64;
+        let c_align = unsafe { ctest_align_of__gregset_t() };
+
+        check_same(rust_size, c_size, "gregset_t size");
+        check_same(rust_align, c_align, "gregset_t align");
+    }
+
+    /// Compare the size and alignment of the type in Rust and C, making sure they are the same.
     pub fn ctest_size_align_Color() {
         extern "C" {
             fn ctest_size_of__Color() -> u64;
@@ -996,6 +1013,7 @@ fn run_all() {
     ctest_const_BLUE();
     ctest_const_GREEN();
     ctest_size_align_Byte();
+    ctest_size_align_gregset_t();
     ctest_size_align_Color();
     ctest_size_align_Person();
     ctest_size_align_Word();

--- a/ctest/tests/input/simple.rs
+++ b/ctest/tests/input/simple.rs
@@ -1,6 +1,9 @@
-use std::ffi::{c_char, c_int, c_void};
+use std::ffi::{c_char, c_int, c_ulong, c_void};
 
 pub type Byte = u8;
+
+// This should be automatically skipped for roundtripping.
+pub type gregset_t = [c_ulong; 32];
 
 #[repr(C)]
 pub struct Person {


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
This PR adds support for automatically skipping round trip testing for any aliases to arrays.

Closes #4708 
<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
