### PR TITLE
Consolidate CMSG_* implementations

### DIFF
--- a/libc-test/tests/cmsg.rs
+++ b/libc-test/tests/cmsg.rs
@@ -3,11 +3,9 @@
 
 #[cfg(unix)]
 mod t {
-
     use std::mem;
 
     use libc::{
-        self,
         c_uchar,
         c_uint,
         c_void,
@@ -50,9 +48,7 @@ mod t {
     #[test]
     fn test_cmsg_len() {
         for l in 0..128 {
-            unsafe {
-                assert_eq!(libc::CMSG_LEN(l) as usize, cmsg_len(l));
-            }
+            assert_eq!(libc::CMSG_LEN(l) as usize, unsafe { cmsg_len(l) });
         }
     }
 
@@ -108,10 +104,8 @@ mod t {
 
     #[test]
     fn test_cmsg_space() {
-        unsafe {
-            for l in 0..128 {
-                assert_eq!(libc::CMSG_SPACE(l) as usize, cmsg_space(l));
-            }
+        for l in 0..128 {
+            assert_eq!(libc::CMSG_SPACE(l) as usize, unsafe { cmsg_space(l) });
         }
     }
 }

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -3000,6 +3000,8 @@ pub const O_NOFOLLOW: c_int = 0x00000080;
 pub const HUGETLB_FLAG_ENCODE_SHIFT: u32 = 26;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 
+// END_PUB_CONST
+
 // intentionally not public, only used for fd_set
 cfg_if! {
     if #[cfg(target_pointer_width = "32")] {
@@ -3010,8 +3012,6 @@ cfg_if! {
         // Unknown target_pointer_width
     }
 }
-
-// END_PUB_CONST
 
 f! {
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
@@ -3068,40 +3068,6 @@ f! {
 
     pub fn CPU_EQUAL(set1: &cpu_set_t, set2: &cpu_set_t) -> bool {
         set1.bits == set2.bits
-    }
-
-    pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        cmsg.offset(1) as *mut c_uchar
-    }
-
-    pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        if ((*cmsg).cmsg_len as size_t) < size_of::<cmsghdr>() {
-            core::ptr::null_mut::<cmsghdr>()
-        } else if __CMSG_NEXT(cmsg).add(size_of::<cmsghdr>()) >= __MHDR_END(mhdr) {
-            core::ptr::null_mut::<cmsghdr>()
-        } else {
-            __CMSG_NEXT(cmsg).cast()
-        }
-    }
-
-    pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as size_t >= size_of::<cmsghdr>() {
-            (*mhdr).msg_control.cast()
-        } else {
-            core::ptr::null_mut::<cmsghdr>()
-        }
-    }
-
-    pub const fn CMSG_ALIGN(len: size_t) -> size_t {
-        (len + size_of::<size_t>() - 1) & !(size_of::<size_t>() - 1)
-    }
-
-    pub const fn CMSG_SPACE(len: c_uint) -> c_uint {
-        (CMSG_ALIGN(len as size_t) + CMSG_ALIGN(size_of::<cmsghdr>())) as c_uint
-    }
-
-    pub const fn CMSG_LEN(len: c_uint) -> c_uint {
-        (CMSG_ALIGN(size_of::<cmsghdr>()) + len as size_t) as c_uint
     }
 }
 
@@ -3166,19 +3132,6 @@ safe_f! {
         minor |= (dev & 0x00000ffffff00000) >> 12;
         minor as c_uint
     }
-}
-
-fn __CMSG_LEN(cmsg: *const cmsghdr) -> ssize_t {
-    ((unsafe { (*cmsg).cmsg_len as size_t } + size_of::<c_long>() - 1) & !(size_of::<c_long>() - 1))
-        as ssize_t
-}
-
-fn __CMSG_NEXT(cmsg: *const cmsghdr) -> *mut c_uchar {
-    (unsafe { cmsg.offset(__CMSG_LEN(cmsg)) }) as *mut c_uchar
-}
-
-fn __MHDR_END(mhdr: *const msghdr) -> *mut c_uchar {
-    unsafe { (*mhdr).msg_control.offset((*mhdr).msg_controllen as isize) }.cast()
 }
 
 // EXTERN_FN

--- a/src/new/aix/mod.rs
+++ b/src/new/aix/mod.rs
@@ -3,4 +3,5 @@
 //! * Headers are not public
 //! * Manual pages: <https://www.ibm.com/docs/en/aix> (under "Technical reference" for that version)
 
+pub(crate) mod sys;
 pub(crate) mod unistd;

--- a/src/new/aix/sys/mod.rs
+++ b/src/new/aix/sys/mod.rs
@@ -1,0 +1,3 @@
+//! Directory: `sys/`
+
+pub(crate) mod socket;

--- a/src/new/aix/sys/socket.rs
+++ b/src/new/aix/sys/socket.rs
@@ -1,0 +1,9 @@
+//! Header: `sys/socket.h`
+
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_NXTHDR,
+    CMSG_SPACE,
+};

--- a/src/new/apple/libc/mod.rs
+++ b/src/new/apple/libc/mod.rs
@@ -1,0 +1,6 @@
+//! Entrypoint for Apple headers, usually found as part of the Xcode SDK.
+//!
+//! <https://github.com/apple-oss-distributions/Libc/tree/main/include>
+
+pub(crate) mod signal;
+pub(crate) mod unistd;

--- a/src/new/apple/mod.rs
+++ b/src/new/apple/mod.rs
@@ -3,18 +3,12 @@
 //! The Xcode SDK includes interfaces that are split across a couple of different libraries. Most
 //! of these are available at <https://github.com/apple-oss-distributions>.
 
-/// Entrypoint for Apple headers, usually found as part of the Xcode SDK.
-///
-/// <https://github.com/apple-oss-distributions/Libc/tree/main/include>
-mod libc {
-    pub(crate) mod signal;
-    pub(crate) mod unistd;
-}
+mod libc;
+pub(crate) use libc::*;
 
 mod libpthread;
-mod xnu;
-
-pub(crate) use libc::*;
 pub(crate) use libpthread::pthread_;
 pub(crate) use pthread_::pthread;
+
+mod xnu;
 pub(crate) use xnu::*;

--- a/src/new/apple/xnu/sys/mod.rs
+++ b/src/new/apple/xnu/sys/mod.rs
@@ -3,6 +3,7 @@
 //! <https://github.com/apple-oss-distributions/xnu/tree/main/bsd/sys>
 
 pub(crate) mod signal;
+pub(crate) mod socket;
 
 /// Directory: `sys/_types`
 ///

--- a/src/new/apple/xnu/sys/socket.rs
+++ b/src/new/apple/xnu/sys/socket.rs
@@ -1,0 +1,11 @@
+//! Header: `sys/socket.h`
+//!
+//! <https://github.com/apple-oss-distributions/xnu/blob/main/bsd/sys/socket.h>
+
+pub use crate::new::common::bsd::sys::socket::CMSG_NXTHDR;
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_SPACE,
+};

--- a/src/new/bionic_libc/sys/socket.rs
+++ b/src/new/bionic_libc/sys/socket.rs
@@ -1,4 +1,6 @@
 //! Header: `sys/socket.h`
+//!
+//! <https://android.googlesource.com/platform/bionic/+/refs/heads/main/libc/include/sys/socket.h>
 
 use crate::prelude::*;
 
@@ -25,6 +27,15 @@ s! {
         pub gid: crate::gid_t,
     }
 }
+
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_ALIGN,
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_NXTHDR,
+    CMSG_SPACE,
+};
 
 extern "C" {
     pub fn recvmmsg(

--- a/src/new/common/bsd/mod.rs
+++ b/src/new/common/bsd/mod.rs
@@ -1,1 +1,3 @@
 //! Interfaces common across the BSD family.
+
+pub(crate) mod sys;

--- a/src/new/common/bsd/sys/mod.rs
+++ b/src/new/common/bsd/sys/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod socket;

--- a/src/new/common/bsd/sys/socket.rs
+++ b/src/new/common/bsd/sys/socket.rs
@@ -1,0 +1,11 @@
+#[cfg(not(target_os = "dragonfly"))]
+pub unsafe fn CMSG_NXTHDR(
+    mhdr: *const crate::msghdr,
+    cmsg: *const crate::cmsghdr,
+) -> *mut crate::cmsghdr {
+    if cmsg.is_null() {
+        return crate::CMSG_FIRSTHDR(mhdr);
+    }
+
+    crate::new::common::posix::sys::socket::CMSG_NXTHDR(mhdr, cmsg)
+}

--- a/src/new/common/posix/mod.rs
+++ b/src/new/common/posix/mod.rs
@@ -13,3 +13,5 @@
 ))]
 pub(crate) mod pthread;
 pub(crate) mod unistd;
+
+pub(crate) mod sys;

--- a/src/new/common/posix/sys/mod.rs
+++ b/src/new/common/posix/sys/mod.rs
@@ -1,0 +1,3 @@
+//! Directory: `sys/`
+
+pub(crate) mod socket;

