### PR TITLE
links old version of cf{g,s}et{i,o}speed for glibc

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4784,6 +4784,30 @@ fn test_linux(target: &str) {
         _ => false,
     });
 
+    if gnu {
+        // old constants, so tests fail if glibc is too new
+        cfg.skip_const(|s| {
+            [
+                "B50", "B75", "B110", "B134", "B150", "B200", "B300", "B600", "B1200", "B1800",
+                "B2400", "B4800", "B9600", "B19200", "B38400", "EXTA", "EXTB", "B57600", "B115200",
+                "B230400", "B460800", "B500000", "B576000", "B921600", "B1000000", "B1152000",
+                "B1500000", "B2000000", "B2500000", "B3000000", "B3500000", "B4000000",
+            ]
+            .contains(&s.ident())
+        });
+        // old symbols, so tests fail if glibc is too new
+        cfg.skip_fn_ptrcheck(|s| {
+            [
+                "cfgetispeed",
+                "cfgetospeed",
+                "cfsetispeed",
+                "cfsetospeed",
+                "cfsetspeed",
+            ]
+            .contains(&s)
+        });
+    }
+
     ctest::generate_test(&mut cfg, "../src/lib.rs", "ctest_output.rs").unwrap();
 
     if !l4re {

--- a/libc-test/tests/linux_gnu_baud.rs
+++ b/libc-test/tests/linux_gnu_baud.rs
@@ -1,0 +1,33 @@
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[test]
+fn baud() {
+    use libc::*;
+    let controller_fd = unsafe { posix_openpt(O_RDWR | O_NOCTTY) };
+    assert!(controller_fd >= 0);
+    unsafe {
+        grantpt(controller_fd);
+        unlockpt(controller_fd);
+    }
+    let mut buffer = [0; 256];
+    let ret = unsafe { ptsname_r(controller_fd, buffer.as_mut_ptr(), 256) };
+    assert!(ret >= 0);
+    let terminal_fd = unsafe { open(buffer.as_ptr(), O_RDWR | O_NOCTTY) };
+    assert!(terminal_fd >= 0);
+    let mut tio: termios = unsafe { std::mem::zeroed() };
+    let ret = unsafe { tcgetattr(terminal_fd, &mut tio) };
+    assert!(ret >= 0);
+    assert_eq!(unsafe { cfgetispeed(&tio) }, B38400);
+    assert_eq!(unsafe { cfgetospeed(&tio) }, B38400);
+    let ret = unsafe { cfsetspeed(&mut tio, B1000000) };
+    assert!(ret >= 0);
+    assert_eq!(unsafe { cfgetispeed(&tio) }, B1000000);
+    assert_eq!(unsafe { cfgetospeed(&tio) }, B1000000);
+    let ret = unsafe { cfsetispeed(&mut tio, B9600) };
+    assert!(ret >= 0);
+    assert_eq!(unsafe { cfgetispeed(&tio) }, B9600);
+    assert!(matches!(unsafe { cfgetospeed(&tio) }, B9600 | B1000000));
+    let ret = unsafe { cfsetospeed(&mut tio, B19200) };
+    assert!(ret >= 0);
+    assert!(matches!(unsafe { cfgetispeed(&tio) }, B9600 | B19200));
+    assert_eq!(unsafe { cfgetospeed(&tio) }, B19200);
+}

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1614,9 +1614,377 @@ extern "C" {
         link_name = "tcdrain$UNIX2003"
     )]
     pub fn tcdrain(fd: c_int) -> c_int;
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "arm"),
+        link_name = "cfgetispeed@GLIBC_2.4"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "csky"),
+        link_name = "cfgetispeed@GLIBC_2.29"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "m68k"),
+        link_name = "cfgetispeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "mips"),
+        link_name = "cfgetispeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "powerpc"),
+        link_name = "cfgetispeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "riscv32"),
+        link_name = "cfgetispeed@GLIBC_2.33"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "sparc"),
+        link_name = "cfgetispeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "x86"),
+        link_name = "cfgetispeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "aarch64"),
+        link_name = "cfgetispeed@GLIBC_2.17"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "loongarch64"),
+        link_name = "cfgetispeed@GLIBC_2.36"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "mips64"),
+        link_name = "cfgetispeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            target_arch = "powerpc64",
+            target_endian = "big"
+        ),
+        link_name = "cfgetispeed@GLIBC_2.3"
+    )]
+    #[cfg_attr(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            target_arch = "powerpc64",
+            target_endian = "little"
+        ),
+        link_name = "cfgetispeed@GLIBC_2.17"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "riscv64"),
+        link_name = "cfgetispeed@GLIBC_2.27"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "s390x"),
+        link_name = "cfgetispeed@GLIBC_2.2"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "sparc64"),
+        link_name = "cfgetispeed@GLIBC_2.2"
+    )]
+    #[cfg_attr(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            target_arch = "x86_64",
+            target_pointer_width = "64"
+        ),
+        link_name = "cfgetispeed@GLIBC_2.2.5"
+    )]
+    #[cfg_attr(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            target_arch = "x86_64",
+            target_pointer_width = "32"
+        ),
+        link_name = "cfgetispeed@GLIBC_2.16"
+    )]
     pub fn cfgetispeed(termios: *const crate::termios) -> crate::speed_t;
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "arm"),
+        link_name = "cfgetospeed@GLIBC_2.4"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "csky"),
+        link_name = "cfgetospeed@GLIBC_2.29"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "m68k"),
+        link_name = "cfgetospeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "mips"),
+        link_name = "cfgetospeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "powerpc"),
+        link_name = "cfgetospeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "riscv32"),
+        link_name = "cfgetospeed@GLIBC_2.33"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "sparc"),
+        link_name = "cfgetospeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "x86"),
+        link_name = "cfgetospeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "aarch64"),
+        link_name = "cfgetospeed@GLIBC_2.17"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "loongarch64"),
+        link_name = "cfgetospeed@GLIBC_2.36"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "mips64"),
+        link_name = "cfgetospeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            target_arch = "powerpc64",
+            target_endian = "big"
+        ),
+        link_name = "cfgetospeed@GLIBC_2.3"
+    )]
+    #[cfg_attr(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            target_arch = "powerpc64",
+            target_endian = "little"
+        ),
+        link_name = "cfgetospeed@GLIBC_2.17"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "riscv64"),
+        link_name = "cfgetospeed@GLIBC_2.27"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "s390x"),
+        link_name = "cfgetospeed@GLIBC_2.2"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "sparc64"),
+        link_name = "cfgetospeed@GLIBC_2.2"
+    )]
+    #[cfg_attr(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            target_arch = "x86_64",
+            target_pointer_width = "64"
+        ),
+        link_name = "cfgetospeed@GLIBC_2.2.5"
+    )]
+    #[cfg_attr(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            target_arch = "x86_64",
+            target_pointer_width = "32"
+        ),
+        link_name = "cfgetospeed@GLIBC_2.16"
+    )]
     pub fn cfgetospeed(termios: *const crate::termios) -> crate::speed_t;
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "arm"),
+        link_name = "cfsetispeed@GLIBC_2.4"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "csky"),
+        link_name = "cfsetispeed@GLIBC_2.29"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "m68k"),
+        link_name = "cfsetispeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "mips"),
+        link_name = "cfsetispeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "powerpc"),
+        link_name = "cfsetispeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "riscv32"),
+        link_name = "cfsetispeed@GLIBC_2.33"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "sparc"),
+        link_name = "cfsetispeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "x86"),
+        link_name = "cfsetispeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "aarch64"),
+        link_name = "cfsetispeed@GLIBC_2.17"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "loongarch64"),
+        link_name = "cfsetispeed@GLIBC_2.36"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "mips64"),
+        link_name = "cfsetispeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            target_arch = "powerpc64",
+            target_endian = "big"
+        ),
+        link_name = "cfsetispeed@GLIBC_2.3"
+    )]
+    #[cfg_attr(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            target_arch = "powerpc64",
+            target_endian = "little"
+        ),
+        link_name = "cfsetispeed@GLIBC_2.17"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "riscv64"),
+        link_name = "cfsetispeed@GLIBC_2.27"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "s390x"),
+        link_name = "cfsetispeed@GLIBC_2.2"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "sparc64"),
+        link_name = "cfsetispeed@GLIBC_2.2"
+    )]
+    #[cfg_attr(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            target_arch = "x86_64",
+            target_pointer_width = "64"
+        ),
+        link_name = "cfsetispeed@GLIBC_2.2.5"
+    )]
+    #[cfg_attr(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            target_arch = "x86_64",
+            target_pointer_width = "32"
+        ),
+        link_name = "cfsetispeed@GLIBC_2.16"
+    )]
     pub fn cfsetispeed(termios: *mut crate::termios, speed: crate::speed_t) -> c_int;
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "arm"),
+        link_name = "cfsetospeed@GLIBC_2.4"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "csky"),
+        link_name = "cfsetospeed@GLIBC_2.29"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "m68k"),
+        link_name = "cfsetospeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "mips"),
+        link_name = "cfsetospeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "powerpc"),
+        link_name = "cfsetospeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "riscv32"),
+        link_name = "cfsetospeed@GLIBC_2.33"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "sparc"),
+        link_name = "cfsetospeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "x86"),
+        link_name = "cfsetospeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "aarch64"),
+        link_name = "cfsetospeed@GLIBC_2.17"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "loongarch64"),
+        link_name = "cfsetospeed@GLIBC_2.36"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "mips64"),
+        link_name = "cfsetospeed@GLIBC_2.0"
+    )]
+    #[cfg_attr(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            target_arch = "powerpc64",
+            target_endian = "big"
+        ),
+        link_name = "cfsetospeed@GLIBC_2.3"
+    )]
+    #[cfg_attr(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            target_arch = "powerpc64",
+            target_endian = "little"
+        ),
+        link_name = "cfsetospeed@GLIBC_2.17"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "riscv64"),
+        link_name = "cfsetospeed@GLIBC_2.27"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "s390x"),
+        link_name = "cfsetospeed@GLIBC_2.2"
+    )]
+    #[cfg_attr(
+        all(target_os = "linux", target_env = "gnu", target_arch = "sparc64"),
+        link_name = "cfsetospeed@GLIBC_2.2"
+    )]
+    #[cfg_attr(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            target_arch = "x86_64",
+            target_pointer_width = "64"
+        ),
+        link_name = "cfsetospeed@GLIBC_2.2.5"
+    )]
+    #[cfg_attr(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            target_arch = "x86_64",
+            target_pointer_width = "32"
+        ),
+        link_name = "cfsetospeed@GLIBC_2.16"
+    )]
     pub fn cfsetospeed(termios: *mut crate::termios, speed: crate::speed_t) -> c_int;
     pub fn tcgetattr(fd: c_int, termios: *mut crate::termios) -> c_int;
     pub fn tcsetattr(fd: c_int, optional_actions: c_int, termios: *const crate::termios) -> c_int;
