### PR TITLE
Fix QNX build error

### DIFF
--- a/src/unix/nto/neutrino.rs
+++ b/src/unix/nto/neutrino.rs
@@ -1245,13 +1245,13 @@ extern "C" {
         __id: crate::clockid_t,
         _new: *const crate::_clockperiod,
         __old: *mut crate::_clockperiod,
-        __reserved: Padding<c_int>,
+        __reserved: c_int,
     ) -> c_int;
     pub fn ClockPeriod_r(
         __id: crate::clockid_t,
         _new: *const crate::_clockperiod,
         __old: *mut crate::_clockperiod,
-        __reserved: Padding<c_int>,
+        __reserved: c_int,
     ) -> c_int;
     pub fn ClockId(__pid: crate::pid_t, __tid: c_int) -> c_int;
     pub fn ClockId_r(__pid: crate::pid_t, __tid: c_int) -> c_int;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

As noted in https://github.com/rust-lang/libc/pull/4609/files#r2607712816, on `*-nto-qnx710` the codebase seems to currently fail to compile:

```
error: type `types::Padding<i32>` is more private than the item `neutrino::ClockPeriod`
    --> src/unix/nto/neutrino.rs:1244:5
     |
1244 | /     pub fn ClockPeriod(
1245 | |         __id: crate::clockid_t,
1246 | |         _new: *const crate::_clockperiod,
1247 | |         __old: *mut crate::_clockperiod,
1248 | |         __reserved: Padding<c_int>,
1249 | |     ) -> c_int;
     | |_______________^ function `neutrino::ClockPeriod` is reachable at visibility `pub`
     |
note: but type `types::Padding<i32>` is only usable at visibility `pub(crate)`
    --> src/types.rs:17:1
     |
  17 | pub(crate) struct Padding<T: Copy>(MaybeUninit<T>);
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: `-D private-interfaces` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(private_interfaces)]`
```

I believe the change from that PR may have been inadvertent given the other contents.

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
   - This failed with 
   ```
     cargo:rustc-link-search=native=/home/ana/git/rust-lang/libc/target/x86_64-pc-nto-qnx710/debug/build/libc-test-ae02735b35db6470/out

  --- stderr

  thread 'main' panicked at ctest/src/ffi_items.rs:141:25:
  not implemented: Foreign functions are unlikely to have any other pattern.
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  ```
<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
