### PR TITLE
musl: Fix incorrect definitions of struct stat on some architectures

### DIFF
--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -27,12 +27,18 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl32_time64))]
-        pub st_atim: crate::timespec,
-        #[cfg(not(musl32_time64))]
-        pub st_mtim: crate::timespec,
-        #[cfg(not(musl32_time64))]
-        pub st_ctim: crate::timespec,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_atime: crate::time_t,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_atime_nsec: c_long,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_mtime: crate::time_t,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_mtime_nsec: c_long,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_ctime: crate::time_t,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_ctime_nsec: c_long,
 
         pub st_ino: crate::ino_t,
 

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -25,12 +25,18 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl32_time64))]
-        pub st_atim: crate::timespec,
-        #[cfg(not(musl32_time64))]
-        pub st_mtim: crate::timespec,
-        #[cfg(not(musl32_time64))]
-        pub st_ctim: crate::timespec,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_atime: crate::time_t,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_atime_nsec: c_long,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_mtime: crate::time_t,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_mtime_nsec: c_long,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_ctime: crate::time_t,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_ctime_nsec: c_long,
 
         pub st_blksize: crate::blksize_t,
         __st_padding3: Padding<c_long>,

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -37,12 +37,18 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl32_time64))]
-        pub st_atim: crate::timespec,
-        #[cfg(not(musl32_time64))]
-        pub st_mtim: crate::timespec,
-        #[cfg(not(musl32_time64))]
-        pub st_ctim: crate::timespec,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_atime: crate::time_t,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_atime_nsec: c_long,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_mtime: crate::time_t,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_mtime_nsec: c_long,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_ctime: crate::time_t,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_ctime_nsec: c_long,
 
         __unused: Padding<[c_long; 2]>,
 

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -27,12 +27,18 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl32_time64))]
-        pub st_atim: crate::timespec,
-        #[cfg(not(musl32_time64))]
-        pub st_mtim: crate::timespec,
-        #[cfg(not(musl32_time64))]
-        pub st_ctim: crate::timespec,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_atime: crate::time_t,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_atime_nsec: c_long,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_mtime: crate::time_t,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_mtime_nsec: c_long,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_ctime: crate::time_t,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_ctime_nsec: c_long,
 
         pub st_ino: crate::ino_t,
 


### PR DESCRIPTION
Fixes: rust-lang/libc#4913

# Description

This fixes the regression introduced in 793fa971aabfbadb1ef9564cdc9fcdc31f3ef636 and ensures the old struct stat definitions remain.

# Checklist

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated