### PR TITLE
ci: Add an x86_64-apple job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -212,6 +212,8 @@ jobs:
           - target: wasm32-unknown-emscripten
           - target: wasm32-wasip1
           - target: wasm32-wasip2
+          - target: x86_64-apple-darwin
+            os: macos-15-intel
           - target: x86_64-linux-android
           # FIXME: Exec format error (os error 8)
           # - target: x86_64-unknown-linux-gnux32

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -309,13 +309,16 @@ fn test_apple(target: &str) {
         (x86_64, "crt_externs.h"),
     );
 
-    cfg.skip_struct(|s| {
+    cfg.skip_struct(move |s| {
         match s.ident() {
             // FIXME(macos): The size is changed in recent macOSes.
             "malloc_zone_t" => true,
             // it is a moving target, changing through versions
             // also contains bitfields members
             "tcp_connection_info" => true,
+
+            // FIXME(macos): The size is changed in recent macOSes.
+            "malloc_introspection_t" if x86_64 => true,
             _ => false,
         }
     });
@@ -337,6 +340,8 @@ fn test_apple(target: &str) {
     cfg.skip_fn(move |func| {
         // skip those that are manually verified
         match func.ident() {
+            // close calls the close_nocancel system call on x86
+            "close" if x86_64 => true,
             // FIXME(1.0): std removed libresolv support: https://github.com/rust-lang/rust/pull/102766
             "res_init" => true,
             _ => false,

--- a/src/unix/bsd/apple/b64/x86_64/mod.rs
+++ b/src/unix/bsd/apple/b64/x86_64/mod.rs
@@ -7,6 +7,8 @@ s! {
         _private: [crate::uintptr_t; 16], // FIXME(macos): keeping private for now
     }
 
+    // FIXME(1.0): This should not implement `PartialEq`
+    #[allow(unpredictable_function_pointer_comparisons)]
     pub struct malloc_zone_t {
         _reserved1: *mut c_void,
         _reserved2: *mut c_void,


### PR DESCRIPTION
I'm not sure why this was missing: possibly because it was only
previously only possible to test with macos-13. GHA now has
macos-15-intel which makes this easier.