--- a/src/new/common/posix/sys/socket.rs
+++ b/src/new/common/posix/sys/socket.rs
@@ -1,0 +1,300 @@
+//! Header: `sys/socket.h`
+//!
+//! <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/sys_socket.h.html>
+
+// TEMP: until allow(unsafe_op_in_unsafe_fn) is removed in global level.
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use core::mem::size_of;
+
+use crate::prelude::*;
+use crate::{
+    cmsghdr,
+    msghdr,
+};
+
+/// Rounds `len` *up* to the next alignment boundary.
+pub const fn CMSG_ALIGN(len: size_t) -> size_t {
+    align_impl(len, size_of::<__ALIGN_BOUNDARY>())
+}
+
+pub(crate) const fn align_impl(len: usize, align: usize) -> usize {
+    let mask = align - 1;
+    (len + mask) & !mask
+}
+
+// FIXME(#3240): consider changing signatures to `CMSG_{SPACE,LEN}(length: size_t) -> size_`
+
+/// Total length of a non-padded control message for a payload of size `length`.
+///
+/// This function is almost exclusively used setting [`cmsghdr::cmsg_len`].
+/// It should *not* be used for determining the actual ancillary data buffer
+/// size. [`CMSG_SPACE`] should instead be for that.
+#[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
+pub const fn CMSG_LEN(length: c_uint) -> c_uint {
+    let length = length as size_t;
+
+    // See `CMSG_SPACE` impl about this sometimes being a no-op.
+    let len = CMSG_ALIGN(size_of::<cmsghdr>()) + length;
+
+    len as c_uint
+}
+
+/// Total length of a padded control message for a payload of size `length`.
+///
+/// This can be used to allocate space dynamically for the ancillary data.
+/// It should should *not* be used to initialize [cmsghdr::cmsg_len], given
+/// that the returned value includes padding bytes. Use instead [`CMSG_LEN`]
+/// for that.
+pub const fn CMSG_SPACE(length: c_uint) -> c_uint {
+    let length = length as size_t;
+
+    // NB: left hand side `align` is no-op when `size_of::<cmsghdr>() %
+    // size_of::<__ALIGN_BOUNDARY>() == 0`. Such is the case on Linux, and
+    // probably why some implementations there don't bother with the lhs
+    // align.
+    let space = CMSG_ALIGN(size_of::<cmsghdr>()) + CMSG_ALIGN(length);
+
+    space as c_uint
+}
+
+/// Returns a pointer to the payload data array associated with for the provided header.
+///
+/// # Safety
+///
+/// Safety in calling this function are based on the safety conditions needed for calling `ptr.offset()`.
+///
+/// * `cmsg` must point to some allocation and the resulting offset may not wrap around an address space.
+//
+// TODO: From https://man7.org/linux/man-pages/man3/cmsg.3.html, include it for the rest?
+//
+// The pointer returned cannot be assumed to be suitably aligned for
+// accessing arbitrary payload data types. Applications should not cast it
+// to a pointer type matching the payload, but should instead use `memcpy`
+// to copy data to or from a suitably declared object.
+#[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
+pub const unsafe fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
+    let ptr = cmsg as *mut crate::c_uchar;
+    // See `CMSG_SPACE` impl about this sometimes being a no-op.
+    let byte_offset = CMSG_ALIGN(size_of::<cmsghdr>()) as isize;
+
+    // SAFETY:
+    // - Offset fits in isize (at most size_of::<u128>() = 16)
+    // - Caller must uphold the safety contract of non-wrapping offset
+    unsafe { ptr.offset(byte_offset) }
+}
+
+/// Return a pointer to the first [`cmsghdr`] in [`msghdr`].
+///
+/// A null pointer is returned if [`msghdr::msg_controllen`] is less than
+/// `size_of::<cmsghdr>()`. This can mean that there was no ancillary data
+/// in the first place (msg_controllen is zero), or that the ancillary data
+/// has been truncated.
+pub const unsafe fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
+    // IMPROVEMENT: take mhdr by ref and make CMSG_FIRSTHDR safe?
+    let msghdr = unsafe { *mhdr };
+
+    // Linux's syscall interface uses `size_t` for `msg_controllen` even if
+    // POSIX dictates it being `socklen_t` (>=u32). The cast accommodates
+    // for both, even if redundant for Linux.
+    #[allow(clippy::unnecessary_cast)]
+    let msg_controllen = msghdr.msg_controllen as size_t;
+
+    if msg_controllen < size_of::<cmsghdr>() {
+        core::ptr::null_mut()
+    } else {
+        msghdr.msg_control.cast()
+    }
+}
+
+/// # SAFETY
+///
+/// Safety in calling this function are based on the safety conditions needed for dereferencing `cmsg`:
+///
+/// * Caller must enure `cmsg` is not null.
+///
+/// * `cmsg` is returned from a previous call to `CMSG_NXTHDR`, or
+///   originally retrieved from a call to `CMSG_FIRSTHDR`.
+#[cfg(not(any(
+    target_env = "musl",
+    target_env = "ohos",
+    target_os = "emscripten",
+    target_os = "fuchsia"
+)))]
+pub unsafe fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
+    unsafe { next_impl(mhdr, cmsg, true) }
+}
+
+pub(crate) unsafe fn next_impl(
+    mhdr: *const msghdr,
+    cmsg: *const cmsghdr,
+    allow_zero_sized_payload: bool,
+) -> *mut cmsghdr {
+    // SAFETY:
+    // - Caller ensured pointer is not null.
+    // - Pointer retrieved from either CMSG_FIRSTHDR or CMSG_NXTDR,
+    //   thus ensuring that is lies between mhdr_addr and mhdr_addr +
+    //   msg_controllen.
+    let cmsg_len = unsafe { *cmsg }.cmsg_len;
+
+    if (cmsg_len as usize) < size_of::<cmsghdr>() {
+        return core::ptr::null_mut();
+    }
+
+    // FIXME(msrv): `.wrapping_byte_add()` stabilized in 1.75
+    let next_cmsg = cmsg
+        .cast::<u8>()
+        .wrapping_add(CMSG_ALIGN(cmsg_len as usize))
+        .cast::<cmsghdr>();
+
+    // In case the addition wrapped. `next_addr > max_addr`
+    // would otherwise not work as intended.
+    if (next_cmsg as usize) < (cmsg as usize) {
+        return core::ptr::null_mut();
+    }
+
+    let mut max_addr = {
+        // IMPROVEMENT: why not take mhdr by ref?
+        let msghdr = unsafe { *mhdr };
+        msghdr.msg_control as usize + msghdr.msg_controllen as usize
+    };
+
+    if !allow_zero_sized_payload {
+        // musl and some of its descendants do `>= max_addr`
+        // comparisons in the if statement below.
+        // https://www.openwall.com/lists/musl/2025/12/27/1
+        max_addr -= 1;
+    }
+
+    if next_cmsg as usize + CMSG_ALIGN(size_of::<cmsghdr>()) > max_addr {
+        core::ptr::null_mut()
+    } else {
+        next_cmsg as *mut cmsghdr
+    }
+}
+
+// HACK: AIX does not use any alignment/padding for ancillary data. Setting
+// this to 1 it makes possible to reuse the CMSG_* implementatinos as the extra
+// CMSG_ALIGN calls become no-op.
+#[cfg(target_os = "aix")]
+pub(crate) type __ALIGN_BOUNDARY = u8;
+
+#[cfg(target_os = "android")]
+pub(crate) type __ALIGN_BOUNDARY = usize;
+
+#[cfg(target_vendor = "apple")]
+pub(crate) type __ALIGN_BOUNDARY = u32;
+
+#[cfg(target_os = "hurd")]
+pub(crate) type __ALIGN_BOUNDARY = usize;
+
+#[cfg(target_os = "cygwin")]
+pub(crate) type __ALIGN_BOUNDARY = usize;
+
+#[cfg(target_os = "dragonfly")]
+pub(crate) type __ALIGN_BOUNDARY = c_long;
+
+#[cfg(target_os = "emscripten")]
+pub(crate) type __ALIGN_BOUNDARY = usize;
+
+#[cfg(target_os = "fuchsia")]
+pub(crate) type __ALIGN_BOUNDARY = c_long;
+
+#[cfg(target_os = "haiku")]
+pub(crate) type __ALIGN_BOUNDARY = usize;
+
+#[cfg(target_os = "l4re")]
+pub(crate) type __ALIGN_BOUNDARY = usize;
+
+#[cfg(target_os = "linux")]
+pub(crate) type __ALIGN_BOUNDARY = usize;
+
+#[cfg(target_os = "nto")]
+pub(crate) type __ALIGN_BOUNDARY = usize;
+
+#[cfg(target_os = "redox")]
+pub(crate) type __ALIGN_BOUNDARY = size_t;
+
+#[cfg(target_os = "vxworks")]
+pub(crate) type __ALIGN_BOUNDARY = usize;
+
+cfg_if! {
+    if #[cfg(any(target_os = "illumos", target_os = "solaris"))] {
+        #[cfg(target_arch = "sparc64")]
+        pub(crate) type __ALIGN_BOUNDARY = u64;
+        #[cfg(not(target_arch = "sparc64"))]
+        pub(crate) type __ALIGN_BOUNDARY = u32;
+    }
+}
+
+cfg_if! {
+    if #[cfg(target_os = "netbsd")] {
+        cfg_if! {
+            if #[cfg(target_arch = "x86")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_int;
+            } else if #[cfg(target_arch = "x86_64")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_long;
+            } else if #[cfg(target_arch = "aarch64")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_int;
+            } else if #[cfg(target_arch = "arm")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_longlong;
+            } else if #[cfg(target_arch = "mips")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_longlong;
+            } else if #[cfg(target_arch = "powerpc")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_double;
+            } else if #[cfg(target_arch = "riscv64")] {
+                pub(crate) type __ALIGN_BOUNDARY = u128;
+            } else if #[cfg(target_arch = "sparc64")] {
+                pub(crate) type __ALIGN_BOUNDARY = u128;
+            }
+        }
+    }
+}
+
+cfg_if! {
+    if #[cfg(target_os = "freebsd")] {
+        cfg_if! {
+            if #[cfg(target_arch = "x86")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_long;
+            } else if #[cfg(target_arch = "x86_64")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_long;
+            } else if #[cfg(target_arch = "aarch64")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_longlong;
+            } else if #[cfg(target_arch = "arm")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_int;
+            } else if #[cfg(target_arch = "powerpc")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_int;
+            } else if #[cfg(target_arch = "powerpc64")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_long;
+            } else if #[cfg(target_arch = "riscv64")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_longlong;
+            }
+        }
+    }
+}
+
+cfg_if! {
+    if #[cfg(target_os = "openbsd")] {
+        cfg_if! {
+            if #[cfg(target_arch = "x86")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_int;
+            } else if #[cfg(target_arch = "x86_64")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_long;
+            } else if #[cfg(target_arch = "aarch64")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_long;
+            } else if #[cfg(target_arch = "arm")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_double;
+            } else if #[cfg(target_arch = "mips64")] {
+                pub(crate) type __ALIGN_BOUNDARY = u64;
+            } else if #[cfg(target_arch = "powerpc")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_double;
+            } else if #[cfg(target_arch = "powerpc64")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_long;
+            } else if #[cfg(target_arch = "riscv64")] {
+                pub(crate) type __ALIGN_BOUNDARY = c_long;
+            } else if #[cfg(target_arch = "sparc64")] {
+                pub(crate) type __ALIGN_BOUNDARY = u128;
+            }
+        }
+    }
+}

