### PR TITLE
ci: FreeBSD: Revert the workaround for Rust bug 132185

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,9 +3,6 @@ task:
   env:
     HOME: /tmp  # cargo cache needs it
     TARGET: x86_64-unknown-freebsd
-    # FIXME(freebsd): FreeBSD has a segfault when `RUST_BACKTRACE` is set
-    # https://github.com/rust-lang/rust/issues/132185
-    RUST_BACKTRACE: "0"
   matrix:
     # FIXME(#4740): FreeBSD 13 tests are extremely flaky and fail most of the time
     # - name: nightly freebsd-13 x86_64


### PR DESCRIPTION
It's been fixed since probably sometime in February.

https://github.com/rust-lang/rust/issues/132185

# Description

Reenable RUST_BACKTRACE in CI

# Checklist

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI


@rustbot label +stable-nominated

