### PR TITLE
qurt: Add support for Qualcomm QuRT

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -38,7 +38,7 @@ const CHECK_CFG_EXTRA: &[(&str, &[&str])] = &[
     (
         "target_os",
         &[
-            "switch", "aix", "ohos", "hurd", "rtems", "visionos", "nuttx", "cygwin",
+            "switch", "aix", "ohos", "hurd", "rtems", "visionos", "nuttx", "cygwin", "qurt",
         ],
     ),
     (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,14 @@ cfg_if! {
         pub use crate::vxworks::*;
 
         prelude!();
+    } else if #[cfg(target_os = "qurt")] {
+        mod primitives;
+        pub use crate::primitives::*;
+
+        mod qurt;
+        pub use crate::qurt::*;
+
+        prelude!();
     } else if #[cfg(target_os = "solid_asp3")] {
         mod primitives;
         pub use crate::primitives::*;

--- a/src/new/common/posix/mod.rs
+++ b/src/new/common/posix/mod.rs
@@ -8,6 +8,7 @@
     target_os = "emscripten",
     target_os = "l4re",
     target_os = "linux",
+    target_os = "qurt",
     target_vendor = "apple",
 ))]
 pub(crate) mod pthread;

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -102,6 +102,9 @@ cfg_if! {
     } else if #[cfg(target_os = "openbsd")] {
         mod openbsd;
         pub(crate) use openbsd::*;
+    } else if #[cfg(target_os = "qurt")] {
+        mod qurt;
+        pub(crate) use qurt::*;
     } else if #[cfg(target_os = "redox")] {
         mod redox;
         // pub(crate) use redox::*;
