### PR TITLE
netbsd/riscv64.rs: make changes so that this builds again.

### DIFF
--- a/src/unix/bsd/netbsdlike/netbsd/riscv64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/riscv64.rs
@@ -2,17 +2,9 @@ use crate::prelude::*;
 use crate::PT_FIRSTMACH;
 
 pub type __greg_t = u64;
-pub type __cpu_simple_lock_nv_t = c_int;
-pub type __gregset = [__greg_t; _NGREG];
-pub type __fregset = [__fpreg; _NFREG];
-
-s! {
-    pub struct mcontext_t {
-        pub __gregs: __gregset,
-        pub __fregs: __fregset,
-        __spare: [crate::__greg_t; 7],
-    }
-}
+pub type __cpu_simple_lock_nv_t = c_uint;
+pub type __gregset_t = [__greg_t; _NGREG];
+pub type __fregset_t = [__fpreg; _NFREG];
 
 s_no_extra_traits! {
     pub union __fpreg {
@@ -21,23 +13,36 @@ s_no_extra_traits! {
     }
 }
 
+s! {
+    pub struct mcontext_t {
+        pub __gregs: __gregset_t,
+        pub __fregs: __fregset_t,
+        __spare: [crate::__greg_t; 7],
+    }
+}
+
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
         impl PartialEq for __fpreg {
-            fn eq(&self, other: &Self) -> bool {
-                unsafe { self.u_u64 == other.u_u64 }
+            fn eq(&self, other: &__fpreg) -> bool {
+                unsafe { self.u_u64 == other.u_u64 || self.u_d == other.u_d }
             }
         }
         impl Eq for __fpreg {}
         impl hash::Hash for __fpreg {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
-                unsafe { self.u_u64.hash(state) };
+                unsafe {
+                    self.u_u64.hash(state);
+                }
             }
         }
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
+// gcc for riscv64 defines `BIGGEST_ALIGNMENT`, but it's mesured in bits.
+pub(crate) const __BIGGEST_ALIGNMENT_IN_BITS__: usize = 128;
+// `_ALIGNBYTES` is measured in, well, bytes.
+pub(crate) const _ALIGNBYTES: usize = (__BIGGEST_ALIGNMENT_IN_BITS__ / 8) - 1;
 
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 0;
 pub const PT_SETREGS: c_int = PT_FIRSTMACH + 1;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

These are changes which appear to be required to get this file to build (and cross-build) again.
Admittedly, some of the additions are based on error messages emitted by the rustc compiler.

# Sources

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
