### PR TITLE
Remove `[no-mentions]` handler in our triagebot config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -15,9 +15,6 @@ contributing_url = "https://github.com/rust-lang/libc/blob/HEAD/CONTRIBUTING.md"
 [issue-links]
 check-commits = false # don't forbid links to issues
 
-# Prevents mentions in commits to avoid users being spammed
-[no-mentions]
-
 # Enable comments linking to triagebot range-diff when a PR is rebased
 # onto a different base commit
 # Documentation at: https://forge.rust-lang.org/triagebot/range-diff.html


### PR DESCRIPTION
This PR removes the `[no-mentions]` handler in our triagebot config as [GitHub is removing notifications for @-mentions in commit messages on December 8th 2025.](https://github.blog/changelog/2025-11-07-removing-notifications-for-mentions-in-commit-messages/)

cf. https://github.com/rust-lang/triagebot/issues/2225