### PR TITLE
build: Replace `RUST_LIBC_UNSTABLE` env with `libc_unstable*` cfg

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -195,30 +195,30 @@ jobs:
           - target: aarch64-linux-android
           - target: aarch64-unknown-linux-musl
           - target: aarch64-unknown-linux-musl
-            env: { RUST_LIBC_UNSTABLE_MUSL_V1_2_3: 1 }
+            env: { TEST_MUSL_V1_2_3: 1 }
             artifact-tag: new-musl
           - target: arm-linux-androideabi
           - target: arm-unknown-linux-gnueabihf
           - target: arm-unknown-linux-musleabihf
           - target: arm-unknown-linux-musleabihf
-            env: { RUST_LIBC_UNSTABLE_MUSL_V1_2_3: 1 }
+            env: { TEST_MUSL_V1_2_3: 1 }
             artifact-tag: new-musl
           # FIXME(#4297): Disabled due to spurious failue
           # - target: i686-linux-android
           - target: i686-unknown-linux-musl
           - target: i686-unknown-linux-musl
-            env: { RUST_LIBC_UNSTABLE_MUSL_V1_2_3: 1 }
+            env: { TEST_MUSL_V1_2_3: 1 }
             artifact-tag: new-musl
           - target: loongarch64-unknown-linux-gnu
           - target: loongarch64-unknown-linux-musl
           - target: loongarch64-unknown-linux-musl
-            env: { RUST_LIBC_UNSTABLE_MUSL_V1_2_3: 1 }
+            env: { TEST_MUSL_V1_2_3: 1 }
             artifact-tag: new-musl
           - target: powerpc64-unknown-linux-gnu
           - target: powerpc64le-unknown-linux-gnu
           - target: powerpc64le-unknown-linux-musl
           - target: powerpc64le-unknown-linux-musl
-            env: { RUST_LIBC_UNSTABLE_MUSL_V1_2_3: 1 }
+            env: { TEST_MUSL_V1_2_3: 1 }
             artifact-tag: new-musl
           - target: riscv64gc-unknown-linux-gnu
           - target: s390x-unknown-linux-gnu
@@ -232,7 +232,7 @@ jobs:
           # - target: x86_64-unknown-linux-gnux32
           - target: x86_64-unknown-linux-musl
           - target: x86_64-unknown-linux-musl
-            env: { RUST_LIBC_UNSTABLE_MUSL_V1_2_3: 1 }
+            env: { TEST_MUSL_V1_2_3: 1 }
             artifact-tag: new-musl
           # FIXME: It seems some items in `src/unix/mod.rs` aren't defined on redox actually.
           # - target: x86_64-unknown-redox

--- a/build.rs
+++ b/build.rs
@@ -109,8 +109,7 @@ fn main() {
         _ => (),
     }
 
-    let mut musl_v1_2_3 = env_flag("RUST_LIBC_UNSTABLE_MUSL_V1_2_3");
-    println!("cargo:rerun-if-env-changed=RUST_LIBC_UNSTABLE_MUSL_V1_2_3");
+    let mut musl_v1_2_3 = env_flag("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2_3");
 
     // OpenHarmony uses a fork of the musl libc
     let musl = target_env == "musl" || target_env == "ohos";
@@ -136,8 +135,6 @@ fn main() {
         set_cfg("linux_time_bits64");
     }
 
-    println!("cargo:rerun-if-env-changed=RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS");
-    println!("cargo:rerun-if-env-changed=RUST_LIBC_UNSTABLE_GNU_TIME_BITS");
     if target_env == "gnu"
         && target_os == "linux"
         && target_ptr_width == "32"
