### PR TITLE
redox: add get/setresgid and get/setresuid

### DIFF
--- a/libc-test/semver/redox.txt
+++ b/libc-test/semver/redox.txt
@@ -302,6 +302,8 @@ getgrouplist
 getline
 getpwent
 getpwnam_r
+getresgid
+getresuid
 getrlimit
 getrusage
 getservbyport

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -1186,6 +1186,16 @@ extern "C" {
     // unistd.h
     pub fn pipe2(fds: *mut c_int, flags: c_int) -> c_int;
     pub fn getdtablesize() -> c_int;
+    pub fn getresgid(
+        rgid: *mut crate::gid_t,
+        egid: *mut crate::gid_t,
+        sgid: *mut crate::gid_t,
+    ) -> c_int;
+    pub fn getresuid(
+        ruid: *mut crate::uid_t,
+        euid: *mut crate::uid_t,
+        suid: *mut crate::uid_t,
+    ) -> c_int;
     pub fn setresgid(rgid: crate::gid_t, egid: crate::gid_t, sgid: crate::gid_t) -> c_int;
     pub fn setresuid(ruid: crate::uid_t, euid: crate::uid_t, suid: crate::uid_t) -> c_int;
 


### PR DESCRIPTION
# Description

This defines 4 functions in `unistd.h` for redox daemon system to work:

+ `getresgid`
+ `getresuid`
+ `setresgid`
+ `setresuid`

These functions have been tested in C ports that uses them, such as nginx.

# Sources


+ [`getresgid`](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/unistd/mod.rs?ref_type=heads#L651)
+ [`getresuid`](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/unistd/mod.rs?ref_type=heads#L663)
+ [`setresgid`](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/unistd/mod.rs?ref_type=heads#L954)
+ [`setresuid`](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/unistd/mod.rs?ref_type=heads#L962)

# Checklist

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
