### PR TITLE
OpenBSD: add `ppoll`

### DIFF
--- a/libc-test/semver/openbsd.txt
+++ b/libc-test/semver/openbsd.txt
@@ -1248,6 +1248,7 @@ posix_spawnattr_setschedpolicy
 posix_spawnattr_setsigdefault
 posix_spawnattr_setsigmask
 posix_spawnp
+ppoll
 preadv
 pseudo_AF_HDRCMPLT
 pseudo_AF_PFLOW

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -732,6 +732,12 @@ extern "C" {
         param: *mut sched_param,
     ) -> c_int;
     pub fn pipe2(fds: *mut c_int, flags: c_int) -> c_int;
+    pub fn ppoll(
+        fds: *mut crate::pollfd,
+        nfds: crate::nfds_t,
+        ts: *const crate::timespec,
+        sigmask: *const crate::sigset_t,
+    ) -> c_int;
 
     pub fn getgrouplist(
         name: *const c_char,

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2194,12 +2194,6 @@ extern "C" {
         ts: *const crate::timespec,
         sigmask: *const crate::sigset_t,
     ) -> c_int;
-    pub fn ppoll(
-        fds: *mut crate::pollfd,
-        nfds: crate::nfds_t,
-        ts: *const crate::timespec,
-        sigmask: *const crate::sigset_t,
-    ) -> c_int;
     pub fn getrandom(buf: *mut c_void, buflen: size_t, flags: c_uint) -> ssize_t;
 
     pub fn reboot(mode: c_int, bootstr: *mut c_char) -> c_int;


### PR DESCRIPTION
# Description

Moves the `ppoll` declaration from `netbsd/mod.rs` to `netbsdlike/mod.rs`, as OpenBSD has also had `ppoll` since 5.4.

# Sources

[Has been around since April 2013.](https://github.com/openbsd/src/blob/17132ff2f50b3e4acd4801692230c7ffd78ee56e/sys/sys/poll.h#L81)

PSA for others linking to OpenBSD sources: CVSWeb will look fine on your end but will redirect your friends to localhost because their IP address is different from the one with which the link was obtained. Do not bother with it and just link to the GitHub mirror.

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
