### PR TITLE
musl: introduce musl_stat_timespec cfg for struct stat

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,6 +28,7 @@ const ALLOWED_CFGS: &[&str] = &[
     // Corresponds to `__USE_TIME_BITS64` in UAPI
     "linux_time_bits64",
     "musl_v1_2_3",
+    "musl_stat_timespec",
     // Corresponds to `_REDIR_TIME64` in musl
     "musl32_time64",
     "vxworks_lt_25_09",
@@ -53,6 +54,9 @@ const CHECK_CFG_EXTRA: &[(&str, &[&str])] = &[
 
 /// Musl architectures that set `#define _REDIR_TIME64 1`.
 const MUSL_REDIR_TIME64_ARCHES: &[&str] = &["arm", "mips", "powerpc", "x86"];
+
+/// Musl architectures that switched to out-of-line time fields in struct stat.
+const MUSL_STAT_TIMESPEC_ARCHES: &[&str] = &[];
 
 fn main() {
     // Avoid unnecessary re-building.
@@ -109,6 +113,10 @@ fn main() {
 
     // OpenHarmony uses a fork of the musl libc
     let musl = target_env == "musl" || target_env == "ohos";
+
+    if musl && (musl_v1_2_3 || MUSL_STAT_TIMESPEC_ARCHES.contains(&target_arch.as_str())) {
+        set_cfg("musl_stat_timespec");
+    }
 
     // loongarch64 and ohos only exist with recent musl
     if target_arch == "loongarch64" || target_env == "ohos" {

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -27,17 +27,17 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime_nsec: c_long,
 
         pub st_ino: crate::ino_t,

--- a/src/unix/linux_like/linux/musl/b32/hexagon.rs
+++ b/src/unix/linux_like/linux/musl/b32/hexagon.rs
@@ -18,24 +18,24 @@ s! {
         __st_blksize_padding: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_int; 2]>,

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -25,17 +25,17 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime_nsec: c_long,
 
         pub st_blksize: crate::blksize_t,

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -37,17 +37,17 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime_nsec: c_long,
 
         __unused: Padding<[c_long; 2]>,

--- a/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
@@ -22,24 +22,24 @@ s! {
         pub __pad2: c_int,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_int; 2usize]>,

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -27,17 +27,17 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime_nsec: c_long,
 
         pub st_ino: crate::ino_t,

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -24,24 +24,24 @@ s! {
         __pad1: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_uint; 2]>,

--- a/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
@@ -27,24 +27,24 @@ s! {
         __pad2: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_int; 2usize]>,

--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -23,24 +23,24 @@ s! {
         pub st_size: off_t,
         __pad3: Padding<c_int>,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_ctim: crate::timespec,
 
         pub st_blksize: crate::blksize_t,

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -34,24 +34,24 @@ s! {
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_long; 3]>,

--- a/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
@@ -27,24 +27,24 @@ s! {
         __pad2: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_int; 2usize]>,

--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -41,24 +41,24 @@ s! {
         pub st_rdev: crate::dev_t,
         pub st_size: off_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_ctim: crate::timespec,
 
         pub st_blksize: crate::blksize_t,

--- a/src/unix/linux_like/linux/musl/b64/wasm32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/wasm32/mod.rs
@@ -25,24 +25,24 @@ s! {
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_long; 3]>,

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -24,24 +24,24 @@ s! {
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_stat_timespec))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_stat_timespec)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_long; 3]>,


### PR DESCRIPTION
# Description

Some musl targets use out-of-line timespec fields in struct stat. This property is independent of the `musl_v1_2_3` switch.

Add a new `musl_stat_timespec` cfg and use it to control the presence of inline time fields in musl struct stat definitions, avoiding incorrect API assumptions based on musl version alone.

# Sources

- https://github.com/kraj/musl/tree/v1.2.5

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