@@ -1907,6 +2275,98 @@ cfg_if! {
     )))] {
         extern "C" {
             #[cfg(not(target_os = "l4re"))]
+            #[cfg_attr(
+                all(target_os = "linux", target_env = "gnu", target_arch = "arm"),
+                link_name = "cfsetspeed@GLIBC_2.4"
+            )]
+            #[cfg_attr(
+                all(target_os = "linux", target_env = "gnu", target_arch = "csky"),
+                link_name = "cfsetspeed@GLIBC_2.29"
+            )]
+            #[cfg_attr(
+                all(target_os = "linux", target_env = "gnu", target_arch = "m68k"),
+                link_name = "cfsetspeed@GLIBC_2.0"
+            )]
+            #[cfg_attr(
+                all(target_os = "linux", target_env = "gnu", target_arch = "mips"),
+                link_name = "cfsetspeed@GLIBC_2.0"
+            )]
+            #[cfg_attr(
+                all(target_os = "linux", target_env = "gnu", target_arch = "powerpc"),
+                link_name = "cfsetspeed@GLIBC_2.0"
+            )]
+            #[cfg_attr(
+                all(target_os = "linux", target_env = "gnu", target_arch = "riscv32"),
+                link_name = "cfsetspeed@GLIBC_2.33"
+            )]
+            #[cfg_attr(
+                all(target_os = "linux", target_env = "gnu", target_arch = "sparc"),
+                link_name = "cfsetspeed@GLIBC_2.0"
+            )]
+            #[cfg_attr(
+                all(target_os = "linux", target_env = "gnu", target_arch = "x86"),
+                link_name = "cfsetspeed@GLIBC_2.0"
+            )]
+            #[cfg_attr(
+                all(target_os = "linux", target_env = "gnu", target_arch = "aarch64"),
+                link_name = "cfsetspeed@GLIBC_2.17"
+            )]
+            #[cfg_attr(
+                all(target_os = "linux", target_env = "gnu", target_arch = "loongarch64"),
+                link_name = "cfsetspeed@GLIBC_2.36"
+            )]
+            #[cfg_attr(
+                all(target_os = "linux", target_env = "gnu", target_arch = "mips64"),
+                link_name = "cfsetspeed@GLIBC_2.0"
+            )]
+            #[cfg_attr(
+                all(
+                    target_os = "linux",
+                    target_env = "gnu",
+                    target_arch = "powerpc64",
+                    target_endian = "big"
+                ),
+                link_name = "cfsetspeed@GLIBC_2.3"
+            )]
+            #[cfg_attr(
+                all(
+                    target_os = "linux",
+                    target_env = "gnu",
+                    target_arch = "powerpc64",
+                    target_endian = "little"
+                ),
+                link_name = "cfsetspeed@GLIBC_2.17"
+            )]
+            #[cfg_attr(
+                all(target_os = "linux", target_env = "gnu", target_arch = "riscv64"),
+                link_name = "cfsetspeed@GLIBC_2.27"
+            )]
+            #[cfg_attr(
+                all(target_os = "linux", target_env = "gnu", target_arch = "s390x"),
+                link_name = "cfsetspeed@GLIBC_2.2"
+            )]
+            #[cfg_attr(
+                all(target_os = "linux", target_env = "gnu", target_arch = "sparc64"),
+                link_name = "cfsetspeed@GLIBC_2.2"
+            )]
+            #[cfg_attr(
+                all(
+                    target_os = "linux",
+                    target_env = "gnu",
+                    target_arch = "x86_64",
+                    target_pointer_width = "64"
+                ),
+                link_name = "cfsetspeed@GLIBC_2.2.5"
+            )]
+            #[cfg_attr(
+                all(
+                    target_os = "linux",
+                    target_env = "gnu",
+                    target_arch = "x86_64",
+                    target_pointer_width = "32"
+                ),
+                link_name = "cfsetspeed@GLIBC_2.16"
+            )]
             pub fn cfsetspeed(termios: *mut crate::termios, speed: crate::speed_t) -> c_int;
         }
     }


