### PR TITLE
wasip2: Invert conditional to include p2 APIs

### DIFF
--- a/src/wasi/mod.rs
+++ b/src/wasi/mod.rs
@@ -846,7 +846,7 @@ extern "C" {
 }
 
 cfg_if! {
-    if #[cfg(target_env = "p2")] {
+    if #[cfg(not(target_env = "p1"))] {
         mod p2;
         pub use self::p2::*;
     }


### PR DESCRIPTION


This commit switches `cfg(target_feature = "p2")` to instead using `cfg(not(target_feature = "p1"))` to be more future-proof of new Rust targets such as `wasm32-wasip3`. All future targets will support the same set of functionality in `wasm32-wasip2`, so this should be valid for future targets.


@rustbot label +stable-nominated