--- a/src/new/common/solarish/mod.rs
+++ b/src/new/common/solarish/mod.rs
@@ -1,1 +1,3 @@
 //! Interfaces common in solaris-derived operating systems. This includes Solaris and Illumos.
+
+pub(crate) mod sys;

--- a/src/new/common/solarish/sys/mod.rs
+++ b/src/new/common/solarish/sys/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod socket;

--- a/src/new/common/solarish/sys/socket.rs
+++ b/src/new/common/solarish/sys/socket.rs
@@ -1,0 +1,25 @@
+use crate::prelude::*;
+use crate::{
+    cmsghdr,
+    msghdr,
+};
+
+const fn _CMSG_DATA_ALIGN(p: usize) -> usize {
+    crate::new::common::posix::sys::socket::align_impl(p, size_of::<c_int>())
+}
+
+pub const fn CMSG_LEN(length: c_uint) -> c_uint {
+    _CMSG_DATA_ALIGN(size_of::<cmsghdr>()) as c_uint + length
+}
+
+pub unsafe fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
+    _CMSG_DATA_ALIGN(cmsg.offset(1) as usize) as *mut c_uchar
+}
+
+pub unsafe fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
+    if cmsg.is_null() {
+        return crate::CMSG_FIRSTHDR(mhdr);
+    }
+
+    crate::new::common::posix::sys::socket::CMSG_NXTHDR(mhdr, cmsg)
+}

--- a/src/new/cygwin/mod.rs
+++ b/src/new/cygwin/mod.rs
@@ -2,4 +2,5 @@
 //!
 //! * Headers: <https://github.com/cygwin/cygwin/tree/main/winsup/cygwin/include>
 
+pub(crate) mod sys;
 pub(crate) mod unistd;

--- a/src/new/cygwin/sys/mod.rs
+++ b/src/new/cygwin/sys/mod.rs
@@ -1,0 +1,3 @@
+//! Directory: `sys/`
+
+pub(crate) mod socket;

--- a/src/new/cygwin/sys/socket.rs
+++ b/src/new/cygwin/sys/socket.rs
@@ -1,0 +1,12 @@
+//! Header: `sys/socket.h`
+//!
+//! <https://github.com/cygwin/cygwin/blob/main/winsup/cygwin/include/cygwin/socket.h>
+
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_ALIGN,
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_NXTHDR,
+    CMSG_SPACE,
+};

--- a/src/new/dragonfly/mod.rs
+++ b/src/new/dragonfly/mod.rs
@@ -3,4 +3,5 @@
 //! * Headers: <https://github.com/DragonFlyBSD/DragonFlyBSD>
 //! * Manual pages: <https://leaf.dragonflybsd.org/cgi/web-man>
 
+pub(crate) mod sys;
 pub(crate) mod unistd;

--- a/src/new/dragonfly/sys/mod.rs
+++ b/src/new/dragonfly/sys/mod.rs
@@ -1,0 +1,3 @@
+//! Directory: `sys/`
+
+pub(crate) mod socket;

--- a/src/new/dragonfly/sys/socket.rs
+++ b/src/new/dragonfly/sys/socket.rs
@@ -1,0 +1,11 @@
+//! Header: `sys/socket.h`
+//!
+//! <https://github.com/DragonFlyBSD/DragonFlyBSD/blob/master/sys/sys/socket.h>
+
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_NXTHDR,
+    CMSG_SPACE,
+};

--- a/src/new/emscripten/mod.rs
+++ b/src/new/emscripten/mod.rs
@@ -4,4 +4,5 @@
 
 pub(crate) mod pthread;
 pub(crate) mod sched;
+pub(crate) mod sys;
 pub(crate) mod unistd;

--- a/src/new/emscripten/sys/mod.rs
+++ b/src/new/emscripten/sys/mod.rs
@@ -1,0 +1,3 @@
+//! Directory: `sys/`
+
+pub(crate) mod socket;

--- a/src/new/emscripten/sys/socket.rs
+++ b/src/new/emscripten/sys/socket.rs
@@ -1,0 +1,18 @@
+//! Header: `sys/socket.h`
+//!
+//! <https://github.com/emscripten-core/emscripten/blob/main/system/lib/libc/musl/include/sys/socket.h>
+
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_ALIGN,
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_SPACE,
+};
+
+pub unsafe fn CMSG_NXTHDR(
+    mhdr: *const crate::msghdr,
+    cmsg: *const crate::cmsghdr,
+) -> *mut crate::cmsghdr {
+    crate::new::common::posix::sys::socket::next_impl(mhdr, cmsg, false)
+}

--- a/src/new/freebsd/mod.rs
+++ b/src/new/freebsd/mod.rs
@@ -3,4 +3,5 @@
 //! * Headers: <https://github.com/freebsd/freebsd-src/blob/main/sys/riscv/include/ucontext.h>
 //! * Symbol map: <https://github.com/freebsd/freebsd-src/blob/main/lib/libc/gen/Symbol.map>
 
+pub(crate) mod sys;
 pub(crate) mod unistd;

--- a/src/new/freebsd/sys/mod.rs
+++ b/src/new/freebsd/sys/mod.rs
@@ -1,0 +1,3 @@
+//! Directory: `sys/`
+
+pub(crate) mod socket;

--- a/src/new/freebsd/sys/socket.rs
+++ b/src/new/freebsd/sys/socket.rs
@@ -1,0 +1,11 @@
+//! Header: `sys/socket.h`
+//!
+//! <https://github.com/freebsd/freebsd-src/blob/main/sys/sys/socket.h>
+
+pub use crate::new::common::bsd::sys::socket::CMSG_NXTHDR;
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_SPACE,
+};

--- a/src/new/fuchsia/mod.rs
+++ b/src/new/fuchsia/mod.rs
@@ -1,4 +1,6 @@
-//! Fuschia libc.
-// FIXME(fuchsia): link to headers needed.
+//! Fuchsia libc.
+//!
+//! Header files: <https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/zircon/third_party/ulib/musl/include>
 
+pub(crate) mod sys;
 pub(crate) mod unistd;

--- a/src/new/fuchsia/sys/mod.rs
+++ b/src/new/fuchsia/sys/mod.rs
@@ -1,0 +1,3 @@
+//! Directory: `sys/`
+
+pub(crate) mod socket;

--- a/src/new/fuchsia/sys/socket.rs
+++ b/src/new/fuchsia/sys/socket.rs
@@ -1,0 +1,18 @@
+//! Header: `sys/socket.h`
+//!
+//! <https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/zircon/third_party/ulib/musl/include/sys/socket.h>
+
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_ALIGN,
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_SPACE,
+};
+
+pub unsafe fn CMSG_NXTHDR(
+    mhdr: *const crate::msghdr,
+    cmsg: *const crate::cmsghdr,
+) -> *mut crate::cmsghdr {
+    crate::new::common::posix::sys::socket::next_impl(mhdr, cmsg, false)
+}

--- a/src/new/glibc/sysdeps/unix/linux/mod.rs
+++ b/src/new/glibc/sysdeps/unix/linux/mod.rs
@@ -8,3 +8,5 @@
 pub(crate) mod net {
     pub(crate) mod route;
 }
+
+pub(crate) mod sys;

--- a/src/new/glibc/sysdeps/unix/linux/sys/mod.rs
+++ b/src/new/glibc/sysdeps/unix/linux/sys/mod.rs
@@ -1,0 +1,3 @@
+//! Directory: `sys/`
+
+pub(crate) mod socket;