### PR DESCRIPTION
# Description

~Fixes~ https://github.com/rust-lang/libc/issues/4692.

# Sources

https://github.com/bminor/glibc

<details>

<summary>cfsetspeed</summary>

```
./sysdeps/mach/hurd/i386/libc.abilist:GLIBC_2.2.6 cfsetspeed
./sysdeps/mach/hurd/x86_64/libc.abilist:GLIBC_2.38 cfsetspeed
./sysdeps/unix/sysv/linux/aarch64/libc.abilist:GLIBC_2.17 cfsetspeed
./sysdeps/unix/sysv/linux/aarch64/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/alpha/libc.abilist:GLIBC_2.0 cfsetspeed
./sysdeps/unix/sysv/linux/alpha/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/arc/libc.abilist:GLIBC_2.32 cfsetspeed
./sysdeps/unix/sysv/linux/arc/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/arm/be/libc.abilist:GLIBC_2.4 cfsetspeed
./sysdeps/unix/sysv/linux/arm/be/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/arm/le/libc.abilist:GLIBC_2.4 cfsetspeed
./sysdeps/unix/sysv/linux/arm/le/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/csky/libc.abilist:GLIBC_2.29 cfsetspeed
./sysdeps/unix/sysv/linux/csky/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/hppa/libc.abilist:GLIBC_2.2 cfsetspeed
./sysdeps/unix/sysv/linux/hppa/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/i386/libc.abilist:GLIBC_2.0 cfsetspeed
./sysdeps/unix/sysv/linux/i386/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/loongarch/lp64/libc.abilist:GLIBC_2.36 cfsetspeed
./sysdeps/unix/sysv/linux/loongarch/lp64/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/m68k/coldfire/libc.abilist:GLIBC_2.4 cfsetspeed
./sysdeps/unix/sysv/linux/m68k/coldfire/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/m68k/m680x0/libc.abilist:GLIBC_2.0 cfsetspeed
./sysdeps/unix/sysv/linux/m68k/m680x0/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/microblaze/be/libc.abilist:GLIBC_2.18 cfsetspeed
./sysdeps/unix/sysv/linux/microblaze/be/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/microblaze/le/libc.abilist:GLIBC_2.18 cfsetspeed
./sysdeps/unix/sysv/linux/microblaze/le/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/mips/mips32/fpu/libc.abilist:GLIBC_2.0 cfsetspeed
./sysdeps/unix/sysv/linux/mips/mips32/fpu/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/mips/mips32/nofpu/libc.abilist:GLIBC_2.0 cfsetspeed
./sysdeps/unix/sysv/linux/mips/mips32/nofpu/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/mips/mips64/n32/libc.abilist:GLIBC_2.0 cfsetspeed
./sysdeps/unix/sysv/linux/mips/mips64/n32/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/mips/mips64/n64/libc.abilist:GLIBC_2.0 cfsetspeed
./sysdeps/unix/sysv/linux/mips/mips64/n64/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/or1k/libc.abilist:GLIBC_2.35 cfsetspeed
./sysdeps/unix/sysv/linux/or1k/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/fpu/libc.abilist:GLIBC_2.0 cfsetspeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/fpu/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/nofpu/libc.abilist:GLIBC_2.0 cfsetspeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/nofpu/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/be/libc.abilist:GLIBC_2.3 cfsetspeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/be/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/le/libc.abilist:GLIBC_2.17 cfsetspeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/le/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/riscv/rv32/libc.abilist:GLIBC_2.33 cfsetspeed
./sysdeps/unix/sysv/linux/riscv/rv32/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/riscv/rv64/libc.abilist:GLIBC_2.27 cfsetspeed
./sysdeps/unix/sysv/linux/riscv/rv64/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/s390/s390-32/libc.abilist:GLIBC_2.0 cfsetspeed
./sysdeps/unix/sysv/linux/s390/s390-32/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/s390/s390-64/libc.abilist:GLIBC_2.2 cfsetspeed
./sysdeps/unix/sysv/linux/s390/s390-64/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/sh/be/libc.abilist:GLIBC_2.2 cfsetspeed
./sysdeps/unix/sysv/linux/sh/be/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/sh/le/libc.abilist:GLIBC_2.2 cfsetspeed
./sysdeps/unix/sysv/linux/sh/le/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/sparc/sparc32/libc.abilist:GLIBC_2.0 cfsetspeed
./sysdeps/unix/sysv/linux/sparc/sparc32/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/sparc/sparc64/libc.abilist:GLIBC_2.2 cfsetspeed
./sysdeps/unix/sysv/linux/sparc/sparc64/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/x86_64/64/libc.abilist:GLIBC_2.2.5 cfsetspeed
./sysdeps/unix/sysv/linux/x86_64/64/libc.abilist:GLIBC_2.42 cfsetspeed
./sysdeps/unix/sysv/linux/x86_64/x32/libc.abilist:GLIBC_2.16 cfsetspeed
./sysdeps/unix/sysv/linux/x86_64/x32/libc.abilist:GLIBC_2.42 cfsetspeed
```

