### PR TITLE
ci: Forward RUSTFLAGS to docker via EXTRA_RUSTFLAGS

### DIFF
--- a/ci/docker/aarch64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-musl/Dockerfile
@@ -20,6 +20,6 @@ RUN /install-musl.sh aarch64 "$MUSL_VERSION"
 # FIXME: shouldn't need the `-lgcc` here, shouldn't that be in std?
 ENV PATH=$PATH:/musl-aarch64/bin:/rust/bin \
     CC_aarch64_unknown_linux_musl=musl-gcc \
-    RUSTFLAGS='-Clink-args=-lgcc -L /musl-aarch64/lib' \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
-    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER="qemu-aarch64 -L /musl-aarch64"
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER="qemu-aarch64 -L /musl-aarch64" \
+    EXTRA_RUSTFLAGS="-Clink-args=-lgcc -L /musl-aarch64/lib"

--- a/ci/docker/arm-unknown-linux-musleabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-musleabihf/Dockerfile
@@ -24,4 +24,4 @@ ENV PATH=$PATH:/musl-arm/bin:/rust/bin \
     CC_arm_unknown_linux_musleabihf=musl-gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_LINKER=musl-gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_RUNNER="qemu-arm -L /musl-arm" \
-    RUSTFLAGS="-L /musl-arm/lib"
+    EXTRA_RUSTFLAGS="-L /musl-arm/lib"

--- a/ci/docker/i686-unknown-linux-musl/Dockerfile
+++ b/ci/docker/i686-unknown-linux-musl/Dockerfile
@@ -22,4 +22,4 @@ RUN /install-musl.sh i686 "$MUSL_VERSION"
 
 ENV PATH=$PATH:/musl-i686/bin:/rust/bin \
     CC_i686_unknown_linux_musl=musl-gcc \
-    RUSTFLAGS="-L /musl-i686/lib"
+    EXTRA_RUSTFLAGS="-L /musl-i686/lib"

--- a/ci/docker/loongarch64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/loongarch64-unknown-linux-musl/Dockerfile
@@ -17,10 +17,10 @@ ARG MUSL_VERSION
 COPY install-musl.sh /
 RUN /install-musl.sh loongarch64 "$MUSL_VERSION"
 
-ENV CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
-    CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_MUSL_RUNNER="qemu-loongarch64" \
-    CC_loongarch64_unknown_linux_musl=musl-gcc \
+ENV CC_loongarch64_unknown_linux_musl=musl-gcc \
     CFLAGS_loongarch64_unknown_linux_musl="-mabi=lp64d -fPIC" \
-    RUSTFLAGS="-Ctarget-feature=+crt-static" \
+    CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
+    CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_MUSL_RUNNER="qemu-loongarch64" \
+    EXTRA_RUSTFLAGS="-Ctarget-feature=+crt-static" \
     QEMU_LD_PREFIX=/musl-loongarch64 \
     PATH=$PATH:/musl-loongarch64/bin:/rust/bin

--- a/ci/docker/powerpc64le-unknown-linux-musl/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-musl/Dockerfile
@@ -20,6 +20,6 @@ RUN /install-musl.sh powerpc64le "$MUSL_VERSION"
 # FIXME: shouldn't need the `-lgcc` here, shouldn't that be in std?
 ENV PATH=$PATH:/musl-powerpc64/bin:/rust/bin \
     CC_powerpc64le_unknown_linux_musl=musl-gcc \
-    RUSTFLAGS='-Clink-args=-lgcc -L /musl-powerpc64/lib' \
     CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
-    CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_MUSL_RUNNER="qemu-ppc64le -L /musl-powerpc64"
+    CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_MUSL_RUNNER="qemu-ppc64le -L /musl-powerpc64" \
+    EXTRA_RUSTFLAGS="-Clink-args=-lgcc -L /musl-powerpc64/lib"

--- a/ci/docker/s390x-unknown-linux-musl/Dockerfile
+++ b/ci/docker/s390x-unknown-linux-musl/Dockerfile
@@ -15,8 +15,8 @@ COPY install-musl.sh /
 RUN /install-musl.sh s390x "$MUSL_VERSION"
 
 # FIXME: shouldn't need the `-lgcc` here, shouldn't that be in std?
-ENV CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-linux-gnu-gcc \
+ENV CC_s390x_unknown_linux_gnu=musl-gcc \
+    CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-linux-gnu-gcc \
     CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_RUNNER="qemu-s390x -L /musl-s390x" \
-    CC_s390x_unknown_linux_gnu=musl-gcc \
-    RUSTFLAGS='-Clink-args=-lgcc -L /musl-s390x/lib' \
+    EXTRA_RUSTFLAGS="-Clink-args=-lgcc -L /musl-s390x/lib" \
     PATH=$PATH:/musl-s390x/bin:/rust/bin

--- a/ci/docker/wasm32-wasip1/Dockerfile
+++ b/ci/docker/wasm32-wasip1/Dockerfile
@@ -10,7 +10,7 @@ RUN /wasi.sh
 # library.
 ENV CARGO_TARGET_WASM32_WASIP1_RUNNER=wasmtime \
     CARGO_TARGET_WASM32_WASIP1_LINKER=/opt/wasi-sdk/bin/clang \
-    CARGO_TARGET_WASM32_WASIP1_RUSTFLAGS="-Clink-self-contained=n -lwasi-emulated-process-clocks" \
+    EXTRA_RUSTFLAGS="-Clink-self-contained=n -lwasi-emulated-process-clocks" \
     CC_wasm32_wasip1=/opt/wasi-sdk/bin/clang \
     CFLAGS_wasm32_wasip1=-D_WASI_EMULATED_PROCESS_CLOCKS \
     PATH=$PATH:/rust/bin:/wasmtime

--- a/ci/docker/wasm32-wasip2/Dockerfile
+++ b/ci/docker/wasm32-wasip2/Dockerfile
@@ -9,7 +9,7 @@ RUN /wasi.sh
 # itself, this should be fixed upstream.
 ENV CARGO_TARGET_WASM32_WASIP2_RUNNER=wasmtime \
     CARGO_TARGET_WASM32_WASIP2_LINKER=/opt/wasi-sdk/bin/clang \
-    CARGO_TARGET_WASM32_WASIP2_RUSTFLAGS="-Clink-self-contained=n -lwasi-emulated-process-clocks -Clink-arg=-Wl,--export,cabi_realloc" \
+    EXTRA_RUSTFLAGS="-Clink-self-contained=n -lwasi-emulated-process-clocks -Clink-arg=-Wl,--export,cabi_realloc" \
     CC_wasm32_wasip2=/opt/wasi-sdk/bin/clang \
     CFLAGS_wasm32_wasip2=-D_WASI_EMULATED_PROCESS_CLOCKS \
     PATH=$PATH:/rust/bin:/wasmtime

--- a/ci/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -16,4 +16,4 @@ COPY install-musl.sh /
 RUN /install-musl.sh x86_64 "$MUSL_VERSION"
 
 ENV PATH=$PATH:/musl-x86_64/bin:/rust/bin \
-    RUSTFLAGS="-L /musl-x86_64/lib"
+    EXTRA_RUSTFLAGS="-L /musl-x86_64/lib"

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -59,6 +59,7 @@ run() {
         --user "$(id -u)":"$(id -g)" \
         --env LIBC_CI \
         --env LIBC_CI_ZBUILD_STD \
+        --env RUSTFLAGS \
         --env RUSTDOCFLAGS \
         --env RUST_BACKTRACE \
         --env RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -8,6 +8,10 @@ set -eux
 target="$1"
 
 export RUST_BACKTRACE="${RUST_BACKTRACE:-1}"
+# Add target-specific rustflags set in dockerfiles
+export RUSTFLAGS="${EXTRA_RUSTFLAGS:-} ${RUSTFLAGS:-}"
+
+echo "RUSTFLAGS: '$RUSTFLAGS'"
 
 # For logging
 uname -a


### PR DESCRIPTION
This needs to be a separate environment variable since otherwise it
overwrites `RUSTFLAGS` as set in CI. This is currently happening, which
is why warnings were not getting denied.