### PR TITLE
ci: Run gnu env tests as part of the main job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,12 +122,6 @@ jobs:
           - target: i686-pc-windows-msvc
             os: windows-2025
           - target: i686-unknown-linux-gnu
-          - target: i686-unknown-linux-gnu
-            artifact-tag: offset-bits64
-            env: { RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS: 64 }
-          - target: i686-unknown-linux-gnu
-            artifact-tag: time-bits64
-            env: { RUST_LIBC_UNSTABLE_GNU_TIME_BITS: 64 }
           - target: x86_64-pc-windows-gnu
             os: windows-2025
             env: { ARCH_BITS: 64, ARCH: x86_64 }
@@ -189,12 +183,6 @@ jobs:
             artifact-tag: new-musl
           - target: arm-linux-androideabi
           - target: arm-unknown-linux-gnueabihf
-          - target: arm-unknown-linux-gnueabihf
-            env: { RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS: 64 }
-            artifact-tag: offset-bits64
-          - target: arm-unknown-linux-gnueabihf
-            env: { RUST_LIBC_UNSTABLE_GNU_TIME_BITS: 64 }
-            artifact-tag: time-bits64
           - target: arm-unknown-linux-musleabihf
           - target: arm-unknown-linux-musleabihf
             env: { RUST_LIBC_UNSTABLE_MUSL_V1_2_3: 1 }
@@ -236,12 +224,6 @@ jobs:
           # FIXME(ppc): SIGILL running tests, see
           # https://github.com/rust-lang/libc/pull/4254#issuecomment-2636288713
           # - target: powerpc-unknown-linux-gnu
-          # - target: powerpc-unknown-linux-gnu
-          #   env: { RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS: 64 }
-          #   artifact-tag: offset-bits64
-          # - target: powerpc-unknown-linux-gnu
-          #   env: { RUST_LIBC_UNSTABLE_GNU_TIME_BITS: 64 }
-          #   artifact-tag: time-bits64
     runs-on: ${{ matrix.os && matrix.os || 'ubuntu-24.04' }}
     timeout-minutes: 25
     env:

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -32,9 +32,21 @@ case "$target" in
     *loongarch*) cmd="$cmd --exclude ctest --exclude ctest-test --exclude ctest-next" ;;
 esac
 
+env="$(rustc --print cfg --target "$target" | sed -n 's/target_env="\(.*\)"/\1/p')"
+bits="$(rustc --print cfg --target "$target" | sed -n 's/target_pointer_width="\(.*\)"/\1/p')"
+
 # shellcheck disable=SC2086
 $cmd --no-default-features -- $test_flags
 # shellcheck disable=SC2086
 $cmd -- $test_flags
 # shellcheck disable=SC2086
 $cmd --features extra_traits -- $test_flags
+
+# On relevant platforms, also test with our optional settings
+
+if [ "$env" = "gnu" ] && [ "$bits" = "32" ]; then
+    # shellcheck disable=SC2086
+    RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS=64 $cmd -- $test_flags
+    # shellcheck disable=SC2086
+    RUST_LIBC_UNSTABLE_GNU_TIME_BITS=64 $cmd -- $test_flags
+fi


### PR DESCRIPTION
Since glibc supports both 32- and 64-bit time_t and off_t without
different setup (just a header define in libc-test), these don't have
any need to be standalone jobs. Switch glibc config variants to be
checked as part of `run.sh`, which means we are now covering all 32-bit
platforms by default.