### PR TITLE
openbsd add elf_aux_info

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -525,6 +525,7 @@ fn test_openbsd(target: &str) {
         "sys/syscall.h",
         "sys/shm.h",
         "sys/param.h",
+        "sys/auxv.h",
     }
 
     cfg.rename_type(|ty| match ty {

--- a/libc-test/semver/openbsd.txt
+++ b/libc-test/semver/openbsd.txt
@@ -63,6 +63,11 @@ ATF_PUBL
 ATF_USETRAILERS
 AT_EACCESS
 AT_FDCWD
+AT_HWCAP
+AT_HWCAP2
+AT_IGNORE
+AT_NULL
+AT_PAGESZ
 AT_REMOVEDIR
 AT_SYMLINK_FOLLOW
 AT_SYMLINK_NOFOLLOW
@@ -1090,6 +1095,7 @@ dl_phdr_info
 drand48
 dup3
 duplocale
+elf_aux_info
 endgrent
 endpwent
 endservent

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1040,6 +1040,12 @@ pub const AT_SYMLINK_NOFOLLOW: c_int = 0x02;
 pub const AT_SYMLINK_FOLLOW: c_int = 0x04;
 pub const AT_REMOVEDIR: c_int = 0x08;
 
+pub const AT_NULL: c_int = 0;
+pub const AT_IGNORE: c_int = 1;
+pub const AT_PAGESZ: c_int = 6;
+pub const AT_HWCAP: c_int = 25;
+pub const AT_HWCAP2: c_int = 26;
+
 #[deprecated(since = "0.2.64", note = "Not stable across OS versions")]
 pub const RLIM_NLIMITS: c_int = 9;
 
@@ -2074,6 +2080,8 @@ extern "C" {
     pub fn fstatfs(fd: c_int, buf: *mut statfs) -> c_int;
     pub fn getmntinfo(mntbufp: *mut *mut crate::statfs, flags: c_int) -> c_int;
     pub fn getfsstat(buf: *mut statfs, bufsize: size_t, flags: c_int) -> c_int;
+
+    pub fn elf_aux_info(aux: c_int, buf: *mut c_void, buflen: c_int) -> c_int;
 }
 
 #[link(name = "execinfo")]


### PR DESCRIPTION
# Description

add elf_aux_info() support for OpenBSD.

Necessary for https://github.com/rust-lang/rust/pull/147024

# Sources

https://github.com/openbsd/src/blob/d99593d0c5b5a00fb7a49103acc0c0b24b4aac53/sys/sys/auxv.h

@rustbot label +stable-nominated