@@ -145,34 +142,52 @@ fn main() {
         && target_arch != "x86_64"
     {
         let defaultbits = "32";
-        let tb_env = env::var("RUST_LIBC_UNSTABLE_GNU_TIME_BITS");
-        let fb_env = env::var("RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS");
+
+        let mut tb_env = env::var("CARGO_CFG_LIBC_UNSTABLE_GNU_TIME_BITS");
+        let mut fb_env = env::var("CARGO_CFG_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS");
+
+        // FIXME: remove these fallbacks in a few releases
+        if let Ok(old_tb_env) = env::var("RUST_LIBC_UNSTABLE_GNU_TIME_BITS") {
+            println!(
+                "cargo:warning=RUST_LIBC_UNSTABLE_GNU_TIME_BITS will be removed; \
+                set `--cfg=libc_unstable_gnu_time_bits=\"...\"` via RUSTFLAGS instead"
+            );
+            tb_env = tb_env.or(Ok(old_tb_env));
+        }
+        if let Ok(old_fb_env) = env::var("RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS") {
+            println!(
+                "cargo:warning=RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS will be removed; \
+                set `--cfg=libc_unstable_gnu_file_offset_bits=\"...\"` via RUSTFLAGS instead"
+            );
+            fb_env = fb_env.or(Ok(old_fb_env));
+        }
+
         let (timebits, filebits) = match (tb_env.as_deref(), fb_env.as_deref()) {
             (Ok(_), Ok(_)) => panic!(
-                "Do not set both RUST_LIBC_UNSTABLE_GNU_TIME_BITS and \
-                RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS"
+                "Do not set both libc_unstable_gnu_time_bits and \
+                libc_unstable_gnu_file_offset_bits"
             ),
             (Err(_), Err(_)) => (defaultbits, defaultbits),
             (Ok(tb), Err(_)) if tb == "64" => (tb, tb),
             (Ok(tb), Err(_)) if tb == "32" => (tb, defaultbits),
             (Ok(_), Err(_)) => {
-                panic!("Invalid value for RUST_LIBC_UNSTABLE_GNU_TIME_BITS, must be 32 or 64")
+                panic!("Invalid value for libc_unstable_gnu_time_bits, must be 32 or 64")
             }
             (Err(_), Ok(fb)) if fb == "32" || fb == "64" => (defaultbits, fb),
-            (Err(_), Ok(_)) => panic!(
-                "Invalid value for RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS, must be 32 or 64"
-            ),
+            (Err(_), Ok(_)) => {
+                panic!("Invalid value for libc_unstable_gnu_file_offset_bits, must be 32 or 64")
+            }
         };
         let valid_bits = ["32", "64"];
         assert!(
             valid_bits.contains(&filebits) && valid_bits.contains(&timebits),
-            "Invalid value for RUST_LIBC_UNSTABLE_GNU_TIME_BITS or \
-            RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS. Must be 32, 64 or unset"
+            "Invalid value for libc_unstable_gnu_time_bits or \
+            libc_unstable_gnu_file_offset_bits. Must be 32, 64 or unset"
         );
         assert!(
             !(filebits == "32" && timebits == "64"),
-            "RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS must be 64 or unset if \
-            RUST_LIBC_UNSTABLE_GNU_TIME_BITS is 64"
+            "libc_unstable_gnu_file_offset_bits must be 64 or unset if \
+            libc_unstable_gnu_time_bits is 64"
         );
         if timebits == "64" {
             set_cfg("linux_time_bits64");

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -36,15 +36,19 @@ run() {
         "ci/"
     )
 
+    # FIXME(ci): we could probably build both versions in the same dockerfile
+    # and test them both in `ci/run.sh` more similar to what we do with glibc,
+    # rather than needing two separate jobs.
     if [[ "$run_target" = *"musl"* ]]; then
-        if [ -n "${RUST_LIBC_UNSTABLE_MUSL_V1_2_3:-}" ]; then
+        if [ -n "${TEST_MUSL_V1_2_3:-}" ]; then
+            export RUSTFLAGS="$RUSTFLAGS --cfg=libc_unstable_musl_v1_2_3"
             build_args+=("--build-arg=MUSL_VERSION=new")
         else
             build_args+=("--build-arg=MUSL_VERSION=old")
         fi
     fi
 
-    if [ -n "${TEST_UCLIBC_TIME64:-}" ]; then 
+    if [ -n "${TEST_UCLIBC_TIME64:-}" ]; then
         build_args+=("--build-arg=TEST_UCLIBC_TIME64=1")
         export RUSTFLAGS="$RUSTFLAGS --cfg=libc_unstable_uclibc_time64"
     fi
@@ -67,9 +71,6 @@ run() {
         --env RUSTFLAGS \
         --env RUSTDOCFLAGS \
         --env RUST_BACKTRACE \
-        --env RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS \
-        --env RUST_LIBC_UNSTABLE_GNU_TIME_BITS \
-        --env RUST_LIBC_UNSTABLE_MUSL_V1_2_3 \
         --env CARGO_TERM_COLOR \
         --env CARGO_TERM_VERBOSE \
         --env CARGO_HOME=/cargo \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -52,7 +52,7 @@ $cmd --features extra_traits -- $test_flags
 
 if [ "$env" = "gnu" ] && [ "$bits" = "32" ]; then
     # shellcheck disable=SC2086
-    RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS=64 $cmd -- $test_flags
+    RUSTFLAGS="$RUSTFLAGS --cfg=libc_unstable_gnu_file_offset_bits=\"64\"" $cmd -- $test_flags
     # shellcheck disable=SC2086
-    RUST_LIBC_UNSTABLE_GNU_TIME_BITS=64 $cmd -- $test_flags
+    RUSTFLAGS="$RUSTFLAGS --cfg=libc_unstable_gnu_time_bits=\"64\"" $cmd -- $test_flags
 fi

--- a/ci/verify-build.py
+++ b/ci/verify-build.py
@@ -402,30 +402,18 @@ def test_target(cfg: Cfg, target: Target) -> TargetResult:
         run(["rustup", "target", "add", tname, "--toolchain", cfg.toolchain_name])
 
     # Test with expected combinations of features
-    run(cmd, env=env, rustflags=rustflags)
-    run([*cmd, "--features=extra_traits"], env=env, rustflags=rustflags)
+    run(cmd, rustflags=rustflags)
+    run([*cmd, "--features=extra_traits"], rustflags=rustflags)
 
     if "gnu" in target_env and target_bits == "32":
         # Equivalent of _FILE_OFFSET_BITS=64
-        run(
-            cmd,
-            env=env | {"RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS": "64"},
-            rustflags=rustflags,
-        )
+        run(cmd, rustflags=f'{rustflags} --cfg=libc_unstable_gnu_file_offset_bits="64"')
         # Equivalent of _TIME_BITS=64
-        run(
-            cmd,
-            env=env | {"RUST_LIBC_UNSTABLE_GNU_TIME_BITS": "64"},
-            rustflags=rustflags,
-        )
+        run(cmd, rustflags=f'{rustflags} --cfg=libc_unstable_gnu_time_bits="64"')
 
     if "musl" in target_env:
         # Check with breaking changes from musl, including 64-bit time_t on 32-bit
-        run(
-            cmd,
-            env=env | {"RUST_LIBC_UNSTABLE_MUSL_V1_2_3": "1"},
-            rustflags=rustflags,
-        )
+        run(cmd, rustflags=f"{rustflags} --cfg=libc_unstable_musl_v1_2_3")
 
     # Test again without default features, i.e. without `std`
     run([*cmd, "--no-default-features"], rustflags=rustflags)

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3644,34 +3644,51 @@ fn config_gnu_bits(target: &str, cfg: &mut ctest::TestGenerator) {
         && pointer_width == "32"
     {
         let defaultbits = "32";
-        let tb_env = env::var("RUST_LIBC_UNSTABLE_GNU_TIME_BITS");
-        let fb_env = env::var("RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS");
+        let mut tb_env = env::var("CARGO_CFG_LIBC_UNSTABLE_GNU_TIME_BITS");
+        let mut fb_env = env::var("CARGO_CFG_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS");
+
+        // FIXME: remove these fallbacks in a few releases
+        if let Ok(old_tb_env) = env::var("RUST_LIBC_UNSTABLE_GNU_TIME_BITS") {
+            println!(
+                "cargo:warning=RUST_LIBC_UNSTABLE_GNU_TIME_BITS will be removed; \
+                set `--cfg=libc_unstable_gnu_time_bits=\"...\"` via RUSTFLAGS instead"
+            );
+            tb_env = tb_env.or(Ok(old_tb_env));
+        }
+        if let Ok(old_fb_env) = env::var("RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS") {
+            println!(
+                "cargo:warning=RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS will be removed; \
+                set `--cfg=libc_unstable_gnu_file_offset_bits=\"...\"` via RUSTFLAGS instead"
+            );
+            fb_env = fb_env.or(Ok(old_fb_env));
+        }
+
         let (timebits, filebits) = match (tb_env.as_deref(), fb_env.as_deref()) {
             (Ok(_), Ok(_)) => panic!(
-                "Do not set both RUST_LIBC_UNSTABLE_GNU_TIME_BITS and \
-                RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS"
+                "Do not set both libc_unstable_gnu_time_bits and \
+                libc_unstable_gnu_file_offset_bits"
             ),
             (Err(_), Err(_)) => (defaultbits, defaultbits),
             (Ok(tb), Err(_)) if tb == "64" => (tb, tb),
             (Ok(tb), Err(_)) if tb == "32" => (tb, defaultbits),
             (Ok(_), Err(_)) => {
-                panic!("Invalid value for RUST_LIBC_UNSTABLE_GNU_TIME_BITS, must be 32 or 64")
+                panic!("Invalid value for libc_unstable_gnu_time_bits, must be 32 or 64")
             }
             (Err(_), Ok(fb)) if fb == "32" || fb == "64" => (defaultbits, fb),
-            (Err(_), Ok(_)) => panic!(
-                "Invalid value for RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS, must be 32 or 64"
-            ),
+            (Err(_), Ok(_)) => {
+                panic!("Invalid value for libc_unstable_gnu_file_offset_bits, must be 32 or 64")
+            }
         };
         let valid_bits = ["32", "64"];
         assert!(
             valid_bits.contains(&filebits) && valid_bits.contains(&timebits),
-            "Invalid value for RUST_LIBC_UNSTABLE_GNU_TIME_BITS or \
-            RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS, must be 32, 64 or unset"
+            "Invalid value for libc_unstable_gnu_time_bits or \
+            libc_unstable_gnu_file_offset_bits. Must be 32, 64 or unset"
         );
         assert!(
             !(filebits == "32" && timebits == "64"),
-            "RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS must be 64 or unset if \
-            RUST_LIBC_UNSTABLE_GNU_TIME_BITS is 64"
+            "libc_unstable_gnu_file_offset_bits must be 64 or unset if \
+            libc_unstable_gnu_time_bits is 64"
         );
         if timebits == "64" {
             cfg.define("_TIME_BITS", Some("64"));
@@ -3740,7 +3757,7 @@ fn test_linux(target: &str) {
     let mips64 = target.contains("mips64");
     let mips32 = mips && !mips64;
 
-    let musl_v1_2_3 = env::var("RUST_LIBC_UNSTABLE_MUSL_V1_2_3").is_ok();
+    let musl_v1_2_3 = env::var("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2_3").is_ok();
     if musl_v1_2_3 {
         assert!(musl);
     }


### PR DESCRIPTION
The current environment variable setup makes it easy to set a
configuration for both the host (build scripts) and target, even when
that is not the intent. Change to a rustc cfg, which is easier to set
for only the target.

This was briefly discussed on Zulip around [1].

[1]: https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/Questions.20and.20polls.20about.20.60libc.60.201.2E0/near/511723332