--- a/src/new/glibc/sysdeps/unix/linux/sys/socket.rs
+++ b/src/new/glibc/sysdeps/unix/linux/sys/socket.rs
@@ -1,0 +1,12 @@
+//! Header: `sys/socket.h`
+//!
+//! <https://github.com/bminor/glibc/blob/master/sysdeps/unix/sysv/linux/bits/socket.h>
+
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_ALIGN,
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_NXTHDR,
+    CMSG_SPACE,
+};

--- a/src/new/haiku/mod.rs
+++ b/src/new/haiku/mod.rs
@@ -1,4 +1,6 @@
 //! Haiku OS libc.
-// FIXME(haiku): link to headers needed.
+//!
+//! <https://github.com/haiku/haiku/tree/master/headers/posix>
 
+pub(crate) mod sys;
 pub(crate) mod unistd;

--- a/src/new/haiku/sys/mod.rs
+++ b/src/new/haiku/sys/mod.rs
@@ -1,0 +1,3 @@
+//! Directory: `sys/`
+
+pub(crate) mod socket;

--- a/src/new/haiku/sys/socket.rs
+++ b/src/new/haiku/sys/socket.rs
@@ -1,0 +1,21 @@
+//! Header: `sys/socket.h`
+//!
+//! <https://github.com/haiku/haiku/blob/master/headers/posix/sys/socket.h>
+
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_SPACE,
+};
+
+pub unsafe fn CMSG_NXTHDR(
+    mhdr: *const crate::msghdr,
+    cmsg: *const crate::cmsghdr,
+) -> *mut crate::cmsghdr {
+    if cmsg.is_null() {
+        return CMSG_FIRSTHDR(mhdr);
+    }
+
+    crate::new::common::posix::sys::socket::CMSG_NXTHDR(mhdr, cmsg)
+}

--- a/src/new/hurd/mod.rs
+++ b/src/new/hurd/mod.rs
@@ -1,2 +1,5 @@
 //! GNU Hurd libc.
-// FIXME(hurd): link to headers needed.
+//!
+//! Header files: <https://github.com/bminor/glibc/tree/master/sysdeps/mach/hurd/bits>
+
+pub(crate) mod sys;

--- a/src/new/hurd/sys/mod.rs
+++ b/src/new/hurd/sys/mod.rs
@@ -1,0 +1,3 @@
+//! Directory: `sys/`
+
+pub(crate) mod socket;

--- a/src/new/hurd/sys/socket.rs
+++ b/src/new/hurd/sys/socket.rs
@@ -1,0 +1,12 @@
+//! Header: `sys/socket.h`
+//!
+//! <https://github.com/bminor/glibc/blob/master/sysdeps/mach/hurd/bits/socket.h>
+
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_ALIGN,
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_NXTHDR,
+    CMSG_SPACE,
+};

--- a/src/new/illumos/mod.rs
+++ b/src/new/illumos/mod.rs
@@ -1,4 +1,6 @@
 //! Illumos libc.
-// FIXME(illumos): link to headers needed.
+//!
+//! Header files: <https://github.com/illumos/illumos-gate/tree/master/usr/src/uts/common>
 
+pub(crate) mod sys;
 pub(crate) mod unistd;

--- a/src/new/illumos/sys/mod.rs
+++ b/src/new/illumos/sys/mod.rs
@@ -1,0 +1,3 @@
+//! Directory: `sys/`
+
+pub(crate) mod socket;

--- a/src/new/illumos/sys/socket.rs
+++ b/src/new/illumos/sys/socket.rs
@@ -1,0 +1,13 @@
+//! Header: `sys/socket.h`
+//!
+//! <https://github.com/illumos/illumos-gate/blob/master/usr/src/uts/common/sys/socket.h>
+
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_FIRSTHDR,
+    CMSG_SPACE,
+};
+pub use crate::new::common::solarish::sys::socket::{
+    CMSG_DATA,
+    CMSG_LEN,
+    CMSG_NXTHDR,
+};

--- a/src/new/l4re/mod.rs
+++ b/src/new/l4re/mod.rs
@@ -1,3 +1,5 @@
 //! L4re.
 //!
 //! * Headers: <https://github.com/kernkonzept/l4re-core/tree/master/libc/uclibc-ng>
+
+pub(crate) mod sys;

--- a/src/new/l4re/sys/mod.rs
+++ b/src/new/l4re/sys/mod.rs
@@ -1,0 +1,3 @@
+//! Directory: `sys/`
+
+pub(crate) mod socket;

--- a/src/new/l4re/sys/socket.rs
+++ b/src/new/l4re/sys/socket.rs
@@ -1,0 +1,12 @@
+//! Header: `sys/socket.h`
+//!
+//! <https://github.com/kernkonzept/l4re-core/blob/master/libc/uclibc-ng/contrib/uclibc/libc/sysdeps/linux/common/bits/socket.h>
+
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_ALIGN,
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_NXTHDR,
+    CMSG_SPACE,
+};

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -80,13 +80,13 @@ cfg_if! {
         // pub(crate) use horizon::*;
     } else if #[cfg(target_os = "hurd")] {
         mod hurd;
-        // pub(crate) use hurd::*;
+        pub(crate) use hurd::*;
     } else if #[cfg(target_os = "illumos")] {
         mod illumos;
         pub(crate) use illumos::*;
     } else if #[cfg(target_os = "l4re")] {
         mod l4re;
-        // pub(crate) use l4re::*;
+        pub(crate) use l4re::*;
     } else if #[cfg(target_os = "linux")] {
         mod linux_uapi;
         pub(crate) use linux_uapi::*;
@@ -107,7 +107,7 @@ cfg_if! {
         pub(crate) use qurt::*;
     } else if #[cfg(target_os = "redox")] {
         mod redox;
-        // pub(crate) use redox::*;
+        pub(crate) use redox::*;
     } else if #[cfg(target_os = "rtems")] {
         mod rtems;
         pub(crate) use rtems::*;
@@ -173,7 +173,35 @@ cfg_if! {
 
 // Per-OS headers we export
 cfg_if! {
-    if #[cfg(target_os = "android")] {
+    if #[cfg(target_os = "aix")] {
+        pub use sys::socket::*;
+    } else if #[cfg(target_os = "android")] {
+        pub use sys::socket::*;
+    } else if #[cfg(target_vendor = "apple")] {
+        pub use pthread::*;
+        pub use pthread_::introspection::*;
+        pub use pthread_::pthread_spis::*;
+        pub use pthread_::spawn::*;
+        pub use pthread_::stack_np::*;
+        pub use signal::*;
+        pub use sys::socket::*;
+    } else if #[cfg(target_os = "cygwin")] {
+        pub use sys::socket::*;
+    } else if #[cfg(target_os = "dragonfly")] {
+        pub use sys::socket::*;
+    } else if #[cfg(target_os = "emscripten")] {
+        pub use sys::socket::*;
+    } else if #[cfg(target_os = "freebsd")] {
+        pub use sys::socket::*;
+    } else if #[cfg(target_os = "fuchsia")] {
+        pub use sys::socket::*;
+    } else if #[cfg(target_os = "haiku")] {
+        pub use sys::socket::*;
+    } else if #[cfg(target_os = "hurd")] {
+        pub use sys::socket::*;
+    } else if #[cfg(target_os = "illumos")] {
+        pub use sys::socket::*;
+    } else if #[cfg(target_os = "l4re")] {
         pub use sys::socket::*;
     } else if #[cfg(target_os = "linux")] {
         pub use linux::can::bcm::*;
@@ -183,32 +211,38 @@ cfg_if! {
         pub use linux::keyctl::*;
         pub use linux::membarrier::*;
         pub use linux::netlink::*;
-        #[cfg(target_env = "gnu")]
-        pub use net::route::*;
-    } else if #[cfg(target_vendor = "apple")] {
-        pub use pthread::*;
-        pub use pthread_::introspection::*;
-        pub use pthread_::pthread_spis::*;
-        pub use pthread_::spawn::*;
-        pub use pthread_::stack_np::*;
-        pub use signal::*;
+
+        // per-linux-env headers
+        cfg_if! {
+            if #[cfg(any(target_env = "musl", target_env = "ohos"))] {
+                // ./musl
+                pub use sys::socket::*;
+            } else if #[cfg(target_env = "gnu")] {
+                // ./glibc/sysdeps/unix/linux
+                pub use net::route::*;
+                pub use sys::socket::*;
+            }
+        }
     } else if #[cfg(target_os = "netbsd")] {
         pub use net::if_::*;
         pub use sys::ipc::*;
+        pub use sys::socket::*;
         pub use sys::statvfs::*;
         pub use sys::time::*;
         pub use sys::timex::*;
         pub use sys::types::*;
         pub use utmp_::*;
         pub use utmpx_::*;
+    } else if #[cfg(target_os = "nto")] {
+        pub use sys::socket::*;
     } else if #[cfg(target_os = "openbsd")] {
         pub use sys::ipc::*;
-    }
-}
-
-// Per-env headers we export
-cfg_if! {
-    if #[cfg(any(target_env = "musl", target_env = "ohos"))] {
+        pub use sys::socket::*;
+    } else if #[cfg(target_os = "redox")] {
+        pub use sys::socket::*;
+    } else if #[cfg(target_os = "solaris")] {
+        pub use sys::socket::*;
+    } else if #[cfg(target_os = "vxworks")] {
         pub use sys::socket::*;
     }
 }

