### PR TITLE
Add LINK_STATE_* definitions to NetBSD and OpenBSD.

### DIFF
--- a/src/new/netbsd/net/if_.rs
+++ b/src/new/netbsd/net/if_.rs
@@ -29,6 +29,10 @@ s! {
     }
 }
 
+pub const LINK_STATE_UNKNOWN: c_int = 0; // link invalid/unknown
+pub const LINK_STATE_DOWN: c_int = 1; // link is down
+pub const LINK_STATE_UP: c_int = 2; // link is up
+
 pub const IFF_UP: c_int = 0x0001; // interface is up
 pub const IFF_BROADCAST: c_int = 0x0002; // broadcast address valid
 pub const IFF_DEBUG: c_int = 0x0004; // turn on debugging

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1445,6 +1445,15 @@ const SI_PAD: size_t = (SI_MAXSZ / size_of::<c_int>()) - 3;
 pub const MAP_STACK: c_int = 0x4000;
 pub const MAP_CONCEAL: c_int = 0x8000;
 
+// https://github.com/openbsd/src/blob/f8a2f73b6503213f5eb24ca315ac7e1f9421c0c9/sys/net/if.h#L135
+pub const LINK_STATE_UNKNOWN: c_int = 0; // link unknown
+pub const LINK_STATE_INVALID: c_int = 1; // link invalid
+pub const LINK_STATE_DOWN: c_int = 2; // link is down
+pub const LINK_STATE_KALIVE_DOWN: c_int = 3; // keepalive reports down
+pub const LINK_STATE_UP: c_int = 4; // link is up
+pub const LINK_STATE_HALF_DUPLEX: c_int = 5; // link is up and half duplex
+pub const LINK_STATE_FULL_DUPLEX: c_int = 6; // link is up and full duplex
+
 // https://github.com/openbsd/src/blob/HEAD/sys/net/if.h#L187
 pub const IFF_UP: c_int = 0x1; // interface is up
 pub const IFF_BROADCAST: c_int = 0x2; // broadcast address valid


### PR DESCRIPTION
# Description

Add missing interface LINK_STATE_* definitions from sys/net/if.h

# Sources

https://github.com/NetBSD/src/blob/54613ac4db31045d0ca58a7e2da7af005c6b5cd2/sys/net/if.h#L207
https://github.com/openbsd/src/blob/bac4ed8757bbe68d4cac117487958588ae27e7c2/sys/net/if.h#L135

# Checklist

- [ x] Relevant tests in `libc-test/semver` have been updated
- [x ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
