### PR TITLE
ci: Ensure TARGET_REF is set during scheduled jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,8 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: full
-  TARGET_REF: ${{ github.base_ref || github.event.merge_group.base_ref }}
+  # Base branch for PRs or for merges, current ref for cron runs on a branch.
+  TARGET_REF: ${{ github.base_ref || github.event.merge_group.base_ref || github.ref }}
 
 defaults:
   run:


### PR DESCRIPTION
This was causing a failure in prep-semver-baseline.sh for the daily cache-building job since there is no base for jobs that run on a branch.