### PR TITLE
[0.2] ci: Run semver checks even on non-host targets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: full
+  TARGET_REF: ${{ github.base_ref || github.event.merge_group.base_ref }}
 
 defaults:
   run:
@@ -75,6 +76,10 @@ jobs:
         uses: taiki-e/install-action@cargo-semver-checks
         if: matrix.toolchain == 'stable'
 
+      - name: Retrieve semver baseline
+        if: matrix.toolchain == 'stable'
+        run: ./ci/prep-semver-baseline.sh
+
       # FIXME(ci): These `du` statements are temporary for debugging cache
       - name: Target size before restoring cache
         run: du -sh target | sort -k 2 || true
@@ -91,6 +96,7 @@ jobs:
           [ "${{ matrix.toolchain }}" = "1.63.0" ] && export RUSTFLAGS=""
           python3 ci/verify-build.py \
             --toolchain "$TOOLCHAIN" \
+            ${BASELINE_CRATE_DIR:+"--baseline-crate-dir" "$BASELINE_CRATE_DIR"} \
             ${{ matrix.only && format('--only "{0}"', matrix.only) }} \
             ${{ matrix.half && format('--half "{0}"', matrix.half) }}
       - name: Target size after job completion

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,3 +182,5 @@ used_underscore_binding = "allow"
 [package.metadata.cargo-semver-checks.lints]
 # Alignment is an internal detail that users must not rely upon
 repr_align_removed = "warn"
+# We deprecate things all the time
+global_value_marked_deprecated = "warn"

--- a/ci/prep-semver-baseline.sh
+++ b/ci/prep-semver-baseline.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Download a baseline crate to run semver checks against
+
+set -euxo pipefail
+
+# Retrieve the index for libc
+index=$(curl -L https://index.crates.io/li/bc/libc)
+
+# Regex for versions matching what we want to check against. Note we check only
+# a suffix since in the merge queue `base_ref` is set to something like
+# `refs/heads/main` rather than only the branch name.
+if [[ "${TARGET_REF:-}" = *"libc-0.2" ]]; then
+    pat="^0.2"
+elif [[ "${TARGET_REF:-}" = *"main" ]]; then
+    pat="^1.0"
+else
+    echo "TARGET_REF must be set and end with either 'libc-0.2' or 'main'"
+    exit 1
+fi
+
+# Find the most recent version matching a pattern.
+version=$(
+    echo "$index" |
+    jq -er --slurp --arg pat "$pat" '
+        map(select(.vers | test($pat)))
+        | last
+        | debug("version:", .)
+        | .vers
+        '
+)
+
+libc_cache="${XDG_CACHE_DIR:-$HOME/.cache}/libc-ci/"
+mkdir -p "$libc_cache"
+
+curl -L "https://static.crates.io/crates/libc/libc-$version.crate" | tar xzf - -C "$libc_cache"
+crate_dir="$libc_cache/libc-$version"
+
+echo "BASELINE_CRATE_DIR=$crate_dir" >> "$GITHUB_ENV"


### PR DESCRIPTION
Add a version of semver checks that run on non-host targets by building
rustdoc JSON output and passing that to `cargo-semver-checks`.
Unfortunately this doesn't have a way to suppress false positives, so we
need to leave the checks as optional rather than enforced for now (i.e.
the exit code isn't checked).

Link: https://github.com/obi1kenobi/cargo-semver-checks/issues/827