### PR TITLE
ci: Use mirrors for kernel.org in install-musl.sh

### DIFF
--- a/ci/install-musl.sh
+++ b/ci/install-musl.sh
@@ -112,10 +112,14 @@ git clone -n --depth=1 --filter=tree:0 -b "${alpine_version}-stable" "$alpine_gi
         echo "\$sha512sums" > alpine-sha512sums
 EOF
 
-    # Retrieve all the variables
-    sh APKBUILD.vars
+    # Use a mirror since kernel.org can be a bit inconsistent
+    sed -i 's|https://kernel.org/pub/linux/kernel|https://ci-mirrors.rust-lang.org/linux/kernel|g' \
+        APKBUILD.vars
 
     cat APKBUILD.vars
+
+    # Retrieve all the variables
+    sh APKBUILD.vars
 
     kernel_version=$(tr -d "[:space:]" < alpine-kernver)
     pkg_version=$(tr -d "[:space:]" < alpine-pkgver)


### PR DESCRIPTION
We have had a high number of CI failures in the past few days due to errors like:

    #9 857.0 curl: (28) Failed to connect to kernel.org port 443 after 135536 ms: Couldn't connect to server
    #9 ERROR: process "/bin/sh -c /install-musl.sh arm" did not complete successfully: exit code: 28

Replace the Alpine kernel.org URLs with a rust-lang mirror to mitigate this.