### PR TITLE
Implement `Default` for `timeval` and `timespec`

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -99,11 +99,13 @@ s! {
         pub modtime: time_t,
     }
 
+    #[derive(Default)]
     pub struct timeval {
         pub tv_sec: time_t,
         pub tv_usec: suseconds_t,
     }
 
+    #[derive(Default)]
     pub struct timespec {
         pub tv_sec: time_t,
         pub tv_nsec: c_long,

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -108,6 +108,7 @@ s! {
         pub st_ctim: timespec,
     }
 
+    #[derive(Default)]
     pub struct timespec {
         pub tv_sec: time_t,
         pub tv_nsec: i32,

--- a/src/new/qurt/mod.rs
+++ b/src/new/qurt/mod.rs
@@ -137,11 +137,13 @@ s! {
         pub tm_isdst: c_int,
     }
 
+    #[derive(Default)]
     pub struct timespec {
         pub tv_sec: time_t,
         pub tv_nsec: c_long,
     }
 
+    #[derive(Default)]
     pub struct timeval {
         pub tv_sec: time_t,
         pub tv_usec: suseconds_t,

--- a/src/solid/mod.rs
+++ b/src/solid/mod.rs
@@ -169,6 +169,7 @@ s! {
         pub iov_len: size_t,
     }
 
+    #[derive(Default)]
     pub struct timeval {
         pub tv_sec: c_long,
         pub tv_usec: c_long,

--- a/src/teeos/mod.rs
+++ b/src/teeos/mod.rs
@@ -99,11 +99,13 @@ s! {
         bits: [c_ulong; 128 / size_of::<c_ulong>()],
     }
 
+    #[derive(Default)]
     pub struct timespec {
         pub tv_sec: time_t,
         pub tv_nsec: c_long,
     }
 
+    #[derive(Default)]
     pub struct timeval {
         pub tv_sec: time_t,
         pub tv_usec: suseconds_t,

--- a/src/trusty.rs
+++ b/src/trusty.rs
@@ -27,6 +27,7 @@ s! {
         pub iov_len: size_t,
     }
 
+    #[derive(Default)]
     pub struct timespec {
         pub tv_sec: time_t,
         pub tv_nsec: c_long,

--- a/src/unix/bsd/apple/b64/mod.rs
+++ b/src/unix/bsd/apple/b64/mod.rs
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 s! {
+    #[derive(Default)]
     pub struct timeval32 {
         pub tv_sec: i32,
         pub tv_usec: i32,

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -431,6 +431,7 @@ s! {
         pub si_value: crate::sigval,
     }
 
+    #[derive(Default)]
     pub struct timespec {
         pub tv_sec: __time_t,
         pub tv_nsec: __syscall_slong_t,

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -297,6 +297,7 @@ s! {
 
     // linux x32 compatibility
     // See https://sourceware.org/bugzilla/show_bug.cgi?id=16437
+    #[derive(Default)]
     pub struct timespec {
         pub tv_sec: time_t,
         #[cfg(all(gnu_time_bits64, target_endian = "big"))]

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -57,6 +57,7 @@ s! {
         pub modtime: time_t,
     }
 
+    #[derive(Default)]
     pub struct timeval {
         pub tv_sec: time_t,
         #[cfg(not(gnu_time_bits64))]
@@ -69,6 +70,7 @@ s! {
 
     // linux x32 compatibility
     // See https://sourceware.org/bugzilla/show_bug.cgi?id=16437
+    #[derive(Default)]
     #[cfg(not(target_env = "gnu"))]
     pub struct timespec {
         pub tv_sec: time_t,

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -158,6 +158,7 @@ s! {
     }
 
     // b_struct_timeval.h
+    #[derive(Default)]
     pub struct timeval {
         pub tv_sec: crate::time_t,
         pub tv_usec: crate::suseconds_t,
@@ -332,6 +333,7 @@ s! {
     }
 
     // b_struct_timespec.h
+    #[derive(Default)]
     pub struct timespec {
         pub tv_sec: crate::time_t,
         pub tv_nsec: c_long,

--- a/src/wasi/mod.rs
+++ b/src/wasi/mod.rs
@@ -87,11 +87,13 @@ s! {
         pub __tm_nsec: c_int,
     }
 
+    #[derive(Default)]
     pub struct timeval {
         pub tv_sec: time_t,
         pub tv_usec: suseconds_t,
     }
 
+    #[derive(Default)]
     pub struct timespec {
         pub tv_sec: time_t,
         pub tv_nsec: c_long,

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -72,11 +72,13 @@ s! {
         pub tm_isdst: c_int,
     }
 
+    #[derive(Default)]
     pub struct timeval {
         pub tv_sec: c_long,
         pub tv_usec: c_long,
     }
 
+    #[derive(Default)]
     pub struct timespec {
         pub tv_sec: time_t,
         pub tv_nsec: c_long,


### PR DESCRIPTION
With the experimental time64 support, some of these structs gain a padding field on 32-bit platforms. We are planning to give everything a `Default` impl anyway ([1]) so start with these to ease the transition.

[1]: https://github.com/rust-lang/libc/issues/4975