### PR TITLE
fmt: Use vertical import formatting within `libc`

### DIFF
--- a/ci/style.sh
+++ b/ci/style.sh
@@ -40,7 +40,7 @@ while IFS= read -r file; do
     # Format the file. We need to invoke `rustfmt` directly since `cargo fmt`
     # can't figure out the module tree with the hacks in place.
     failed=false
-    rustfmt --config-path rustfmt.toml "$file" ${check:+"$check"} || failed=true
+    rustfmt "$file" ${check:+"$check"} || failed=true
 
     # Restore all changes to the files.
     perl -pi -e 's/fn (\w+)_fmt_tmp\(\)/$1!/g' "$file"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+# Note that there is a separate configuration for `src/`
 edition = "2021"
 error_on_line_overflow = true
 group_imports = "StdExternalCrate"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -76,26 +76,59 @@ macro_rules! prelude {
             #[allow(unused_imports)]
             pub(crate) use core::default::Default;
             #[allow(unused_imports)]
-            pub(crate) use core::marker::{Copy, Send, Sync};
+            pub(crate) use core::marker::{
+                Copy,
+                Send,
+                Sync,
+            };
             #[allow(unused_imports)]
             pub(crate) use core::option::Option;
             #[allow(unused_imports)]
             pub(crate) use core::prelude::v1::derive;
             #[allow(unused_imports)]
-            pub(crate) use core::{fmt, hash, iter, mem, ptr};
+            pub(crate) use core::{
+                fmt,
+                hash,
+                iter,
+                mem,
+                ptr,
+            };
 
             #[allow(unused_imports)]
             pub(crate) use fmt::Debug;
             #[allow(unused_imports)]
-            pub(crate) use mem::{align_of, align_of_val, size_of, size_of_val};
+            pub(crate) use mem::{
+                align_of,
+                align_of_val,
+                size_of,
+                size_of_val,
+            };
 
             #[allow(unused_imports)]
-            pub(crate) use crate::types::{CEnumRepr, Padding};
+            pub(crate) use crate::types::{
+                CEnumRepr,
+                Padding,
+            };
             // Commonly used types defined in this crate
             #[allow(unused_imports)]
             pub(crate) use crate::{
-                c_char, c_double, c_float, c_int, c_long, c_longlong, c_short, c_uchar, c_uint,
-                c_ulong, c_ulonglong, c_ushort, c_void, intptr_t, size_t, ssize_t, uintptr_t,
+                c_char,
+                c_double,
+                c_float,
+                c_int,
+                c_long,
+                c_longlong,
+                c_short,
+                c_uchar,
+                c_uint,
+                c_ulong,
+                c_ulonglong,
+                c_ushort,
+                c_void,
+                intptr_t,
+                size_t,
+                ssize_t,
+                uintptr_t,
             };
         }
     };

--- a/src/rustfmt.toml
+++ b/src/rustfmt.toml
@@ -1,0 +1,7 @@
+# Note that there is a separate top-level configuration for everything else
+edition = "2021"
+error_on_line_overflow = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+# This crate gets large lists of reexports. Use vertical to reduce conflicts.
+imports_layout = "Vertical"

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
-use crate::{in_addr_t, in_port_t};
+use crate::{
+    in_addr_t,
+    in_port_t,
+};
 
 pub type caddr_t = *mut c_char;
 pub type clockid_t = c_longlong;

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -3,7 +3,10 @@
 //! This covers *-apple-* triples currently
 
 use crate::prelude::*;
-use crate::{cmsghdr, off_t};
+use crate::{
+    cmsghdr,
+    off_t,
+};
 
 pub type wchar_t = i32;
 pub type clock_t = c_ulong;

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
-use crate::{cmsghdr, off_t};
+use crate::{
+    cmsghdr,
+    off_t,
+};
 
 pub type dev_t = u32;
 pub type wchar_t = i32;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