</details>
<details>

<summary>cfsetispeed</summary>

```
./sysdeps/mach/hurd/i386/libc.abilist:GLIBC_2.2.6 cfsetispeed
./sysdeps/mach/hurd/x86_64/libc.abilist:GLIBC_2.38 cfsetispeed
./sysdeps/unix/sysv/linux/aarch64/libc.abilist:GLIBC_2.17 cfsetispeed
./sysdeps/unix/sysv/linux/aarch64/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/alpha/libc.abilist:GLIBC_2.0 cfsetispeed
./sysdeps/unix/sysv/linux/alpha/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/arc/libc.abilist:GLIBC_2.32 cfsetispeed
./sysdeps/unix/sysv/linux/arc/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/arm/be/libc.abilist:GLIBC_2.4 cfsetispeed
./sysdeps/unix/sysv/linux/arm/be/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/arm/le/libc.abilist:GLIBC_2.4 cfsetispeed
./sysdeps/unix/sysv/linux/arm/le/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/csky/libc.abilist:GLIBC_2.29 cfsetispeed
./sysdeps/unix/sysv/linux/csky/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/hppa/libc.abilist:GLIBC_2.2 cfsetispeed
./sysdeps/unix/sysv/linux/hppa/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/i386/libc.abilist:GLIBC_2.0 cfsetispeed
./sysdeps/unix/sysv/linux/i386/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/loongarch/lp64/libc.abilist:GLIBC_2.36 cfsetispeed
./sysdeps/unix/sysv/linux/loongarch/lp64/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/m68k/coldfire/libc.abilist:GLIBC_2.4 cfsetispeed
./sysdeps/unix/sysv/linux/m68k/coldfire/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/m68k/m680x0/libc.abilist:GLIBC_2.0 cfsetispeed
./sysdeps/unix/sysv/linux/m68k/m680x0/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/microblaze/be/libc.abilist:GLIBC_2.18 cfsetispeed
./sysdeps/unix/sysv/linux/microblaze/be/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/microblaze/le/libc.abilist:GLIBC_2.18 cfsetispeed
./sysdeps/unix/sysv/linux/microblaze/le/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/mips/mips32/fpu/libc.abilist:GLIBC_2.0 cfsetispeed
./sysdeps/unix/sysv/linux/mips/mips32/fpu/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/mips/mips32/nofpu/libc.abilist:GLIBC_2.0 cfsetispeed
./sysdeps/unix/sysv/linux/mips/mips32/nofpu/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/mips/mips64/n32/libc.abilist:GLIBC_2.0 cfsetispeed
./sysdeps/unix/sysv/linux/mips/mips64/n32/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/mips/mips64/n64/libc.abilist:GLIBC_2.0 cfsetispeed
./sysdeps/unix/sysv/linux/mips/mips64/n64/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/or1k/libc.abilist:GLIBC_2.35 cfsetispeed
./sysdeps/unix/sysv/linux/or1k/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/fpu/libc.abilist:GLIBC_2.0 cfsetispeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/fpu/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/nofpu/libc.abilist:GLIBC_2.0 cfsetispeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/nofpu/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/be/libc.abilist:GLIBC_2.3 cfsetispeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/be/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/le/libc.abilist:GLIBC_2.17 cfsetispeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/le/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/riscv/rv32/libc.abilist:GLIBC_2.33 cfsetispeed
./sysdeps/unix/sysv/linux/riscv/rv32/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/riscv/rv64/libc.abilist:GLIBC_2.27 cfsetispeed
./sysdeps/unix/sysv/linux/riscv/rv64/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/s390/s390-32/libc.abilist:GLIBC_2.0 cfsetispeed
./sysdeps/unix/sysv/linux/s390/s390-32/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/s390/s390-64/libc.abilist:GLIBC_2.2 cfsetispeed
./sysdeps/unix/sysv/linux/s390/s390-64/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/sh/be/libc.abilist:GLIBC_2.2 cfsetispeed
./sysdeps/unix/sysv/linux/sh/be/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/sh/le/libc.abilist:GLIBC_2.2 cfsetispeed
./sysdeps/unix/sysv/linux/sh/le/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/sparc/sparc32/libc.abilist:GLIBC_2.0 cfsetispeed
./sysdeps/unix/sysv/linux/sparc/sparc32/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/sparc/sparc64/libc.abilist:GLIBC_2.2 cfsetispeed
./sysdeps/unix/sysv/linux/sparc/sparc64/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/x86_64/64/libc.abilist:GLIBC_2.2.5 cfsetispeed
./sysdeps/unix/sysv/linux/x86_64/64/libc.abilist:GLIBC_2.42 cfsetispeed
./sysdeps/unix/sysv/linux/x86_64/x32/libc.abilist:GLIBC_2.16 cfsetispeed
./sysdeps/unix/sysv/linux/x86_64/x32/libc.abilist:GLIBC_2.42 cfsetispeed
```

