### PR TITLE
Enable clone3() syscall on SPARC which was added in Linux v7.0

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4853,9 +4853,6 @@ fn test_linux(target: &str) {
             // FIXME(value): IPPROTO_MAX was increased in 5.6 for IPPROTO_MPTCP:
             "IPPROTO_MAX" => true,
 
-            // FIXME(linux): Not yet implemented on sparc64
-            "SYS_clone3" if sparc64 => true,
-
             // Requires >= 6.9 kernel headers.
             n if (arm || ppc32) && n.starts_with("FUTEX2_") => kernel < (6, 9),
 

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -849,7 +849,6 @@ pub const SYS_fsconfig: c_long = 431;
 pub const SYS_fsmount: c_long = 432;
 pub const SYS_fspick: c_long = 433;
 pub const SYS_pidfd_open: c_long = 434;
-// Reserved in the kernel, but not actually implemented yet
 pub const SYS_clone3: c_long = 435;
 pub const SYS_close_range: c_long = 436;
 pub const SYS_openat2: c_long = 437;

--- a/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
@@ -882,7 +882,6 @@ pub const SYS_fsconfig: c_long = 431;
 pub const SYS_fsmount: c_long = 432;
 pub const SYS_fspick: c_long = 433;
 pub const SYS_pidfd_open: c_long = 434;
-// Reserved in the kernel, but not actually implemented yet
 pub const SYS_clone3: c_long = 435;
 pub const SYS_close_range: c_long = 436;
 pub const SYS_openat2: c_long = 437;


### PR DESCRIPTION
clone3() has been added for SPARC in Linux v7.0, thus enable it.