--- a/src/new/musl/sys/socket.rs
+++ b/src/new/musl/sys/socket.rs
@@ -34,6 +34,18 @@ s! {
     }
 }
 
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_ALIGN,
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_SPACE,
+};
+
+pub unsafe fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
+    crate::new::common::posix::sys::socket::next_impl(mhdr, cmsg, false)
+}
+
 extern "C" {
     pub fn sendmmsg(
         sockfd: c_int,

--- a/src/new/netbsd/sys/mod.rs
+++ b/src/new/netbsd/sys/mod.rs
@@ -3,6 +3,7 @@
 //! https://github.com/NetBSD/src/tree/trunk/sys/sys
 
 pub(crate) mod ipc;
+pub(crate) mod socket;
 pub(crate) mod statvfs;
 pub(crate) mod time;
 pub(crate) mod timex;

--- a/src/new/netbsd/sys/socket.rs
+++ b/src/new/netbsd/sys/socket.rs
@@ -1,0 +1,11 @@
+//! Header: `sys/socket.h`
+//!
+//! <https://github.com/NetBSD/src/blob/trunk/sys/sys/socket.h>
+
+pub use crate::new::common::bsd::sys::socket::CMSG_NXTHDR;
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_SPACE,
+};

--- a/src/new/nto/mod.rs
+++ b/src/new/nto/mod.rs
@@ -1,4 +1,6 @@
 //! QNX Neutrino libc.
-// FIXME(nto): link to manpages needed.
+//!
+//! Manual pages: <https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.lib_ref/topic/about.html>
 
+pub(crate) mod sys;
 pub(crate) mod unistd;

--- a/src/new/nto/sys/mod.rs
+++ b/src/new/nto/sys/mod.rs
@@ -1,0 +1,3 @@
+//! Directory: `sys/`
+
+pub(crate) mod socket;

--- a/src/new/nto/sys/socket.rs
+++ b/src/new/nto/sys/socket.rs
@@ -1,0 +1,11 @@
+//! Header: `sys/socket.h`
+//!
+//! Manual pages: <https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.io_sock/topic/socket_api.html#socket_api__socket_api>
+
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_NXTHDR,
+    CMSG_SPACE,
+};

--- a/src/new/openbsd/sys/mod.rs
+++ b/src/new/openbsd/sys/mod.rs
@@ -3,3 +3,4 @@
 //! https://github.com/openbsd/src/tree/trunk/sys/sys
 
 pub(crate) mod ipc;
+pub(crate) mod socket;

--- a/src/new/openbsd/sys/socket.rs
+++ b/src/new/openbsd/sys/socket.rs
@@ -1,0 +1,11 @@
+//! Header: `sys/socket.h`
+//!
+//! <https://github.com/openbsd/src/blob/master/sys/sys/socket.h>
+
+pub use crate::new::common::bsd::sys::socket::CMSG_NXTHDR;
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_SPACE,
+};

--- a/src/new/redox/mod.rs
+++ b/src/new/redox/mod.rs
@@ -1,3 +1,5 @@
 //! Redox libc.
 //!
 //! * Headers: <https://gitlab.redox-os.org/redox-os/relibc>
+
+pub(crate) mod sys;

--- a/src/new/redox/sys/mod.rs
+++ b/src/new/redox/sys/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod socket;

--- a/src/new/redox/sys/socket.rs
+++ b/src/new/redox/sys/socket.rs
@@ -1,0 +1,12 @@
+//! Header: `sys/socket.h`
+//!
+//! <https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/sys_socket/mod.rs>
+
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_ALIGN,
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_NXTHDR,
+    CMSG_SPACE,
+};

--- a/src/new/solaris/mod.rs
+++ b/src/new/solaris/mod.rs
@@ -2,4 +2,5 @@
 //!
 //! * Manual pages: <https://docs.oracle.com/cd/E36784_01/> (under "Reference Manuals")
 
+pub(crate) mod sys;
 pub(crate) mod unistd;

--- a/src/new/solaris/sys/mod.rs
+++ b/src/new/solaris/sys/mod.rs
@@ -1,0 +1,3 @@
+//! Directory: `sys/`
+
+pub(crate) mod socket;

--- a/src/new/solaris/sys/socket.rs
+++ b/src/new/solaris/sys/socket.rs
@@ -1,0 +1,11 @@
+//! Header: `sys/socket.h`
+
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_FIRSTHDR,
+    CMSG_SPACE,
+};
+pub use crate::new::common::solarish::sys::socket::{
+    CMSG_DATA,
+    CMSG_LEN,
+    CMSG_NXTHDR,
+};

--- a/src/new/vxworks/mod.rs
+++ b/src/new/vxworks/mod.rs
@@ -2,3 +2,5 @@
 // FIXME(vxworks): link to headers needed.
 
 pub(crate) mod unistd;
+
+pub(crate) mod sys;

--- a/src/new/vxworks/sys/mod.rs
+++ b/src/new/vxworks/sys/mod.rs
@@ -1,0 +1,3 @@
+//! Directory: `sys`
+
+pub(crate) mod socket;

--- a/src/new/vxworks/sys/socket.rs
+++ b/src/new/vxworks/sys/socket.rs
@@ -1,0 +1,10 @@
+//! Header: `sys/socket.h`
+
+pub use crate::new::common::posix::sys::socket::{
+    CMSG_ALIGN,
+    CMSG_DATA,
+    CMSG_FIRSTHDR,
+    CMSG_LEN,
+    CMSG_NXTHDR,
+    CMSG_SPACE,
+};

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -2420,41 +2420,6 @@ pub const DEAD_PROCESS: c_short = 8;
 pub const ACCOUNTING: c_short = 9;
 
 f! {
-    pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
-            (*mhdr).msg_control as *mut cmsghdr
-        } else {
-            core::ptr::null_mut::<cmsghdr>()
-        }
-    }
-
-    pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        if cmsg.is_null() {
-            CMSG_FIRSTHDR(mhdr)
-        } else {
-            if (cmsg as usize + (*cmsg).cmsg_len as usize + size_of::<cmsghdr>())
-                > ((*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize)
-            {
-                core::ptr::null_mut::<cmsghdr>()
-            } else {
-                // AIX does not have any alignment/padding for ancillary data, so we don't need _CMSG_ALIGN here.
-                (cmsg as usize + (*cmsg).cmsg_len as usize) as *mut cmsghdr
-            }
-        }
-    }
-
-    pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(size_of::<cmsghdr>() as isize)
-    }
-
-    pub const fn CMSG_LEN(length: c_uint) -> c_uint {
-        size_of::<cmsghdr>() as c_uint + length
-    }
-
-    pub const fn CMSG_SPACE(length: c_uint) -> c_uint {
-        size_of::<cmsghdr>() as c_uint + length
-    }
-
     pub fn FD_ZERO(set: *mut fd_set) -> () {
         for slot in (*set).fds_bits.iter_mut() {
             *slot = 0;

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -2,11 +2,8 @@
 //!
 //! This covers *-apple-* triples currently
 
+use crate::off_t;
 use crate::prelude::*;
-use crate::{
-    cmsghdr,
-    off_t,
-};
 
 pub type wchar_t = i32;
 pub type clock_t = c_ulong;
@@ -3965,11 +3962,6 @@ pub const VMADDR_CID_RESERVED: c_uint = 1;
 pub const VMADDR_CID_HOST: c_uint = 2;
 pub const VMADDR_PORT_ANY: c_uint = 0xFFFFFFFF;
 
-const fn __DARWIN_ALIGN32(p: usize) -> usize {
-    const __DARWIN_ALIGNBYTES32: usize = size_of::<u32>() - 1;
-    (p + __DARWIN_ALIGNBYTES32) & !__DARWIN_ALIGNBYTES32
-}
-
 pub const THREAD_EXTENDED_POLICY_COUNT: mach_msg_type_number_t =
     (size_of::<thread_extended_policy_data_t>() / size_of::<integer_t>()) as mach_msg_type_number_t;
 pub const THREAD_TIME_CONSTRAINT_POLICY_COUNT: mach_msg_type_number_t =
@@ -4033,32 +4025,6 @@ pub const DOT3COMPLIANCE_COLLS: c_int = 2;
 pub const MAX_KCTL_NAME: usize = 96;
 
 f! {
-    pub fn CMSG_NXTHDR(mhdr: *const crate::msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        if cmsg.is_null() {
-            return crate::CMSG_FIRSTHDR(mhdr);
-        }
-        let cmsg_len = (*cmsg).cmsg_len as usize;
-        let next = cmsg as usize + __DARWIN_ALIGN32(cmsg_len);
-        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
-        if next + __DARWIN_ALIGN32(size_of::<cmsghdr>()) > max {
-            core::ptr::null_mut()
-        } else {
-            next as *mut cmsghdr
-        }
-    }
-
-    pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).add(__DARWIN_ALIGN32(size_of::<cmsghdr>()))
-    }
-
-    pub const fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (__DARWIN_ALIGN32(size_of::<cmsghdr>()) + __DARWIN_ALIGN32(length as usize)) as c_uint
-    }
-
-    pub const fn CMSG_LEN(length: c_uint) -> c_uint {
-        (__DARWIN_ALIGN32(size_of::<cmsghdr>()) + length as usize) as c_uint
-    }
-
     pub const fn VM_MAKE_TAG(id: u8) -> u32 {
         (id as u32) << 24u32
     }

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1,8 +1,5 @@
+use crate::off_t;
 use crate::prelude::*;
