### PR TITLE
ctest: Release 0.5.0-beta.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "ctest"
-version = "0.5.0-beta.1"
+version = "0.5.0-beta.2"
 dependencies = [
  "askama",
  "cc",

--- a/ctest/Cargo.toml
+++ b/ctest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctest"
-version = "0.5.0-beta.1"
+version = "0.5.0-beta.2"
 edition = "2024"
 description = "Automated testing of FFI bindings in Rust."
 rust-version = "1.88"


### PR DESCRIPTION
This is the same description as d399a9660578 ("ctest: Release 0.5.0-beta.2"). That was a typo, it actually released 0.5.0-beta.1.