### PR TITLE
feat(linux): add `tgkill` for Linux and Android

### DIFF
--- a/libc-test/semver/android.txt
+++ b/libc-test/semver/android.txt
@@ -4061,6 +4061,7 @@ tee
 telldir
 termios
 termios2
+tgkill
 time
 time_t
 timegm

--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -675,6 +675,7 @@ sgetspent_r
 statx
 statx_timestamp
 tcp_info
+tgkill
 timex
 utmpname
 utmpx

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -3640,6 +3640,8 @@ extern "C" {
 
     pub fn gettid() -> crate::pid_t;
 
+    pub fn tgkill(tgid: crate::pid_t, tid: crate::pid_t, sig: c_int) -> c_int;
+
     pub fn getauxval(type_: c_ulong) -> c_ulong;
 
     /// Only available in API Version 28+

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1228,6 +1228,8 @@ extern "C" {
     ) -> c_int;
 
     pub fn mempcpy(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
+
+    pub fn tgkill(tgid: crate::pid_t, tid: crate::pid_t, sig: c_int) -> c_int;
 }
 
 cfg_if! {


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Add the `tgkill(tgid, tid, sig)` function wrapper. The `SYS_tgkill` syscall numbers were already defined for the nescessary targets

# Sources

Glibc https://github.com/bminor/glibc/blob/04e750e75b73957cf1c791535a3f4319534a52fc/sysdeps/unix/sysv/linux/bits/signal_ext.h#L29

Linux https://github.com/torvalds/linux/blob/582a1ef360a05bff4350bbf6e383f61d26b804f0/include/linux/syscalls.h#L666

Bionic https://cs.android.com/android/platform/superproject/main/+/main:bionic/libc/include/signal.h;l=148

<!-- All API changes must have permalinks to headers. Common sources:

* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated

