### PR TITLE
Flip `Copy` and `PartialEq, Hash` derives for packed struct support

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -154,14 +154,14 @@ macro_rules! s {
     (it: $(#[$attr:meta])* $pub:vis struct $i:ident { $($field:tt)* }) => (
         __item! {
             #[repr(C)]
-            #[cfg_attr(
-                feature = "extra_traits",
-                ::core::prelude::v1::derive(Eq, Hash, PartialEq)
-            )]
             #[::core::prelude::v1::derive(
                 ::core::clone::Clone,
                 ::core::marker::Copy,
                 ::core::fmt::Debug,
+            )]
+            #[cfg_attr(
+                feature = "extra_traits",
+                ::core::prelude::v1::derive(Eq, Hash, PartialEq)
             )]
             #[allow(deprecated)]
             $(#[$attr])*


### PR DESCRIPTION
1.63 doesn't support deriving `PartialEq` on non-`Copy` packed structs and will error out here because it doesn't realize `Copy` is added later. Swapping the order of the derives resolves this issue and enables us to derive `extra_traits` even on packed structs.