### PR TITLE
NetBSD if_msghdr fix for ilp32 hosts

### DIFF
--- a/src/new/netbsd/net/if_.rs
+++ b/src/new/netbsd/net/if_.rs
@@ -50,6 +50,7 @@ pub const IFF_LINK2: c_int = 0x4000; // per link layer defined bit
 pub const IFF_MULTICAST: c_int = 0x8000; // supports multicast
 
 s! {
+    #[repr(C, align(8))]
     pub struct if_msghdr {
         pub ifm_msglen: c_ushort,
         pub ifm_version: c_uchar,


### PR DESCRIPTION
# Description

This fixes the following errors from `cd libc-test; cargo test`:

```
    bad `if_msghdr` size: rust: 148 != c 152
    bad `if_msghdr` align: rust: 4 != c 8
and
    size of `struct if_msghdr` is 152 in C and 148 in Rust
```

as verified natively on NetBSD/i386 10.0 with rust 1.92.0.

# Sources

* https://nxr.netbsd.org/xref/src/sys/net/if.h#790 for the original C definition of `struct if_msghdr`.

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
