### PR TITLE
[0.2] Revert "musl: convert inline timespecs to timespec"

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4105,9 +4105,9 @@ fn test_linux(target: &str) {
     cfg.rename_struct_field(move |struct_, field| {
         match (struct_.ident(), field.ident()) {
             // Our stat *_nsec fields normally don't actually exist but are part
-            // of a timeval struct - this is fixed in musl_v1_2_3
+            // of a timeval struct
             ("stat" | "statfs" | "statvfs" | "stat64" | "statfs64" | "statvfs64", f)
-                if !musl_v1_2_3 && f.ends_with("_nsec") =>
+                if f.ends_with("_nsec") =>
             {
                 Some(f.replace("e_nsec", ".tv_nsec"))
             }

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -27,27 +27,30 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl_v1_2_3))]
-        pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_ctime_nsec: c_long,
-
+        #[cfg(musl_v1_2_3)]
         pub st_ino: crate::ino_t,
 
-        #[cfg(musl32_time64)]
-        pub st_atim: crate::timespec,
-        #[cfg(musl32_time64)]
-        pub st_mtim: crate::timespec,
-        #[cfg(musl32_time64)]
-        pub st_ctim: crate::timespec,
+        pub st_atime: crate::time_t,
+        #[cfg(all(musl32_time64, target_endian = "big"))]
+        __pad0: Padding<u32>,
+        pub st_atime_nsec: c_long,
+        #[cfg(all(musl32_time64, target_endian = "little"))]
+        __pad0: Padding<u32>,
+        pub st_mtime: crate::time_t,
+        #[cfg(all(musl32_time64, target_endian = "big"))]
+        __pad1: Padding<u32>,
+        pub st_mtime_nsec: c_long,
+        #[cfg(all(musl32_time64, target_endian = "little"))]
+        __pad1: Padding<u32>,
+        pub st_ctime: crate::time_t,
+        #[cfg(all(musl32_time64, target_endian = "big"))]
+        __pad2: Padding<u32>,
+        pub st_ctime_nsec: c_long,
+        #[cfg(all(musl32_time64, target_endian = "little"))]
+        __pad2: Padding<u32>,
+
+        #[cfg(not(musl_v1_2_3))]
+        pub st_ino: crate::ino_t,
     }
 
     struct __c_anonymous_timespec32 {

--- a/src/unix/linux_like/linux/musl/b32/hexagon.rs
+++ b/src/unix/linux_like/linux/musl/b32/hexagon.rs
@@ -18,25 +18,24 @@ s! {
         __st_blksize_padding: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(all(musl32_time64, target_endian = "big"))]
+        __pad0: Padding<u32>,
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(all(musl32_time64, target_endian = "little"))]
+        __pad0: Padding<u32>,
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(all(musl32_time64, target_endian = "big"))]
+        __pad1: Padding<u32>,
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(all(musl32_time64, target_endian = "little"))]
+        __pad1: Padding<u32>,
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(all(musl32_time64, target_endian = "big"))]
+        __pad2: Padding<u32>,
         pub st_ctime_nsec: c_long,
-
-        #[cfg(musl_v1_2_3)]
-        pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_ctim: crate::timespec,
+        #[cfg(all(musl32_time64, target_endian = "little"))]
+        __pad2: Padding<u32>,
 
         __unused: Padding<[c_int; 2]>,
     }

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -25,33 +25,42 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl_v1_2_3))]
-        pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_ctime_nsec: c_long,
-
+        #[cfg(musl_v1_2_3)]
         pub st_blksize: crate::blksize_t,
+        #[cfg(musl_v1_2_3)]
         __st_padding3: Padding<c_long>,
+        #[cfg(musl_v1_2_3)]
         pub st_blocks: crate::blkcnt_t,