-use crate::{
-    cmsghdr,
-    off_t,
-};
 
 pub type dev_t = u32;
 pub type wchar_t = i32;
@@ -1170,35 +1167,7 @@ pub const RTAX_MPLS2: c_int = 9;
 pub const RTAX_MPLS3: c_int = 10;
 pub const RTAX_MAX: c_int = 11;
 
-const fn _CMSG_ALIGN(n: usize) -> usize {
-    (n + (size_of::<c_long>() - 1)) & !(size_of::<c_long>() - 1)
-}
-
 f! {
-    pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(_CMSG_ALIGN(size_of::<cmsghdr>()) as isize)
-    }
-
-    pub const fn CMSG_LEN(length: c_uint) -> c_uint {
-        (_CMSG_ALIGN(size_of::<cmsghdr>()) + length as usize) as c_uint
-    }
-
-    pub fn CMSG_NXTHDR(mhdr: *const crate::msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        let next = cmsg as usize
-            + _CMSG_ALIGN((*cmsg).cmsg_len as usize)
-            + _CMSG_ALIGN(size_of::<cmsghdr>());
-        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
-        if next <= max {
-            (cmsg as usize + _CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr
-        } else {
-            core::ptr::null_mut::<cmsghdr>()
-        }
-    }
-
-    pub const fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (_CMSG_ALIGN(size_of::<cmsghdr>()) + _CMSG_ALIGN(length as usize)) as c_uint
-    }
-
     pub fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {
         for slot in cpuset.ary.iter_mut() {
             *slot = 0;

--- a/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/aarch64.rs
@@ -33,8 +33,6 @@ s! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_longlong>() - 1;
-
 pub const BIOCSRTIMEOUT: c_ulong = 0x8010426d;
 pub const BIOCGRTIMEOUT: c_ulong = 0x4010426e;
 pub const MAP_32BIT: c_int = 0x00080000;

--- a/src/unix/bsd/freebsdlike/freebsd/arm.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/arm.rs
@@ -17,8 +17,6 @@ s! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_int>() - 1;
-
 pub const BIOCSRTIMEOUT: c_ulong = 0x8010426d;
 pub const BIOCGRTIMEOUT: c_ulong = 0x4010426e;
 

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -1,8 +1,5 @@
+use crate::off_t;
 use crate::prelude::*;
-use crate::{
-    cmsghdr,
-    off_t,
-};
 
 pub type fflags_t = u32;
 
@@ -4178,36 +4175,7 @@ pub const fn MAP_ALIGNED(a: c_int) -> c_int {
     a << 24
 }
 
-const fn _ALIGN(p: usize) -> usize {
-    (p + _ALIGNBYTES) & !_ALIGNBYTES
-}
-
 f! {
-    pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).add(_ALIGN(size_of::<cmsghdr>()))
-    }
-
-    pub const fn CMSG_LEN(length: c_uint) -> c_uint {
-        _ALIGN(size_of::<cmsghdr>()) as c_uint + length
-    }
-
-    pub fn CMSG_NXTHDR(mhdr: *const crate::msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        if cmsg.is_null() {
-            return crate::CMSG_FIRSTHDR(mhdr);
-        }
-        let next = cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize) + _ALIGN(size_of::<cmsghdr>());
-        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
-        if next > max {
-            core::ptr::null_mut::<cmsghdr>()
-        } else {
-            (cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr
-        }
-    }
-
-    pub const fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (_ALIGN(size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
-    }
-
     pub fn MALLOCX_ALIGN(lg: c_uint) -> c_int {
         ffsl(lg as c_long - 1)
     }

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc.rs
@@ -21,8 +21,6 @@ s! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_int>() - 1;
-
 pub const BIOCSRTIMEOUT: c_ulong = 0x8010426d;
 pub const BIOCGRTIMEOUT: c_ulong = 0x4010426e;
 pub const MAP_32BIT: c_int = 0x00080000;

--- a/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/powerpc64.rs
@@ -21,8 +21,6 @@ s! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
-
 pub const BIOCSRTIMEOUT: c_ulong = 0x8010426d;
 pub const BIOCGRTIMEOUT: c_ulong = 0x4010426e;
 

--- a/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/riscv64.rs
@@ -35,8 +35,6 @@ s! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_longlong>() - 1;
-
 pub const BIOCSRTIMEOUT: c_ulong = 0x8010426d;
 pub const BIOCGRTIMEOUT: c_ulong = 0x4010426e;
 pub const MAP_32BIT: c_int = 0x00080000;

--- a/src/unix/bsd/freebsdlike/freebsd/x86.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86.rs
@@ -42,8 +42,6 @@ s! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
-
 pub const MINSIGSTKSZ: size_t = 2048; // 512 * 4
 
 pub const BIOCSRTIMEOUT: c_ulong = 0x8008426d;

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -164,8 +164,6 @@ cfg_if! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
-
 pub const BIOCSRTIMEOUT: c_ulong = 0x8010426d;
 pub const BIOCGRTIMEOUT: c_ulong = 0x4010426e;
 

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -507,14 +507,6 @@ pub const RTAX_AUTHOR: c_int = 6;
 pub const RTAX_BRD: c_int = 7;
 
 f! {
-    pub fn CMSG_FIRSTHDR(mhdr: *const crate::msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
-            (*mhdr).msg_control.cast::<cmsghdr>()
-        } else {
-            core::ptr::null_mut()
-        }
-    }
-
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let bits = size_of_val(&(*set).fds_bits[0]) * 8;
         let fd = fd as usize;

--- a/src/unix/bsd/netbsdlike/netbsd/aarch64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/aarch64.rs
@@ -65,8 +65,6 @@ cfg_if! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_int>() - 1;
-
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 0;
 pub const PT_SETREGS: c_int = PT_FIRSTMACH + 1;
 pub const PT_GETFPREGS: c_int = PT_FIRSTMACH + 2;

--- a/src/unix/bsd/netbsdlike/netbsd/arm.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/arm.rs
@@ -3,8 +3,6 @@ use crate::PT_FIRSTMACH;
 
 pub type __cpu_simple_lock_nv_t = c_int;
 
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_longlong>() - 1;
-
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 1;
 pub const PT_SETREGS: c_int = PT_FIRSTMACH + 2;
 pub const PT_GETFPREGS: c_int = PT_FIRSTMACH + 5;

--- a/src/unix/bsd/netbsdlike/netbsd/mips.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mips.rs
@@ -3,8 +3,6 @@ use crate::PT_FIRSTMACH;
 
 pub type __cpu_simple_lock_nv_t = c_int;
 
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_longlong>() - 1;
-
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 1;
 pub const PT_SETREGS: c_int = PT_FIRSTMACH + 2;
 pub const PT_GETFPREGS: c_int = PT_FIRSTMACH + 3;

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use crate::{
-    cmsghdr,
     cpuid_t,
     lwpid_t,
     off_t,
@@ -1759,36 +1758,7 @@ pub const TFD_NONBLOCK: i32 = crate::O_NONBLOCK;
 pub const TFD_TIMER_ABSTIME: i32 = crate::O_WRONLY;
 pub const TFD_TIMER_CANCEL_ON_SET: i32 = crate::O_RDWR;
 
-const fn _ALIGN(p: usize) -> usize {
-    (p + _ALIGNBYTES) & !_ALIGNBYTES
-}
-
 f! {
-    pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).add(_ALIGN(size_of::<cmsghdr>()))
-    }
-
-    pub const fn CMSG_LEN(length: c_uint) -> c_uint {
-        _ALIGN(size_of::<cmsghdr>()) as c_uint + length
-    }
-
-    pub fn CMSG_NXTHDR(mhdr: *const crate::msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        if cmsg.is_null() {
-            return crate::CMSG_FIRSTHDR(mhdr);
-        }
-        let next = cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize) + _ALIGN(size_of::<cmsghdr>());
-        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
-        if next > max {
-            core::ptr::null_mut::<cmsghdr>()
-        } else {
-            (cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr
-        }
-    }
-
-    pub const fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (_ALIGN(size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
-    }
-
     // dirfd() is a macro on netbsd to access
     // the first field of the struct where dirp points to:
     // http://cvsweb.netbsd.org/bsdweb.cgi/src/include/dirent.h?rev=1.36

--- a/src/unix/bsd/netbsdlike/netbsd/powerpc.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/powerpc.rs
@@ -3,8 +3,6 @@ use crate::PT_FIRSTMACH;
 
 pub type __cpu_simple_lock_nv_t = c_int;
 
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_double>() - 1;
-
 pub const PT_STEP: c_int = PT_FIRSTMACH + 0;
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 1;
 pub const PT_SETREGS: c_int = PT_FIRSTMACH + 2;

--- a/src/unix/bsd/netbsdlike/netbsd/riscv64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/riscv64.rs
@@ -39,11 +39,6 @@ cfg_if! {
     }
 }
 
-// gcc for riscv64 defines `BIGGEST_ALIGNMENT`, but it's mesured in bits.
-pub(crate) const __BIGGEST_ALIGNMENT_IN_BITS__: usize = 128;
-// `_ALIGNBYTES` is measured in, well, bytes.
-pub(crate) const _ALIGNBYTES: usize = (__BIGGEST_ALIGNMENT_IN_BITS__ / 8) - 1;
-
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 0;
 pub const PT_SETREGS: c_int = PT_FIRSTMACH + 1;
 pub const PT_GETFPREGS: c_int = PT_FIRSTMACH + 2;

--- a/src/unix/bsd/netbsdlike/netbsd/sparc64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/sparc64.rs
@@ -1,7 +1,3 @@
 use crate::prelude::*;
 
 pub type __cpu_simple_lock_nv_t = c_uchar;
-
-// should be pub(crate), but that requires Rust 1.18.0
-#[doc(hidden)]
-pub const _ALIGNBYTES: usize = 0xf;

--- a/src/unix/bsd/netbsdlike/netbsd/x86.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/x86.rs
@@ -1,5 +1,3 @@
 use crate::prelude::*;
 
 pub type __cpu_simple_lock_nv_t = c_uchar;
-
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_int>() - 1;

--- a/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/x86_64.rs
@@ -23,8 +23,6 @@ s! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
-
 pub const PT_STEP: c_int = PT_FIRSTMACH + 0;
 pub const PT_GETREGS: c_int = PT_FIRSTMACH + 1;
 pub const PT_SETREGS: c_int = PT_FIRSTMACH + 2;

--- a/src/unix/bsd/netbsdlike/openbsd/aarch64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/aarch64.rs
@@ -15,6 +15,4 @@ s! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
-
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/arm.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/arm.rs
@@ -1,5 +1,1 @@
-use crate::prelude::*;
-
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_double>() - 1;
-
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/mips64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mips64.rs
@@ -1,4 +1,1 @@
-#[doc(hidden)]
-pub const _ALIGNBYTES: usize = 7;
-
 pub const _MAX_PAGE_SHIFT: u32 = 14;

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1,9 +1,6 @@
+use crate::off_t;
 use crate::prelude::*;
 use crate::unix::bsd::O_SYNC;
-use crate::{
-    cmsghdr,
-    off_t,
-};
 
 pub type clock_t = i64;
 pub type suseconds_t = c_long;
@@ -1683,37 +1680,6 @@ pub const RTAX_DNS: c_int = 12;
 pub const RTAX_STATIC: c_int = 13;
 pub const RTAX_SEARCH: c_int = 14;
 pub const RTAX_MAX: c_int = 15;
-
-const fn _ALIGN(p: usize) -> usize {
-    (p + _ALIGNBYTES) & !_ALIGNBYTES
-}
-
-f! {
-    pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(_ALIGN(size_of::<cmsghdr>()) as isize)
-    }
-
-    pub const fn CMSG_LEN(length: c_uint) -> c_uint {
-        _ALIGN(size_of::<cmsghdr>()) as c_uint + length
-    }
-
-    pub fn CMSG_NXTHDR(mhdr: *const crate::msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        if cmsg.is_null() {
-            return crate::CMSG_FIRSTHDR(mhdr);
-        }
-        let next = cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize) + _ALIGN(size_of::<cmsghdr>());
-        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
-        if next > max {
-            core::ptr::null_mut::<cmsghdr>()
-        } else {
-            (cmsg as usize + _ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr
-        }
-    }
-
-    pub const fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (_ALIGN(size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
-    }
-}
 
 safe_f! {
     pub const fn WSTOPSIG(status: c_int) -> c_int {

--- a/src/unix/bsd/netbsdlike/openbsd/powerpc.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/powerpc.rs
@@ -1,5 +1,1 @@
-use crate::prelude::*;
-
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_double>() - 1;
-
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/powerpc64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/powerpc64.rs
@@ -1,5 +1,1 @@
-use crate::prelude::*;
-
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
-
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/riscv64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/riscv64.rs
@@ -20,6 +20,4 @@ s! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
-
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/sparc64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/sparc64.rs
@@ -1,4 +1,1 @@
-#[doc(hidden)]
-pub const _ALIGNBYTES: usize = 0xf;
-
 pub const _MAX_PAGE_SHIFT: u32 = 13;

--- a/src/unix/bsd/netbsdlike/openbsd/x86.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/x86.rs
@@ -1,5 +1,1 @@
-use crate::prelude::*;
-
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_int>() - 1;
-
 pub const _MAX_PAGE_SHIFT: u32 = 12;

--- a/src/unix/bsd/netbsdlike/openbsd/x86_64.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/x86_64.rs
@@ -54,8 +54,6 @@ s! {
     }
 }
 
-pub(crate) const _ALIGNBYTES: usize = size_of::<c_long>() - 1;
-
 pub const _MAX_PAGE_SHIFT: u32 = 12;
 
 pub const PT_STEP: c_int = PT_FIRSTMACH + 0;

--- a/src/unix/cygwin/mod.rs
+++ b/src/unix/cygwin/mod.rs
@@ -1748,36 +1748,6 @@ f! {
     pub fn CPU_EQUAL(set1: &cpu_set_t, set2: &cpu_set_t) -> bool {
         set1.bits == set2.bits
     }
-
-    pub fn CMSG_LEN(length: c_uint) -> c_uint {
-        CMSG_ALIGN(size_of::<cmsghdr>()) as c_uint + length
-    }
-
-    pub const fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(size_of::<cmsghdr>())) as c_uint
-    }
-
-    pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
-            (*mhdr).msg_control.cast()
-        } else {
-            core::ptr::null_mut()
-        }
-    }
-
-    pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        let next = (cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr;
-        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
-        if next as usize + CMSG_ALIGN(size_of::<cmsghdr>()) as usize > max {
-            core::ptr::null_mut()
-        } else {
-            next
-        }
-    }
-
-    pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        cmsg.offset(1).cast_mut().cast()
-    }
 }
 
 safe_f! {
@@ -1826,10 +1796,6 @@ safe_f! {
     pub const fn WCOREDUMP(status: c_int) -> bool {
         WIFSIGNALED(status) && (status & 0x80) != 0
     }
-}
-
-const fn CMSG_ALIGN(len: usize) -> usize {
-    len + size_of::<usize>() - 1 & !(size_of::<usize>() - 1)
 }
 
 extern "C" {

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -1376,46 +1376,7 @@ pub const POSIX_SPAWN_SETSIGDEF: c_short = 0x10;
 pub const POSIX_SPAWN_SETSIGMASK: c_short = 0x20;
 pub const POSIX_SPAWN_SETSID: c_short = 0x40;
 
-const fn CMSG_ALIGN(len: usize) -> usize {
-    len + size_of::<usize>() - 1 & !(size_of::<usize>() - 1)
-}
-
 f! {
-    pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
-            (*mhdr).msg_control as *mut cmsghdr
-        } else {
-            core::ptr::null_mut::<cmsghdr>()
-        }
-    }
-
-    pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(CMSG_ALIGN(size_of::<cmsghdr>()) as isize)
-    }
-
-    pub const fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(size_of::<cmsghdr>())) as c_uint
-    }
-
-    pub const fn CMSG_LEN(length: c_uint) -> c_uint {
-        CMSG_ALIGN(size_of::<cmsghdr>()) as c_uint + length
-    }
-
-    pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        if cmsg.is_null() {
-            return crate::CMSG_FIRSTHDR(mhdr);
-        }
-        let next = cmsg as usize
-            + CMSG_ALIGN((*cmsg).cmsg_len as usize)
-            + CMSG_ALIGN(size_of::<cmsghdr>());
-        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
-        if next > max {
-            core::ptr::null_mut::<cmsghdr>()
-        } else {
-            (cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr
-        }
-    }
-
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
         let size = size_of_val(&(*set).fds_bits[0]) * 8;

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -3354,47 +3354,8 @@ pub const PTHREAD_STACK_MIN: size_t = 0;
 // Non-public helper constants
 const _UTSNAME_LENGTH: usize = 1024;
 
