### PR TITLE
illumos: link against non-legacy getifaddrs

### DIFF
--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2341,6 +2341,12 @@ extern "C" {
 
     pub fn gettimeofday(tp: *mut crate::timeval, tz: *mut c_void) -> c_int;
     pub fn settimeofday(tp: *const crate::timeval, tz: *const c_void) -> c_int;
+    // illumos' `getifaddrs` only returned AF_INET[6] until illumos#11196 where
+    // it was updated to also return AF_LINK entries. To preserve existing
+    // binaries, the symbol `getifaddrs` refers to the version with the old
+    // behaviour. Newly compiled programs in actuality link to `__getifaddrs`
+    // and thus get the updated version.
+    #[cfg_attr(target_os = "illumos", link_name = "__getifaddrs")]
     pub fn getifaddrs(ifap: *mut *mut crate::ifaddrs) -> c_int;
     pub fn freeifaddrs(ifa: *mut crate::ifaddrs);
 


### PR DESCRIPTION
# Description

The `libc` crate links against the legacy version of `getifaddrs` on illumos which only returns `AF_INET[6]` entries.

As of [illumos#11196](https://www.illumos.org/issues/11196), `getifaddrs` was updated to also return `AF_LINK` entries but was done in such a way to preserve existing binaries that only expected the old behaviour. That is, the symbol `getifaddrs` would refer to the legacy version but newly compiled C programs would get the new version by linking against `__getifaddrs` (via a `redefine_extname` pragma in `ifaddrs.h`).

```rust
fn main() {
    let mut addrs = std::mem::MaybeUninit::uninit();
    if unsafe { libc::getifaddrs(addrs.as_mut_ptr()) } != 0 {
        return;
    }
    let addrs = unsafe { addrs.assume_init() };
    let mut addr = addrs;
    while !addr.is_null() {
        let a = unsafe { &*addr };
        addr = a.ifa_next;
        let name = unsafe { std::ffi::CStr::from_ptr(a.ifa_name) };
        let name = name.to_string_lossy();
        if a.ifa_addr.is_null() {
            continue;
        }
        let fam = match unsafe { (*a.ifa_addr).sa_family } as libc::c_int {
            libc::AF_INET => "AF_INET",
            libc::AF_INET6 => "AF_INET6",
            libc::AF_LINK => "AF_LINK",
            _ => "<other>",
        };
        println!("{name}\t{fam}");
    }
    unsafe {
        libc::freeifaddrs(addrs);
    }
}
```

Before:
```
$  cargo r
   Compiling getifaddrs-test v0.1.0 (/home/luqman/tmp/getifaddrs-test)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.43s
     Running `target/debug/getifaddrs-test`
lo0     AF_INET
igb0    AF_INET
lo0     AF_INET6
igb0    AF_INET6
```

After:
```
$  cargo r
     Locking 1 package to latest Rust 1.88.0 compatible version
      Adding libc v1.0.0-alpha.1 (/home/luqman/src/libc)
   Compiling libc v1.0.0-alpha.1 (/home/luqman/src/libc)
   Compiling getifaddrs-test v0.1.0 (/home/luqman/tmp/getifaddrs-test)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.65s
     Running `target/debug/getifaddrs-test`
lo0     AF_INET
igb0    AF_INET
lo0     AF_INET6
igb0    AF_INET6
igb0    AF_LINK
igb1    AF_LINK
```

# Sources

* https://www.illumos.org/issues/11196
* https://github.com/illumos/illumos-gate/commit/3ee592424ed4bb7b850d9adccb9f3c493ce7534b
* https://github.com/illumos/illumos-gate/blob/478476fe3be0c0f39128a0b711291b4cfc18cd7b/usr/src/head/ifaddrs.h#L69-L74
* https://illumos.org/man/3SOCKET/getifaddrs

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated (`getifaddrs` is excluded on illumos)
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (See above test program demonstrating issue. But `libc-test` seems broken on illumos on main)

This is potentially a breaking change but it would be nice to get in 0.2. Unsure what the exact policy is there.

@rustbot label +stable-nominated