</details>
<details>

<summary>cfsetospeed</summary>

```
./sysdeps/mach/hurd/i386/libc.abilist:GLIBC_2.2.6 cfsetospeed
./sysdeps/mach/hurd/x86_64/libc.abilist:GLIBC_2.38 cfsetospeed
./sysdeps/unix/sysv/linux/aarch64/libc.abilist:GLIBC_2.17 cfsetospeed
./sysdeps/unix/sysv/linux/aarch64/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/alpha/libc.abilist:GLIBC_2.0 cfsetospeed
./sysdeps/unix/sysv/linux/alpha/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/arc/libc.abilist:GLIBC_2.32 cfsetospeed
./sysdeps/unix/sysv/linux/arc/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/arm/be/libc.abilist:GLIBC_2.4 cfsetospeed
./sysdeps/unix/sysv/linux/arm/be/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/arm/le/libc.abilist:GLIBC_2.4 cfsetospeed
./sysdeps/unix/sysv/linux/arm/le/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/csky/libc.abilist:GLIBC_2.29 cfsetospeed
./sysdeps/unix/sysv/linux/csky/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/hppa/libc.abilist:GLIBC_2.2 cfsetospeed
./sysdeps/unix/sysv/linux/hppa/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/i386/libc.abilist:GLIBC_2.0 cfsetospeed
./sysdeps/unix/sysv/linux/i386/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/loongarch/lp64/libc.abilist:GLIBC_2.36 cfsetospeed
./sysdeps/unix/sysv/linux/loongarch/lp64/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/m68k/coldfire/libc.abilist:GLIBC_2.4 cfsetospeed
./sysdeps/unix/sysv/linux/m68k/coldfire/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/m68k/m680x0/libc.abilist:GLIBC_2.0 cfsetospeed
./sysdeps/unix/sysv/linux/m68k/m680x0/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/microblaze/be/libc.abilist:GLIBC_2.18 cfsetospeed
./sysdeps/unix/sysv/linux/microblaze/be/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/microblaze/le/libc.abilist:GLIBC_2.18 cfsetospeed
./sysdeps/unix/sysv/linux/microblaze/le/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/mips/mips32/fpu/libc.abilist:GLIBC_2.0 cfsetospeed
./sysdeps/unix/sysv/linux/mips/mips32/fpu/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/mips/mips32/nofpu/libc.abilist:GLIBC_2.0 cfsetospeed
./sysdeps/unix/sysv/linux/mips/mips32/nofpu/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/mips/mips64/n32/libc.abilist:GLIBC_2.0 cfsetospeed
./sysdeps/unix/sysv/linux/mips/mips64/n32/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/mips/mips64/n64/libc.abilist:GLIBC_2.0 cfsetospeed
./sysdeps/unix/sysv/linux/mips/mips64/n64/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/or1k/libc.abilist:GLIBC_2.35 cfsetospeed
./sysdeps/unix/sysv/linux/or1k/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/fpu/libc.abilist:GLIBC_2.0 cfsetospeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/fpu/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/nofpu/libc.abilist:GLIBC_2.0 cfsetospeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/nofpu/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/be/libc.abilist:GLIBC_2.3 cfsetospeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/be/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/le/libc.abilist:GLIBC_2.17 cfsetospeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/le/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/riscv/rv32/libc.abilist:GLIBC_2.33 cfsetospeed
./sysdeps/unix/sysv/linux/riscv/rv32/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/riscv/rv64/libc.abilist:GLIBC_2.27 cfsetospeed
./sysdeps/unix/sysv/linux/riscv/rv64/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/s390/s390-32/libc.abilist:GLIBC_2.0 cfsetospeed
./sysdeps/unix/sysv/linux/s390/s390-32/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/s390/s390-64/libc.abilist:GLIBC_2.2 cfsetospeed
./sysdeps/unix/sysv/linux/s390/s390-64/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/sh/be/libc.abilist:GLIBC_2.2 cfsetospeed
./sysdeps/unix/sysv/linux/sh/be/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/sh/le/libc.abilist:GLIBC_2.2 cfsetospeed
./sysdeps/unix/sysv/linux/sh/le/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/sparc/sparc32/libc.abilist:GLIBC_2.0 cfsetospeed
./sysdeps/unix/sysv/linux/sparc/sparc32/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/sparc/sparc64/libc.abilist:GLIBC_2.2 cfsetospeed
./sysdeps/unix/sysv/linux/sparc/sparc64/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/x86_64/64/libc.abilist:GLIBC_2.2.5 cfsetospeed
./sysdeps/unix/sysv/linux/x86_64/64/libc.abilist:GLIBC_2.42 cfsetospeed
./sysdeps/unix/sysv/linux/x86_64/x32/libc.abilist:GLIBC_2.16 cfsetospeed
./sysdeps/unix/sysv/linux/x86_64/x32/libc.abilist:GLIBC_2.42 cfsetospeed
```

