### PR TITLE
netbsd/mod.rs: fix so that self-tests pass on both ilp32 and lp64.

### DIFF
--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -79,6 +79,7 @@ impl siginfo_t {
             _si_signo: c_int,
             _si_errno: c_int,
             _si_code: c_int,
+            #[cfg(target_pointer_width = "64")]
             __pad1: Padding<c_int>,
             _pid: crate::pid_t,
         }
@@ -91,6 +92,7 @@ impl siginfo_t {
             _si_signo: c_int,
             _si_errno: c_int,
             _si_code: c_int,
+            #[cfg(target_pointer_width = "64")]
             __pad1: Padding<c_int>,
             _pid: crate::pid_t,
             _uid: crate::uid_t,
@@ -104,6 +106,7 @@ impl siginfo_t {
             _si_signo: c_int,
             _si_errno: c_int,
             _si_code: c_int,
+            #[cfg(target_pointer_width = "64")]
             __pad1: Padding<c_int>,
             _pid: crate::pid_t,
             _uid: crate::uid_t,
@@ -118,12 +121,10 @@ impl siginfo_t {
             _si_signo: c_int,
             _si_errno: c_int,
             _si_code: c_int,
+            #[cfg(target_pointer_width = "64")]
             __pad1: Padding<c_int>,
             _pid: crate::pid_t,
             _uid: crate::uid_t,
-            _value: crate::sigval,
-            _cpid: crate::pid_t,
-            _cuid: crate::uid_t,
             status: c_int,
         }
         (*(self as *const siginfo_t as *const siginfo_timer)).status
@@ -210,9 +211,13 @@ s! {
         pub si_signo: c_int,
         pub si_code: c_int,
         pub si_errno: c_int,
+        #[cfg(target_pointer_width = "64")]
         __pad1: Padding<c_int>,
         pub si_addr: *mut c_void,
+        #[cfg(target_pointer_width = "64")]
         __pad2: Padding<[u64; 13]>,
+        #[cfg(target_pointer_width = "32")]
+        __pad2: Padding<[u64; 14]>,
     }
 
     pub struct pthread_attr_t {


### PR DESCRIPTION
# Description

This is mostly related to siginfo_t.
An error in si_status() implementation was also fixed.

Tests for now verified to pass on `NetBSD/i386 10.0` with `rust 1.92.0`.

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Sources

* https://nxr.netbsd.org/xref/src/sys/sys/siginfo.h#50 for `ksiginfo_t`, and `siginfo_t` is defined in terms of it.
* https://nxr.netbsd.org/xref/src/sys/sys/siginfo.h#161 for `si_status()` macro.

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