-const fn CMSG_ALIGN(len: usize) -> usize {
-    (len + size_of::<usize>() - 1) & !(size_of::<usize>() - 1)
-}
-
 // functions
 f! {
-    pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
-            (*mhdr).msg_control.cast::<cmsghdr>()
-        } else {
-            core::ptr::null_mut::<cmsghdr>()
-        }
-    }
-
-    pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(CMSG_ALIGN(size_of::<cmsghdr>()) as isize)
-    }
-
-    pub const fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(size_of::<cmsghdr>())) as c_uint
-    }
-
-    pub const fn CMSG_LEN(length: c_uint) -> c_uint {
-        CMSG_ALIGN(size_of::<cmsghdr>()) as c_uint + length
-    }
-
-    pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        if ((*cmsg).cmsg_len as usize) < size_of::<cmsghdr>() {
-            return core::ptr::null_mut::<cmsghdr>();
-        }
-        let next = (cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr;
-        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
-        if (next.offset(1)) as usize > max
-            || next as usize + CMSG_ALIGN((*next).cmsg_len as usize) > max
-        {
-            core::ptr::null_mut::<cmsghdr>()
-        } else {
-            next.cast::<cmsghdr>()
-        }
-    }
-
     pub fn CPU_ALLOC_SIZE(count: c_int) -> size_t {
         let _dummy: cpu_set_t = mem::zeroed();
         let size_in_bits = 8 * size_of_val(&_dummy.bits[0]);

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -1,10 +1,6 @@
 //! Android-specific definitions for linux-like values
 
 use crate::prelude::*;
-use crate::{
-    cmsghdr,
-    msghdr,
-};
 
 cfg_if! {
     if #[cfg(doc)] {
@@ -3269,16 +3265,6 @@ cfg_if! {
 }
 
 f! {
-    pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        let next = (cmsg as usize + super::CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr;
-        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
-        if (next.offset(1)) as usize > max {
-            core::ptr::null_mut::<cmsghdr>()
-        } else {
-            next as *mut cmsghdr
-        }
-    }
-
     pub fn CPU_ALLOC_SIZE(count: c_int) -> size_t {
         let _dummy: cpu_set_t = mem::zeroed();
         let size_in_bits = 8 * size_of_val(&_dummy.__bits[0]);

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1251,19 +1251,6 @@ pub const PRIO_USER: c_int = 2;
 pub const SOMAXCONN: c_int = 128;
 
 f! {
-    pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        if ((*cmsg).cmsg_len as usize) < size_of::<cmsghdr>() {
-            return core::ptr::null_mut::<cmsghdr>();
-        }
-        let next = (cmsg as usize + super::CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr;
-        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
-        if (next.offset(1)) as usize >= max {
-            core::ptr::null_mut::<cmsghdr>()
-        } else {
-            next as *mut cmsghdr
-        }
-    }
-
     pub fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {
         for slot in cpuset.bits.iter_mut() {
             *slot = 0;

--- a/src/unix/linux_like/linux_l4re_shared.rs
+++ b/src/unix/linux_like/linux_l4re_shared.rs
@@ -1480,42 +1480,6 @@ pub const NT_PRFPXREG: c_int = 20;
 pub const MS_NOUSER: c_ulong = 0xffffffff80000000;
 
 f! {
-    pub fn CMSG_NXTHDR(
-        mhdr: *const crate::msghdr,
-        cmsg: *const crate::cmsghdr,
-    ) -> *mut crate::cmsghdr {
-        if ((*cmsg).cmsg_len as usize) < size_of::<crate::cmsghdr>() {
-            return core::ptr::null_mut::<crate::cmsghdr>();
-        }
-
-        // FIXME(msrv): `.wrapping_byte_add()` stabilized in 1.75
-        let next_cmsg = cmsg
-            .cast::<u8>()
-            .wrapping_add(super::CMSG_ALIGN((*cmsg).cmsg_len as usize))
-            .cast::<crate::cmsghdr>();
-
-        // In case the addition wrapped. `next_addr > max_addr`
-        // would otherwise not work as intended.
-        if (next_cmsg as usize) < (cmsg as usize) {
-            return core::ptr::null_mut();
-        }
-
-        let mut max_addr = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
-
-        if cfg!(any(target_env = "musl", target_env = "ohos")) {
-            // musl and some of its descendants do `>= max_addr`
-            // comparisons in the if statement below.
-            // https://www.openwall.com/lists/musl/2025/12/27/1
-            max_addr -= 1;
-        }
-
-        if next_cmsg as usize + size_of::<crate::cmsghdr>() > max_addr {
-            core::ptr::null_mut::<crate::cmsghdr>()
-        } else {
-            next_cmsg as *mut crate::cmsghdr
-        }
-    }
-
     pub fn CPU_ALLOC_SIZE(count: c_int) -> size_t {
         let _dummy: cpu_set_t = mem::zeroed();
         let size_in_bits = 8 * size_of_val(&_dummy.bits[0]);

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1782,31 +1782,7 @@ cfg_if! {
     }
 }
 
-const fn CMSG_ALIGN(len: usize) -> usize {
-    (len + size_of::<usize>() - 1) & !(size_of::<usize>() - 1)
-}
-
 f! {
-    pub fn CMSG_FIRSTHDR(mhdr: *const crate::msghdr) -> *mut crate::cmsghdr {
-        if (*mhdr).msg_controllen as usize >= size_of::<crate::cmsghdr>() {
-            (*mhdr).msg_control.cast::<crate::cmsghdr>()
-        } else {
-            core::ptr::null_mut::<crate::cmsghdr>()
-        }
-    }
-
-    pub fn CMSG_DATA(cmsg: *const crate::cmsghdr) -> *mut c_uchar {
-        cmsg.offset(1) as *mut c_uchar
-    }
-
-    pub const fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(size_of::<crate::cmsghdr>())) as c_uint
-    }
-
-    pub const fn CMSG_LEN(length: c_uint) -> c_uint {
-        CMSG_ALIGN(size_of::<crate::cmsghdr>()) as c_uint + length
-    }
-
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
         let size = size_of_val(&(*set).fds_bits[0]) * 8;

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -1091,17 +1091,6 @@ pub const PRIO_PGRP: c_int = 1;
 pub const PRIO_USER: c_int = 2;
 
 f! {
-    //sys/socket.h
-    pub const fn CMSG_ALIGN(len: size_t) -> size_t {
-        (len + size_of::<size_t>() - 1) & !(size_of::<size_t>() - 1)
-    }
-    pub const fn CMSG_LEN(length: c_uint) -> c_uint {
-        (CMSG_ALIGN(size_of::<cmsghdr>()) + length as usize) as c_uint
-    }
-    pub const fn CMSG_SPACE(len: c_uint) -> c_uint {
-        (CMSG_ALIGN(len as size_t) + CMSG_ALIGN(size_of::<cmsghdr>())) as c_uint
-    }
-
     // wait.h
     pub fn FD_CLR(fd: c_int, set: *mut fd_set) -> () {
         let fd = fd as usize;
@@ -1331,10 +1320,6 @@ extern "C" {
     pub fn getrlimit(resource: c_int, rlim: *mut crate::rlimit) -> c_int;
     pub fn setrlimit(resource: c_int, rlim: *const crate::rlimit) -> c_int;
 
-    // sys/socket.h
-    pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar;
-    pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr;
-    pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr;
     pub fn bind(
         socket: c_int,
         address: *const crate::sockaddr,

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -1418,44 +1418,6 @@ extern_ty! {
     pub enum fpos_t {} // FIXME(vxworks): fill this out with a struct
 }
 
-f! {
-    pub const fn CMSG_ALIGN(len: usize) -> usize {
-        len + size_of::<usize>() - 1 & !(size_of::<usize>() - 1)
-    }
-
-    pub fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        let next = cmsg as usize
-            + CMSG_ALIGN((*cmsg).cmsg_len as usize)
-            + CMSG_ALIGN(size_of::<cmsghdr>());
-        let max = (*mhdr).msg_control as usize + (*mhdr).msg_controllen as usize;
-        if next <= max {
-            (cmsg as usize + CMSG_ALIGN((*cmsg).cmsg_len as usize)) as *mut cmsghdr
-        } else {
-            core::ptr::null_mut::<cmsghdr>()
-        }
-    }
-
-    pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
-        if (*mhdr).msg_controllen as usize > 0 {
-            (*mhdr).msg_control as *mut cmsghdr
-        } else {
-            core::ptr::null_mut::<cmsghdr>()
-        }
-    }
-
-    pub fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
-        (cmsg as *mut c_uchar).offset(CMSG_ALIGN(size_of::<cmsghdr>()) as isize)
-    }
-
-    pub const fn CMSG_SPACE(length: c_uint) -> c_uint {
-        (CMSG_ALIGN(length as usize) + CMSG_ALIGN(size_of::<cmsghdr>())) as c_uint
-    }
-
-    pub const fn CMSG_LEN(length: c_uint) -> c_uint {
-        CMSG_ALIGN(size_of::<cmsghdr>()) as c_uint + length
-    }
-}
-
 extern "C" {
     pub fn isalnum(c: c_int) -> c_int;
     pub fn isalpha(c: c_int) -> c_int;

--- a/tests/const_fn.rs
+++ b/tests/const_fn.rs
@@ -1,3 +1,3 @@
 #[cfg(target_os = "linux")]
-const _FOO: libc::c_uint = unsafe { libc::CMSG_SPACE(1) };
+const _FOO: libc::c_uint = libc::CMSG_SPACE(1);
 //^ if CMSG_SPACE is not const, this will fail to compile


### PR DESCRIPTION
~~Builds upon rust-lang/libc#4903~~Merged


The original intent was to simplify the reasoning for how they differ across platforms. It should as a consequence also make it easier to extend target support.

### Changes:

- CMSG_* functions which can be const are all marked const -- consistently [^*].
- Removes unsafe from `CMSG_ALIGN`, `CMSG_SPACE`, `CMSG_LEN`.

### Fixes:

- Custom CMSG_FIRSTHDR implementation for VxWorks had missed to check that `mhdr.msg_controllen >= size_of::<cmsghdr>()`, as per POSIX 1003.1-2024.

### Documents:

- Usage and safety requirements.
- Adds missing references to upstream headers.

### Breaking API change Suggestions

- Perhaps CMSG_FIRSTHDR can take mhdr by reference? First thing being done is otherwise a raw pointer deref under practically no safety guarantees. Doing so would also remove the need to mark it unsafe.

- Same reasoning can be applied to mhdr in CMSG_NXTHDR, difference being that the function must remain unsafe for dereferencing cmsg.

[^*]: Except `CMSG_DATA` on solarish. It does `align(cmsg_addr + size_of(cmsg))` rather than `cmsg_addr + align(size_of(cmsg>))`. The others can get away with not casting the cmsg pointer to usize by instead casting cmsg to a byte pointer and doing the addition using `byte_ptr.offset()`.