### PR TITLE
AIX: Only test addresses that are multiples of the size of cmsghdr

### DIFF
--- a/libc-test/tests/cmsg.rs
+++ b/libc-test/tests/cmsg.rs
@@ -73,6 +73,14 @@ mod t {
             mhdr.msg_controllen = (160 - trunc) as _;
 
             for cmsg_payload_len in 0..64 {
+                // AIX does not apply any alignment or padding to ancillary
+                // data and CMSG_ALIGN() is a noop. So only test addresses
+                // that are multiples of the size of cmsghdr here.
+                if cfg!(target_os = "aix") && cmsg_payload_len % std::mem::size_of::<cmsghdr>() != 0
+                {
+                    continue;
+                }
+
                 let mut current_cmsghdr_ptr = pcmsghdr;
                 assert!(!current_cmsghdr_ptr.is_null());
                 let mut count = 0;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
AIX does not apply any alignment or padding to ancillary data, and `CMSG_ALIGN()` is a no-op. Therefore, we only test addresses that are multiples of the size of `cmsghdr` on AIX. The original condition for AIX was removed in https://github.com/rust-lang/libc/commit/f391df35f33a15ec71efc81d200d77fb30ef3bbe, which led to the test failure.
<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