</details>
<details>

<summary>cfgetispeed</summary>

```
./sysdeps/mach/hurd/i386/libc.abilist:GLIBC_2.2.6 cfgetispeed
./sysdeps/mach/hurd/x86_64/libc.abilist:GLIBC_2.38 cfgetispeed
./sysdeps/unix/sysv/linux/aarch64/libc.abilist:GLIBC_2.17 cfgetispeed
./sysdeps/unix/sysv/linux/aarch64/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/alpha/libc.abilist:GLIBC_2.0 cfgetispeed
./sysdeps/unix/sysv/linux/alpha/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/arc/libc.abilist:GLIBC_2.32 cfgetispeed
./sysdeps/unix/sysv/linux/arc/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/arm/be/libc.abilist:GLIBC_2.4 cfgetispeed
./sysdeps/unix/sysv/linux/arm/be/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/arm/le/libc.abilist:GLIBC_2.4 cfgetispeed
./sysdeps/unix/sysv/linux/arm/le/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/csky/libc.abilist:GLIBC_2.29 cfgetispeed
./sysdeps/unix/sysv/linux/csky/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/hppa/libc.abilist:GLIBC_2.2 cfgetispeed
./sysdeps/unix/sysv/linux/hppa/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/i386/libc.abilist:GLIBC_2.0 cfgetispeed
./sysdeps/unix/sysv/linux/i386/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/loongarch/lp64/libc.abilist:GLIBC_2.36 cfgetispeed
./sysdeps/unix/sysv/linux/loongarch/lp64/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/m68k/coldfire/libc.abilist:GLIBC_2.4 cfgetispeed
./sysdeps/unix/sysv/linux/m68k/coldfire/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/m68k/m680x0/libc.abilist:GLIBC_2.0 cfgetispeed
./sysdeps/unix/sysv/linux/m68k/m680x0/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/microblaze/be/libc.abilist:GLIBC_2.18 cfgetispeed
./sysdeps/unix/sysv/linux/microblaze/be/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/microblaze/le/libc.abilist:GLIBC_2.18 cfgetispeed
./sysdeps/unix/sysv/linux/microblaze/le/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/mips/mips32/fpu/libc.abilist:GLIBC_2.0 cfgetispeed
./sysdeps/unix/sysv/linux/mips/mips32/fpu/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/mips/mips32/nofpu/libc.abilist:GLIBC_2.0 cfgetispeed
./sysdeps/unix/sysv/linux/mips/mips32/nofpu/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/mips/mips64/n32/libc.abilist:GLIBC_2.0 cfgetispeed
./sysdeps/unix/sysv/linux/mips/mips64/n32/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/mips/mips64/n64/libc.abilist:GLIBC_2.0 cfgetispeed
./sysdeps/unix/sysv/linux/mips/mips64/n64/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/or1k/libc.abilist:GLIBC_2.35 cfgetispeed
./sysdeps/unix/sysv/linux/or1k/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/fpu/libc.abilist:GLIBC_2.0 cfgetispeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/fpu/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/nofpu/libc.abilist:GLIBC_2.0 cfgetispeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/nofpu/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/be/libc.abilist:GLIBC_2.3 cfgetispeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/be/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/le/libc.abilist:GLIBC_2.17 cfgetispeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/le/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/riscv/rv32/libc.abilist:GLIBC_2.33 cfgetispeed
./sysdeps/unix/sysv/linux/riscv/rv32/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/riscv/rv64/libc.abilist:GLIBC_2.27 cfgetispeed
./sysdeps/unix/sysv/linux/riscv/rv64/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/s390/s390-32/libc.abilist:GLIBC_2.0 cfgetispeed
./sysdeps/unix/sysv/linux/s390/s390-32/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/s390/s390-64/libc.abilist:GLIBC_2.2 cfgetispeed
./sysdeps/unix/sysv/linux/s390/s390-64/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/sh/be/libc.abilist:GLIBC_2.2 cfgetispeed
./sysdeps/unix/sysv/linux/sh/be/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/sh/le/libc.abilist:GLIBC_2.2 cfgetispeed
./sysdeps/unix/sysv/linux/sh/le/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/sparc/sparc32/libc.abilist:GLIBC_2.0 cfgetispeed
./sysdeps/unix/sysv/linux/sparc/sparc32/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/sparc/sparc64/libc.abilist:GLIBC_2.2 cfgetispeed
./sysdeps/unix/sysv/linux/sparc/sparc64/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/x86_64/64/libc.abilist:GLIBC_2.2.5 cfgetispeed
./sysdeps/unix/sysv/linux/x86_64/64/libc.abilist:GLIBC_2.42 cfgetispeed
./sysdeps/unix/sysv/linux/x86_64/x32/libc.abilist:GLIBC_2.16 cfgetispeed
./sysdeps/unix/sysv/linux/x86_64/x32/libc.abilist:GLIBC_2.42 cfgetispeed
```

