### PR TITLE
linux, fuchsia: Mark mq_attr padding area as such

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -941,7 +941,7 @@ s! {
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         pub mq_curmsgs: i64,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
-        pad: [i64; 4],
+        pad: Padding<[i64; 4]>,
 
         #[cfg(not(all(target_arch = "x86_64", target_pointer_width = "32")))]
         pub mq_flags: c_long,
@@ -952,7 +952,7 @@ s! {
         #[cfg(not(all(target_arch = "x86_64", target_pointer_width = "32")))]
         pub mq_curmsgs: c_long,
         #[cfg(not(all(target_arch = "x86_64", target_pointer_width = "32")))]
-        pad: [c_long; 4],
+        pad: Padding<[c_long; 4]>,
     }
 
     pub struct sockaddr_nl {

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -365,7 +365,7 @@ s! {
         pub mq_maxmsg: c_long,
         pub mq_msgsize: c_long,
         pub mq_curmsgs: c_long,
-        pad: [c_long; 4],
+        pad: Padding<[c_long; 4]>,
     }
 
     #[cfg_attr(target_pointer_width = "32", repr(align(4)))]

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1424,7 +1424,7 @@ s! {
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
         pub mq_curmsgs: i64,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
-        pad: [i64; 4],
+        pad: Padding<[i64; 4]>,
 
         #[cfg(not(all(target_arch = "x86_64", target_pointer_width = "32")))]
         pub mq_flags: c_long,
@@ -1435,7 +1435,7 @@ s! {
         #[cfg(not(all(target_arch = "x86_64", target_pointer_width = "32")))]
         pub mq_curmsgs: c_long,
         #[cfg(not(all(target_arch = "x86_64", target_pointer_width = "32")))]
-        pad: [c_long; 4],
+        pad: Padding<[c_long; 4]>,
     }
 
     pub struct hwtstamp_config {


### PR DESCRIPTION
# Description

As per commit c100954964 (see https://github.com/rust-lang/libc/pull/4806#issuecomment-3603204960) the hard-coded partial equality implementations
have been dropped in favor for auto-generated ones, but they did not
work for mq_attr, since the padding area was not typed correctly.

Fix this, using the Padding type.

<!-- Add a short description about what this change does -->
# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
