### PR TITLE
linux: update ptrace_syscall_info struct

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4150,6 +4150,10 @@ fn test_linux(target: &str) {
             // FIXME(musl): New fields in newer versions
             "utmpx" if !old_musl => true,
 
+            // FIXME(linux): Requires >= 6.16 kernel headers.
+            // On 64 bits the size did not change, skip only for 32 bits.
+            "ptrace_syscall_info" if pointer_width == 32 => true,
+
             _ => false,
         }
     });
@@ -4702,7 +4706,9 @@ fn test_linux(target: &str) {
                 true
             }
             // the `u` field is in fact an anonymous union
-            ("ptrace_syscall_info", "u" | "pad") if gnu => true,
+            ("ptrace_syscall_info", "u") if gnu => true,
+            // FIXME(linux): `flags` requires >= 6.16 kernel headers
+            ("ptrace_syscall_info", "flags") if gnu => true,
             // the vregs field is a `__uint128_t` C's type.
             ("user_fpsimd_struct", "vregs") => true,
             // Linux >= 5.11 tweaked the `svm_zero` field of the `sockaddr_vm` struct.

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -180,11 +180,13 @@ s! {
         pub nr: crate::__u64,
         pub args: [crate::__u64; 6],
         pub ret_data: crate::__u32,
+        reserved2: Padding<crate::__u32>,
     }
 
     pub struct ptrace_syscall_info {
         pub op: crate::__u8,
-        pub pad: [crate::__u8; 3],
+        reserved: Padding<crate::__u8>,
+        pub flags: crate::__u16,
         pub arch: crate::__u32,
         pub instruction_pointer: crate::__u64,
         pub stack_pointer: crate::__u64,


### PR DESCRIPTION
Hi,

# Description

linux: update `ptrace_syscall_info struct`:
- Add new `flags` field and reserveds.

The updated version has a different size on 32 bits arches (84 -> 88 bytes) while the size stays the same on 64 bits.

# Sources

[ptrace.h](https://github.com/torvalds/linux/blob/72c395024dac5e215136cbff793455f065603b06/include/uapi/linux/ptrace.h#L83-L106)
[kernel lore](https://lore.kernel.org/lkml/20250303112044.GF24170@strace.io/)

# Checklist

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated