### PR TITLE
ctest: Emit the `enum` keyword for enum field tests

### DIFF
--- a/ctest/src/translator.rs
+++ b/ctest/src/translator.rs
@@ -234,13 +234,7 @@ impl<'a> Translator<'a> {
         }
 
         let name = last.ident.to_string();
-        let item = if self.ffi_items.contains_struct(&name) {
-            MapInput::StructType(&name)
-        } else if self.ffi_items.contains_union(&name) {
-            MapInput::UnionType(&name)
-        } else {
-            MapInput::Type(&name)
-        };
+        let item = self.map_rust_name_to_c(&name);
 
         Ok(cdecl::named(
             &self.generator.rty_to_cty(item),
@@ -285,6 +279,18 @@ impl<'a> Translator<'a> {
                 }
             }
             _ => false,
+        }
+    }
+
+    pub(crate) fn map_rust_name_to_c<'name>(&self, name: &'name str) -> MapInput<'name> {
+        if self.ffi_items.contains_struct(name) {
+            MapInput::StructType(name)
+        } else if self.ffi_items.contains_union(name) {
+            MapInput::UnionType(name)
+        } else if self.generator.c_enums.iter().any(|f| f(name)) {
+            MapInput::CEnumType(name)
+        } else {
+            MapInput::Type(name)
         }
     }
 }

--- a/ctest/tests/input/simple.h
+++ b/ctest/tests/input/simple.h
@@ -6,11 +6,19 @@ typedef unsigned long gregset_t[32];
 
 Byte byte = 0x42;
 
+enum Color
+{
+    RED,
+    BLUE,
+    GREEN
+};
+
 struct Person
 {
     const char *name;
     uint8_t age;
     void (*job)(uint8_t, const char *);
+    enum Color favorite_color;
 };
 
 union Word
@@ -21,13 +29,6 @@ union Word
 
 #define A "abc"
 #define C_B "bac"
-
-enum Color
-{
-    RED,
-    BLUE,
-    GREEN
-};
 
 extern void *calloc(size_t num, size_t size);
 extern Byte byte;

--- a/ctest/tests/input/simple.out.with-renames.c
+++ b/ctest/tests/input/simple.out.with-renames.c
@@ -124,6 +124,16 @@ CTEST_EXTERN uint64_t ctest_size_of__Person__job(void) {
 }
 
 // Return the offset of a struct/union field.
+CTEST_EXTERN uint64_t ctest_offset_of__Person__favorite_color(void) {
+    return offsetof(struct Person, favorite_color);
+}
+
+// Return the size of a struct/union field.
+CTEST_EXTERN uint64_t ctest_size_of__Person__favorite_color(void) {
+    return sizeof(((struct Person){}).favorite_color);
+}
+
+// Return the offset of a struct/union field.
 CTEST_EXTERN uint64_t ctest_offset_of__Word__word(void) {
     return offsetof(union Word, word);
 }
@@ -168,6 +178,15 @@ typedef void (**ctest_field_ty__Person__job)(uint8_t, const char *);
 CTEST_EXTERN ctest_field_ty__Person__job
 ctest_field_ptr__Person__job(struct Person *b) {
     return &b->job;
+}
+
+// Return a pointer to a struct/union field.
+// This field can have a normal data type, or it could be a function pointer or an array, which
+// have different syntax. A typedef is used for convenience, but the syntax must be precomputed.
+typedef enum Color *ctest_field_ty__Person__favorite_color;
+CTEST_EXTERN ctest_field_ty__Person__favorite_color
+ctest_field_ptr__Person__favorite_color(struct Person *b) {
+    return &b->favorite_color;
 }
 
 // Return a pointer to a struct/union field.

--- a/ctest/tests/input/simple.rs
+++ b/ctest/tests/input/simple.rs
@@ -5,11 +5,17 @@ pub type Byte = u8;
 // This should be automatically skipped for roundtripping.
 pub type gregset_t = [c_ulong; 32];
 
+pub type Color = c_int;
+pub const RED: Color = 0;
+pub const BLUE: Color = RED + 1;
+pub const GREEN: Color = BLUE + 1;
+
 #[repr(C)]
 pub struct Person {
     pub name: *const c_char,
     pub age: u8,
     pub job: extern "C" fn(u8, *const c_char),
+    pub favorite_color: Color,
 }
 
 #[repr(C)]
@@ -20,11 +26,6 @@ pub union Word {
 
 const A: *const c_char = c"abc".as_ptr();
 const B: *const c_char = c"bac".as_ptr();
-
-pub type Color = c_int;
-pub const RED: Color = 0;
-pub const BLUE: Color = RED + 1;
-pub const GREEN: Color = BLUE + 1;
 
 unsafe extern "C" {
     pub fn calloc(num: usize, size: usize) -> *mut c_void;


### PR DESCRIPTION
Currently the return type for a function is missing the `enum` keyword. Resolve this by using the same logic for struct fields as for translating other paths.