### PR TITLE
ci: Add rtems to basic tier 3 checks

### DIFF
--- a/ci/verify-build.py
+++ b/ci/verify-build.py
@@ -155,6 +155,7 @@ TARGETS = [
     Target("aarch64-unknown-openbsd", dist=False),
     Target("aarch64-wrs-vxworks", dist=False),
     Target("armebv7r-none-eabihf", dist=False),
+    Target("armv7-rtems-eabihf", dist=False),
     Target("armv7-wrs-vxworks-eabihf", dist=False),
     Target("armv7r-none-eabihf", dist=False),
     Target("armv7s-apple-ios", dist=False),

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -110,7 +110,7 @@ cfg_if! {
         // pub(crate) use redox::*;
     } else if #[cfg(target_os = "rtems")] {
         mod rtems;
-        pub(crate) use rtems::*;
+        // pub(crate) use rtems::*;
     } else if #[cfg(target_os = "solaris")] {
         mod solaris;
         pub(crate) use solaris::*;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

This PR adds rtems to the basic tier 3 target checks.

# Sources

N/A

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated --> N/A
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131)) --> N/A
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI --> does not compile, but same for other tier 3 targets

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
