### PR TITLE
[AIX] Make errno EWOULDBLOCK an alias of EAGAIN

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -5180,11 +5180,9 @@ fn test_aix(target: &str) {
         // Skip 'sighandler_t' assignments.
         "SIG_DFL" | "SIG_ERR" | "SIG_IGN" => true,
 
-        // _ALL_SOURCE defines these errno values as aliases of other errno
-        // values, but POSIX requires each errno to be unique. Skip these
-        // values because non-unique values are being used which will
-        // fail the test when _ALL_SOURCE is defined.
-        "EWOULDBLOCK" | "ENOTEMPTY" => true,
+        // _ALL_SOURCE defines ENOTEMPTY as an alias of EEXIST, but POSIX
+        // requires its value to be unique. Skip.
+        "ENOTEMPTY" => true,
 
         // FIXME(ctest): These constants are intended for use as the 'int request' argument
         // to 'ioctl()'. However, the AIX headers do not explicitly define their types. If a

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -1275,7 +1275,8 @@ pub const ENOLCK: c_int = 49;
 pub const ENOCONNECT: c_int = 50;
 pub const ESTALE: c_int = 52;
 pub const EDIST: c_int = 53;
-pub const EWOULDBLOCK: c_int = 54;
+// POSIX allows EWOULDBLOCK to be the same value as EAGAIN.
+pub const EWOULDBLOCK: c_int = EAGAIN;
 pub const EINPROGRESS: c_int = 55;
 pub const EALREADY: c_int = 56;
 pub const ENOTSOCK: c_int = 57;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
Although the POSIX standard requires `errno` values to be distinct, it allows `EWOULDBLOCK` to have the same value as `EAGAIN` (https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/errno.h.html).
```
[EWOULDBLOCK]
    Operation would block (may be the same value as [EAGAIN]).
```
<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