-        #[cfg(not(musl32_time64))]
+
+        pub st_atime: crate::time_t,
+        #[cfg(all(musl32_time64, target_endian = "big"))]
+        __pad0: Padding<u32>,
+        pub st_atime_nsec: c_long,
+        #[cfg(all(musl32_time64, target_endian = "little"))]
+        __pad0: Padding<u32>,
+        pub st_mtime: crate::time_t,
+        #[cfg(all(musl32_time64, target_endian = "big"))]
+        __pad1: Padding<u32>,
+        pub st_mtime_nsec: c_long,
+        #[cfg(all(musl32_time64, target_endian = "little"))]
+        __pad1: Padding<u32>,
+        pub st_ctime: crate::time_t,
+        #[cfg(all(musl32_time64, target_endian = "big"))]
+        __pad2: Padding<u32>,
+        pub st_ctime_nsec: c_long,
+        #[cfg(all(musl32_time64, target_endian = "little"))]
+        __pad2: Padding<u32>,
+
+        #[cfg(not(musl_v1_2_3))]
+        pub st_blksize: crate::blksize_t,
+        #[cfg(not(musl_v1_2_3))]
+        __st_padding3: Padding<c_long>,
+        #[cfg(not(musl_v1_2_3))]
+        pub st_blocks: crate::blkcnt_t,
+
+        #[cfg(not(musl_v1_2_3))]
         __st_padding4: Padding<[c_long; 14]>,
-
-        #[cfg(musl32_time64)]
-        pub st_atim: crate::timespec,
-        #[cfg(musl32_time64)]
-        pub st_mtim: crate::timespec,
-        #[cfg(musl32_time64)]
-        pub st_ctim: crate::timespec,
-
-        #[cfg(musl32_time64)]
+        #[cfg(musl_v1_2_3)]
         __st_padding4: Padding<[c_long; 2]>,
     }
 

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -37,27 +37,30 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl_v1_2_3))]
-        pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_ctime_nsec: c_long,
-
+        #[cfg(musl_v1_2_3)]
         __unused: Padding<[c_long; 2]>,
 
-        #[cfg(musl32_time64)]
-        pub st_atim: crate::timespec,
-        #[cfg(musl32_time64)]
-        pub st_mtim: crate::timespec,
-        #[cfg(musl32_time64)]
-        pub st_ctim: crate::timespec,
+        pub st_atime: crate::time_t,
+        #[cfg(all(musl32_time64, target_endian = "big"))]
+        __pad0: Padding<u32>,
+        pub st_atime_nsec: c_long,
+        #[cfg(all(musl32_time64, target_endian = "little"))]
+        __pad0: Padding<u32>,
+        pub st_mtime: crate::time_t,
+        #[cfg(all(musl32_time64, target_endian = "big"))]
+        __pad1: Padding<u32>,
+        pub st_mtime_nsec: c_long,
+        #[cfg(all(musl32_time64, target_endian = "little"))]
+        __pad1: Padding<u32>,
+        pub st_ctime: crate::time_t,
+        #[cfg(all(musl32_time64, target_endian = "big"))]
+        __pad2: Padding<u32>,
+        pub st_ctime_nsec: c_long,
+        #[cfg(all(musl32_time64, target_endian = "little"))]
+        __pad2: Padding<u32>,
+
+        #[cfg(not(musl_v1_2_3))]
+        __unused: Padding<[c_long; 2]>,
     }
 
     struct __c_anonymous_timespec32 {

--- a/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
@@ -21,27 +21,24 @@ s! {
         pub st_blksize: crate::blksize_t,
         pub __pad2: c_int,
         pub st_blocks: crate::blkcnt_t,
-
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(all(musl32_time64, target_endian = "big"))]
+        __pad0: Padding<u32>,
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(all(musl32_time64, target_endian = "little"))]
+        __pad0: Padding<u32>,
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(all(musl32_time64, target_endian = "big"))]
+        __pad1: Padding<u32>,
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(all(musl32_time64, target_endian = "little"))]
+        __pad1: Padding<u32>,
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(all(musl32_time64, target_endian = "big"))]
+        __pad2: Padding<u32>,
         pub st_ctime_nsec: c_long,
-
-        #[cfg(musl_v1_2_3)]
-        pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_ctim: crate::timespec,
-
+        #[cfg(all(musl32_time64, target_endian = "little"))]
+        __pad2: Padding<u32>,
         __unused: Padding<[c_int; 2usize]>,
     }
 

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -27,27 +27,24 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl_v1_2_3))]
-        pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
-        pub st_ctime_nsec: c_long,
-
+        #[cfg(musl_v1_2_3)]
         pub st_ino: crate::ino_t,
 
+        pub st_atime: crate::time_t,
+        pub st_atime_nsec: c_long,
         #[cfg(musl32_time64)]
-        pub st_atim: crate::timespec,
+        __pad0: Padding<u32>,
+        pub st_mtime: crate::time_t,
+        pub st_mtime_nsec: c_long,
         #[cfg(musl32_time64)]
