### PR TITLE
fix(ci): update aports Git repo URL

### DIFF
--- a/ci/install-musl.sh
+++ b/ci/install-musl.sh
@@ -101,7 +101,7 @@ rm -rf "$musl"
 
 # Alpine follows stable kernel releases, 3.20 uses Linux 6.6 headers.
 alpine_version=3.20
-alpine_git=https://gitlab.alpinelinux.org/alpine/aports
+alpine_git=https://git.alpinelinux.org/aports
 
 # This routine piggybacks on: https://git.alpinelinux.org/aports/tree/main/linux-headers?h=3.20-stable
 git clone -n --depth=1 --filter=tree:0 -b "${alpine_version}-stable" "$alpine_git"


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

The aports repo now returns:

```
[54](https://github.com/rust-lang/libc/actions/runs/21417799907/job/61670614213?pr=4946#step:7:2455)
14.37 + git clone -n --depth=1 --filter=tree:0 -b 3.20-stable https://gitlab.alpinelinux.org/alpine/aports
14.37 Cloning into 'aports'...
14.70 fatal: unable to access 'https://gitlab.alpinelinux.org/alpine/aports/': The requested URL returned error: 418
```

418 is unclear but auth or something else might be involved here.
This replaces it with a mirror URL as it works fine fortunately.

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
