### PR TITLE
ci: Use a mirror for musl downloads

### DIFF
--- a/ci/install-musl.sh
+++ b/ci/install-musl.sh
@@ -19,9 +19,11 @@ esac
 
 musl="musl-${musl_version}"
 
-# Download, configure, build, and install musl:
-curl --retry 5 "https://www.musl-libc.org/releases/${musl}.tar.gz" | tar xzf -
+# Note that if a new version of musl is needed, it needs to be added to the mirror
+# first. See https://github.com/rust-lang/ci-mirrors/blob/main/files/libc.toml.
+curl --retry 5 "https://ci-mirrors.rust-lang.org/libc/${musl}.tar.gz" | tar xzf -
 
+# Configure, build, and install musl:
 cd "$musl"
 case ${1} in
     aarch64)


### PR DESCRIPTION
The musl server has been a bit flaky, so the files we needed have been added to rust-lang mirrors. Update CI setup here to make use of them.

Link: https://github.com/rust-lang/ci-mirrors/blob/15a6d341341e858c2b7be872a47a39f546cc6759/files/libc.toml