### PR TITLE
Add a definition of max_align_t to nto

### DIFF
--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -795,6 +795,23 @@ s_no_extra_traits! {
         pub __owner: c_uint,
         pub __spare: c_uint,
     }
+
+    // There is no canonical definition of c_longdouble in Rust. For both AArch64 and x86_64,
+    // however, the size and alignment properties are that of the gcc __int128 which corresponds (at
+    // least on rustc 1.78+ with LLVM 18, see
+    // https://blog.rust-lang.org/2024/03/30/i128-layout-update/) to i128. Use this instead until we
+    // get native f128 support.
+    //
+    // The definition was taken from the definition of the _Maxalignt struct in the QNX SDK.
+    // However, on QNX7, there is a different definition of std::max_align_t (the C++ version of
+    // this type). In practice, this doesn't make a difference for the _alignment_ properties of the
+    // type - however, it changes the size, so using in in any other form than the zero-sized array
+    // form would be bogus and it would potentially change the size of the data type. On QNX8, this
+    // got fixed and both C and C++ are using the same definition.
+    pub struct max_align_t {
+        _ll: crate::c_longlong,
+        _ld: i128,
+    }
 }
 
 pub const _SYSNAME_SIZE: usize = 256 + 1;


### PR DESCRIPTION
The definition of this type is a bit tricky for nto for multiple reasons:
* The C definition is different from the C++ definition in some versions of the QNX SDK.
* It uses long double, which does not exist inside libc.
* The definition on C uses alignment modifiers per field, which aren't supported in Rust. However, since they just reuse the field type, they're actually redundant so that we can safely skip them.

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

The change adds a definition for max_align_t for QNX.

# Sources

Source of the QNX SDP is closed source and can only be accessed by owning a developer license.

Docs available at https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.lib_ref/topic/m/max_align_t.html.

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated (No updates needed as max_align_t isn't part of unix.txt)
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI (Test cannot be run for the target also on HEAD; code that uses max_align_t compiles and runs fine, though. Test for host platform runs fine, no surprises here.)

@rustbot label +stable-nominated
