### PR TITLE
Add siginfo_t::si_status

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -770,10 +770,9 @@ impl siginfo_t {
         #[repr(C)]
         struct siginfo_proc {
             _si_signo: c_int,
-            _si_errno: c_int,
             _si_code: c_int,
-            #[cfg(target_pointer_width = "64")]
-            __pad1: Padding<c_int>,
+            _si_errno: c_int,
+            _pad: Padding<[c_int; SI_PAD]>,
             _pid: crate::pid_t,
             _uid: crate::uid_t,
             _utime: crate::clock_t,


### PR DESCRIPTION
# Description

Adds `siginfo_t::si_status`.

# Sources

Definition of `siginfo_t`: https://github.com/openbsd/src/blob/7a3d6f69f0a9b1766a54f549b550113ea4d460f1/sys/sys/siginfo.h#L133-L174

Accessing `si_status`: https://github.com/openbsd/src/blob/7a3d6f69f0a9b1766a54f549b550113ea4d460f1/sys/sys/siginfo.h#L179

# Checklist

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated