### PR TITLE
linux: change PTRACE_*ET_SYSCALL_USER_DISPATCH_CONFIG type to c_uint

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4475,10 +4475,6 @@ fn test_linux(target: &str) {
             "SO_DEVMEM_LINEAR" | "SO_DEVMEM_DMABUF" | "SO_DEVMEM_DONTNEED"
             | "SCM_DEVMEM_LINEAR" | "SCM_DEVMEM_DMABUF" => true,
 
-            // FIXME(linux): Requires >= 6.4 kernel headers.
-            "PTRACE_SET_SYSCALL_USER_DISPATCH_CONFIG"
-            | "PTRACE_GET_SYSCALL_USER_DISPATCH_CONFIG" => true,
-
             // FIXME(linux): Requires >= 6.14 kernel headers.
             "SECBIT_EXEC_DENY_INTERACTIVE"
             | "SECBIT_EXEC_DENY_INTERACTIVE_LOCKED"

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -752,8 +752,8 @@ pub const PTRACE_SYSCALL_INFO_NONE: crate::__u8 = 0;
 pub const PTRACE_SYSCALL_INFO_ENTRY: crate::__u8 = 1;
 pub const PTRACE_SYSCALL_INFO_EXIT: crate::__u8 = 2;
 pub const PTRACE_SYSCALL_INFO_SECCOMP: crate::__u8 = 3;
-pub const PTRACE_SET_SYSCALL_USER_DISPATCH_CONFIG: crate::__u8 = 0x4210;
-pub const PTRACE_GET_SYSCALL_USER_DISPATCH_CONFIG: crate::__u8 = 0x4211;
+pub const PTRACE_SET_SYSCALL_USER_DISPATCH_CONFIG: c_uint = 0x4210;
+pub const PTRACE_GET_SYSCALL_USER_DISPATCH_CONFIG: c_uint = 0x4211;
 
 // linux/rtnetlink.h
 pub const TCA_PAD: c_ushort = 9;


### PR DESCRIPTION
# Description

fixes rust-lang/libc#4935 by changing PTRACE_GET_SYSCALL_USER_DISPATCH_CONFIG and PTRACE_SET_SYSCALL_USER_DISPATCH_CONFIG type to `c_uint`.

This is a breaking change.

# Sources

https://github.com/torvalds/linux/blob/a66191c590b3b58eaff05d2277971f854772bd5b/include/uapi/linux/ptrace.h#L118-L119

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