</details>
<details>

<summary>cfgetospeed</summary>

```
./sysdeps/mach/hurd/i386/libc.abilist:GLIBC_2.2.6 cfgetospeed
./sysdeps/mach/hurd/x86_64/libc.abilist:GLIBC_2.38 cfgetospeed
./sysdeps/unix/sysv/linux/aarch64/libc.abilist:GLIBC_2.17 cfgetospeed
./sysdeps/unix/sysv/linux/aarch64/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/alpha/libc.abilist:GLIBC_2.0 cfgetospeed
./sysdeps/unix/sysv/linux/alpha/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/arc/libc.abilist:GLIBC_2.32 cfgetospeed
./sysdeps/unix/sysv/linux/arc/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/arm/be/libc.abilist:GLIBC_2.4 cfgetospeed
./sysdeps/unix/sysv/linux/arm/be/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/arm/le/libc.abilist:GLIBC_2.4 cfgetospeed
./sysdeps/unix/sysv/linux/arm/le/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/csky/libc.abilist:GLIBC_2.29 cfgetospeed
./sysdeps/unix/sysv/linux/csky/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/hppa/libc.abilist:GLIBC_2.2 cfgetospeed
./sysdeps/unix/sysv/linux/hppa/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/i386/libc.abilist:GLIBC_2.0 cfgetospeed
./sysdeps/unix/sysv/linux/i386/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/loongarch/lp64/libc.abilist:GLIBC_2.36 cfgetospeed
./sysdeps/unix/sysv/linux/loongarch/lp64/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/m68k/coldfire/libc.abilist:GLIBC_2.4 cfgetospeed
./sysdeps/unix/sysv/linux/m68k/coldfire/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/m68k/m680x0/libc.abilist:GLIBC_2.0 cfgetospeed
./sysdeps/unix/sysv/linux/m68k/m680x0/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/microblaze/be/libc.abilist:GLIBC_2.18 cfgetospeed
./sysdeps/unix/sysv/linux/microblaze/be/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/microblaze/le/libc.abilist:GLIBC_2.18 cfgetospeed
./sysdeps/unix/sysv/linux/microblaze/le/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/mips/mips32/fpu/libc.abilist:GLIBC_2.0 cfgetospeed
./sysdeps/unix/sysv/linux/mips/mips32/fpu/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/mips/mips32/nofpu/libc.abilist:GLIBC_2.0 cfgetospeed
./sysdeps/unix/sysv/linux/mips/mips32/nofpu/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/mips/mips64/n32/libc.abilist:GLIBC_2.0 cfgetospeed
./sysdeps/unix/sysv/linux/mips/mips64/n32/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/mips/mips64/n64/libc.abilist:GLIBC_2.0 cfgetospeed
./sysdeps/unix/sysv/linux/mips/mips64/n64/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/or1k/libc.abilist:GLIBC_2.35 cfgetospeed
./sysdeps/unix/sysv/linux/or1k/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/fpu/libc.abilist:GLIBC_2.0 cfgetospeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/fpu/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/nofpu/libc.abilist:GLIBC_2.0 cfgetospeed
./sysdeps/unix/sysv/linux/powerpc/powerpc32/nofpu/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/be/libc.abilist:GLIBC_2.3 cfgetospeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/be/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/le/libc.abilist:GLIBC_2.17 cfgetospeed
./sysdeps/unix/sysv/linux/powerpc/powerpc64/le/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/riscv/rv32/libc.abilist:GLIBC_2.33 cfgetospeed
./sysdeps/unix/sysv/linux/riscv/rv32/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/riscv/rv64/libc.abilist:GLIBC_2.27 cfgetospeed
./sysdeps/unix/sysv/linux/riscv/rv64/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/s390/s390-32/libc.abilist:GLIBC_2.0 cfgetospeed
./sysdeps/unix/sysv/linux/s390/s390-32/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/s390/s390-64/libc.abilist:GLIBC_2.2 cfgetospeed
./sysdeps/unix/sysv/linux/s390/s390-64/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/sh/be/libc.abilist:GLIBC_2.2 cfgetospeed
./sysdeps/unix/sysv/linux/sh/be/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/sh/le/libc.abilist:GLIBC_2.2 cfgetospeed
./sysdeps/unix/sysv/linux/sh/le/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/sparc/sparc32/libc.abilist:GLIBC_2.0 cfgetospeed
./sysdeps/unix/sysv/linux/sparc/sparc32/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/sparc/sparc64/libc.abilist:GLIBC_2.2 cfgetospeed
./sysdeps/unix/sysv/linux/sparc/sparc64/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/x86_64/64/libc.abilist:GLIBC_2.2.5 cfgetospeed
./sysdeps/unix/sysv/linux/x86_64/64/libc.abilist:GLIBC_2.42 cfgetospeed
./sysdeps/unix/sysv/linux/x86_64/x32/libc.abilist:GLIBC_2.16 cfgetospeed
./sysdeps/unix/sysv/linux/x86_64/x32/libc.abilist:GLIBC_2.42 cfgetospeed
```

</details>

@rustbot label stable-nominated