-        pub st_mtim: crate::timespec,
+        __pad1: Padding<u32>,
+        pub st_ctime: crate::time_t,
+        pub st_ctime_nsec: c_long,
         #[cfg(musl32_time64)]
-        pub st_ctim: crate::timespec,
+        __pad2: Padding<u32>,
+
+        #[cfg(not(musl_v1_2_3))]
+        pub st_ino: crate::ino_t,
     }
 
     struct __c_anonymous_timespec32 {

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -23,27 +23,12 @@ s! {
         pub st_blksize: crate::blksize_t,
         __pad1: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
-
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_ctime_nsec: c_long,
-
-        #[cfg(musl_v1_2_3)]
-        pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_ctim: crate::timespec,
-
         __unused: Padding<[c_uint; 2]>,
     }
 

--- a/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
@@ -26,27 +26,12 @@ s! {
         pub st_blksize: crate::blksize_t,
         __pad2: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
-
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_ctime_nsec: c_long,
-
-        #[cfg(musl_v1_2_3)]
-        pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_ctim: crate::timespec,
-
         __unused: Padding<[c_int; 2usize]>,
     }
 

--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -22,27 +22,12 @@ s! {
         __pad2: Padding<[c_uint; 2]>,
         pub st_size: off_t,
         __pad3: Padding<c_int>,
-
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_ctime_nsec: c_long,
-
-        #[cfg(musl_v1_2_3)]
-        pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_ctim: crate::timespec,
-
         pub st_blksize: crate::blksize_t,
         __pad4: Padding<c_uint>,
         pub st_blocks: crate::blkcnt_t,

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -33,27 +33,12 @@ s! {
         pub st_size: off_t,
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
-
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_ctime_nsec: c_long,
-
-        #[cfg(musl_v1_2_3)]
-        pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_ctim: crate::timespec,
-
         __unused: Padding<[c_long; 3]>,
     }
 

--- a/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
@@ -26,27 +26,12 @@ s! {
         pub st_blksize: crate::blksize_t,
         __pad2: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
-
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_ctime_nsec: c_long,
-
-        #[cfg(musl_v1_2_3)]
-        pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_ctim: crate::timespec,
-
         __unused: Padding<[c_int; 2usize]>,
     }
 

--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -40,27 +40,12 @@ s! {
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
         pub st_size: off_t,
-
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_ctime_nsec: c_long,
-
-        #[cfg(musl_v1_2_3)]
-        pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_ctim: crate::timespec,
-
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
         __unused: Padding<[c_long; 3]>,

--- a/src/unix/linux_like/linux/musl/b64/wasm32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/wasm32/mod.rs
@@ -24,27 +24,12 @@ s! {
         pub st_size: off_t,
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
-
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
         pub st_ctime_nsec: c_long,
-
-        #[cfg(musl_v1_2_3)]
-        pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_ctim: crate::timespec,
-
         __unused: Padding<[c_long; 3]>,
     }
 

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -23,27 +23,21 @@ s! {
         pub st_size: off_t,
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
-
-        #[cfg(not(musl_v1_2_3))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(all(musl32_time64, target_pointer_width = "32"))]
+        pub st_atime_nsec: i64,
+        #[cfg(not(all(musl32_time64, target_pointer_width = "32")))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(all(musl32_time64, target_pointer_width = "32"))]
+        pub st_mtime_nsec: i64,
+        #[cfg(not(all(musl32_time64, target_pointer_width = "32")))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(all(musl32_time64, target_pointer_width = "32"))]
+        pub st_ctime_nsec: i64,
+        #[cfg(not(all(musl32_time64, target_pointer_width = "32")))]
         pub st_ctime_nsec: c_long,
-
-        #[cfg(musl_v1_2_3)]
-        pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
-        pub st_ctim: crate::timespec,
-
         __unused: Padding<[c_long; 3]>,
     }
 


### PR DESCRIPTION
# Description

This reverts commit 55fa65b3e026594c6418eb2bc8e98c1feb7667da, as suggested by https://github.com/rust-lang/libc/pull/4942#issuecomment-3832489311.

Fixes rust-lang/libc#4939

# Sources

- https://github.com/kraj/musl/tree/v1.1.20
- https://github.com/kraj/musl/tree/v1.2.5


# Checklist

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI