### PR TITLE
VxWorks: Add missing defines/functions needed by rust stdlib

### DIFF
--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -963,6 +963,11 @@ pub const SI_MESGQ: c_int = -5;
 pub const SI_CHILD: c_int = -6;
 pub const SI_KILL: c_int = SI_USER;
 
+pub const AT_FDCWD: c_int = -100;
+pub const AT_SYMLINK_NOFOLLOW: c_int = 0x100;
+pub const AT_REMOVEDIR: c_int = 0x200;
+pub const AT_SYMLINK_FOLLOW: c_int = 0x400;
+
 // vxParams.h definitions
 pub const _PARM_NAME_MAX: c_int = 255;
 pub const _PARM_PATH_MAX: c_int = 1024;
@@ -1028,6 +1033,7 @@ pub const RTP_ID_ERROR: crate::RTP_ID = -1;
 
 // h/public/unistd.h
 pub const _SC_GETPW_R_SIZE_MAX: c_int = 21; // Via unistd.h
+pub const _SC_HOST_NAME_MAX: c_int = 22;
 pub const _SC_PAGESIZE: c_int = 39;
 pub const O_ACCMODE: c_int = 3;
 pub const O_CLOEXEC: c_int = 0x100000; // fcntlcom
@@ -1177,6 +1183,7 @@ extern "C" {
     pub fn strcasecmp(s1: *const c_char, s2: *const c_char) -> c_int;
     pub fn strncasecmp(s1: *const c_char, s2: *const c_char, n: size_t) -> c_int;
     pub fn strlen(cs: *const c_char) -> size_t;
+    pub fn strnlen(cs: *const c_char, n: size_t) -> size_t;
     pub fn strerror(n: c_int) -> *mut c_char;
     pub fn strtok(s: *mut c_char, t: *const c_char) -> *mut c_char;
     pub fn strxfrm(s: *mut c_char, ct: *const c_char, n: size_t) -> size_t;
@@ -1260,6 +1267,13 @@ extern "C" {
     pub fn utimes(filename: *const c_char, times: *const crate::timeval) -> c_int;
 
     pub fn futimens(fd: c_int, times: *const crate::timespec) -> c_int;
+
+    pub fn utimensat(
+        dirfd: c_int,
+        path: *const c_char,
+        times: *const crate::timespec,
+        flag: c_int,
+    ) -> c_int;
 
     #[link_name = "_rtld_dlopen"]
     pub fn dlopen(filename: *const c_char, flag: c_int) -> *mut c_void;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

This adds a few defines/functions which are needed to build rust stdlib. (https://github.com/rust-lang/rust/issues/148125)

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

VxWorks sources are copyrighted.

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:


-->
@rustbot label +stable-nominated
