### PR TITLE
fix struct ptrace_thread_state on OpenBSD

### DIFF
--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -535,6 +535,7 @@ s! {
 
     pub struct ptrace_thread_state {
         pub pts_tid: crate::pid_t,
+        pub pts_name: [c_char; PT_PTS_NAMELEN as usize],
     }
 
     // search.h
@@ -1482,6 +1483,8 @@ pub const PT_GET_PROCESS_STATE: c_int = 14;
 pub const PT_GET_THREAD_FIRST: c_int = 15;
 pub const PT_GET_THREAD_NEXT: c_int = 16;
 pub const PT_FIRSTMACH: c_int = 32;
+
+pub const PT_PTS_NAMELEN: c_int = 32;
 
 pub const SOCK_CLOEXEC: c_int = 0x8000;
 pub const SOCK_NONBLOCK: c_int = 0x4000;


### PR DESCRIPTION
# Description

Fix the `struct ptrace_thread_state` definition for OpenBSD

# Sources

`struct ptrace_thread_state` definition: https://github.com/openbsd/src/blob/7a3d6f69f0a9b1766a54f549b550113ea4d460f1/sys/sys/ptrace.h#L87

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

unsure if could be considered as stable-nominated… feel free to remove the label.

@rustbot label +stable-nominated