### PR TITLE
Remove rogue definition of SIGSTKFLT for mips32-linux-musl

### DIFF
--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -363,7 +363,6 @@ pub const SIGTSTP: c_int = 24;
 pub const SIGURG: c_int = 21;
 pub const SIGIO: c_int = 22;
 pub const SIGSYS: c_int = 12;
-pub const SIGSTKFLT: c_int = 7;
 pub const SIGPOLL: c_int = crate::SIGIO;
 pub const SIGPWR: c_int = 19;
 pub const SIG_SETMASK: c_int = 3;


### PR DESCRIPTION
Linux' arch/mips/include/uapi/asm/signal.h does not define SIGSTKFLT.
For one MIPS architecture, we define it as 7 for unknown reasons,
but 7 is already SIGEMT.  This [was  confusing](https://github.com/fish-shell/fish-shell/issues/11965) and is probably useless.
Remove it.
