### PR TITLE
Fix the import path for size_of and align_of

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -78,6 +78,8 @@ macro_rules! prelude {
             #[allow(unused_imports)]
             pub(crate) use core::marker::{Copy, Send, Sync};
             #[allow(unused_imports)]
+            pub(crate) use core::mem::{align_of, align_of_val, size_of, size_of_val};
+            #[allow(unused_imports)]
             pub(crate) use core::option::Option;
             #[allow(unused_imports)]
             pub(crate) use core::prelude::v1::derive;
@@ -86,8 +88,6 @@ macro_rules! prelude {
 
             #[allow(unused_imports)]
             pub(crate) use fmt::Debug;
-            #[allow(unused_imports)]
-            pub(crate) use mem::{align_of, align_of_val, size_of, size_of_val};
 
             #[allow(unused_imports)]
             pub(crate) use crate::types::{CEnumRepr, Padding};


### PR DESCRIPTION

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

This change fixes to import `size_of` and `align_of` from the core crate.

We have seen an error failing to resolve this import directive.

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:
-->

@rustbot label +stable-nominated