@@ -210,7 +213,7 @@ cfg_if! {
 
 // Per-family headers we export
 cfg_if! {
-    if #[cfg(target_family = "unix")] {
+    if #[cfg(all(target_family = "unix", not(target_os = "qurt")))] {
         // FIXME(pthread): eventually all platforms should use this module
         #[cfg(any(
             target_os = "android",

--- a/src/new/qurt/errno.rs
+++ b/src/new/qurt/errno.rs
@@ -1,0 +1,154 @@
+//! Header: `errno.h`
+
+use super::*;
+use crate::prelude::*;
+
+// Standard error codes - verified to match QuRT SDK
+pub const EPERM: c_int = 1;
+pub const ENOENT: c_int = 2;
+pub const ESRCH: c_int = 3;
+pub const EINTR: c_int = 4;
+pub const EIO: c_int = 5;
+pub const ENXIO: c_int = 6;
+pub const E2BIG: c_int = 7;
+pub const ENOEXEC: c_int = 8;
+pub const EBADF: c_int = 9;
+pub const ECHILD: c_int = 10;
+pub const EAGAIN: c_int = 11;
+pub const ENOMEM: c_int = 12;
+pub const EACCES: c_int = 13;
+pub const EFAULT: c_int = 14;
+pub const ENOTBLK: c_int = 15;
+pub const EBUSY: c_int = 16;
+pub const EEXIST: c_int = 17;
+pub const EXDEV: c_int = 18;
+pub const ENODEV: c_int = 19;
+pub const ENOTDIR: c_int = 20;
+pub const EISDIR: c_int = 21;
+pub const EINVAL: c_int = 22;
+pub const ENFILE: c_int = 23;
+pub const EMFILE: c_int = 24;
+pub const ENOTTY: c_int = 25;
+pub const ETXTBSY: c_int = 26;
+pub const EFBIG: c_int = 27;
+pub const ENOSPC: c_int = 28;
+pub const ESPIPE: c_int = 29;
+pub const EROFS: c_int = 30;
+pub const EMLINK: c_int = 31;
+pub const EPIPE: c_int = 32;
+pub const EDOM: c_int = 33;
+pub const ERANGE: c_int = 34;
+pub const EDEADLK: c_int = 35;
+pub const ENAMETOOLONG: c_int = 36;
+pub const ENOLCK: c_int = 37;
+pub const ENOSYS: c_int = 38;
+pub const ENOTEMPTY: c_int = 39;
+pub const ELOOP: c_int = 40;
+pub const EWOULDBLOCK: c_int = EAGAIN;
+pub const ENOMSG: c_int = 42;
+pub const EIDRM: c_int = 43;
+pub const ECHRNG: c_int = 44;
+pub const EL2NSYNC: c_int = 45;
+pub const EL3HLT: c_int = 46;
+pub const EL3RST: c_int = 47;
+pub const ELNRNG: c_int = 48;
+pub const EUNATCH: c_int = 49;
+pub const ENOCSI: c_int = 50;
+pub const EL2HLT: c_int = 51;
+pub const EBADE: c_int = 52;
+pub const EBADR: c_int = 53;
+pub const EXFULL: c_int = 54;
+pub const ENOANO: c_int = 55;
+pub const EBADRQC: c_int = 56;
+pub const EBADSLT: c_int = 57;
+pub const EDEADLOCK: c_int = EDEADLK;
+pub const EBFONT: c_int = 59;
+pub const ENOSTR: c_int = 60;
+pub const ENODATA: c_int = 61;
+pub const ETIME: c_int = 62;
+pub const ENOSR: c_int = 63;
+pub const ENONET: c_int = 64;
+pub const ENOPKG: c_int = 65;
+pub const EREMOTE: c_int = 66;
+pub const ENOLINK: c_int = 67;
+pub const EADV: c_int = 68;
+pub const ESRMNT: c_int = 69;
+pub const ECOMM: c_int = 70;
+pub const EPROTO: c_int = 71;
+pub const EMULTIHOP: c_int = 72;
+pub const EDOTDOT: c_int = 73;
+pub const EBADMSG: c_int = 74;
+pub const EOVERFLOW: c_int = 75;
+pub const ENOTUNIQ: c_int = 76;
+pub const EBADFD: c_int = 77;
+pub const EREMCHG: c_int = 78;
+pub const ELIBACC: c_int = 79;
+pub const ELIBBAD: c_int = 80;
+pub const ELIBSCN: c_int = 81;
+pub const ELIBMAX: c_int = 82;
+pub const ELIBEXEC: c_int = 83;
+pub const EILSEQ: c_int = 84;
+pub const ERESTART: c_int = 85;
+pub const ESTRPIPE: c_int = 86;
+pub const EUSERS: c_int = 87;
+pub const ENOTSOCK: c_int = 88;
+pub const EDESTADDRREQ: c_int = 89;
+pub const EMSGSIZE: c_int = 90;
+pub const EPROTOTYPE: c_int = 91;
+pub const ENOPROTOOPT: c_int = 92;
+pub const EPROTONOSUPPORT: c_int = 93;
+pub const ESOCKTNOSUPPORT: c_int = 94;
+pub const EOPNOTSUPP: c_int = 95;
+pub const ENOTSUP: c_int = EOPNOTSUPP;
+pub const EPFNOSUPPORT: c_int = 96;
+pub const EAFNOSUPPORT: c_int = 97;
+pub const EADDRINUSE: c_int = 98;
+pub const EADDRNOTAVAIL: c_int = 99;
+pub const ENETDOWN: c_int = 100;
+pub const ENETUNREACH: c_int = 101;
+pub const ENETRESET: c_int = 102;
+pub const ECONNABORTED: c_int = 103;
+pub const ECONNRESET: c_int = 104;
+pub const ENOBUFS: c_int = 105;
+pub const EISCONN: c_int = 106;
+pub const ENOTCONN: c_int = 107;
+pub const ESHUTDOWN: c_int = 108;
+pub const ETOOMANYREFS: c_int = 109;
+pub const ETIMEDOUT: c_int = 110;
+pub const ECONNREFUSED: c_int = 111;
+pub const EHOSTDOWN: c_int = 112;
+pub const EHOSTUNREACH: c_int = 113;
+pub const EALREADY: c_int = 114;
+pub const EINPROGRESS: c_int = 115;
+pub const ESTALE: c_int = 116;
+pub const EUCLEAN: c_int = 117;
+pub const ENOTNAM: c_int = 118;
+pub const ENAVAIL: c_int = 119;
+pub const EISNAM: c_int = 120;
+pub const EREMOTEIO: c_int = 121;
+pub const EDQUOT: c_int = 122;
+pub const ENOMEDIUM: c_int = 123;
+pub const EMEDIUMTYPE: c_int = 124;
+pub const ECANCELED: c_int = 125;
+pub const ENOKEY: c_int = 126;
+pub const EKEYEXPIRED: c_int = 127;
+pub const EKEYREVOKED: c_int = 128;
+pub const EKEYREJECTED: c_int = 129;
+pub const EOWNERDEAD: c_int = 130;
+pub const ENOTRECOVERABLE: c_int = 131;
+pub const ERFKILL: c_int = 132;
+pub const EHWPOISON: c_int = 133;
+
+extern "C" {
+    // Error number access
+    #[link_name = "__errno_location"]
+    pub fn __errno_location() -> *mut c_int;
+}
+
+pub unsafe fn errno() -> c_int {
+    *__errno_location()
+}
+
+pub unsafe fn set_errno(value: c_int) {
+    *__errno_location() = value;
+}

--- a/src/new/qurt/fcntl.rs
+++ b/src/new/qurt/fcntl.rs
@@ -1,0 +1,49 @@
+//! Header: `fcntl.h`
+
+use super::*;
+use crate::prelude::*;
+
+// File access modes
+pub const O_RDONLY: c_int = 0x0000;
+pub const O_WRONLY: c_int = 0x0001;
+pub const O_RDWR: c_int = 0x0002;
+pub const O_ACCMODE: c_int = 0x0003;
+
+// File creation flags
+pub const O_CREAT: c_int = 0x0040;
+pub const O_EXCL: c_int = 0x0080;
+pub const O_NOCTTY: c_int = 0x0100;
+pub const O_TRUNC: c_int = 0x0200;
+
+// File status flags
+pub const O_APPEND: c_int = 0x0400;
+pub const O_NONBLOCK: c_int = 0x0800;
+pub const O_SYNC: c_int = 0x1000;
+pub const O_FSYNC: c_int = O_SYNC;
+pub const O_DSYNC: c_int = 0x1000;
+
+// fcntl() commands
+pub const F_DUPFD: c_int = 0;
+pub const F_GETFD: c_int = 1;
+pub const F_SETFD: c_int = 2;
+pub const F_GETFL: c_int = 3;
+pub const F_SETFL: c_int = 4;
+pub const F_GETLK: c_int = 5;
+pub const F_SETLK: c_int = 6;
+pub const F_SETLKW: c_int = 7;
+
+// File descriptor flags
+pub const FD_CLOEXEC: c_int = 1;
+
+// Lock types for fcntl()
+pub const F_RDLCK: c_int = 0;
+pub const F_WRLCK: c_int = 1;
+pub const F_UNLCK: c_int = 2;
+
+// Functions
+extern "C" {
+    pub fn open(pathname: *const c_char, flags: c_int, ...) -> c_int;
+    pub fn openat(dirfd: c_int, pathname: *const c_char, flags: c_int, ...) -> c_int;
+    pub fn creat(pathname: *const c_char, mode: mode_t) -> c_int;
+    pub fn fcntl(fd: c_int, cmd: c_int, ...) -> c_int;
+}

--- a/src/new/qurt/limits.rs
+++ b/src/new/qurt/limits.rs
@@ -1,0 +1,41 @@
+//! Header: `limits.h`
+
+use super::*;
+use crate::prelude::*;
+
+// Character properties
+pub const CHAR_BIT: c_uint = 8;
+pub const CHAR_MAX: c_char = 255; // unsigned char on Hexagon
+pub const CHAR_MIN: c_char = 0;
+pub const SCHAR_MAX: c_schar = 127;
+pub const SCHAR_MIN: c_schar = -128;
+pub const UCHAR_MAX: c_uchar = 255;
+
+// Integer properties
+pub const INT_MAX: c_int = 2147483647;
+pub const INT_MIN: c_int = (-2147483647 - 1);
+pub const UINT_MAX: c_uint = 4294967295;
+
+pub const LONG_MAX: c_long = 2147483647;
+pub const LONG_MIN: c_long = (-2147483647 - 1);
+pub const ULONG_MAX: c_ulong = 4294967295;
+
+pub const SHRT_MAX: c_short = 32767;
+pub const SHRT_MIN: c_short = (-32768);
+pub const USHRT_MAX: c_ushort = 65535;
+
+// POSIX Limits
+pub const ARG_MAX: c_int = 4096;
+pub const CHILD_MAX: c_int = 25;
+pub const LINK_MAX: c_int = 8;
+pub const MAX_CANON: c_int = 255;
+pub const MAX_INPUT: c_int = 255;
+pub const NAME_MAX: c_int = 255;
+pub const OPEN_MAX: c_int = 20;
+pub const PATH_MAX: c_int = 260;
+pub const PIPE_BUF: c_int = 512;
+pub const STREAM_MAX: c_int = 20;
+pub const TZNAME_MAX: c_int = 50;
+
+// Additional limits
+pub const IOV_MAX: c_int = 16;

--- a/src/new/qurt/mod.rs
+++ b/src/new/qurt/mod.rs
@@ -1,0 +1,163 @@
+//! QuRT (Qualcomm Real-Time OS) bindings
+//!
+//! QuRT is Qualcomm's real-time operating system for Hexagon DSP architectures.
+//! Headers available via the
+//! Hexagon SDK: https://softwarecenter.qualcomm.com/catalog/item/Hexagon_SDK
+
+use crate::prelude::*;
+
+// Basic C types for QRT
+pub type intptr_t = isize;
+pub type uintptr_t = usize;
+pub type ptrdiff_t = isize;
+pub type size_t = uintptr_t;
+pub type ssize_t = intptr_t;
+
+// Process and system types
+pub type pid_t = c_int;
+pub type uid_t = c_uint;
+pub type gid_t = c_uint;
+
+// Time types
+pub type time_t = c_longlong;
+pub type suseconds_t = c_long;
+pub type useconds_t = c_ulong;
+pub type clockid_t = c_int;
+pub type timer_t = *mut c_void;
+
+// File system types
+pub type dev_t = c_ulong;
+pub type ino_t = c_ulong;
+pub type mode_t = c_uint;
+pub type nlink_t = c_uint;
+pub type off_t = c_long;
+pub type blkcnt_t = c_long;
+pub type blksize_t = c_long;
+
+// Thread types based on QuRT pthread implementation
+pub type pthread_t = c_uint;
+pub type pthread_key_t = c_int;
+pub type pthread_once_t = c_int;
+pub type pthread_mutex_t = c_uint;
+pub type pthread_mutexattr_t = c_uint;
+pub type pthread_cond_t = c_uint;
+pub type pthread_condattr_t = c_uint;
+pub type pthread_attr_t = c_uint;
+pub type pthread_rwlock_t = c_uint;
+pub type pthread_rwlockattr_t = c_uint;
+pub type pthread_spinlock_t = c_uint;
+pub type pthread_barrier_t = c_uint;
+pub type pthread_barrierattr_t = c_uint;
+
+// Network types
+pub type socklen_t = c_uint;
+pub type sa_family_t = c_ushort;
+pub type in_addr_t = c_uint;
+pub type in_port_t = c_ushort;
+
+// File descriptor types
+pub type fd_set = c_ulong;
+
+// Standard C library types
+extern_ty! {
+    pub enum FILE {}
+}
+pub type fpos_t = c_long;
+pub type clock_t = c_long;
+
+// POSIX semaphore types
+pub type sem_t = c_uint;
+
+// Message queue types
+pub type mqd_t = c_int;
+
+// Additional file system types
+pub type nfds_t = c_ulong;
+
+// Signal types
+pub type sigset_t = c_ulong;
+
+// Variadic argument list type
+pub type va_list = *mut c_char;
+
+// Additional missing types
+pub type c_schar = i8;
+
+// Division result types
+s! {
+    pub struct div_t {
+        pub quot: c_int,
+        pub rem: c_int,
+    }
+
+    pub struct ldiv_t {
+        pub quot: c_long,
+        pub rem: c_long,
+    }
+
+    pub struct lldiv_t {
+        pub quot: c_longlong,
+        pub rem: c_longlong,
+    }
+
+    pub struct stat {
+        pub st_dev: dev_t,
+        pub st_ino: ino_t,
+        pub st_mode: mode_t,
+        pub st_nlink: nlink_t,
+        pub st_uid: uid_t,
+        pub st_gid: gid_t,
+        pub st_rdev: dev_t,
+        pub st_size: off_t,
+        pub st_blksize: blksize_t,
+        pub st_blocks: blkcnt_t,
+        pub st_atime: time_t,
+        pub st_mtime: time_t,
+        pub st_ctime: time_t,
+    }
+
+    pub struct tm {
+        pub tm_sec: c_int,
+        pub tm_min: c_int,
+        pub tm_hour: c_int,
+        pub tm_mday: c_int,
+        pub tm_mon: c_int,
+        pub tm_year: c_int,
+        pub tm_wday: c_int,
+        pub tm_yday: c_int,
+        pub tm_isdst: c_int,
+    }
+
+    pub struct timespec {
+        pub tv_sec: time_t,
+        pub tv_nsec: c_long,
+    }
+
+    pub struct timeval {
+        pub tv_sec: time_t,
+        pub tv_usec: suseconds_t,
+    }
+
+    pub struct itimerspec {
+        pub it_interval: timespec,
+        pub it_value: timespec,
+    }
+
+    pub struct sigevent {
+        pub sigev_notify: c_int,
+        pub sigev_signo: c_int,
+        pub sigev_value: c_int,
+    }
+}
+
+pub(crate) mod errno;
+pub(crate) mod fcntl;
+pub(crate) mod limits;
+pub(crate) mod pthread;
+pub(crate) mod semaphore;
+pub(crate) mod signal;
+pub(crate) mod stdio;
+pub(crate) mod stdlib;
+pub(crate) mod sys;
+pub(crate) mod time;
+pub(crate) mod unistd;

--- a/src/new/qurt/pthread.rs
+++ b/src/new/qurt/pthread.rs
@@ -1,0 +1,150 @@
+//! Header: `pthread.h`
+//!
+//! QuRT provides a subset of POSIX pthread functionality optimized for real-time systems.
+
+use super::*;
+use crate::prelude::*;
+use crate::{
+    cpu_set_t,
+    pthread_attr_t,
+    pthread_barrier_t,
+    pthread_barrierattr_t,
+    pthread_cond_t,
+    pthread_condattr_t,
+    pthread_key_t,
+    pthread_mutex_t,
+    pthread_mutexattr_t,
+    pthread_once_t,
+    pthread_rwlock_t,
+    pthread_rwlockattr_t,
+    pthread_spinlock_t,
+    pthread_t,
+    timespec,
+};
+
+// Thread creation attributes
+pub const PTHREAD_CREATE_JOINABLE: c_int = 0;
+pub const PTHREAD_CREATE_DETACHED: c_int = 1;
+
+// Mutex types
+pub const PTHREAD_MUTEX_NORMAL: c_int = 0;
+pub const PTHREAD_MUTEX_RECURSIVE: c_int = 1;
+pub const PTHREAD_MUTEX_ERRORCHECK: c_int = 2;
+pub const PTHREAD_MUTEX_DEFAULT: c_int = PTHREAD_MUTEX_NORMAL;
+
+// Mutex protocol
+pub const PTHREAD_PRIO_NONE: c_int = 0;
+pub const PTHREAD_PRIO_INHERIT: c_int = 1;
+pub const PTHREAD_PRIO_PROTECT: c_int = 2;
+
+// Thread priority constants
+pub const PTHREAD_MIN_PRIORITY: c_int = 0;
+pub const PTHREAD_MAX_PRIORITY: c_int = 255;
+
+// Scheduling policies
+pub const SCHED_OTHER: c_int = 0;
+pub const SCHED_FIFO: c_int = 1;
+pub const SCHED_RR: c_int = 2;
+
+// Initializer constants
+pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = 0xFFFFFFFF;
+pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = 0xFFFFFFFF;
+pub const PTHREAD_ONCE_INIT: pthread_once_t = 0;
+
+// Stack size
+pub const PTHREAD_STACK_MIN: size_t = 8192;
+
+// Additional pthread types and attributes
+pub const PTHREAD_SCOPE_SYSTEM: c_int = 0;
+pub const PTHREAD_SCOPE_PROCESS: c_int = 1;
+
+pub const PTHREAD_INHERIT_SCHED: c_int = 0;
+pub const PTHREAD_EXPLICIT_SCHED: c_int = 1;
+
+extern "C" {
+    // Thread management
+    pub fn pthread_create(
+        thread: *mut pthread_t,
+        attr: *const pthread_attr_t,
+        start_routine: extern "C" fn(*mut c_void) -> *mut c_void,
+        arg: *mut c_void,
+    ) -> c_int;
+    pub fn pthread_join(thread: pthread_t, retval: *mut *mut c_void) -> c_int;
+    pub fn pthread_detach(thread: pthread_t) -> c_int;
+    pub fn pthread_exit(retval: *mut c_void) -> !;
+    pub fn pthread_self() -> pthread_t;
+    pub fn pthread_equal(t1: pthread_t, t2: pthread_t) -> c_int;
+
+    // Thread attributes
+    pub fn pthread_attr_init(attr: *mut pthread_attr_t) -> c_int;
+    pub fn pthread_attr_destroy(attr: *mut pthread_attr_t) -> c_int;
+    pub fn pthread_attr_setstacksize(attr: *mut pthread_attr_t, stacksize: size_t) -> c_int;
+    pub fn pthread_attr_getstacksize(attr: *const pthread_attr_t, stacksize: *mut size_t) -> c_int;
+    pub fn pthread_attr_setdetachstate(attr: *mut pthread_attr_t, detachstate: c_int) -> c_int;
+    pub fn pthread_attr_getdetachstate(
+        attr: *const pthread_attr_t,
+        detachstate: *mut c_int,
+    ) -> c_int;
+
+    // Mutex operations
+    pub fn pthread_mutex_init(
+        mutex: *mut pthread_mutex_t,
+        attr: *const pthread_mutexattr_t,
+    ) -> c_int;
+    pub fn pthread_mutex_destroy(mutex: *mut pthread_mutex_t) -> c_int;
+    pub fn pthread_mutex_lock(mutex: *mut pthread_mutex_t) -> c_int;
+    pub fn pthread_mutex_trylock(mutex: *mut pthread_mutex_t) -> c_int;
+    pub fn pthread_mutex_unlock(mutex: *mut pthread_mutex_t) -> c_int;
+
+    // Mutex attributes
+    pub fn pthread_mutexattr_init(attr: *mut pthread_mutexattr_t) -> c_int;
+    pub fn pthread_mutexattr_destroy(attr: *mut pthread_mutexattr_t) -> c_int;
+    pub fn pthread_mutexattr_settype(attr: *mut pthread_mutexattr_t, kind: c_int) -> c_int;
+    pub fn pthread_mutexattr_gettype(attr: *const pthread_mutexattr_t, kind: *mut c_int) -> c_int;
+
+    // Condition variables
+    pub fn pthread_cond_init(cond: *mut pthread_cond_t, attr: *const pthread_condattr_t) -> c_int;
+    pub fn pthread_cond_destroy(cond: *mut pthread_cond_t) -> c_int;
+    pub fn pthread_cond_wait(cond: *mut pthread_cond_t, mutex: *mut pthread_mutex_t) -> c_int;
+    pub fn pthread_cond_timedwait(
+        cond: *mut pthread_cond_t,
+        mutex: *mut pthread_mutex_t,
+        abstime: *const timespec,
+    ) -> c_int;
+    pub fn pthread_cond_signal(cond: *mut pthread_cond_t) -> c_int;
+    pub fn pthread_cond_broadcast(cond: *mut pthread_cond_t) -> c_int;
+
+    // Condition variable attributes
+    pub fn pthread_condattr_init(attr: *mut pthread_condattr_t) -> c_int;
+    pub fn pthread_condattr_destroy(attr: *mut pthread_condattr_t) -> c_int;
+
+    // Thread-local storage
+    pub fn pthread_key_create(
+        key: *mut pthread_key_t,
+        destructor: Option<extern "C" fn(*mut c_void)>,
+    ) -> c_int;
+    pub fn pthread_key_delete(key: pthread_key_t) -> c_int;
+    pub fn pthread_getspecific(key: pthread_key_t) -> *mut c_void;
+    pub fn pthread_setspecific(key: pthread_key_t, value: *const c_void) -> c_int;
+
+    // One-time initialization
+    pub fn pthread_once(once_control: *mut pthread_once_t, init_routine: extern "C" fn()) -> c_int;
+
+    // GNU extensions
+    pub fn pthread_getname_np(thread: pthread_t, name: *mut c_char, len: size_t) -> c_int;
+
+    pub fn pthread_attr_setaffinity_np(
+        attr: *mut pthread_attr_t,
+        cpusetsize: size_t,
+        cpuset: *const cpu_set_t,
+    ) -> c_int;
+
+    pub fn pthread_attr_getaffinity_np(
+        attr: *mut pthread_attr_t,
+        cpusetsize: size_t,
+        cpuset: *mut cpu_set_t,
+    ) -> c_int;
+
+    // POSIX standard
+    pub fn posix_memalign(memptr: *mut *mut c_void, alignment: size_t, size: size_t) -> c_int;
+}

--- a/src/new/qurt/semaphore.rs
+++ b/src/new/qurt/semaphore.rs
@@ -1,0 +1,13 @@
+//! Header: `semaphore.h`
+
+use super::*;
+use crate::prelude::*;
+
+extern "C" {
+    pub fn sem_init(sem: *mut sem_t, pshared: c_int, value: c_uint) -> c_int;
+    pub fn sem_destroy(sem: *mut sem_t) -> c_int;
+    pub fn sem_wait(sem: *mut sem_t) -> c_int;
+    pub fn sem_trywait(sem: *mut sem_t) -> c_int;
+    pub fn sem_post(sem: *mut sem_t) -> c_int;
+    pub fn sem_getvalue(sem: *mut sem_t, sval: *mut c_int) -> c_int;
+}

--- a/src/new/qurt/signal.rs
+++ b/src/new/qurt/signal.rs
@@ -1,0 +1,67 @@
+//! Header: `signal.h`
+
+use super::*;
+use crate::prelude::*;
+
+// Standard signal numbers
+pub const SIGHUP: c_int = 1;
+pub const SIGINT: c_int = 2;
+pub const SIGQUIT: c_int = 3;
+pub const SIGILL: c_int = 4;
+pub const SIGTRAP: c_int = 5;
+pub const SIGABRT: c_int = 6;
+pub const SIGBUS: c_int = 7;
+pub const SIGFPE: c_int = 8;
+pub const SIGKILL: c_int = 9;
+pub const SIGUSR1: c_int = 10;
+pub const SIGSEGV: c_int = 11;
+pub const SIGUSR2: c_int = 12;
+pub const SIGPIPE: c_int = 13;
+pub const SIGALRM: c_int = 14;
+pub const SIGTERM: c_int = 15;
+pub const SIGSTKFLT: c_int = 16;
+pub const SIGCHLD: c_int = 17;
+pub const SIGCONT: c_int = 18;
+pub const SIGSTOP: c_int = 19;
+pub const SIGTSTP: c_int = 20;
+pub const SIGTTIN: c_int = 21;
+pub const SIGTTOU: c_int = 22;
+pub const SIGURG: c_int = 23;
+pub const SIGXCPU: c_int = 24;
+pub const SIGXFSZ: c_int = 25;
+pub const SIGVTALRM: c_int = 26;
+pub const SIGPROF: c_int = 27;
+pub const SIGWINCH: c_int = 28;
+pub const SIGIO: c_int = 29;
+pub const SIGPWR: c_int = 30;
+pub const SIGSYS: c_int = 31;
+
+// Signal handling constants
+pub const SIG_DFL: sighandler_t = 0 as sighandler_t;
+pub const SIG_IGN: sighandler_t = 1 as sighandler_t;
+pub const SIG_ERR: sighandler_t = !0 as sighandler_t;
+
+// Signal mask operations
+pub const SIG_BLOCK: c_int = 0;
+pub const SIG_UNBLOCK: c_int = 1;
+pub const SIG_SETMASK: c_int = 2;
+
+pub type sighandler_t = size_t;
+
+extern "C" {
+    pub fn signal(sig: c_int, handler: sighandler_t) -> sighandler_t;
+    pub fn kill(pid: pid_t, sig: c_int) -> c_int;
+    pub fn raise(sig: c_int) -> c_int;
+    pub fn alarm(seconds: c_uint) -> c_uint;
+    pub fn pause() -> c_int;
+
+    // Signal mask functions
+    pub fn sigemptyset(set: *mut sigset_t) -> c_int;
+    pub fn sigfillset(set: *mut sigset_t) -> c_int;
+    pub fn sigaddset(set: *mut sigset_t, signum: c_int) -> c_int;
+    pub fn sigdelset(set: *mut sigset_t, signum: c_int) -> c_int;
+    pub fn sigismember(set: *const sigset_t, signum: c_int) -> c_int;
+    pub fn sigprocmask(how: c_int, set: *const sigset_t, oldset: *mut sigset_t) -> c_int;
+    pub fn sigpending(set: *mut sigset_t) -> c_int;
+    pub fn sigsuspend(mask: *const sigset_t) -> c_int;
+}

--- a/src/new/qurt/stdio.rs
+++ b/src/new/qurt/stdio.rs
@@ -1,0 +1,78 @@
+//! Header: `stdio.h`
+
+use super::*;
+use crate::prelude::*;
+
+// File position constants
+pub const SEEK_SET: c_int = 0;
+pub const SEEK_CUR: c_int = 1;
+pub const SEEK_END: c_int = 2;
+
+// Buffer size
+pub const BUFSIZ: c_uint = 1024;
+pub const FILENAME_MAX: c_uint = 260;
+
+// End of file
+pub const EOF: c_int = -1;
+
+extern "C" {
+    // File operations
+    pub fn fopen(filename: *const c_char, mode: *const c_char) -> *mut FILE;
+    pub fn freopen(filename: *const c_char, mode: *const c_char, stream: *mut FILE) -> *mut FILE;
+    pub fn fclose(stream: *mut FILE) -> c_int;
+    pub fn fflush(stream: *mut FILE) -> c_int;
+    pub fn fread(ptr: *mut c_void, size: size_t, nmemb: size_t, stream: *mut FILE) -> size_t;
+    pub fn fwrite(ptr: *const c_void, size: size_t, nmemb: size_t, stream: *mut FILE) -> size_t;
+
+    // Character I/O
+    pub fn fgetc(stream: *mut FILE) -> c_int;
+    pub fn fputc(c: c_int, stream: *mut FILE) -> c_int;
+    pub fn getchar() -> c_int;
+    pub fn putchar(c: c_int) -> c_int;
+    pub fn ungetc(c: c_int, stream: *mut FILE) -> c_int;
+
+    // Line I/O
+    pub fn fgets(s: *mut c_char, size: c_int, stream: *mut FILE) -> *mut c_char;
+    pub fn fputs(s: *const c_char, stream: *mut FILE) -> c_int;
+    pub fn gets(s: *mut c_char) -> *mut c_char;
+    pub fn puts(s: *const c_char) -> c_int;
+
+    // Formatted I/O
+    pub fn printf(format: *const c_char, ...) -> c_int;
+    pub fn fprintf(stream: *mut FILE, format: *const c_char, ...) -> c_int;
+    pub fn sprintf(s: *mut c_char, format: *const c_char, ...) -> c_int;
+    pub fn snprintf(s: *mut c_char, n: size_t, format: *const c_char, ...) -> c_int;
+    pub fn vprintf(format: *const c_char, ap: crate::va_list) -> c_int;
+    pub fn vfprintf(stream: *mut FILE, format: *const c_char, ap: crate::va_list) -> c_int;
+    pub fn vsprintf(s: *mut c_char, format: *const c_char, ap: crate::va_list) -> c_int;
+    pub fn vsnprintf(s: *mut c_char, n: size_t, format: *const c_char, ap: crate::va_list)
+        -> c_int;
+
+    // Input formatted functions
+    pub fn scanf(format: *const c_char, ...) -> c_int;
+    pub fn fscanf(stream: *mut FILE, format: *const c_char, ...) -> c_int;
+    pub fn sscanf(s: *const c_char, format: *const c_char, ...) -> c_int;
+
+    // File positioning
+    pub fn fseek(stream: *mut FILE, offset: c_long, whence: c_int) -> c_int;
+    pub fn ftell(stream: *mut FILE) -> c_long;
+    pub fn rewind(stream: *mut FILE);
+    pub fn fgetpos(stream: *mut FILE, pos: *mut fpos_t) -> c_int;
+    pub fn fsetpos(stream: *mut FILE, pos: *const fpos_t) -> c_int;
+
+    // Error handling
+    pub fn clearerr(stream: *mut FILE);
+    pub fn feof(stream: *mut FILE) -> c_int;
+    pub fn ferror(stream: *mut FILE) -> c_int;
+    pub fn perror(s: *const c_char);
+
+    // File management
+    pub fn remove(filename: *const c_char) -> c_int;
+    pub fn rename(old: *const c_char, new: *const c_char) -> c_int;
+    pub fn tmpfile() -> *mut FILE;
+    pub fn tmpnam(s: *mut c_char) -> *mut c_char;
+
+    // Buffer control
+    pub fn setvbuf(stream: *mut FILE, buffer: *mut c_char, mode: c_int, size: size_t) -> c_int;
+    pub fn setbuf(stream: *mut FILE, buffer: *mut c_char);
+}

--- a/src/new/qurt/stdlib.rs
+++ b/src/new/qurt/stdlib.rs
@@ -1,0 +1,67 @@
+//! Header: `stdlib.h`
+
+use super::*;
+use crate::prelude::*;
+
+// Exit status constants
+pub const EXIT_SUCCESS: c_int = 0;
+pub const EXIT_FAILURE: c_int = 1;
+
+// Maximum values
+pub const RAND_MAX: c_int = 32767;
+
+extern "C" {
+    // Memory management
+    pub fn malloc(size: size_t) -> *mut c_void;
+    pub fn calloc(nmemb: size_t, size: size_t) -> *mut c_void;
+    pub fn realloc(ptr: *mut c_void, size: size_t) -> *mut c_void;
+    pub fn free(ptr: *mut c_void);
+
+    // Process control
+    pub fn abort() -> !;
+    pub fn exit(status: c_int) -> !;
+    pub fn atexit(function: extern "C" fn()) -> c_int;
+
+    // Environment
+    pub fn getenv(name: *const c_char) -> *mut c_char;
+    pub fn setenv(name: *const c_char, value: *const c_char, overwrite: c_int) -> c_int;
+    pub fn unsetenv(name: *const c_char) -> c_int;
+
+    // String/number conversion
+    pub fn atoi(nptr: *const c_char) -> c_int;
+    pub fn atol(nptr: *const c_char) -> c_long;
+    pub fn atoll(nptr: *const c_char) -> c_longlong;
+    pub fn strtol(nptr: *const c_char, endptr: *mut *mut c_char, base: c_int) -> c_long;
+    pub fn strtoul(nptr: *const c_char, endptr: *mut *mut c_char, base: c_int) -> c_ulong;
+    pub fn strtoll(nptr: *const c_char, endptr: *mut *mut c_char, base: c_int) -> c_longlong;
+    pub fn strtoull(nptr: *const c_char, endptr: *mut *mut c_char, base: c_int) -> c_ulonglong;
+    pub fn strtod(nptr: *const c_char, endptr: *mut *mut c_char) -> c_double;
+    pub fn strtof(nptr: *const c_char, endptr: *mut *mut c_char) -> c_float;
+
+    // Random numbers
+    pub fn rand() -> c_int;
+    pub fn srand(seed: c_uint);
+
+    // Searching and sorting
+    pub fn qsort(
+        base: *mut c_void,
+        nmemb: size_t,
+        size: size_t,
+        compar: extern "C" fn(*const c_void, *const c_void) -> c_int,
+    );
+    pub fn bsearch(
+        key: *const c_void,
+        base: *const c_void,
+        nmemb: size_t,
+        size: size_t,
+        compar: extern "C" fn(*const c_void, *const c_void) -> c_int,
+    ) -> *mut c_void;
+
+    // Integer arithmetic
+    pub fn abs(j: c_int) -> c_int;
+    pub fn labs(j: c_long) -> c_long;
+    pub fn llabs(j: c_longlong) -> c_longlong;
+    pub fn div(numer: c_int, denom: c_int) -> div_t;
+    pub fn ldiv(numer: c_long, denom: c_long) -> ldiv_t;
+    pub fn lldiv(numer: c_longlong, denom: c_longlong) -> lldiv_t;
+}

--- a/src/new/qurt/sys/mod.rs
+++ b/src/new/qurt/sys/mod.rs
@@ -1,0 +1,4 @@
+//! System headers (`sys/*`)
+
+pub(crate) mod stat;
+pub(crate) mod types;

--- a/src/new/qurt/sys/stat.rs
+++ b/src/new/qurt/sys/stat.rs
@@ -1,0 +1,42 @@
+//! Header: `sys/stat.h`
+
+use super::super::*;
+use crate::prelude::*;
+
+// File type constants for stat.st_mode
+pub const S_IFMT: mode_t = 0o170000;
+pub const S_IFSOCK: mode_t = 0o140000;
+pub const S_IFLNK: mode_t = 0o120000;
+pub const S_IFREG: mode_t = 0o100000;
+pub const S_IFBLK: mode_t = 0o060000;
+pub const S_IFDIR: mode_t = 0o040000;
+pub const S_IFCHR: mode_t = 0o020000;
+pub const S_IFIFO: mode_t = 0o010000;
+
+// File permission constants
+pub const S_ISUID: mode_t = 0o4000;
+pub const S_ISGID: mode_t = 0o2000;
+pub const S_ISVTX: mode_t = 0o1000;
+pub const S_IRWXU: mode_t = 0o0700;
+pub const S_IRUSR: mode_t = 0o0400;
+pub const S_IWUSR: mode_t = 0o0200;
+pub const S_IXUSR: mode_t = 0o0100;
+pub const S_IRWXG: mode_t = 0o0070;
+pub const S_IRGRP: mode_t = 0o0040;
+pub const S_IWGRP: mode_t = 0o0020;
+pub const S_IXGRP: mode_t = 0o0010;
+pub const S_IRWXO: mode_t = 0o0007;
+pub const S_IROTH: mode_t = 0o0004;
+pub const S_IWOTH: mode_t = 0o0002;
+pub const S_IXOTH: mode_t = 0o0001;
+
+extern "C" {
+    pub fn stat(pathname: *const c_char, statbuf: *mut stat) -> c_int;
+    pub fn fstat(fd: c_int, statbuf: *mut stat) -> c_int;
+    pub fn lstat(pathname: *const c_char, statbuf: *mut stat) -> c_int;
+    pub fn chmod(pathname: *const c_char, mode: mode_t) -> c_int;
+    pub fn fchmod(fd: c_int, mode: mode_t) -> c_int;
+    pub fn mkdir(pathname: *const c_char, mode: mode_t) -> c_int;
+    pub fn mkfifo(pathname: *const c_char, mode: mode_t) -> c_int;
+    pub fn umask(mask: mode_t) -> mode_t;
+}

--- a/src/new/qurt/sys/types.rs
+++ b/src/new/qurt/sys/types.rs
@@ -1,0 +1,9 @@
+//! Header: `sys/types.h`
+//!
+//! Note: Basic types are defined at the crate root level for qurt.
+//! This module provides sys/types.h specific functions and constants.
+
+use super::super::*;
+use crate::prelude::*;
+
+pub type cpu_set_t = c_uint;

--- a/src/new/qurt/time.rs
+++ b/src/new/qurt/time.rs
@@ -1,0 +1,52 @@
+//! Header: `time.h`
+
+use super::*;
+use crate::prelude::*;
+
+// Clock types
+pub const CLOCK_REALTIME: clockid_t = 0;
+pub const CLOCK_MONOTONIC: clockid_t = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: clockid_t = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: clockid_t = 3;
+
+// Timer flags
+pub const TIMER_ABSTIME: c_int = 1;
+
+extern "C" {
+    // Time functions
+    pub fn time(tloc: *mut time_t) -> time_t;
+    pub fn difftime(time1: time_t, time0: time_t) -> c_double;
+    pub fn mktime(tm: *mut tm) -> time_t;
+    pub fn gmtime(timep: *const time_t) -> *mut tm;
+    pub fn gmtime_r(timep: *const time_t, result: *mut tm) -> *mut tm;
+    pub fn localtime(timep: *const time_t) -> *mut tm;
+    pub fn localtime_r(timep: *const time_t, result: *mut tm) -> *mut tm;
+    pub fn asctime(tm: *const tm) -> *mut c_char;
+    pub fn asctime_r(tm: *const tm, buf: *mut c_char) -> *mut c_char;
+    pub fn ctime(timep: *const time_t) -> *mut c_char;
+    pub fn ctime_r(timep: *const time_t, buf: *mut c_char) -> *mut c_char;
+    pub fn strftime(
+        s: *mut c_char,
+        maxsize: size_t,
+        format: *const c_char,
+        timeptr: *const tm,
+    ) -> size_t;
+
+    // High-resolution time functions
+    pub fn clock_gettime(clk_id: clockid_t, tp: *mut timespec) -> c_int;
+    pub fn clock_settime(clk_id: clockid_t, tp: *const timespec) -> c_int;
+    pub fn clock_getres(clk_id: clockid_t, res: *mut timespec) -> c_int;
+    pub fn nanosleep(req: *const timespec, rem: *mut timespec) -> c_int;
+
+    // Timer functions
+    pub fn timer_create(clockid: clockid_t, sevp: *mut sigevent, timerid: *mut timer_t) -> c_int;
+    pub fn timer_delete(timerid: timer_t) -> c_int;
+    pub fn timer_settime(
+        timerid: timer_t,
+        flags: c_int,
+        new_value: *const itimerspec,
+        old_value: *mut itimerspec,
+    ) -> c_int;
+    pub fn timer_gettime(timerid: timer_t, curr_value: *mut itimerspec) -> c_int;
+    pub fn timer_getoverrun(timerid: timer_t) -> c_int;
+}

--- a/src/new/qurt/unistd.rs
+++ b/src/new/qurt/unistd.rs
@@ -1,0 +1,58 @@
+//! Header: `unistd.h`
+
+use super::*;
+pub use crate::new::common::posix::unistd::{
+    STDERR_FILENO,
+    STDIN_FILENO,
+    STDOUT_FILENO,
+};
+use crate::prelude::*;
+
+// Access mode constants
+pub const F_OK: c_int = 0;
+pub const X_OK: c_int = 1;
+pub const W_OK: c_int = 2;
+pub const R_OK: c_int = 4;
+
+// Whence constants for lseek
+pub const SEEK_SET: c_int = 0;
+pub const SEEK_CUR: c_int = 1;
+pub const SEEK_END: c_int = 2;
+
+extern "C" {
+    // File operations
+    pub fn access(pathname: *const c_char, mode: c_int) -> c_int;
+    pub fn close(fd: c_int) -> c_int;
+    pub fn dup(oldfd: c_int) -> c_int;
+    pub fn dup2(oldfd: c_int, newfd: c_int) -> c_int;
+    pub fn lseek(fd: c_int, offset: off_t, whence: c_int) -> off_t;
+    pub fn read(fd: c_int, buf: *mut c_void, count: size_t) -> ssize_t;
+    pub fn write(fd: c_int, buf: *const c_void, count: size_t) -> ssize_t;
+
+    // Process operations
+    pub fn getpid() -> pid_t;
+    pub fn getppid() -> pid_t;
+    pub fn getuid() -> uid_t;
+    pub fn geteuid() -> uid_t;
+    pub fn getgid() -> gid_t;
+    pub fn getegid() -> gid_t;
+    pub fn getpgid(pid: pid_t) -> pid_t;
+    pub fn getpgrp() -> pid_t;
+    pub fn setpgrp() -> pid_t;
+    pub fn seteuid(uid: uid_t) -> c_int;
+    pub fn setuid(uid: uid_t) -> c_int;
+    pub fn setpgid(pid: pid_t, pgid: pid_t) -> c_int;
+    pub fn setsid() -> pid_t;
+
+    // File synchronization
+    pub fn fsync(fd: c_int) -> c_int;
+
+    // Sleep functions
+    pub fn sleep(seconds: c_uint) -> c_uint;
+    pub fn usleep(usec: useconds_t) -> c_int;
+
+    // System configuration
+    pub fn sysconf(name: c_int) -> c_long;
+    pub fn pathconf(path: *const c_char, name: c_int) -> c_long;
+    pub fn fpathconf(fd: c_int, name: c_int) -> c_long;
+}

--- a/src/qurt/hexagon.rs
+++ b/src/qurt/hexagon.rs
@@ -1,0 +1,340 @@
+use crate::prelude::*;
+
+pub type wchar_t = u32;
+
+pub type cpu_set_t = c_uint;
+
+s! {
+    pub struct stat {
+        pub st_dev: crate::dev_t,
+        pub st_ino: crate::ino_t,
+        pub st_mode: crate::mode_t,
+        pub st_nlink: crate::nlink_t,
+        pub st_uid: crate::uid_t,
+        pub st_gid: crate::gid_t,
+        pub st_rdev: crate::dev_t,
+        pub st_size: crate::off_t,
+        pub st_blksize: crate::blksize_t,
+        pub st_blocks: crate::blkcnt_t,
+        pub st_atime: crate::time_t,
+        pub st_atime_nsec: c_long,
+        pub st_mtime: crate::time_t,
+        pub st_mtime_nsec: c_long,
+        pub st_ctime: crate::time_t,
+        pub st_ctime_nsec: c_long,
+    }
+
+    pub struct dirent {
+        pub d_ino: crate::ino_t,
+        pub d_type: c_uchar,
+        pub d_name: [c_char; 256],
+    }
+}
+
+// File type constants for stat.st_mode
+pub const S_IFMT: crate::mode_t = 0o170000;
+pub const S_IFSOCK: crate::mode_t = 0o140000;
+pub const S_IFLNK: crate::mode_t = 0o120000;
+pub const S_IFREG: crate::mode_t = 0o100000;
+pub const S_IFBLK: crate::mode_t = 0o060000;
+pub const S_IFDIR: crate::mode_t = 0o040000;
+pub const S_IFCHR: crate::mode_t = 0o020000;
+pub const S_IFIFO: crate::mode_t = 0o010000;
+
+// File permission constants
+pub const S_ISUID: crate::mode_t = 0o4000;
+pub const S_ISGID: crate::mode_t = 0o2000;
+pub const S_ISVTX: crate::mode_t = 0o1000;
+pub const S_IRWXU: crate::mode_t = 0o0700;
+pub const S_IRUSR: crate::mode_t = 0o0400;
+pub const S_IWUSR: crate::mode_t = 0o0200;
+pub const S_IXUSR: crate::mode_t = 0o0100;
+pub const S_IRWXG: crate::mode_t = 0o0070;
+pub const S_IRGRP: crate::mode_t = 0o0040;
+pub const S_IWGRP: crate::mode_t = 0o0020;
+pub const S_IXGRP: crate::mode_t = 0o0010;
+pub const S_IRWXO: crate::mode_t = 0o0007;
+pub const S_IROTH: crate::mode_t = 0o0004;
+pub const S_IWOTH: crate::mode_t = 0o0002;
+pub const S_IXOTH: crate::mode_t = 0o0001;
+
+// Directory entry types
+pub const DT_UNKNOWN: c_uchar = 0;
+pub const DT_FIFO: c_uchar = 1;
+pub const DT_CHR: c_uchar = 2;
+pub const DT_DIR: c_uchar = 4;
+pub const DT_BLK: c_uchar = 6;
+pub const DT_REG: c_uchar = 8;
+pub const DT_LNK: c_uchar = 10;
+pub const DT_SOCK: c_uchar = 12;
+
+// Size types
+pub const PAGESIZE: size_t = 4096;
+pub const PAGE_SIZE: size_t = 4096;
+
+// pathconf constants (from bits/confname.h)
+pub const _PC_LINK_MAX: c_int = 0;
+pub const _PC_MAX_CANON: c_int = 1;
+pub const _PC_MAX_INPUT: c_int = 2;
+pub const _PC_NAME_MAX: c_int = 3;
+pub const _PC_PATH_MAX: c_int = 4;
+pub const _PC_PIPE_BUF: c_int = 5;
+pub const _PC_CHOWN_RESTRICTED: c_int = 6;
+pub const _PC_NO_TRUNC: c_int = 7;
+pub const _PC_VDISABLE: c_int = 8;
+pub const _PC_SYNC_IO: c_int = 9;
+pub const _PC_ASYNC_IO: c_int = 10;
+pub const _PC_PRIO_IO: c_int = 11;
+pub const _PC_SOCK_MAXBUF: c_int = 12;
+pub const _PC_FILESIZEBITS: c_int = 13;
+pub const _PC_REC_INCR_XFER_SIZE: c_int = 14;
+pub const _PC_REC_MAX_XFER_SIZE: c_int = 15;
+pub const _PC_REC_MIN_XFER_SIZE: c_int = 16;
+pub const _PC_REC_XFER_ALIGN: c_int = 17;
+pub const _PC_ALLOC_SIZE_MIN: c_int = 18;
+pub const _PC_SYMLINK_MAX: c_int = 19;
+pub const _PC_2_SYMLINKS: c_int = 20;
+
+// sysconf constants (from bits/confname.h)
+pub const _SC_ARG_MAX: c_int = 0;
+pub const _SC_CHILD_MAX: c_int = 1;
+pub const _SC_CLK_TCK: c_int = 2;
+pub const _SC_NGROUPS_MAX: c_int = 3;
+pub const _SC_OPEN_MAX: c_int = 4;
+pub const _SC_STREAM_MAX: c_int = 5;
+pub const _SC_TZNAME_MAX: c_int = 6;
+pub const _SC_JOB_CONTROL: c_int = 7;
+pub const _SC_SAVED_IDS: c_int = 8;
+pub const _SC_REALTIME_SIGNALS: c_int = 9;
+pub const _SC_PRIORITY_SCHEDULING: c_int = 10;
+pub const _SC_TIMERS: c_int = 11;
+pub const _SC_ASYNCHRONOUS_IO: c_int = 12;
+pub const _SC_PRIORITIZED_IO: c_int = 13;
+pub const _SC_SYNCHRONIZED_IO: c_int = 14;
+pub const _SC_FSYNC: c_int = 15;
+pub const _SC_MAPPED_FILES: c_int = 16;
+pub const _SC_MEMLOCK: c_int = 17;
+pub const _SC_MEMLOCK_RANGE: c_int = 18;
+pub const _SC_MEMORY_PROTECTION: c_int = 19;
+pub const _SC_MESSAGE_PASSING: c_int = 20;
+pub const _SC_SEMAPHORES: c_int = 21;
+pub const _SC_SHARED_MEMORY_OBJECTS: c_int = 22;
+pub const _SC_AIO_LISTIO_MAX: c_int = 23;
+pub const _SC_AIO_MAX: c_int = 24;
+pub const _SC_AIO_PRIO_DELTA_MAX: c_int = 25;
+pub const _SC_DELAYTIMER_MAX: c_int = 26;
+pub const _SC_MQ_OPEN_MAX: c_int = 27;
+pub const _SC_MQ_PRIO_MAX: c_int = 28;
+pub const _SC_VERSION: c_int = 29;
+pub const _SC_PAGESIZE: c_int = 30;
+pub const _SC_PAGE_SIZE: c_int = _SC_PAGESIZE;
+pub const _SC_RTSIG_MAX: c_int = 31;
+pub const _SC_SEM_NSEMS_MAX: c_int = 32;
+pub const _SC_SEM_VALUE_MAX: c_int = 33;
+pub const _SC_SIGQUEUE_MAX: c_int = 34;
+pub const _SC_TIMER_MAX: c_int = 35;
+
+// POSIX2 sysconf options
+pub const _SC_BC_BASE_MAX: c_int = 36;
+pub const _SC_BC_DIM_MAX: c_int = 37;
+pub const _SC_BC_SCALE_MAX: c_int = 38;
+pub const _SC_BC_STRING_MAX: c_int = 39;
+pub const _SC_COLL_WEIGHTS_MAX: c_int = 40;
+pub const _SC_EQUIV_CLASS_MAX: c_int = 41;
+pub const _SC_EXPR_NEST_MAX: c_int = 42;
+pub const _SC_LINE_MAX: c_int = 43;
+pub const _SC_RE_DUP_MAX: c_int = 44;
+pub const _SC_CHARCLASS_NAME_MAX: c_int = 45;
+
+pub const _SC_2_VERSION: c_int = 46;
+pub const _SC_2_C_BIND: c_int = 47;
+pub const _SC_2_C_DEV: c_int = 48;
+pub const _SC_2_FORT_DEV: c_int = 49;
+pub const _SC_2_FORT_RUN: c_int = 50;
+pub const _SC_2_SW_DEV: c_int = 51;
+pub const _SC_2_LOCALEDEF: c_int = 52;
+
+pub const _SC_PII: c_int = 53;
+pub const _SC_PII_XTI: c_int = 54;
+pub const _SC_PII_SOCKET: c_int = 55;
+pub const _SC_PII_INTERNET: c_int = 56;
+pub const _SC_PII_OSI: c_int = 57;
+pub const _SC_POLL: c_int = 58;
+pub const _SC_SELECT: c_int = 59;
+pub const _SC_UIO_MAXIOV: c_int = 60;
+pub const _SC_IOV_MAX: c_int = _SC_UIO_MAXIOV;
+pub const _SC_PII_INTERNET_STREAM: c_int = 61;
+pub const _SC_PII_INTERNET_DGRAM: c_int = 62;
+pub const _SC_PII_OSI_COTS: c_int = 63;
+pub const _SC_PII_OSI_CLTS: c_int = 64;
+pub const _SC_PII_OSI_M: c_int = 65;
+pub const _SC_T_IOV_MAX: c_int = 66;
+
+// POSIX threads sysconf options
+pub const _SC_THREADS: c_int = 67;
+pub const _SC_THREAD_SAFE_FUNCTIONS: c_int = 68;
+pub const _SC_GETGR_R_SIZE_MAX: c_int = 69;
+pub const _SC_GETPW_R_SIZE_MAX: c_int = 70;
+pub const _SC_LOGIN_NAME_MAX: c_int = 71;
+pub const _SC_TTY_NAME_MAX: c_int = 72;
+pub const _SC_THREAD_DESTRUCTOR_ITERATIONS: c_int = 73;
+pub const _SC_THREAD_KEYS_MAX: c_int = 74;
+pub const _SC_THREAD_STACK_MIN: c_int = 75;
+pub const _SC_THREAD_THREADS_MAX: c_int = 76;
+pub const _SC_THREAD_ATTR_STACKADDR: c_int = 77;
+pub const _SC_THREAD_ATTR_STACKSIZE: c_int = 78;
+pub const _SC_THREAD_PRIORITY_SCHEDULING: c_int = 79;
+pub const _SC_THREAD_PRIO_INHERIT: c_int = 80;
+pub const _SC_THREAD_PRIO_PROTECT: c_int = 81;
+pub const _SC_THREAD_PROCESS_SHARED: c_int = 82;
+
+pub const _SC_NPROCESSORS_CONF: c_int = 83;
+pub const _SC_NPROCESSORS_ONLN: c_int = 84;
+pub const _SC_PHYS_PAGES: c_int = 85;
+pub const _SC_AVPHYS_PAGES: c_int = 86;
+pub const _SC_ATEXIT_MAX: c_int = 87;
+pub const _SC_PASS_MAX: c_int = 88;
+
+pub const _SC_XOPEN_VERSION: c_int = 89;
+pub const _SC_XOPEN_XCU_VERSION: c_int = 90;
+pub const _SC_XOPEN_UNIX: c_int = 91;
+pub const _SC_XOPEN_CRYPT: c_int = 92;
+pub const _SC_XOPEN_ENH_I18N: c_int = 93;
+pub const _SC_XOPEN_SHM: c_int = 94;
+
+pub const _SC_2_CHAR_TERM: c_int = 95;
+pub const _SC_2_C_VERSION: c_int = 96;
+pub const _SC_2_UPE: c_int = 97;
+
+pub const _SC_XOPEN_XPG2: c_int = 98;
+pub const _SC_XOPEN_XPG3: c_int = 99;
+pub const _SC_XOPEN_XPG4: c_int = 100;
+
+pub const _SC_CHAR_BIT: c_int = 101;
+pub const _SC_CHAR_MAX: c_int = 102;
+pub const _SC_CHAR_MIN: c_int = 103;
+pub const _SC_INT_MAX: c_int = 104;
+pub const _SC_INT_MIN: c_int = 105;
+pub const _SC_LONG_BIT: c_int = 106;
+pub const _SC_WORD_BIT: c_int = 107;
+pub const _SC_MB_LEN_MAX: c_int = 108;
+pub const _SC_NZERO: c_int = 109;
+pub const _SC_SSIZE_MAX: c_int = 110;
+pub const _SC_SCHAR_MAX: c_int = 111;
+pub const _SC_SCHAR_MIN: c_int = 112;
+pub const _SC_SHRT_MAX: c_int = 113;
+pub const _SC_SHRT_MIN: c_int = 114;
+pub const _SC_UCHAR_MAX: c_int = 115;
+pub const _SC_UINT_MAX: c_int = 116;
+pub const _SC_ULONG_MAX: c_int = 117;
+pub const _SC_USHRT_MAX: c_int = 118;
+
+pub const _SC_NL_ARGMAX: c_int = 119;
+pub const _SC_NL_LANGMAX: c_int = 120;
+pub const _SC_NL_MSGMAX: c_int = 121;
+pub const _SC_NL_NMAX: c_int = 122;
+pub const _SC_NL_SETMAX: c_int = 123;
+pub const _SC_NL_TEXTMAX: c_int = 124;
+
+pub const _SC_XBS5_ILP32_OFF32: c_int = 125;
+pub const _SC_XBS5_ILP32_OFFBIG: c_int = 126;
+pub const _SC_XBS5_LP64_OFF64: c_int = 127;
+pub const _SC_XBS5_LPBIG_OFFBIG: c_int = 128;
+
+pub const _SC_XOPEN_LEGACY: c_int = 129;
+pub const _SC_XOPEN_REALTIME: c_int = 130;
+pub const _SC_XOPEN_REALTIME_THREADS: c_int = 131;
+
+pub const _SC_ADVISORY_INFO: c_int = 132;
+pub const _SC_BARRIERS: c_int = 133;
+pub const _SC_BASE: c_int = 134;
+pub const _SC_C_LANG_SUPPORT: c_int = 135;
+pub const _SC_C_LANG_SUPPORT_R: c_int = 136;
+pub const _SC_CLOCK_SELECTION: c_int = 137;
+pub const _SC_CPUTIME: c_int = 138;
+pub const _SC_THREAD_CPUTIME: c_int = 139;
+pub const _SC_DEVICE_IO: c_int = 140;
+pub const _SC_DEVICE_SPECIFIC: c_int = 141;
+pub const _SC_DEVICE_SPECIFIC_R: c_int = 142;
+pub const _SC_FD_MGMT: c_int = 143;
+pub const _SC_FIFO: c_int = 144;
+pub const _SC_PIPE: c_int = 145;
+pub const _SC_FILE_ATTRIBUTES: c_int = 146;
+pub const _SC_FILE_LOCKING: c_int = 147;
+pub const _SC_FILE_SYSTEM: c_int = 148;
+pub const _SC_MONOTONIC_CLOCK: c_int = 149;
+pub const _SC_MULTI_PROCESS: c_int = 150;
+pub const _SC_SINGLE_PROCESS: c_int = 151;
+pub const _SC_NETWORKING: c_int = 152;
+pub const _SC_READER_WRITER_LOCKS: c_int = 153;
+pub const _SC_SPIN_LOCKS: c_int = 154;
+pub const _SC_REGEXP: c_int = 155;
+pub const _SC_REGEX_VERSION: c_int = 156;
+pub const _SC_SHELL: c_int = 157;
+pub const _SC_SIGNALS: c_int = 158;
+pub const _SC_SPAWN: c_int = 159;
+pub const _SC_SPORADIC_SERVER: c_int = 160;
+pub const _SC_THREAD_SPORADIC_SERVER: c_int = 161;
+pub const _SC_SYSTEM_DATABASE: c_int = 162;
+pub const _SC_SYSTEM_DATABASE_R: c_int = 163;
+pub const _SC_TIMEOUTS: c_int = 164;
+pub const _SC_TYPED_MEMORY_OBJECTS: c_int = 165;
+pub const _SC_USER_GROUPS: c_int = 166;
+pub const _SC_USER_GROUPS_R: c_int = 167;
+pub const _SC_2_PBS: c_int = 168;
+pub const _SC_2_PBS_ACCOUNTING: c_int = 169;
+pub const _SC_2_PBS_LOCATE: c_int = 170;
+pub const _SC_2_PBS_MESSAGE: c_int = 171;
+pub const _SC_2_PBS_TRACK: c_int = 172;
+pub const _SC_SYMLOOP_MAX: c_int = 173;
+pub const _SC_STREAMS: c_int = 174;
+pub const _SC_2_PBS_CHECKPOINT: c_int = 175;
+
+pub const _SC_V6_ILP32_OFF32: c_int = 176;
+pub const _SC_V6_ILP32_OFFBIG: c_int = 177;
+pub const _SC_V6_LP64_OFF64: c_int = 178;
+pub const _SC_V6_LPBIG_OFFBIG: c_int = 179;
+
+pub const _SC_HOST_NAME_MAX: c_int = 180;
+pub const _SC_TRACE: c_int = 181;
+pub const _SC_TRACE_EVENT_FILTER: c_int = 182;
+pub const _SC_TRACE_INHERIT: c_int = 183;
+pub const _SC_TRACE_LOG: c_int = 184;
+
+pub const _SC_LEVEL1_ICACHE_SIZE: c_int = 185;
+pub const _SC_LEVEL1_ICACHE_ASSOC: c_int = 186;
+pub const _SC_LEVEL1_ICACHE_LINESIZE: c_int = 187;
+pub const _SC_LEVEL1_DCACHE_SIZE: c_int = 188;
+pub const _SC_LEVEL1_DCACHE_ASSOC: c_int = 189;
+pub const _SC_LEVEL1_DCACHE_LINESIZE: c_int = 190;
+pub const _SC_LEVEL2_CACHE_SIZE: c_int = 191;
+pub const _SC_LEVEL2_CACHE_ASSOC: c_int = 192;
+pub const _SC_LEVEL2_CACHE_LINESIZE: c_int = 193;
+pub const _SC_LEVEL3_CACHE_SIZE: c_int = 194;
+pub const _SC_LEVEL3_CACHE_ASSOC: c_int = 195;
+pub const _SC_LEVEL3_CACHE_LINESIZE: c_int = 196;
+pub const _SC_LEVEL4_CACHE_SIZE: c_int = 197;
+pub const _SC_LEVEL4_CACHE_ASSOC: c_int = 198;
+pub const _SC_LEVEL4_CACHE_LINESIZE: c_int = 199;
+
+pub const _SC_IPV6: c_int = 235;
+pub const _SC_RAW_SOCKETS: c_int = 236;
+
+pub const _SC_V7_ILP32_OFF32: c_int = 237;
+pub const _SC_V7_ILP32_OFFBIG: c_int = 238;
+pub const _SC_V7_LP64_OFF64: c_int = 239;
+pub const _SC_V7_LPBIG_OFFBIG: c_int = 240;
+
+pub const _SC_SS_REPL_MAX: c_int = 241;
+
+pub const _SC_TRACE_EVENT_NAME_MAX: c_int = 242;
+pub const _SC_TRACE_NAME_MAX: c_int = 243;
+pub const _SC_TRACE_SYS_MAX: c_int = 244;
+pub const _SC_TRACE_USER_EVENT_MAX: c_int = 245;
+
+pub const _SC_XOPEN_STREAMS: c_int = 246;
+
+pub const _SC_THREAD_ROBUST_PRIO_INHERIT: c_int = 247;
+pub const _SC_THREAD_ROBUST_PRIO_PROTECT: c_int = 248;
+
+// Note: QuRT doesn't use traditional syscalls but has its own API

--- a/src/qurt/mod.rs
+++ b/src/qurt/mod.rs
@@ -1,0 +1,334 @@
+//! Interface to QuRT (Qualcomm Real-Time OS) C library
+
+use crate::prelude::*;
+
+// Forward declarations for opaque types
+#[derive(Debug)]
+pub enum DIR {}
+impl Copy for DIR {}
+impl Clone for DIR {
+    fn clone(&self) -> DIR {
+        *self
+    }
+}
+
+// Network types
+pub type socklen_t = c_uint;
+pub type in_addr_t = u32;
+
+// Error type
+pub type errno_t = c_int;
+
+// Resource limit type
+pub type rlim_t = c_ulong;
+
+// Terminal types
+pub type speed_t = c_uint;
+pub type tcflag_t = c_uint;
+
+// File descriptor set type for select()
+pub type fd_set = c_ulong;
+
+// POSIX semaphore types
+pub type sem_t = c_uint;
+
+// Message queue types
+pub type mqd_t = c_int;
+
+// Additional file system types
+pub type nfds_t = c_ulong;
+
+// Architecture-specific modules
+cfg_if! {
+    if #[cfg(target_arch = "hexagon")] {
+        mod hexagon;
+        pub use self::hexagon::*;
+    } else {
+        // Add other architectures as needed
+    }
+}
+
+// Structures based on QuRT headers
+s! {
+    pub struct sigval {
+        pub sival_int: c_int,
+        pub sival_ptr: *mut c_void,
+    }
+
+    pub struct sigevent {
+        pub sigev_notify: c_int,
+        pub sigev_signo: c_int,
+        pub sigev_value: sigval,
+        pub sigev_notify_function: Option<extern "C" fn(sigval)>,
+        pub sigev_notify_attributes: *mut pthread_attr_t,
+    }
+
+    pub struct siginfo_t {
+        pub si_signo: c_int,
+        pub si_code: c_int,
+        pub si_value: sigval,
+    }
+
+    pub struct sigaction {
+        pub sa_handler: Option<extern "C" fn(c_int)>,
+        pub sa_mask: sigset_t,
+        pub sa_flags: c_int,
+        pub sa_sigaction: Option<extern "C" fn(c_int, *mut siginfo_t, *mut c_void)>,
+    }
+
+    pub struct termios {
+        pub c_iflag: tcflag_t,
+        pub c_oflag: tcflag_t,
+        pub c_cflag: tcflag_t,
+        pub c_lflag: tcflag_t,
+        pub c_cc: [c_uchar; 32],
+        pub c_ispeed: speed_t,
+        pub c_ospeed: speed_t,
+    }
+
+    pub struct dirent {
+        pub d_ino: ino_t,
+        pub d_type: c_uchar,
+        pub d_name: [c_char; 256],
+    }
+
+    pub struct tm {
+        pub tm_sec: c_int,
+        pub tm_min: c_int,
+        pub tm_hour: c_int,
+        pub tm_mday: c_int,
+        pub tm_mon: c_int,
+        pub tm_year: c_int,
+        pub tm_wday: c_int,
+        pub tm_yday: c_int,
+        pub tm_isdst: c_int,
+    }
+
+    pub struct sched_param {
+        pub sched_priority: c_int,
+    }
+
+    pub struct iovec {
+        pub iov_base: *mut c_void,
+        pub iov_len: size_t,
+    }
+
+    pub struct rlimit {
+        pub rlim_cur: rlim_t,
+        pub rlim_max: rlim_t,
+    }
+
+    pub struct rusage {
+        pub ru_utime: timeval,
+        pub ru_stime: timeval,
+        pub ru_maxrss: c_long,
+        pub ru_ixrss: c_long,
+        pub ru_idrss: c_long,
+        pub ru_isrss: c_long,
+        pub ru_minflt: c_long,
+        pub ru_majflt: c_long,
+        pub ru_nswap: c_long,
+        pub ru_inblock: c_long,
+        pub ru_oublock: c_long,
+        pub ru_msgsnd: c_long,
+        pub ru_msgrcv: c_long,
+        pub ru_nsignals: c_long,
+        pub ru_nvcsw: c_long,
+        pub ru_nivcsw: c_long,
+    }
+
+    pub struct flock {
+        pub l_type: c_short,
+        pub l_whence: c_short,
+        pub l_start: off_t,
+        pub l_len: off_t,
+        pub l_pid: pid_t,
+    }
+}
+
+// Memory mapping constants (from sys/mman.h)
+pub const PROT_NONE: c_int = 0x00;
+pub const PROT_READ: c_int = 0x01;
+pub const PROT_WRITE: c_int = 0x02;
+pub const PROT_EXEC: c_int = 0x04;
+
+pub const MAP_SHARED: c_int = 0x0001;
+pub const MAP_PRIVATE: c_int = 0x0002;
+pub const MAP_FIXED: c_int = 0x0010;
+pub const MAP_ANON: c_int = 0x1000;
+pub const MAP_ANONYMOUS: c_int = MAP_ANON;
+pub const MAP_FILE: c_int = 0x0000;
+pub const MAP_RENAME: c_int = 0x0020;
+pub const MAP_NORESERVE: c_int = 0x0040;
+pub const MAP_INHERIT: c_int = 0x0080;
+pub const MAP_HASSEMAPHORE: c_int = 0x0200;
+pub const MAP_TRYFIXED: c_int = 0x0400;
+pub const MAP_WIRED: c_int = 0x0800;
+
+pub const MAP_FAILED: *mut c_void = !0 as *mut c_void;
+
+pub const MS_ASYNC: c_int = 0x01;
+pub const MS_INVALIDATE: c_int = 0x02;
+pub const MS_SYNC: c_int = 0x04;
+
+pub const MCL_CURRENT: c_int = 0x01;
+pub const MCL_FUTURE: c_int = 0x02;
+
+// Dynamic linking constants (from dlfcn.h)
+pub const RTLD_LAZY: c_int = 1;
+pub const RTLD_NOW: c_int = 2;
+pub const RTLD_GLOBAL: c_int = 0x100;
+pub const RTLD_LOCAL: c_int = 0x200;
+
+// Semaphore constants
+pub const SEM_FAILED: *mut sem_t = 0 as *mut sem_t;
+
+// Additional constants
+pub const PTHREAD_NAME_LEN: c_int = 16;
+pub const PTHREAD_MAX_THREADS: c_uint = 512;
+pub const PTHREAD_MIN_STACKSIZE: c_int = 512;
+pub const PTHREAD_MAX_STACKSIZE: c_int = 1048576;
+pub const PTHREAD_DEFAULT_STACKSIZE: c_int = 16384;
+pub const PTHREAD_DEFAULT_PRIORITY: c_int = 1;
+pub const PTHREAD_SPINLOCK_UNLOCKED: c_int = 0;
+pub const PTHREAD_SPINLOCK_LOCKED: c_int = 1;
+pub const TIME_CONV_SCLK_FREQ: c_int = 19200000;
+pub const CLOCK_MONOTONIC_RAW: clockid_t = 4;
+pub const CLOCK_REALTIME_COARSE: clockid_t = 5;
+pub const CLOCK_MONOTONIC_COARSE: clockid_t = 6;
+pub const CLOCK_BOOTTIME: clockid_t = 7;
+pub const L_tmpnam: c_uint = 260;
+pub const TMP_MAX: c_uint = 25;
+pub const FOPEN_MAX: c_uint = 20;
+pub const AT_FDCWD: c_int = -100;
+pub const AT_EACCESS: c_int = 0x200;
+pub const AT_SYMLINK_NOFOLLOW: c_int = 0x100;
+pub const AT_SYMLINK_FOLLOW: c_int = 0x400;
+pub const AT_REMOVEDIR: c_int = 0x200;
+pub const EOK: c_int = 0;
+pub const POSIX_MSG: c_int = 7;
+pub const POSIX_NOTIF: c_int = 8;
+pub const SIGRTMIN: c_int = 10;
+pub const SIGRTMAX: c_int = 32;
+pub const SIGEV_NONE: c_int = 0;
+pub const SIGEV_SIGNAL: c_int = 1;
+pub const SIGEV_THREAD: c_int = 2;
+pub const SA_SIGINFO: c_int = 1;
+
+// Function declarations for QuRT POSIX API
+extern "C" {
+    // Signal functions
+    pub fn sigwait(set: *const sigset_t, sig: *mut c_int) -> c_int;
+    pub fn _sigaction(sig: c_int, act: *const sigaction, oact: *mut sigaction) -> c_int;
+    pub fn sigtimedwait(
+        set: *const sigset_t,
+        info: *mut siginfo_t,
+        timeout: *const timespec,
+    ) -> c_int;
+
+    // Additional pthread functions
+    pub fn pthread_attr_getstack(
+        attr: *const pthread_attr_t,
+        stackaddr: *mut *mut c_void,
+        stacksize: *mut size_t,
+    ) -> c_int;
+    pub fn pthread_attr_setstack(
+        attr: *mut pthread_attr_t,
+        stackaddr: *mut c_void,
+        stacksize: size_t,
+    ) -> c_int;
+    pub fn pthread_mutexattr_gettype(attr: *const pthread_mutexattr_t, type_: *mut c_int) -> c_int;
+    pub fn pthread_mutexattr_settype(attr: *mut pthread_mutexattr_t, type_: c_int) -> c_int;
+
+    // Additional time functions
+    pub fn clock_getcpuclockid(pid: pid_t, clock_id: *mut clockid_t) -> c_int;
+
+    // POSIX semaphore functions
+    pub fn sem_open(name: *const c_char, oflag: c_int, ...) -> *mut sem_t;
+    pub fn sem_close(sem: *mut sem_t) -> c_int;
+    pub fn sem_unlink(name: *const c_char) -> c_int;
+
+    // Additional stdlib functions
+    pub fn aligned_alloc(alignment: size_t, size: size_t) -> *mut c_void;
+
+    // String functions
+    pub fn strlen(s: *const c_char) -> size_t;
+    pub fn strcpy(dest: *mut c_char, src: *const c_char) -> *mut c_char;
+    pub fn strncpy(dest: *mut c_char, src: *const c_char, n: size_t) -> *mut c_char;
+    pub fn strcat(dest: *mut c_char, src: *const c_char) -> *mut c_char;
+    pub fn strncat(dest: *mut c_char, src: *const c_char, n: size_t) -> *mut c_char;
+    pub fn strcmp(s1: *const c_char, s2: *const c_char) -> c_int;
+    pub fn strncmp(s1: *const c_char, s2: *const c_char, n: size_t) -> c_int;
+    pub fn strcoll(s1: *const c_char, s2: *const c_char) -> c_int;
+    pub fn strxfrm(dest: *mut c_char, src: *const c_char, n: size_t) -> size_t;
+    pub fn strchr(s: *const c_char, c: c_int) -> *mut c_char;
+    pub fn strrchr(s: *const c_char, c: c_int) -> *mut c_char;
+    pub fn strspn(s: *const c_char, accept: *const c_char) -> size_t;
+    pub fn strcspn(s: *const c_char, reject: *const c_char) -> size_t;
+    pub fn strpbrk(s: *const c_char, accept: *const c_char) -> *mut c_char;
+    pub fn strstr(haystack: *const c_char, needle: *const c_char) -> *mut c_char;
+    pub fn strtok(s: *mut c_char, delim: *const c_char) -> *mut c_char;
+    pub fn strerror(errnum: c_int) -> *mut c_char;
+    pub fn memchr(s: *const c_void, c: c_int, n: size_t) -> *mut c_void;
+    pub fn memcmp(s1: *const c_void, s2: *const c_void, n: size_t) -> c_int;
+    pub fn memcpy(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
+    pub fn memmove(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
+    pub fn memset(s: *mut c_void, c: c_int, n: size_t) -> *mut c_void;
+
+    // Additional unistd functions
+    pub fn fork() -> pid_t;
+    pub fn execve(
+        filename: *const c_char,
+        argv: *const *const c_char,
+        envp: *const *const c_char,
+    ) -> c_int;
+
+    // Directory functions
+    pub fn opendir(name: *const c_char) -> *mut DIR;
+    pub fn closedir(dirp: *mut DIR) -> c_int;
+    pub fn readdir(dirp: *mut DIR) -> *mut dirent;
+    pub fn rewinddir(dirp: *mut DIR);
+    pub fn telldir(dirp: *mut DIR) -> c_long;
+    pub fn seekdir(dirp: *mut DIR, loc: c_long);
+
+    // Memory mapping functions
+    pub fn mmap(
+        addr: *mut c_void,
+        len: size_t,
+        prot: c_int,
+        flags: c_int,
+        fd: c_int,
+        offset: off_t,
+    ) -> *mut c_void;
+    pub fn munmap(addr: *mut c_void, len: size_t) -> c_int;
+    pub fn mprotect(addr: *mut c_void, len: size_t, prot: c_int) -> c_int;
+    pub fn mlock(addr: *const c_void, len: size_t) -> c_int;
+    pub fn munlock(addr: *const c_void, len: size_t) -> c_int;
+    pub fn mlockall(flags: c_int) -> c_int;
+    pub fn munlockall() -> c_int;
+    pub fn msync(addr: *mut c_void, len: size_t, flags: c_int) -> c_int;
+
+    // Dynamic linking functions
+    pub fn dlopen(filename: *const c_char, flag: c_int) -> *mut c_void;
+    pub fn dlclose(handle: *mut c_void) -> c_int;
+    pub fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
+    pub fn dlerror() -> *mut c_char;
+
+    // Character classification functions
+    pub fn isalnum(c: c_int) -> c_int;
+    pub fn isalpha(c: c_int) -> c_int;
+    pub fn iscntrl(c: c_int) -> c_int;
+    pub fn isdigit(c: c_int) -> c_int;
+    pub fn isgraph(c: c_int) -> c_int;
+    pub fn islower(c: c_int) -> c_int;
+    pub fn isprint(c: c_int) -> c_int;
+    pub fn ispunct(c: c_int) -> c_int;
+    pub fn isspace(c: c_int) -> c_int;
+    pub fn isupper(c: c_int) -> c_int;
+    pub fn isxdigit(c: c_int) -> c_int;
+    pub fn tolower(c: c_int) -> c_int;
+    pub fn toupper(c: c_int) -> c_int;
+}
+
+// Re-export common prelude items
+pub use crate::*;


### PR DESCRIPTION
The QuRT RTOS -- used primarily on the Hexagon architecture -- has support for large parts of POSIX.

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Add support for Hexagon QuRT OS.

# Sources

The corresponding sources from the Hexagon SDK from https://github.com/snapdragon-toolchain/hexagon-sdk or https://softwarecenter.qualcomm.com/catalog/item/Hexagon_SDK

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] N/A - Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
