### PR TITLE
Declare field 'tv_nsec' of structure 'timespec' as 'i32' for AIX

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -5587,6 +5587,12 @@ fn test_aix(target: &str) {
             // The field 'data' is actually a unnamed union in the AIX header.
             "pollfd_ext" if field.ident() == "data" => true,
 
+            // On AIX, <stat.h> declares 'tv_nsec' as 'long', but the
+            // underlying system calls return a 32-bit value in both 32-bit
+            // and 64-bit modes. In the 'libc' crate it is declared as 'i32'
+            // to match the system call. Skip this field.
+            "timespec" if field.ident() == "tv_nsec" => true,
+
             _ => false,
         }
     });

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -264,6 +264,15 @@ s! {
         pub tv_nsec: c_int,
     }
 
+    // On AIX, <stat.h> declares 'tv_nsec' as 'long', but the underlying
+    // system calls return a 4-byte value in both 32-bit and 64-bit modes.
+    // It is declared as 'c_int' here to avoid using the other undefined 4
+    // bytes in the 64-bit mode.
+    pub struct timespec {
+        pub tv_sec: time_t,
+        pub tv_nsec: c_int,
+    }
+
     pub struct statfs64 {
         pub f_version: c_int,
         pub f_type: c_int,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -68,7 +68,7 @@ s! {
 
     // linux x32 compatibility
     // See https://sourceware.org/bugzilla/show_bug.cgi?id=16437
-    #[cfg(not(target_env = "gnu"))]
+    #[cfg(all(not(target_env = "gnu"), not(target_os = "aix")))]
     pub struct timespec {
         pub tv_sec: time_t,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]


### PR DESCRIPTION
 On AIX, <sys/stat.h> declares field `tv_nsec` of `struct timespec` as `long`, but the underlying system calls return a 4-byte value in both 32-bit and 64-bit modes. This PR changes to declare `tv_nsec` as `i32` in the `libc` crate to avoid including the other undefined 4 bytes in the 64-bit mode.

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
