### PR TITLE
newlib: Fix ambiguous glob exports and other warnings for Vita and 3DS

### DIFF
--- a/src/new/vita/mod.rs
+++ b/src/new/vita/mod.rs
@@ -1,4 +1,2 @@
 //! VITASDK system library.
 // FIXME(vita): link to headers or manpages needed.
-
-pub(crate) mod unistd;

--- a/src/new/vita/unistd.rs
+++ b/src/new/vita/unistd.rs
@@ -1,7 +1,0 @@
-//! Header: `unistd.h`
-
-pub use crate::new::common::posix::unistd::{
-    STDERR_FILENO,
-    STDIN_FILENO,
-    STDOUT_FILENO,
-};

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -142,7 +142,7 @@ s! {
         pub ipv6mr_interface: c_uint,
     }
 
-    #[cfg(not(target_os = "cygwin"))]
+    #[cfg(all(not(target_os = "cygwin"), not(target_os = "horizon")))]
     pub struct hostent {
         pub h_name: *mut c_char,
         pub h_aliases: *mut *mut c_char,
@@ -156,6 +156,7 @@ s! {
         pub iov_len: size_t,
     }
 
+    #[cfg(not(target_os = "horizon"))]
     pub struct pollfd {
         pub fd: c_int,
         pub events: c_short,

--- a/src/unix/newlib/generic.rs
+++ b/src/unix/newlib/generic.rs
@@ -1,16 +1,15 @@
 //! Common types used by most newlib platforms
 
-use crate::off_t;
+#[allow(unused_imports)] // needed for platforms that don't use the prelude here
 use crate::prelude::*;
 
 s! {
+    #[cfg(all(not(target_os = "vita"), not(target_os = "horizon")))]
     pub struct sigset_t {
-        #[cfg(target_os = "horizon")]
-        __val: [c_ulong; 16],
-        #[cfg(not(target_os = "horizon"))]
         __val: u32,
     }
 
+    #[cfg(all(not(target_os = "vita"), not(target_os = "horizon")))]
     pub struct stat {
         pub st_dev: crate::dev_t,
         pub st_ino: crate::ino_t,
@@ -19,7 +18,7 @@ s! {
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
-        pub st_size: off_t,
+        pub st_size: crate::off_t,
         pub st_atime: crate::time_t,
         pub st_spare1: c_long,
         pub st_mtime: crate::time_t,
@@ -31,6 +30,7 @@ s! {
         pub st_spare4: [c_long; 2usize],
     }
 
+    #[cfg(not(target_os = "vita"))]
     pub struct dirent {
         pub d_ino: crate::ino_t,
         pub d_type: c_uchar,

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -28,6 +28,12 @@ s! {
         pub h_addr_list: *mut *mut c_char,
     }
 
+    pub struct pollfd {
+        pub fd: c_int,
+        pub events: c_int,
+        pub revents: c_int,
+    }
+
     pub struct sockaddr {
         pub sa_family: crate::sa_family_t,
         pub sa_data: [c_char; 26usize],
@@ -140,9 +146,6 @@ pub const MSG_WAITALL: c_int = 0;
 pub const MSG_MORE: c_int = 0;
 pub const MSG_NOSIGNAL: c_int = 0;
 pub const SOL_CONFIG: c_uint = 65534;
-
-pub const _SC_PAGESIZE: c_int = 8;
-pub const _SC_GETPW_R_SIZE_MAX: c_int = 51;
 
 pub const PTHREAD_STACK_MIN: size_t = 4096;
 pub const WNOHANG: c_int = 1;

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -64,21 +64,6 @@ cfg_if! {
     }
 }
 
-cfg_if! {
-    if #[cfg(not(target_os = "horizon"))] {
-        s! {
-            pub struct hostent {
-                pub h_name: *mut c_char,
-                pub h_aliases: *mut *mut c_char,
-                pub h_addrtype: c_int,
-                pub h_length: c_int,
-                pub h_addr_list: *mut *mut c_char,
-                pub h_addr: *mut c_char,
-            }
-        }
-    }
-}
-
 s! {
     // The order of the `ai_addr` field in this struct is crucial
     // for converting between the Rust and C types.
@@ -108,19 +93,8 @@ s! {
         pub imr_interface: in_addr,
     }
 
-    pub struct linger {
-        pub l_onoff: c_int,
-        pub l_linger: c_int,
-    }
-
     pub struct in_addr {
         pub s_addr: crate::in_addr_t,
-    }
-
-    pub struct pollfd {
-        pub fd: c_int,
-        pub events: c_int,
-        pub revents: c_int,
     }
 
     pub struct lconv {

--- a/src/unix/newlib/rtems/mod.rs
+++ b/src/unix/newlib/rtems/mod.rs
@@ -73,8 +73,6 @@ pub const EAI_SERVICE: c_int = 9;
 pub const EAI_SYSTEM: c_int = 11;
 pub const EAI_OVERFLOW: c_int = 14;
 
-pub const _SC_PAGESIZE: c_int = 8;
-pub const _SC_GETPW_R_SIZE_MAX: c_int = 51;
 pub const PTHREAD_STACK_MIN: size_t = 0;
 
 // sys/wait.h

--- a/src/unix/newlib/vita/mod.rs
+++ b/src/unix/newlib/vita/mod.rs
@@ -164,8 +164,6 @@ pub const EAI_MEMORY: c_int = -10;
 pub const EAI_SYSTEM: c_int = -11;
 pub const EAI_OVERFLOW: c_int = -12;
 
-pub const _SC_PAGESIZE: c_int = 8;
-pub const _SC_GETPW_R_SIZE_MAX: c_int = 51;
 pub const PTHREAD_STACK_MIN: size_t = 32 * 1024;
 
 pub const IP_HDRINCL: c_int = 2;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

This is actually a followup of rust-lang/libc#4811. It turns out that it accidentally introduced an ambiguous glob export for `_SC_PAGESIZE` and `_SC_GETPW_R_SIZE_MAX`. After updating newlib, rustc is fails to compile for these targets as it can't resolve `_SC_PAGESIZE` here: https://github.com/rust-lang/rust/blob/5325015e29874334003d33d77b295d57f593f06a/library/std/src/sys/pal/unix/os.rs#L530-L532

While checking, I realized there were also other warnings, for many newlib structures that ended up being unused, which I fixed:

### `hostent` definitions:

1. src/unix/mod.rs: The only actually resolved by rustc, and the most similar to [newlib since at least 2017](https://github.com/bminor/newlib/blob/f49f54b00d80ec12d6875def9252afba37f51825/newlib/libc/sys/rtems/include/netdb.h#L106-L113)

2. src/unix/newlib/mod.rs: This one has been there since the start of the newlib module, which matched the 3DS upstream definition at the time. Since then, rust-lang/libc#3863 arrived removing the 3DS (horizon) from that definition as the upstream header had been updated.

3. src/unix/newlib/horizon/mod.rs: This one is the new correct definition for horizon, which was deliberately added in rust-lang/libc#3863 but is not being used as it's shadowed by `1.`. I updated `1.` so this definition will now be used.

### `pollfd`

The definition in src/unix/mod.rs is the one being used and it matches with upstream newlib and the vita. 

The definition in src/unix/newlib/mod.rs was unused but it matches with the 3ds headers, so I moved it into horizon and opted it out from the above.

### `unix::newlib::generic::{sigset_t, stat, dirent}` 

All unused as they were shadowed by `vita`'s own definitions. Same goes for `horizon` except for `dirent`.

# Sources

- newlib hostent: https://github.com/bminor/newlib/blob/f49f54b00d80ec12d6875def9252afba37f51825/newlib/libc/sys/rtems/include/netdb.h#L106-L113
- vita hostent: https://github.com/vitasdk/newlib/blob/11c38129967fe2f8893d24dd7742b6ed6bd54d5f/newlib/libc/sys/vita/include/netdb.h#L40-L46
- horizon hostent: https://github.com/devkitPro/libctru/blob/00760077a8418284554980290e20f85231c69c2b/libctru/include/netdb.h#L11-L17
- newlib pollfd: https://github.com/bminor/newlib/blob/f49f54b00d80ec12d6875def9252afba37f51825/newlib/libc/sys/rtems/include/sys/poll.h#L51-L55
- vita pollfd: https://github.com/vitasdk/newlib/blob/11c38129967fe2f8893d24dd7742b6ed6bd54d5f/newlib/libc/sys/vita/sys/poll.h#L49-L53
- horizon pollfd: https://github.com/devkitPro/libctru/blob/00760077a8418284554980290e20f85231c69c2b/libctru/include/poll.h#L12-L17

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

Checked locally using `cargo +nightly check --target {target} -Z build-std=core` for:

- `armv7-sony-vita-newlibeabihf`: No warnings
- `armv6k-nintendo-3ds`: No warnings
- `armv7-rtems-eabihf`: Only an unused import warning on `src/new/mod.rs`: `pub(crate) use rtems::*;`

@rustbot label +stable-nominated