-use crate::{cmsghdr, off_t};
+use crate::{
+    cmsghdr,
+    off_t,
+};
 
 pub type fflags_t = u32;
 

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
-use crate::{cmsghdr, off_t};
+use crate::{
+    cmsghdr,
+    off_t,
+};
 
 pub type clock_t = c_uint;
 pub type suseconds_t = c_int;

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1,6 +1,9 @@
 use crate::prelude::*;
 use crate::unix::bsd::O_SYNC;
-use crate::{cmsghdr, off_t};
+use crate::{
+    cmsghdr,
+    off_t,
+};
 
 pub type clock_t = i64;
 pub type suseconds_t = c_long;

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -1,7 +1,10 @@
 //! Android-specific definitions for linux-like values
 
 use crate::prelude::*;
-use crate::{cmsghdr, msghdr};
+use crate::{
+    cmsghdr,
+    msghdr,
+};
 
 cfg_if! {
     if #[cfg(doc)] {

--- a/src/unix/linux_like/emscripten/lfs64.rs
+++ b/src/unix/linux_like/emscripten/lfs64.rs
@@ -109,7 +109,10 @@ pub unsafe extern "C" fn mmap64(
 //
 // These aliases are mostly fine though, neither function takes a LFS64-namespaced type as an
 // argument, nor do their names clash with any declared types.
-pub use crate::{open as open64, openat as openat64};
+pub use crate::{
+    open as open64,
+    openat as openat64,
+};
 
 #[inline]
 pub unsafe extern "C" fn posix_fadvise64(

--- a/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
-use crate::{off64_t, off_t};
+use crate::{
+    off64_t,
+    off_t,
+};
 
 pub type wchar_t = u32;
 

--- a/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
-use crate::{off64_t, off_t};
+use crate::{
+    off64_t,
+    off_t,
+};
 
 pub type wchar_t = u32;
 

--- a/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
-use crate::{off64_t, off_t};
+use crate::{
+    off64_t,
+    off_t,
+};
 
 pub type wchar_t = i32;
 

--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
-use crate::{off64_t, off_t};
+use crate::{
+    off64_t,
+    off_t,
+};
 
 pub type wchar_t = i32;
 

--- a/src/unix/linux_like/linux/gnu/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/gnu/b32/powerpc.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
-use crate::{off64_t, off_t};
+use crate::{
+    off64_t,
+    off_t,
+};
 
 pub type wchar_t = i32;
 

--- a/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
@@ -1,7 +1,10 @@
 //! RISC-V-specific definitions for 32-bit linux-like values
 
 use crate::prelude::*;
-use crate::{off64_t, off_t};
+use crate::{
+    off64_t,
+    off_t,
+};
 
 pub type wchar_t = c_int;
 

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -1,7 +1,10 @@
 //! SPARC-specific definitions for 32-bit linux-like values
 
 use crate::prelude::*;
-use crate::{off64_t, off_t};
+use crate::{
+    off64_t,
+    off_t,
+};
 
 pub type wchar_t = i32;
 

--- a/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
-use crate::{off64_t, off_t};
+use crate::{
+    off64_t,
+    off_t,
+};
 
 pub type wchar_t = i32;
 pub type greg_t = i32;

--- a/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
@@ -1,7 +1,10 @@
 //! AArch64-specific definitions for 64-bit linux-like values
 
 use crate::prelude::*;
-use crate::{off64_t, off_t};
+use crate::{
+    off64_t,
+    off_t,
+};
 
 pub type wchar_t = u32;
 pub type nlink_t = u32;

--- a/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
@@ -1,5 +1,9 @@
 use crate::prelude::*;
-use crate::{off64_t, off_t, pthread_mutex_t};
+use crate::{
+    off64_t,
+    off_t,
+    pthread_mutex_t,
+};
 
 pub type wchar_t = i32;
 

--- a/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
@@ -1,5 +1,9 @@
 use crate::prelude::*;
-use crate::{off64_t, off_t, pthread_mutex_t};
+use crate::{
+    off64_t,
+    off_t,
+    pthread_mutex_t,
+};
 
 pub type blksize_t = i64;
 pub type nlink_t = u64;

--- a/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
@@ -1,7 +1,11 @@
 //! PowerPC64-specific definitions for 64-bit linux-like values
 
 use crate::prelude::*;
-use crate::{off64_t, off_t, pthread_mutex_t};
+use crate::{
+    off64_t,
+    off_t,
+    pthread_mutex_t,
+};
 
 pub type wchar_t = i32;
 pub type nlink_t = u64;

--- a/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
@@ -1,7 +1,10 @@
 //! RISC-V-specific definitions for 64-bit linux-like values
 
 use crate::prelude::*;
-use crate::{off64_t, off_t};
+use crate::{
+    off64_t,
+    off_t,
+};
 
 pub type wchar_t = c_int;
 

--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -1,7 +1,11 @@
 //! s390x
 
 use crate::prelude::*;
-use crate::{off64_t, off_t, pthread_mutex_t};
+use crate::{
+    off64_t,
+    off_t,
+    pthread_mutex_t,
+};
 
 pub type blksize_t = i64;
 pub type nlink_t = u64;

--- a/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
@@ -1,7 +1,11 @@
 //! SPARC64-specific definitions for 64-bit linux-like values
 
 use crate::prelude::*;
-use crate::{off64_t, off_t, pthread_mutex_t};
+use crate::{
+    off64_t,
+    off_t,
+    pthread_mutex_t,
+};
 
 pub type wchar_t = i32;
 pub type nlink_t = u32;

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -1,7 +1,10 @@
 //! x86_64-specific definitions for 64-bit linux-like values
 
 use crate::prelude::*;
-use crate::{off64_t, off_t};
+use crate::{
+    off64_t,
+    off_t,
+};
 
 pub type wchar_t = i32;
 pub type nlink_t = u64;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1,7 +1,13 @@
 //! Linux-specific definitions for linux-like values
 
 use crate::prelude::*;
-use crate::{sock_filter, _IO, _IOR, _IOW, _IOWR};
+use crate::{
+    sock_filter,
+    _IO,
+    _IOR,
+    _IOW,
+    _IOWR,
+};
 
 pub type useconds_t = u32;
 pub type dev_t = u64;

--- a/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
@@ -1,7 +1,10 @@
 //! RISC-V-specific definitions for 32-bit linux-like values
 
 use crate::prelude::*;
-use crate::{off64_t, off_t};
+use crate::{
+    off64_t,
+    off_t,
+};
 
 pub type wchar_t = c_int;
 

--- a/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
@@ -1,7 +1,10 @@
 //! LoongArch-specific definitions for 64-bit linux-like values
 
 use crate::prelude::*;
-use crate::{off64_t, off_t};
+use crate::{
+    off64_t,
+    off_t,
+};
 
 pub type wchar_t = c_int;
 

--- a/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
@@ -1,7 +1,10 @@
 //! RISC-V-specific definitions for 64-bit linux-like values
 
 use crate::prelude::*;
-use crate::{off64_t, off_t};
+use crate::{
+    off64_t,
+    off_t,
+};
 
 pub type wchar_t = c_int;
 

--- a/src/unix/linux_like/linux/musl/lfs64.rs
+++ b/src/unix/linux_like/linux/musl/lfs64.rs
@@ -117,7 +117,10 @@ pub unsafe extern "C" fn mmap64(
 //
 // These aliases are mostly fine though, neither function takes a LFS64-namespaced type as an
 // argument, nor do their names clash with any declared types.
-pub use crate::{open as open64, openat as openat64};
+pub use crate::{
+    open as open64,
+    openat as openat64,
+};
 
 #[inline]
 pub unsafe extern "C" fn posix_fadvise64(

--- a/src/unix/newlib/aarch64/mod.rs
+++ b/src/unix/newlib/aarch64/mod.rs
@@ -49,4 +49,8 @@ pub const MSG_WAITALL: c_int = 0;
 pub const MSG_MORE: c_int = 0;
 pub const MSG_NOSIGNAL: c_int = 0;
 
-pub use crate::unix::newlib::generic::{dirent, sigset_t, stat};
+pub use crate::unix::newlib::generic::{
+    dirent,
+    sigset_t,
+    stat,
+};

--- a/src/unix/newlib/arm/mod.rs
+++ b/src/unix/newlib/arm/mod.rs
@@ -51,4 +51,8 @@ pub const MSG_WAITALL: c_int = 0;
 pub const MSG_MORE: c_int = 0;
 pub const MSG_NOSIGNAL: c_int = 0;
 
-pub use crate::unix::newlib::generic::{dirent, sigset_t, stat};
+pub use crate::unix::newlib::generic::{
+    dirent,
+    sigset_t,
+    stat,
+};

--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -117,4 +117,8 @@ extern "C" {
     pub fn eventfd(initval: c_uint, flags: c_int) -> c_int;
 }
 
-pub use crate::unix::newlib::generic::{dirent, sigset_t, stat};
+pub use crate::unix::newlib::generic::{
+    dirent,
+    sigset_t,
+    stat,
+};

--- a/src/unix/newlib/powerpc/mod.rs
+++ b/src/unix/newlib/powerpc/mod.rs
@@ -3,7 +3,11 @@ use crate::prelude::*;
 pub type clock_t = c_ulong;
 pub type wchar_t = c_int;
 
-pub use crate::unix::newlib::generic::{dirent, sigset_t, stat};
+pub use crate::unix::newlib::generic::{
+    dirent,
+    sigset_t,
+    stat,
+};
 
 // the newlib shipped with devkitPPC does not support the following components:
 // - sockaddr

--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -1,5 +1,10 @@
 use crate::prelude::*;
-use crate::{in6_addr, in_addr_t, timespec, DIR};
+use crate::{
+    in6_addr,
+    in_addr_t,
+    timespec,
+    DIR,
+};
 
 pub type nlink_t = u16;
 pub type ino_t = u16;

--- a/src/unix/solarish/compat.rs
+++ b/src/unix/solarish/compat.rs
@@ -3,7 +3,11 @@
 use core::cmp::min;
 
 use crate::unix::solarish::*;
-use crate::{c_char, c_int, size_t};
+use crate::{
+    c_char,
+    c_int,
+    size_t,
+};
 
 pub unsafe fn cfmakeraw(termios: *mut crate::termios) {
     (*termios).c_iflag &=

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -1,7 +1,13 @@
 use crate::prelude::*;
 use crate::{
-    exit_status, off_t, NET_MAC_AWARE, NET_MAC_AWARE_INHERIT, PRIV_AWARE_RESET, PRIV_DEBUG,
-    PRIV_PFEXEC, PRIV_XPOLICY,
+    exit_status,
+    off_t,
+    NET_MAC_AWARE,
+    NET_MAC_AWARE_INHERIT,
+    PRIV_AWARE_RESET,
+    PRIV_DEBUG,
+    PRIV_PFEXEC,
+    PRIV_XPOLICY,
 };
 
 pub type lgrp_rsrc_t = c_int;

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -1,7 +1,14 @@
 use crate::prelude::*;
 use crate::{
-    exit_status, off_t, termios, NET_MAC_AWARE, NET_MAC_AWARE_INHERIT, PRIV_AWARE_RESET,
-    PRIV_DEBUG, PRIV_PFEXEC, PRIV_XPOLICY,
+    exit_status,
+    off_t,
+    termios,
+    NET_MAC_AWARE,
+    NET_MAC_AWARE_INHERIT,
+    PRIV_AWARE_RESET,
+    PRIV_DEBUG,
+    PRIV_PFEXEC,
+    PRIV_XPOLICY,
 };
 
 pub type door_attr_t = c_uint;


### PR DESCRIPTION
The crate has a lot of reexports and will be getting many more. Change the formatting to vertical to reduce the possibility of conflicts.