### PR TITLE
linux/aarch64: make mcontext_t.__reserved pub

### DIFF
--- a/src/unix/linux_like/android/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/android/b64/aarch64/mod.rs
@@ -74,7 +74,8 @@ s! {
         pub sp: c_ulonglong,
         pub pc: c_ulonglong,
         pub pstate: c_ulonglong,
-        __reserved: [u64; 512],
+        _padding: u64,
+        pub __reserved: [u8; 4096],
     }
 
     pub struct user_fpsimd_struct {

--- a/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
@@ -219,7 +219,8 @@ s! {
         pub sp: c_ulonglong,
         pub pc: c_ulonglong,
         pub pstate: c_ulonglong,
-        __reserved: [u64; 512],
+        _padding: u64,
+        pub __reserved: [u8; 4096],
     }
 
     pub struct user_fpsimd_struct {

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -103,7 +103,8 @@ s! {
         pub sp: c_ulong,
         pub pc: c_ulong,
         pub pstate: c_ulong,
-        __reserved: [u64; 512],
+        _padding: u64,
+        pub __reserved: [u8; 4096],
     }
 
     #[repr(align(8))]


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

The `mcontext_t.__reserved` field is documented to contain extra context, such as FP state and the ESR register.

# Sources

* [Linux uapi](https://github.com/torvalds/linux/blob/dc77806cf3b4788d328fddf245e86c5b529f31a2/arch/arm64/include/uapi/asm/sigcontext.h#L36)
* [Glibc](https://github.com/bminor/glibc/blob/975c8c4e22f73fb60996f6bcc2cf1a6f6af70928/sysdeps/unix/sysv/linux/aarch64/sys/ucontext.h#L63)
* [Musl](https://github.com/bminor/musl/blob/1b76ff0767d01df72f692806ee5adee13c67ef88/arch/aarch64/bits/signal.h#L22)
* [Android](https://android.googlesource.com/platform/bionic.git/+/refs/heads/main/libc/kernel/uapi/asm-arm64/asm/sigcontext.h#17)

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:
-->

@rustbot label +stable-nominated
