### PR TITLE
chore: remove repetitive word in comment

### DIFF
--- a/ctest/templates/test.c
+++ b/ctest/templates/test.c
@@ -124,7 +124,7 @@ CTEST_EXTERN {{ item.c_ty }} ctest_roundtrip__{{ item.id }}(
     int i = 0;
     for (i = 0; i < size; ++i) {
         // We skip padding bytes in both Rust and C because writing to it is undefined.
-        // Instead we just make sure the the placement of the padding bytes remains the same.
+        // Instead we just make sure the placement of the padding bytes remains the same.
         if (is_padding_byte[i]) { continue; }
         value_bytes[i] = p[i];
         // After we check that the pattern remained unchanged from Rust to C, we invert the pattern

--- a/ctest/tests/input/hierarchy.out.c
+++ b/ctest/tests/input/hierarchy.out.c
@@ -64,7 +64,7 @@ CTEST_EXTERN in6_addr ctest_roundtrip__in6_addr(
     int i = 0;
     for (i = 0; i < size; ++i) {
         // We skip padding bytes in both Rust and C because writing to it is undefined.
-        // Instead we just make sure the the placement of the padding bytes remains the same.
+        // Instead we just make sure the placement of the padding bytes remains the same.
         if (is_padding_byte[i]) { continue; }
         value_bytes[i] = p[i];
         // After we check that the pattern remained unchanged from Rust to C, we invert the pattern

--- a/ctest/tests/input/macro.out.c
+++ b/ctest/tests/input/macro.out.c
@@ -134,7 +134,7 @@ CTEST_EXTERN struct VecU8 ctest_roundtrip__VecU8(
     int i = 0;
     for (i = 0; i < size; ++i) {
         // We skip padding bytes in both Rust and C because writing to it is undefined.
-        // Instead we just make sure the the placement of the padding bytes remains the same.
+        // Instead we just make sure the placement of the padding bytes remains the same.
         if (is_padding_byte[i]) { continue; }
         value_bytes[i] = p[i];
         // After we check that the pattern remained unchanged from Rust to C, we invert the pattern
@@ -161,7 +161,7 @@ CTEST_EXTERN struct VecU16 ctest_roundtrip__VecU16(
     int i = 0;
     for (i = 0; i < size; ++i) {
         // We skip padding bytes in both Rust and C because writing to it is undefined.
-        // Instead we just make sure the the placement of the padding bytes remains the same.
+        // Instead we just make sure the placement of the padding bytes remains the same.
         if (is_padding_byte[i]) { continue; }
         value_bytes[i] = p[i];
         // After we check that the pattern remained unchanged from Rust to C, we invert the pattern

--- a/ctest/tests/input/simple.out.with-renames.c
+++ b/ctest/tests/input/simple.out.with-renames.c
@@ -247,7 +247,7 @@ CTEST_EXTERN Byte ctest_roundtrip__Byte(
     int i = 0;
     for (i = 0; i < size; ++i) {
         // We skip padding bytes in both Rust and C because writing to it is undefined.
-        // Instead we just make sure the the placement of the padding bytes remains the same.
+        // Instead we just make sure the placement of the padding bytes remains the same.
         if (is_padding_byte[i]) { continue; }
         value_bytes[i] = p[i];
         // After we check that the pattern remained unchanged from Rust to C, we invert the pattern
@@ -274,7 +274,7 @@ CTEST_EXTERN volatile_char ctest_roundtrip__volatile_char(
     int i = 0;
     for (i = 0; i < size; ++i) {
         // We skip padding bytes in both Rust and C because writing to it is undefined.
-        // Instead we just make sure the the placement of the padding bytes remains the same.
+        // Instead we just make sure the placement of the padding bytes remains the same.
         if (is_padding_byte[i]) { continue; }
         value_bytes[i] = p[i];
         // After we check that the pattern remained unchanged from Rust to C, we invert the pattern
@@ -301,7 +301,7 @@ CTEST_EXTERN enum Color ctest_roundtrip__Color(
     int i = 0;
     for (i = 0; i < size; ++i) {
         // We skip padding bytes in both Rust and C because writing to it is undefined.
-        // Instead we just make sure the the placement of the padding bytes remains the same.
+        // Instead we just make sure the placement of the padding bytes remains the same.
         if (is_padding_byte[i]) { continue; }
         value_bytes[i] = p[i];
         // After we check that the pattern remained unchanged from Rust to C, we invert the pattern
@@ -328,7 +328,7 @@ CTEST_EXTERN struct Person ctest_roundtrip__Person(
     int i = 0;
     for (i = 0; i < size; ++i) {
         // We skip padding bytes in both Rust and C because writing to it is undefined.
-        // Instead we just make sure the the placement of the padding bytes remains the same.
+        // Instead we just make sure the placement of the padding bytes remains the same.
         if (is_padding_byte[i]) { continue; }
         value_bytes[i] = p[i];
         // After we check that the pattern remained unchanged from Rust to C, we invert the pattern
@@ -355,7 +355,7 @@ CTEST_EXTERN union Word ctest_roundtrip__Word(
     int i = 0;
     for (i = 0; i < size; ++i) {
         // We skip padding bytes in both Rust and C because writing to it is undefined.
-        // Instead we just make sure the the placement of the padding bytes remains the same.
+        // Instead we just make sure the placement of the padding bytes remains the same.
         if (is_padding_byte[i]) { continue; }
         value_bytes[i] = p[i];
         // After we check that the pattern remained unchanged from Rust to C, we invert the pattern

--- a/ctest/tests/input/simple.out.with-skips.c
+++ b/ctest/tests/input/simple.out.with-skips.c
@@ -56,7 +56,7 @@ CTEST_EXTERN volatile_char ctest_roundtrip__volatile_char(
     int i = 0;
     for (i = 0; i < size; ++i) {
         // We skip padding bytes in both Rust and C because writing to it is undefined.
-        // Instead we just make sure the the placement of the padding bytes remains the same.
+        // Instead we just make sure the placement of the padding bytes remains the same.
         if (is_padding_byte[i]) { continue; }
         value_bytes[i] = p[i];
         // After we check that the pattern remained unchanged from Rust to C, we invert the pattern


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

remove repetitive word in comment

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
