### PR TITLE
fix(ctest): cast fn pointers as `*const ()`

### DIFF
--- a/ctest/templates/test.rs
+++ b/ctest/templates/test.rs
@@ -341,7 +341,7 @@ mod generated_tests {
             fn ctest_foreign_fn__{{ item.id }}() -> unsafe extern "C" fn();
         }
         let actual = unsafe { ctest_foreign_fn__{{ item.id }}() } as u64;
-        let expected = {{ item.id }} as u64;
+        let expected = {{ item.id }} as *const () as u64;
         check_same(actual, expected, "`{{ item.id }}` function pointer");
     }
 {%- endfor +%}

--- a/ctest/tests/input/hierarchy.out.rs
+++ b/ctest/tests/input/hierarchy.out.rs
@@ -238,7 +238,7 @@ mod generated_tests {
             fn ctest_foreign_fn__malloc() -> unsafe extern "C" fn();
         }
         let actual = unsafe { ctest_foreign_fn__malloc() } as u64;
-        let expected = malloc as u64;
+        let expected = malloc as *const () as u64;
         check_same(actual, expected, "`malloc` function pointer");
     }
 

--- a/ctest/tests/input/simple.out.with-renames.rs
+++ b/ctest/tests/input/simple.out.with-renames.rs
@@ -1179,7 +1179,7 @@ mod generated_tests {
             fn ctest_foreign_fn__calloc() -> unsafe extern "C" fn();
         }
         let actual = unsafe { ctest_foreign_fn__calloc() } as u64;
-        let expected = calloc as u64;
+        let expected = calloc as *const () as u64;
         check_same(actual, expected, "`calloc` function pointer");
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

This fixes a newly added lint warning:
```
error: direct cast of function item into an integer
   --> /Users/runner/work/libc/libc/target/aarch64-apple-darwin/debug/build/ctest-test-d036828d8ecc10e7/out/t2gen.rs:577:28
    |
577 |         let expected = T2a as u64;
    |                            ^^^^^^
    |
note: the lint level is defined here
   --> ctest-test/src/bin/t2.rs:2:9
    |
  2 | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(function_casts_as_integer)]` implied by `#[deny(warnings)]`
help: first cast to a pointer `as *const ()`
    |
577 |         let expected = T2a as *const () as u64;
    |                            ++++++++++++

error: could not compile `ctest-test` (bin "t2") due to 1 previous error
```

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
