### PR TITLE
Add missing definitions for QNX8 for several BPF-related structures and constants

### DIFF
--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -203,6 +203,9 @@ cfg_if! {
         pub use utmpx_::*;
     } else if #[cfg(target_os = "openbsd")] {
         pub use sys::ipc::*;
+    } else if #[cfg(target_os = "nto")] {
+        pub use net::bpf::*;
+        pub use net::if_::*;
     }
 }
 

--- a/src/new/nto/mod.rs
+++ b/src/new/nto/mod.rs
@@ -2,3 +2,8 @@
 // FIXME(nto): link to manpages needed.
 
 pub(crate) mod unistd;
+
+pub(crate) mod net {
+    pub(crate) mod bpf;
+    pub(crate) mod if_;
+}

--- a/src/new/nto/net/bpf.rs
+++ b/src/new/nto/net/bpf.rs
@@ -1,0 +1,83 @@
+use crate::bpf_insn;
+
+pub const BPF_LD: u16 = 0x00;
+pub const BPF_LDX: u16 = 0x01;
+pub const BPF_ST: u16 = 0x02;
+pub const BPF_STX: u16 = 0x03;
+pub const BPF_ALU: u16 = 0x04;
+pub const BPF_JMP: u16 = 0x05;
+pub const BPF_RET: u16 = 0x06;
+pub const BPF_MISC: u16 = 0x07;
+pub const BPF_W: u16 = 0x00;
+pub const BPF_H: u16 = 0x08;
+pub const BPF_B: u16 = 0x10;
+pub const BPF_IMM: u16 = 0x00;
+pub const BPF_ABS: u16 = 0x20;
+pub const BPF_IND: u16 = 0x40;
+pub const BPF_MEM: u16 = 0x60;
+pub const BPF_LEN: u16 = 0x80;
+pub const BPF_MSH: u16 = 0xa0;
+pub const BPF_ADD: u16 = 0x00;
+pub const BPF_SUB: u16 = 0x10;
+pub const BPF_MUL: u16 = 0x20;
+pub const BPF_DIV: u16 = 0x30;
+pub const BPF_OR: u16 = 0x40;
+pub const BPF_AND: u16 = 0x50;
+pub const BPF_LSH: u16 = 0x60;
+pub const BPF_RSH: u16 = 0x70;
+pub const BPF_NEG: u16 = 0x80;
+pub const BPF_MOD: u16 = 0x90;
+pub const BPF_XOR: u16 = 0xa0;
+pub const BPF_JA: u16 = 0x00;
+pub const BPF_JEQ: u16 = 0x10;
+pub const BPF_JGT: u16 = 0x20;
+pub const BPF_JGE: u16 = 0x30;
+pub const BPF_JSET: u16 = 0x40;
+pub const BPF_K: u16 = 0x00;
+pub const BPF_X: u16 = 0x08;
+pub const BPF_A: u16 = 0x10;
+pub const BPF_TAX: u16 = 0x00;
+pub const BPF_TXA: u16 = 0x80;
+
+f! {
+    pub fn BPF_CLASS(code: u32) -> u32 {
+        code & 0x07
+    }
+
+    pub fn BPF_SIZE(code: u32) -> u32 {
+        code & 0x18
+    }
+
+    pub fn BPF_MODE(code: u32) -> u32 {
+        code & 0xe0
+    }
+
+    pub fn BPF_OP(code: u32) -> u32 {
+        code & 0xf0
+    }
+
+    pub fn BPF_SRC(code: u32) -> u32 {
+        code & 0x08
+    }
+
+    pub fn BPF_RVAL(code: u32) -> u32 {
+        code & 0x18
+    }
+
+    pub fn BPF_MISCOP(code: u32) -> u32 {
+        code & 0xf8
+    }
+
+    pub fn BPF_STMT(code: u16, k: u32) -> bpf_insn {
+        bpf_insn {
+            code,
+            jt: 0,
+            jf: 0,
+            k,
+        }
+    }
+
+    pub fn BPF_JUMP(code: u16, k: u32, jt: u8, jf: u8) -> bpf_insn {
+        bpf_insn { code, jt, jf, k }
+    }
+}

--- a/src/new/nto/net/if_.rs
+++ b/src/new/nto/net/if_.rs
@@ -1,0 +1,32 @@
+use crate::prelude::*;
+
+s_no_extra_traits! {
+    pub union __c_anonymous_ifr_ifru {
+        pub ifru_addr: crate::sockaddr,
+        pub ifru_dstaddr: crate::sockaddr,
+        pub ifru_broadaddr: crate::sockaddr,
+        pub ifru_buffer: ifreq_buffer,
+        pub ifru_flags: [c_short; 2],
+        pub ifru_index: c_short,
+        pub ifru_jid: c_int,
+        pub ifru_metric: c_int,
+        pub ifru_mtu: c_int,
+        pub ifru_phys: c_int,
+        pub ifru_media: c_int,
+        pub ifru_data: *mut c_char,
+        pub ifru_cap: [c_int; 2],
+        pub ifru_fib: c_uint,
+        pub ifru_vlan_pcp: c_uchar,
+    }
+
+    pub struct ifreq {
+        /// if name, e.g. "en0"
+        pub ifr_name: [c_char; crate::IFNAMSIZ],
+        pub ifr_ifru: __c_anonymous_ifr_ifru,
+    }
+
+    pub struct ifreq_buffer {
+        pub length: size_t,
+        pub buffer: *mut c_void,
+    }
+}

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -876,8 +876,18 @@ pub const MS_SYNC: c_int = 2;
 
 pub const SCM_RIGHTS: c_int = 0x01;
 pub const SCM_TIMESTAMP: c_int = 0x02;
+
+// QNX Network Stack Versioning:
+//
+// The `if` block targets the legacy `io-pkt` stack.
+// - target_env = "nto70": QNX 7.0
+// - target_env = "nto71": Standard QNX 7.1 (default legacy stack)
+//
+// The `else` block targets the modern `io-sock` stack.
+// - target_env = "nto71_iosock": QNX 7.1 with the optional new stack
+// - target_env = "nto80": QNX 8.0
 cfg_if! {
-    if #[cfg(not(target_env = "nto71_iosock"))] {
+    if #[cfg(any(target_env = "nto70", target_env = "nto71"))] {
         pub const SCM_CREDS: c_int = 0x04;
         pub const IFF_NOTRAILERS: c_int = 0x00000020;
         pub const AF_INET6: c_int = 24;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

These structures are required for working with BPF filters and network interfaces on the QNX8 platform. Their absence currently prevents building or using BPF-related functionality with libc on QNX8 targets.

QNX Network Stack Versioning:

- legacy `io-pkt` stack:
> target_env = "nto70": QNX 7.0
> target_env` = "nto71": Standard QNX 7.1 (default legacy stack)

- modern `io-sock` stack:
> target_env = "nto71_iosock": QNX 7.1 with the optional new stack
> target_env = "nto80": QNX 8.0

# Sources
Updated `src/new/*` accordingly
<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [?] Relevant tests in `libc-test/semver` have been updated
       **-> No tests for QNX?**
- [*] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [?] Tested locally (`cd libc-test && cargo test --target mytarget`);  especially relevant for platforms that may not be checked in CI.
       **-> even main branch does not work.
       Error: could not execute process `/home/user/libc/target/x86_64-pc-nto-qnx800/debug/deps/libc-67e46525c5118905` (never executed)**

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
