### PR TITLE
Switch the FreeBSD 15 CI image to FreeBSD-15.0-ALPHA5

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,7 +21,7 @@ task:
         image: freebsd-14-3-release-amd64-ufs
     - name: nightly freebsd-15 x86_64
       freebsd_instance:
-        image: freebsd-15-0-alpha3-amd64-ufs
+        image: freebsd-15-0-alpha5-amd64-ufs
   setup_script:
     - pkg install -y libnghttp2 curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh


### PR DESCRIPTION


# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI