### PR TITLE
Fix Nintendo Switch Target Support

### DIFF
--- a/src/switch.rs
+++ b/src/switch.rs
@@ -1,4 +1,5 @@
 //! Switch C type definitions
+use crate::prelude::*;
 
 pub type intmax_t = i64;
 pub type uintmax_t = u64;


### PR DESCRIPTION
# Description

Fixes a regression caused by https://github.com/rust-lang/libc/commit/95446f458e472511d65e560224c1b85570e50944 in the Nintendo Switch target support. We've recently been updating our standard library fork and noticed this breakage.

The issue is due to the migration of the `c_int` type to a unified location without updating `src/switch.rs` to import these types.

# Sources

Not applicable -- No official docs for target.

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated (not applicable)
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (no changes of this form)
- [x] Tested locally

@rustbot label +stable-nominated
