### PR TITLE
getitimer and setitimer for linux

### DIFF
--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1930,6 +1930,17 @@ extern "C" {
     #[cfg(not(target_os = "l4re"))]
     pub fn clock_getcpuclockid(pid: crate::pid_t, clk_id: *mut crate::clockid_t) -> c_int;
 
+    #[cfg_attr(gnu_time_bits64, link_name = "__getitimer64")]
+    #[cfg_attr(musl32_time64, link_name = "__getitimer_time64")]
+    pub fn getitimer(which: c_int, curr_value: *mut crate::itimerval) -> c_int;
+    #[cfg_attr(gnu_time_bits64, link_name = "__setitimer64")]
+    #[cfg_attr(musl32_time64, link_name = "__setitimer_time64")]
+    pub fn setitimer(
+        which: c_int,
+        new_value: *const crate::itimerval,
+        old_value: *mut crate::itimerval,
+    ) -> c_int;
+
     pub fn dirfd(dirp: *mut crate::DIR) -> c_int;
 
     pub fn memalign(align: size_t, size: size_t) -> *mut c_void;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

fix rust-lang/libc#1347

<!-- Add a short description about what this change does -->

# Sources
- https://github.com/bminor/glibc/blob/ae612c45efb5e34713859a5facf92368307efb6e/time/sys/time.h#L147-L157
- https://github.com/bminor/musl/blob/79bdacff83a6bd5b70ff5ae5eb8b6de82c2f7c30/include/sys/time.h#L22-L23


<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
  - No update. already included
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
