### PR TITLE
illumos: Add _CS_PATH constant

### DIFF
--- a/libc-test/semver/illumos.txt
+++ b/libc-test/semver/illumos.txt
@@ -19,6 +19,7 @@ TFD_CLOEXEC
 TFD_NONBLOCK
 TFD_TIMER_ABSTIME
 TFD_TIMER_CANCEL_ON_SET
+_CS_PATH
 posix_fadvise
 posix_fallocate
 posix_spawn_file_actions_addfchdir_np

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -154,6 +154,8 @@ pub const LOCK_UN: c_int = 8;
 
 pub const _PC_LAST: c_int = 101;
 
+pub const _CS_PATH: c_int = 65;
+
 pub const VSTATUS: usize = 16;
 pub const VERASE2: usize = 17;
 


### PR DESCRIPTION
# Description

Adds `_CS_PATH` constant to `unix/solarish/illumos.rs`. This constant is used with `confstr()` to get the systems default search `PATH` (needed for fish-shell/fish-shell#11099).

# Sources

* [illumos gate _CS_PATH](https://github.com/illumos/illumos-gate/blob/af641d205ecf080be0d900f89c4f3d2adb84f33f/usr/src/uts/common/sys/unistd.h#L50)

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally on x86_64-unknown-illumos (Helios).
   - Tests failed but not because of this change

<details>
  <summary>x86_64-unknown-illumos, Helios test result</summary>

```
~/l/libc-test (add-illumos-cs-path) [101]> cargo test
   Compiling proc-macro2 v1.0.103
   Compiling quote v1.0.41
   Compiling serde v1.0.219
   Compiling memchr v2.7.5
   Compiling winnow v0.7.11
   Compiling rustc-hash v2.1.1
   Compiling thiserror v2.0.17
   Compiling find-msvc-tools v0.1.4
   Compiling shlex v1.3.0
   Compiling ctest v0.5.0 (/home/liams/libc/ctest)
   Compiling regex-syntax v0.8.6
   Compiling itoa v1.0.15
   Compiling percent-encoding v2.3.1
   Compiling libc v1.0.0-alpha.2 (/home/liams/libc)
   Compiling unicode-width v0.2.1
   Compiling anstyle v1.0.11
   Compiling glob v0.3.3
   Compiling cfg-if v1.0.4
   Compiling cc v1.2.43
   Compiling annotate-snippets v0.11.5
   Compiling aho-corasick v1.1.3
   Compiling syn v2.0.108
   Compiling regex-automata v0.4.13
   Compiling basic-toml v0.1.10
   Compiling regex v1.12.2
   Compiling serde_derive v1.0.219
   Compiling thiserror-impl v2.0.17
   Compiling askama_parser v0.14.0
   Compiling askama_derive v0.14.0
   Compiling askama v0.14.0
   Compiling libc-test v0.1.0 (/home/liams/libc/libc-test)
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:8745:53: error: 'TFD_CLOEXEC' undeclared here (not in a function); did you mean 'EFD_CLOEXEC'?
warning: libc-test@0.1.0:  8745 | static int32_t ctest_const_TFD_CLOEXEC_val_static = TFD_CLOEXEC;
warning: libc-test@0.1.0:       |                                                     ^~~~~~~~~~~
warning: libc-test@0.1.0:       |                                                     EFD_CLOEXEC
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:8751:54: error: 'TFD_NONBLOCK' undeclared here (not in a function); did you mean 'EFD_NONBLOCK'?
warning: libc-test@0.1.0:  8751 | static int32_t ctest_const_TFD_NONBLOCK_val_static = TFD_NONBLOCK;
warning: libc-test@0.1.0:       |                                                      ^~~~~~~~~~~~
warning: libc-test@0.1.0:       |                                                      EFD_NONBLOCK
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:8757:59: error: 'TFD_TIMER_ABSTIME' undeclared here (not in a function); did you mean 'TIMER_ABSTIME'?
warning: libc-test@0.1.0:  8757 | static int32_t ctest_const_TFD_TIMER_ABSTIME_val_static = TFD_TIMER_ABSTIME;
warning: libc-test@0.1.0:       |                                                           ^~~~~~~~~~~~~~~~~
warning: libc-test@0.1.0:       |                                                           TIMER_ABSTIME
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:8763:65: error: 'TFD_TIMER_CANCEL_ON_SET' undeclared here (not in a function)
warning: libc-test@0.1.0:  8763 | static int32_t ctest_const_TFD_TIMER_CANCEL_ON_SET_val_static = TFD_TIMER_CANCEL_ON_SET;
warning: libc-test@0.1.0:       |                                                                 ^~~~~~~~~~~~~~~~~~~~~~~
warning: libc-test@0.1.0: In file included from /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:4:
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_offset_of__epoll_event__u64':
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:12986:12: error: 'struct epoll_event' has no member named 'u64'
warning: libc-test@0.1.0: 12986 |     return offsetof(struct epoll_event, u64);
warning: libc-test@0.1.0:       |            ^~~~~~~~
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_size_of__epoll_event__u64':
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:12990:43: error: 'struct epoll_event' has no member named 'u64'
warning: libc-test@0.1.0: 12990 |     return sizeof(((struct epoll_event){}).u64);
warning: libc-test@0.1.0:       |                                           ^
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_field_ptr__epoll_event__u64':
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:15475:14: error: 'struct epoll_event' has no member named 'u64'
warning: libc-test@0.1.0: 15475 |     return &b->u64;
warning: libc-test@0.1.0:       |              ^~
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_foreign_fn__timerfd_create':
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:21985:29: error: 'timerfd_create' undeclared (first use in this function); did you mean 'timer_create'?
warning: libc-test@0.1.0: 21985 |     return (ctest_void_func)timerfd_create;
warning: libc-test@0.1.0:       |                             ^~~~~~~~~~~~~~
warning: libc-test@0.1.0:       |                             timer_create
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:21985:29: note: each undeclared identifier is reported only once for each function it appears in
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_foreign_fn__timerfd_gettime':
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:21989:29: error: 'timerfd_gettime' undeclared (first use in this function); did you mean 'timer_gettime'?
warning: libc-test@0.1.0: 21989 |     return (ctest_void_func)timerfd_gettime;
warning: libc-test@0.1.0:       |                             ^~~~~~~~~~~~~~~
warning: libc-test@0.1.0:       |                             timer_gettime
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_foreign_fn__timerfd_settime':
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:21993:29: error: 'timerfd_settime' undeclared (first use in this function); did you mean 'timer_settime'?
warning: libc-test@0.1.0: 21993 |     return (ctest_void_func)timerfd_settime;
warning: libc-test@0.1.0:       |                             ^~~~~~~~~~~~~~~
warning: libc-test@0.1.0:       |                             timer_settime
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_offset_of__epoll_event__u64':
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:12987:1: error: control reaches end of non-void function [-Werror=return-type]
warning: libc-test@0.1.0: 12987 | }
warning: libc-test@0.1.0:       | ^
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_size_of__epoll_event__u64':
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:12991:1: error: control reaches end of non-void function [-Werror=return-type]
warning: libc-test@0.1.0: 12991 | }
warning: libc-test@0.1.0:       | ^
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_field_ptr__epoll_event__u64':
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:15476:1: error: control reaches end of non-void function [-Werror=return-type]
warning: libc-test@0.1.0: 15476 | }
warning: libc-test@0.1.0:       | ^
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_foreign_fn__timerfd_create':
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:21986:1: error: control reaches end of non-void function [-Werror=return-type]
warning: libc-test@0.1.0: 21986 | }
warning: libc-test@0.1.0:       | ^
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_foreign_fn__timerfd_gettime':
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:21990:1: error: control reaches end of non-void function [-Werror=return-type]
warning: libc-test@0.1.0: 21990 | }
warning: libc-test@0.1.0:       | ^
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_foreign_fn__timerfd_settime':
warning: libc-test@0.1.0: /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:21994:1: error: control reaches end of non-void function [-Werror=return-type]
warning: libc-test@0.1.0: 21994 | }
warning: libc-test@0.1.0:       | ^
warning: libc-test@0.1.0: At top level:
warning: libc-test@0.1.0: cc1: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics
warning: libc-test@0.1.0: cc1: all warnings being treated as errors
error: failed to run custom build command for `libc-test v0.1.0 (/home/liams/libc/libc-test)`

Caused by:
  process didn't exit successfully: `/home/liams/libc/target/debug/build/libc-test-b31fc51279f916ed/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-changed=build.rs
  OUT_DIR = Some(/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out)
  OPT_LEVEL = Some(0)
  TARGET = Some(x86_64-unknown-illumos)
  HOST = Some(x86_64-unknown-illumos)
  cargo:rerun-if-env-changed=CC_x86_64-unknown-illumos
  CC_x86_64-unknown-illumos = None
  cargo:rerun-if-env-changed=CC_x86_64_unknown_illumos
  CC_x86_64_unknown_illumos = None
  cargo:rerun-if-env-changed=HOST_CC
  HOST_CC = None
  cargo:rerun-if-env-changed=CC
  CC = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  RUSTC_WRAPPER = None
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some(true)
  CARGO_CFG_TARGET_FEATURE = Some(fxsr,sse,sse2)
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=HOST_CFLAGS
  HOST_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_illumos
  CFLAGS_x86_64_unknown_illumos = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-illumos
  CFLAGS_x86_64-unknown-illumos = None
  CARGO_ENCODED_RUSTFLAGS = Some()
  cargo:rerun-if-env-changed=AR_x86_64-unknown-illumos
  AR_x86_64-unknown-illumos = None
  cargo:rerun-if-env-changed=AR_x86_64_unknown_illumos
  AR_x86_64_unknown_illumos = None
  cargo:rerun-if-env-changed=HOST_AR
  HOST_AR = None
  cargo:rerun-if-env-changed=AR
  AR = None
  cargo:rerun-if-env-changed=ARFLAGS
  ARFLAGS = None
  cargo:rerun-if-env-changed=HOST_ARFLAGS
  HOST_ARFLAGS = None
  cargo:rerun-if-env-changed=ARFLAGS_x86_64_unknown_illumos
  ARFLAGS_x86_64_unknown_illumos = None
  cargo:rerun-if-env-changed=ARFLAGS_x86_64-unknown-illumos
  ARFLAGS_x86_64-unknown-illumos = None
  cargo:rustc-link-lib=static=cmsg
  cargo:rustc-link-search=native=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out
  OUT_DIR = Some(/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out)
  OPT_LEVEL = Some(0)
  TARGET = Some(x86_64-unknown-illumos)
  HOST = Some(x86_64-unknown-illumos)
  cargo:rerun-if-env-changed=CC_x86_64-unknown-illumos
  CC_x86_64-unknown-illumos = None
  cargo:rerun-if-env-changed=CC_x86_64_unknown_illumos
  CC_x86_64_unknown_illumos = None
  cargo:rerun-if-env-changed=HOST_CC
  HOST_CC = None
  cargo:rerun-if-env-changed=CC
  CC = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  RUSTC_WRAPPER = None
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some(true)
  CARGO_CFG_TARGET_FEATURE = Some(fxsr,sse,sse2)
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=HOST_CFLAGS
  HOST_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_illumos
  CFLAGS_x86_64_unknown_illumos = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-illumos
  CFLAGS_x86_64-unknown-illumos = None
  CARGO_ENCODED_RUSTFLAGS = Some()
  cargo:rerun-if-env-changed=AR_x86_64-unknown-illumos
  AR_x86_64-unknown-illumos = None
  cargo:rerun-if-env-changed=AR_x86_64_unknown_illumos
  AR_x86_64_unknown_illumos = None
  cargo:rerun-if-env-changed=HOST_AR
  HOST_AR = None
  cargo:rerun-if-env-changed=AR
  AR = None
  cargo:rerun-if-env-changed=ARFLAGS
  ARFLAGS = None
  cargo:rerun-if-env-changed=HOST_ARFLAGS
  HOST_ARFLAGS = None
  cargo:rerun-if-env-changed=ARFLAGS_x86_64_unknown_illumos
  ARFLAGS_x86_64_unknown_illumos = None
  cargo:rerun-if-env-changed=ARFLAGS_x86_64-unknown-illumos
  ARFLAGS_x86_64-unknown-illumos = None
  cargo:rustc-link-lib=static=sigrt
  cargo:rustc-link-search=native=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out
  TARGET = Some(x86_64-unknown-illumos)
  OPT_LEVEL = Some(0)
  cargo:rerun-if-env-changed=CC_x86_64-unknown-illumos
  CC_x86_64-unknown-illumos = None
  cargo:rerun-if-env-changed=CC_x86_64_unknown_illumos
  CC_x86_64_unknown_illumos = None
  cargo:rerun-if-env-changed=HOST_CC
  HOST_CC = None
  cargo:rerun-if-env-changed=CC
  CC = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  RUSTC_WRAPPER = None
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some(true)
  CARGO_CFG_TARGET_FEATURE = Some(fxsr,sse,sse2)
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=HOST_CFLAGS
  HOST_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_illumos
  CFLAGS_x86_64_unknown_illumos = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-illumos
  CFLAGS_x86_64-unknown-illumos = None
  CARGO_ENCODED_RUSTFLAGS = Some()
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:8745:53: error: 'TFD_CLOEXEC' undeclared here (not in a function); did you mean 'EFD_CLOEXEC'?
  cargo:warning= 8745 | static int32_t ctest_const_TFD_CLOEXEC_val_static = TFD_CLOEXEC;
  cargo:warning=      |                                                     ^~~~~~~~~~~
  cargo:warning=      |                                                     EFD_CLOEXEC
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:8751:54: error: 'TFD_NONBLOCK' undeclared here (not in a function); did you mean 'EFD_NONBLOCK'?
  cargo:warning= 8751 | static int32_t ctest_const_TFD_NONBLOCK_val_static = TFD_NONBLOCK;
  cargo:warning=      |                                                      ^~~~~~~~~~~~
  cargo:warning=      |                                                      EFD_NONBLOCK
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:8757:59: error: 'TFD_TIMER_ABSTIME' undeclared here (not in a function); did you mean 'TIMER_ABSTIME'?
  cargo:warning= 8757 | static int32_t ctest_const_TFD_TIMER_ABSTIME_val_static = TFD_TIMER_ABSTIME;
  cargo:warning=      |                                                           ^~~~~~~~~~~~~~~~~
  cargo:warning=      |                                                           TIMER_ABSTIME
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:8763:65: error: 'TFD_TIMER_CANCEL_ON_SET' undeclared here (not in a function)
  cargo:warning= 8763 | static int32_t ctest_const_TFD_TIMER_CANCEL_ON_SET_val_static = TFD_TIMER_CANCEL_ON_SET;
  cargo:warning=      |                                                                 ^~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=In file included from /home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:4:
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_offset_of__epoll_event__u64':
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:12986:12: error: 'struct epoll_event' has no member named 'u64'
  cargo:warning=12986 |     return offsetof(struct epoll_event, u64);
  cargo:warning=      |            ^~~~~~~~
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_size_of__epoll_event__u64':
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:12990:43: error: 'struct epoll_event' has no member named 'u64'
  cargo:warning=12990 |     return sizeof(((struct epoll_event){}).u64);
  cargo:warning=      |                                           ^
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_field_ptr__epoll_event__u64':
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:15475:14: error: 'struct epoll_event' has no member named 'u64'
  cargo:warning=15475 |     return &b->u64;
  cargo:warning=      |              ^~
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_foreign_fn__timerfd_create':
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:21985:29: error: 'timerfd_create' undeclared (first use in this function); did you mean 'timer_create'?
  cargo:warning=21985 |     return (ctest_void_func)timerfd_create;
  cargo:warning=      |                             ^~~~~~~~~~~~~~
  cargo:warning=      |                             timer_create
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:21985:29: note: each undeclared identifier is reported only once for each function it appears in
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_foreign_fn__timerfd_gettime':
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:21989:29: error: 'timerfd_gettime' undeclared (first use in this function); did you mean 'timer_gettime'?
  cargo:warning=21989 |     return (ctest_void_func)timerfd_gettime;
  cargo:warning=      |                             ^~~~~~~~~~~~~~~
  cargo:warning=      |                             timer_gettime
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_foreign_fn__timerfd_settime':
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:21993:29: error: 'timerfd_settime' undeclared (first use in this function); did you mean 'timer_settime'?
  cargo:warning=21993 |     return (ctest_void_func)timerfd_settime;
  cargo:warning=      |                             ^~~~~~~~~~~~~~~
  cargo:warning=      |                             timer_settime
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_offset_of__epoll_event__u64':
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:12987:1: error: control reaches end of non-void function [-Werror=return-type]
  cargo:warning=12987 | }
  cargo:warning=      | ^
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_size_of__epoll_event__u64':
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:12991:1: error: control reaches end of non-void function [-Werror=return-type]
  cargo:warning=12991 | }
  cargo:warning=      | ^
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_field_ptr__epoll_event__u64':
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:15476:1: error: control reaches end of non-void function [-Werror=return-type]
  cargo:warning=15476 | }
  cargo:warning=      | ^
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_foreign_fn__timerfd_create':
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:21986:1: error: control reaches end of non-void function [-Werror=return-type]
  cargo:warning=21986 | }
  cargo:warning=      | ^
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_foreign_fn__timerfd_gettime':
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:21990:1: error: control reaches end of non-void function [-Werror=return-type]
  cargo:warning=21990 | }
  cargo:warning=      | ^
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c: In function 'ctest_foreign_fn__timerfd_settime':
  cargo:warning=/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c:21994:1: error: control reaches end of non-void function [-Werror=return-type]
  cargo:warning=21994 | }
  cargo:warning=      | ^
  cargo:warning=At top level:
  cargo:warning=cc1: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics
  cargo:warning=cc1: all warnings being treated as errors

  --- stderr


  error occurred in cc-rs: command did not execute successfully (status code exit status: 1): LC_ALL="C" "gcc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "-m64" "-D_REENTRANT" "-Wall" "-Wextra" "-Wall" "-Wextra" "-Werror" "-Wno-unused-parameter" "-Wno-type-limits" "-Wno-address-of-packed-member" "-Wno-unknown-warning-option" "-Wno-deprecated-declarations" "-Wno-deprecated-declarations" "-D_XOPEN_SOURCE=700" "-D__EXTENSIONS__" "-D_LCONV_C99" "-o" "/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/0017dd8bd2828834-ctest_output.o" "-c" "/home/liams/libc/target/debug/build/libc-test-a406c4b7e58bf64c/out/ctest_output.c"
```

</details>

@rustbot label +stable-nominated