### PR TITLE
[0.2] Increase the MSRV from 1.63 to 1.65

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
     name: Verify build
     strategy:
       matrix:
-        toolchain: [stable, 1.63.0]
+        toolchain: [stable, 1.65.0]
         include:
           # Nightly has a lot of targets, so split it in half
           - toolchain: nightly
@@ -62,7 +62,7 @@ jobs:
           - toolchain: beta
             only: '(aarch64|x86_64)' # just a spot check for beta
           - toolchain: stable
-          - toolchain: 1.63.0 # msrv
+          - toolchain: 1.65.0 # msrv
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     env:
@@ -93,7 +93,7 @@ jobs:
         run: |
           set -eux
           # Remove `-Dwarnings` at the MSRV since lints may be different
-          [ "${{ matrix.toolchain }}" = "1.63.0" ] && export RUSTFLAGS=""
+          [ "${{ matrix.toolchain }}" = "1.65.0" ] && export RUSTFLAGS=""
           python3 ci/verify-build.py \
             --toolchain "$TOOLCHAIN" \
             ${BASELINE_CRATE_DIR:+"--baseline-crate-dir" "$BASELINE_CRATE_DIR"} \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["The Rust Project Developers"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/libc"
-rust-version = "1.63"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 features = ["extra_traits"]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The following features are deprecated:
 
 ## Rust version support
 
-The minimum supported Rust toolchain version is currently **Rust 1.63**.
+The minimum supported Rust toolchain version is currently **Rust 1.65**.
 
 Increases to the MSRV are allowed to change without a major (i.e. semver-
 breaking) release in order to avoid a ripple effect in the ecosystem. A policy


### PR DESCRIPTION
Perform a small MSRV bump by two versions. The main thing this gets is access to the C types in `core::ffi`, which means the ecosystem can start harmonizing around those aliases instead of using e.g. `core::ffi::c_int` in some cases and `libc::c_int` in others.

1.65 is selected as a small bump over 1.64 because it comes with some small "nice" things like workspace-level lints and `cast_mut`. It has been over a year since the last MSRV bump to 1.63 (in 93052d1542de, "Document the MSRV of the stable channel as 1.63") so we could probably bump higher yet, but there isn't anything else on the list at [1] as useful as `core::ffi`.

[1]: https://github.com/rust-lang/libc/issues/4626