### PR TITLE
Re-organized the QNX support.

### DIFF
--- a/src/unix/nto/arch/aarch64.rs
+++ b/src/unix/nto/arch/aarch64.rs
@@ -1,3 +1,12 @@
+//! Definitions specific to QNX on AArch64
+//!
+//! This module applies to:
+//!
+//! * `aarch64-unknown-nto-qnx700`
+//! * `aarch64-unknown-nto-qnx710`
+//! * `aarch64-unknown-nto-qnx710_iosock`
+//! * `aarch64-unknown-nto-qnx800`
+
 use crate::prelude::*;
 
 pub type wchar_t = u32;

--- a/src/unix/nto/arch/i686.rs
+++ b/src/unix/nto/arch/i686.rs
@@ -1,0 +1,10 @@
+//! Definitions specific to QNX on x86
+//!
+//! This module applies to:
+//!
+//! * `i686-pc-nto-qnx700`
+
+use crate::prelude::*;
+
+pub type wchar_t = u32;
+pub type time_t = i64;

--- a/src/unix/nto/arch/mod.rs
+++ b/src/unix/nto/arch/mod.rs
@@ -1,0 +1,13 @@
+//! Architecture-specific definitions for QNX
+
+cfg_if! {
+    if #[cfg(target_arch = "x86_64")] {
+        mod x86_64;
+        pub use self::x86_64::*;
+    } else if #[cfg(target_arch = "aarch64")] {
+        mod aarch64;
+        pub use self::aarch64::*;
+    } else {
+        panic!("Unsupported arch");
+    }
+}

--- a/src/unix/nto/arch/x86_64.rs
+++ b/src/unix/nto/arch/x86_64.rs
@@ -1,3 +1,11 @@
+//! Definitions specific to QNX on x86-64
+//!
+//! This module applies to:
+//!
+//! * `x86_64-pc-nto-qnx710`
+//! * `x86_64-pc-nto-qnx710_iosock`
+//! * `x86_64-pc-nto-qnx800`
+
 use crate::prelude::*;
 
 pub type wchar_t = u32;

--- a/src/unix/nto/io_pkt/mod.rs
+++ b/src/unix/nto/io_pkt/mod.rs
@@ -1,0 +1,160 @@
+//! Definitions specific to QNX versions using io-pkt networking
+//!
+//! This module applies to:
+//!
+//! * `aarch64-unknown-nto-qnx700`
+//! * `i686-pc-nto-qnx700`
+//! * `aarch64-unknown-nto-qnx710`
+//! * `x86_64-pc-nto-qnx710`
+
+use crate::prelude::*;
+
+s! {
+    #[repr(packed)]
+    pub struct in_addr {
+        pub s_addr: crate::in_addr_t,
+    }
+
+    pub struct sockaddr_in {
+        pub sin_len: u8,
+        pub sin_family: crate::sa_family_t,
+        pub sin_port: crate::in_port_t,
+        pub sin_addr: crate::in_addr,
+        pub sin_zero: [i8; 8],
+    }
+
+    pub struct in_pktinfo {
+        pub ipi_addr: crate::in_addr,
+        pub ipi_ifindex: c_uint,
+    }
+
+    #[repr(packed)]
+    pub struct arphdr {
+        pub ar_hrd: u16,
+        pub ar_pro: u16,
+        pub ar_hln: u8,
+        pub ar_pln: u8,
+        pub ar_op: u16,
+    }
+
+    pub struct unpcbid {
+        pub unp_pid: crate::pid_t,
+        pub unp_euid: crate::uid_t,
+        pub unp_egid: crate::gid_t,
+    }
+
+    pub struct mmsghdr {
+        pub msg_hdr: crate::msghdr,
+        pub msg_len: c_uint,
+    }
+
+    pub struct bpf_stat {
+        pub bs_recv: u64,
+        pub bs_drop: u64,
+        pub bs_capt: u64,
+        bs_padding: Padding<[u64; 13]>,
+    }
+
+    pub struct sockaddr_dl {
+        pub sdl_len: c_uchar,
+        pub sdl_family: crate::sa_family_t,
+        pub sdl_index: u16,
+        pub sdl_type: c_uchar,
+        pub sdl_nlen: c_uchar,
+        pub sdl_alen: c_uchar,
+        pub sdl_slen: c_uchar,
+        pub sdl_data: [c_char; 12],
+    }
+}
+
+pub const SCM_CREDS: c_int = 0x04;
+pub const IFF_NOTRAILERS: c_int = 0x00000020;
+pub const AF_INET6: c_int = 24;
+pub const AF_BLUETOOTH: c_int = 31;
+pub const pseudo_AF_KEY: c_int = 29;
+pub const MSG_NOSIGNAL: c_int = 0x0800;
+pub const MSG_WAITFORONE: c_int = 0x2000;
+pub const IP_IPSEC_POLICY_COMPAT: c_int = 22;
+pub const IP_PKTINFO: c_int = 25;
+pub const IPPROTO_DIVERT: c_int = 259;
+pub const IPV6_IPSEC_POLICY_COMPAT: c_int = 28;
+pub const TCP_KEEPALIVE: c_int = 0x04;
+pub const ARPHRD_ARCNET: u16 = 7;
+pub const SO_BINDTODEVICE: c_int = 0x0800;
+pub const EAI_NODATA: c_int = 7;
+pub const IPTOS_ECN_NOT_ECT: u8 = 0x00;
+pub const RTF_BROADCAST: u32 = 0x80000;
+pub const UDP_ENCAP: c_int = 100;
+pub const HW_IOSTATS: c_int = 9;
+pub const HW_MACHINE_ARCH: c_int = 10;
+pub const HW_ALIGNBYTES: c_int = 11;
+pub const HW_CNMAGIC: c_int = 12;
+pub const HW_PHYSMEM64: c_int = 13;
+pub const HW_USERMEM64: c_int = 14;
+pub const HW_IOSTATNAMES: c_int = 15;
+pub const HW_MAXID: c_int = 15;
+pub const CTL_UNSPEC: c_int = 0;
+pub const CTL_QNX: c_int = 9;
+pub const CTL_PROC: c_int = 10;
+pub const CTL_VENDOR: c_int = 11;
+pub const CTL_EMUL: c_int = 12;
+pub const CTL_SECURITY: c_int = 13;
+pub const CTL_MAXID: c_int = 14;
+pub const AF_ARP: c_int = 28;
+pub const AF_IEEE80211: c_int = 32;
+pub const AF_NATM: c_int = 27;
+pub const AF_NS: c_int = 6;
+pub const BIOCGDLTLIST: c_int = -1072676233;
+pub const BIOCGETIF: c_int = 1083196011;
+pub const BIOCGSEESENT: c_int = 1074020984;
+pub const BIOCGSTATS: c_int = 1082147439;
+pub const BIOCSDLT: c_int = -2147204490;
+pub const BIOCSETIF: c_int = -2138029460;
+pub const BIOCSSEESENT: c_int = -2147204487;
+pub const FIONSPACE: c_int = 1074030200;
+pub const FIONWRITE: c_int = 1074030201;
+pub const IFF_ACCEPTRTADV: c_int = 0x40000000;
+pub const IFF_IP6FORWARDING: c_int = 0x20000000;
+pub const IFF_SHIM: c_int = u32_cast_int(0x80000000);
+pub const KERN_ARND: c_int = 81;
+pub const KERN_IOV_MAX: c_int = 38;
+pub const KERN_LOGSIGEXIT: c_int = 46;
+pub const KERN_MAXID: c_int = 83;
+pub const KERN_PROC_ARGS: c_int = 48;
+pub const KERN_PROC_ENV: c_int = 3;
+pub const KERN_PROC_GID: c_int = 7;
+pub const KERN_PROC_RGID: c_int = 8;
+pub const LOCAL_CONNWAIT: c_int = 0x0002;
+pub const LOCAL_CREDS: c_int = 0x0001;
+pub const LOCAL_PEEREID: c_int = 0x0003;
+pub const MSG_NOTIFICATION: c_int = 0x0400;
+pub const NET_RT_IFLIST: c_int = 4;
+pub const NI_NUMERICSCOPE: c_int = 0x00000040;
+pub const PF_ARP: c_int = 28;
+pub const PF_NATM: c_int = 27;
+pub const pseudo_AF_HDRCMPLT: c_int = 30;
+pub const SIOCGIFADDR: c_int = -1064277727;
+pub const SO_FIB: c_int = 0x100a;
+pub const SO_TXPRIO: c_int = 0x100b;
+pub const SO_SETFIB: c_int = 0x100a;
+pub const SO_VLANPRIO: c_int = 0x100c;
+pub const USER_ATEXIT_MAX: c_int = 21;
+pub const USER_MAXID: c_int = 22;
+pub const SO_OVERFLOWED: c_int = 0x1009;
+
+extern "C" {
+    pub fn sendmmsg(
+        sockfd: c_int,
+        msgvec: *mut crate::mmsghdr,
+        vlen: c_uint,
+        flags: c_uint,
+    ) -> c_int;
+
+    pub fn recvmmsg(
+        sockfd: c_int,
+        msgvec: *mut crate::mmsghdr,
+        vlen: c_uint,
+        flags: c_uint,
+        timeout: *mut crate::timespec,
+    ) -> c_int;
+}

--- a/src/unix/nto/io_sock/mod.rs
+++ b/src/unix/nto/io_sock/mod.rs
@@ -1,0 +1,108 @@
+//! Definitions specific to QNX versions using io-sock networking
+//!
+//! This module applies to:
+//!
+//! * `aarch64-unknown-nto-qnx710`
+//! * `x86_64-pc-nto-qnx710`
+//! * `aarch64-unknown-nto-qnx800`
+//! * `x86_64-pc-nto-qnx800`
+
+use crate::prelude::*;
+
+s! {
+    pub struct in_addr {
+        pub s_addr: crate::in_addr_t,
+    }
+
+    pub struct sockaddr_in {
+        pub sin_len: u8,
+        pub sin_family: crate::sa_family_t,
+        pub sin_port: crate::in_port_t,
+        pub sin_addr: crate::in_addr,
+        pub sin_zero: [c_char; 8],
+    }
+
+    pub struct arphdr {
+        pub ar_hrd: u16,
+        pub ar_pro: u16,
+        pub ar_hln: u8,
+        pub ar_pln: u8,
+        pub ar_op: u16,
+    }
+
+    pub struct mmsghdr {
+        pub msg_hdr: crate::msghdr,
+        pub msg_len: ssize_t,
+    }
+
+    pub struct bpf_stat {
+        pub bs_recv: c_uint,
+        pub bs_drop: c_uint,
+    }
+
+    pub struct sockaddr_dl {
+        pub sdl_len: c_uchar,
+        pub sdl_family: c_uchar,
+        pub sdl_index: c_ushort,
+        pub sdl_type: c_uchar,
+        pub sdl_nlen: c_uchar,
+        pub sdl_alen: c_uchar,
+        pub sdl_slen: c_uchar,
+        pub sdl_data: [c_char; 46],
+    }
+}
+
+pub const SCM_CREDS: c_int = 0x03;
+pub const AF_INET6: c_int = 28;
+pub const AF_BLUETOOTH: c_int = 36;
+pub const pseudo_AF_KEY: c_int = 27;
+pub const MSG_NOSIGNAL: c_int = 0x20000;
+pub const MSG_WAITFORONE: c_int = 0x00080000;
+pub const IPPROTO_DIVERT: c_int = 258;
+pub const RTF_BROADCAST: u32 = 0x400000;
+pub const UDP_ENCAP: c_int = 1;
+pub const HW_MACHINE_ARCH: c_int = 11;
+pub const AF_ARP: c_int = 35;
+pub const AF_IEEE80211: c_int = 37;
+pub const AF_NATM: c_int = 29;
+pub const BIOCGDLTLIST: c_ulong = 0xffffffffc0104279;
+pub const BIOCGETIF: c_int = 0x4020426b;
+pub const BIOCGSEESENT: c_int = 0x40044276;
+pub const BIOCGSTATS: c_int = 0x4008426f;
+pub const BIOCSDLT: c_int = u32_cast_int(0x80044278);
+pub const BIOCSETIF: c_int = u32_cast_int(0x8020426c);
+pub const BIOCSSEESENT: c_int = u32_cast_int(0x80044277);
+pub const KERN_ARND: c_int = 37;
+pub const KERN_IOV_MAX: c_int = 35;
+pub const KERN_LOGSIGEXIT: c_int = 34;
+pub const KERN_PROC_ARGS: c_int = 7;
+pub const KERN_PROC_ENV: c_int = 35;
+pub const KERN_PROC_GID: c_int = 11;
+pub const KERN_PROC_RGID: c_int = 10;
+pub const LOCAL_CONNWAIT: c_int = 4;
+pub const LOCAL_CREDS: c_int = 2;
+pub const MSG_NOTIFICATION: c_int = 0x00002000;
+pub const NET_RT_IFLIST: c_int = 3;
+pub const NI_NUMERICSCOPE: c_int = 0x00000020;
+pub const PF_ARP: c_int = AF_ARP;
+pub const PF_NATM: c_int = AF_NATM;
+pub const pseudo_AF_HDRCMPLT: c_int = 31;
+pub const SIOCGIFADDR: c_int = u32_cast_int(0xc0206921);
+pub const SO_SETFIB: c_int = 0x1014;
+
+extern "C" {
+    pub fn sendmmsg(
+        sockfd: c_int,
+        msgvec: *mut crate::mmsghdr,
+        vlen: size_t,
+        flags: c_int,
+    ) -> ssize_t;
+
+    pub fn recvmmsg(
+        sockfd: c_int,
+        msgvec: *mut crate::mmsghdr,
+        vlen: size_t,
+        flags: c_int,
+        timeout: *const crate::timespec,
+    ) -> ssize_t;
+}

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -1,4 +1,47 @@
+//! Definitions for QNX Neutrino and QNX OS
+//!
+//! This module applies to:
+//!
+//! * `aarch64-unknown-nto-qnx700`
+//! * `aarch64-unknown-nto-qnx710`
+//! * `aarch64-unknown-nto-qnx710_iosock`
+//! * `aarch64-unknown-nto-qnx800`
+//! * `i686-pc-nto-qnx700`
+//! * `x86_64-pc-nto-qnx710`
+//! * `x86_64-pc-nto-qnx710_iosock`
+//! * `x86_64-pc-nto-qnx800`
+//!
+//! There are sub-modules for the target architecture, and sub-modules for the
+//! kind of networking library used. QNX Neutrino 7.0 uses `io-pkt`, QNX OS 8.0
+//! uses `io-sock`, and QNX Neutrino 7.1 can be configured to use either.
+
 use crate::prelude::*;
+
+// Things that are QNX specific
+
+mod neutrino;
+pub use self::neutrino::*;
+
+// Things that are architecture specific
+
+mod arch;
+pub use self::arch::*;
+
+// Things that are network-stack specific
+
+cfg_if! {
+    if #[cfg(any(target_env = "nto70", target_env = "nto71"))] {
+        mod io_pkt;
+        pub use self::io_pkt::*;
+    } else if #[cfg(any(target_env = "nto71_iosock", target_env = "nto80"))] {
+        mod io_sock;
+        pub use self::io_sock::*;
+    } else {
+        panic!("Unsupported arch");
+    }
+}
+
+// QNX definitions of common UNIX things
 
 pub type clock_t = u32;
 
@@ -109,33 +152,10 @@ s! {
         pub imr_interface: in_addr,
     }
 
-    #[cfg_attr(any(target_env = "nto71", target_env = "nto70"), repr(packed))]
-    pub struct in_addr {
-        pub s_addr: crate::in_addr_t,
-    }
-
     pub struct sockaddr {
         pub sa_len: u8,
         pub sa_family: sa_family_t,
         pub sa_data: [c_char; 14],
-    }
-
-    #[cfg(not(target_env = "nto71_iosock"))]
-    pub struct sockaddr_in {
-        pub sin_len: u8,
-        pub sin_family: sa_family_t,
-        pub sin_port: crate::in_port_t,
-        pub sin_addr: crate::in_addr,
-        pub sin_zero: [i8; 8],
-    }
-
-    #[cfg(target_env = "nto71_iosock")]
-    pub struct sockaddr_in {
-        pub sin_len: u8,
-        pub sin_family: sa_family_t,
-        pub sin_port: crate::in_port_t,
-        pub sin_addr: crate::in_addr,
-        pub sin_zero: [c_char; 8],
     }
 
     pub struct sockaddr_in6 {
@@ -239,13 +259,6 @@ s! {
         _Reserved: Padding<[*mut c_char; 8]>,
     }
 
-    // Does not exist in io-sock
-    #[cfg(not(target_env = "nto71_iosock"))]
-    pub struct in_pktinfo {
-        pub ipi_addr: crate::in_addr,
-        pub ipi_ifindex: c_uint,
-    }
-
     pub struct ifaddrs {
         pub ifa_next: *mut ifaddrs,
         pub ifa_name: *mut c_char,
@@ -260,27 +273,6 @@ s! {
         pub arp_pa: crate::sockaddr,
         pub arp_ha: crate::sockaddr,
         pub arp_flags: c_int,
-    }
-
-    #[cfg_attr(any(target_env = "nto71", target_env = "nto70"), repr(packed))]
-    pub struct arphdr {
-        pub ar_hrd: u16,
-        pub ar_pro: u16,
-        pub ar_hln: u8,
-        pub ar_pln: u8,
-        pub ar_op: u16,
-    }
-
-    #[cfg(not(target_env = "nto71_iosock"))]
-    pub struct mmsghdr {
-        pub msg_hdr: crate::msghdr,
-        pub msg_len: c_uint,
-    }
-
-    #[cfg(target_env = "nto71_iosock")]
-    pub struct mmsghdr {
-        pub msg_hdr: crate::msghdr,
-        pub msg_len: ssize_t,
     }
 
     #[repr(align(8))]
@@ -610,20 +602,6 @@ s! {
         pub bf_insns: *mut crate::bpf_insn,
     }
 
-    #[cfg(not(target_env = "nto71_iosock"))]
-    pub struct bpf_stat {
-        pub bs_recv: u64,
-        pub bs_drop: u64,
-        pub bs_capt: u64,
-        bs_padding: Padding<[u64; 13]>,
-    }
-
-    #[cfg(target_env = "nto71_iosock")]
-    pub struct bpf_stat {
-        pub bs_recv: c_uint,
-        pub bs_drop: c_uint,
-    }
-
     pub struct bpf_version {
         pub bv_major: c_ushort,
         pub bv_minor: c_ushort,
@@ -646,14 +624,6 @@ s! {
     pub struct bpf_dltlist {
         pub bfl_len: c_uint,
         pub bfl_list: *mut c_uint,
-    }
-
-    // Does not exist in io-sock
-    #[cfg(not(target_env = "nto71_iosock"))]
-    pub struct unpcbid {
-        pub unp_pid: crate::pid_t,
-        pub unp_euid: crate::uid_t,
-        pub unp_egid: crate::gid_t,
     }
 
     pub struct dl_phdr_info {
@@ -719,30 +689,6 @@ s! {
         pub mq_curmsgs: c_long,
         pub mq_sendwait: c_long,
         pub mq_recvwait: c_long,
-    }
-
-    #[cfg(not(target_env = "nto71_iosock"))]
-    pub struct sockaddr_dl {
-        pub sdl_len: c_uchar,
-        pub sdl_family: crate::sa_family_t,
-        pub sdl_index: u16,
-        pub sdl_type: c_uchar,
-        pub sdl_nlen: c_uchar,
-        pub sdl_alen: c_uchar,
-        pub sdl_slen: c_uchar,
-        pub sdl_data: [c_char; 12],
-    }
-
-    #[cfg(target_env = "nto71_iosock")]
-    pub struct sockaddr_dl {
-        pub sdl_len: c_uchar,
-        pub sdl_family: c_uchar,
-        pub sdl_index: c_ushort,
-        pub sdl_type: c_uchar,
-        pub sdl_nlen: c_uchar,
-        pub sdl_alen: c_uchar,
-        pub sdl_slen: c_uchar,
-        pub sdl_data: [c_char; 46],
     }
 }
 
@@ -893,132 +839,6 @@ pub const MS_SYNC: c_int = 2;
 
 pub const SCM_RIGHTS: c_int = 0x01;
 pub const SCM_TIMESTAMP: c_int = 0x02;
-
-// QNX Network Stack Versioning:
-//
-// The `if` block targets the legacy `io-pkt` stack.
-// - target_env = "nto70": QNX 7.0
-// - target_env = "nto71": Standard QNX 7.1 (default legacy stack)
-//
-// The `else` block targets the modern `io-sock` stack.
-// - target_env = "nto71_iosock": QNX 7.1 with the optional new stack
-// - target_env = "nto80": QNX 8.0
-cfg_if! {
-    if #[cfg(any(target_env = "nto70", target_env = "nto71"))] {
-        pub const SCM_CREDS: c_int = 0x04;
-        pub const IFF_NOTRAILERS: c_int = 0x00000020;
-        pub const AF_INET6: c_int = 24;
-        pub const AF_BLUETOOTH: c_int = 31;
-        pub const pseudo_AF_KEY: c_int = 29;
-        pub const MSG_NOSIGNAL: c_int = 0x0800;
-        pub const MSG_WAITFORONE: c_int = 0x2000;
-        pub const IP_IPSEC_POLICY_COMPAT: c_int = 22;
-        pub const IP_PKTINFO: c_int = 25;
-        pub const IPPROTO_DIVERT: c_int = 259;
-        pub const IPV6_IPSEC_POLICY_COMPAT: c_int = 28;
-        pub const TCP_KEEPALIVE: c_int = 0x04;
-        pub const ARPHRD_ARCNET: u16 = 7;
-        pub const SO_BINDTODEVICE: c_int = 0x0800;
-        pub const EAI_NODATA: c_int = 7;
-        pub const IPTOS_ECN_NOT_ECT: u8 = 0x00;
-        pub const RTF_BROADCAST: u32 = 0x80000;
-        pub const UDP_ENCAP: c_int = 100;
-        pub const HW_IOSTATS: c_int = 9;
-        pub const HW_MACHINE_ARCH: c_int = 10;
-        pub const HW_ALIGNBYTES: c_int = 11;
-        pub const HW_CNMAGIC: c_int = 12;
-        pub const HW_PHYSMEM64: c_int = 13;
-        pub const HW_USERMEM64: c_int = 14;
-        pub const HW_IOSTATNAMES: c_int = 15;
-        pub const HW_MAXID: c_int = 15;
-        pub const CTL_UNSPEC: c_int = 0;
-        pub const CTL_QNX: c_int = 9;
-        pub const CTL_PROC: c_int = 10;
-        pub const CTL_VENDOR: c_int = 11;
-        pub const CTL_EMUL: c_int = 12;
-        pub const CTL_SECURITY: c_int = 13;
-        pub const CTL_MAXID: c_int = 14;
-        pub const AF_ARP: c_int = 28;
-        pub const AF_IEEE80211: c_int = 32;
-        pub const AF_NATM: c_int = 27;
-        pub const AF_NS: c_int = 6;
-        pub const BIOCGDLTLIST: c_int = -1072676233;
-        pub const BIOCGETIF: c_int = 1083196011;
-        pub const BIOCGSEESENT: c_int = 1074020984;
-        pub const BIOCGSTATS: c_int = 1082147439;
-        pub const BIOCSDLT: c_int = -2147204490;
-        pub const BIOCSETIF: c_int = -2138029460;
-        pub const BIOCSSEESENT: c_int = -2147204487;
-        pub const FIONSPACE: c_int = 1074030200;
-        pub const FIONWRITE: c_int = 1074030201;
-        pub const IFF_ACCEPTRTADV: c_int = 0x40000000;
-        pub const IFF_IP6FORWARDING: c_int = 0x20000000;
-        pub const IFF_SHIM: c_int = u32_cast_int(0x80000000);
-        pub const KERN_ARND: c_int = 81;
-        pub const KERN_IOV_MAX: c_int = 38;
-        pub const KERN_LOGSIGEXIT: c_int = 46;
-        pub const KERN_MAXID: c_int = 83;
-        pub const KERN_PROC_ARGS: c_int = 48;
-        pub const KERN_PROC_ENV: c_int = 3;
-        pub const KERN_PROC_GID: c_int = 7;
-        pub const KERN_PROC_RGID: c_int = 8;
-        pub const LOCAL_CONNWAIT: c_int = 0x0002;
-        pub const LOCAL_CREDS: c_int = 0x0001;
-        pub const LOCAL_PEEREID: c_int = 0x0003;
-        pub const MSG_NOTIFICATION: c_int = 0x0400;
-        pub const NET_RT_IFLIST: c_int = 4;
-        pub const NI_NUMERICSCOPE: c_int = 0x00000040;
-        pub const PF_ARP: c_int = 28;
-        pub const PF_NATM: c_int = 27;
-        pub const pseudo_AF_HDRCMPLT: c_int = 30;
-        pub const SIOCGIFADDR: c_int = -1064277727;
-        pub const SO_FIB: c_int = 0x100a;
-        pub const SO_TXPRIO: c_int = 0x100b;
-        pub const SO_SETFIB: c_int = 0x100a;
-        pub const SO_VLANPRIO: c_int = 0x100c;
-        pub const USER_ATEXIT_MAX: c_int = 21;
-        pub const USER_MAXID: c_int = 22;
-        pub const SO_OVERFLOWED: c_int = 0x1009;
-    } else {
-        pub const SCM_CREDS: c_int = 0x03;
-        pub const AF_INET6: c_int = 28;
-        pub const AF_BLUETOOTH: c_int = 36;
-        pub const pseudo_AF_KEY: c_int = 27;
-        pub const MSG_NOSIGNAL: c_int = 0x20000;
-        pub const MSG_WAITFORONE: c_int = 0x00080000;
-        pub const IPPROTO_DIVERT: c_int = 258;
-        pub const RTF_BROADCAST: u32 = 0x400000;
-        pub const UDP_ENCAP: c_int = 1;
-        pub const HW_MACHINE_ARCH: c_int = 11;
-        pub const AF_ARP: c_int = 35;
-        pub const AF_IEEE80211: c_int = 37;
-        pub const AF_NATM: c_int = 29;
-        pub const BIOCGDLTLIST: c_ulong = 0xffffffffc0104279;
-        pub const BIOCGETIF: c_int = 0x4020426b;
-        pub const BIOCGSEESENT: c_int = 0x40044276;
-        pub const BIOCGSTATS: c_int = 0x4008426f;
-        pub const BIOCSDLT: c_int = u32_cast_int(0x80044278);
-        pub const BIOCSETIF: c_int = u32_cast_int(0x8020426c);
-        pub const BIOCSSEESENT: c_int = u32_cast_int(0x80044277);
-        pub const KERN_ARND: c_int = 37;
-        pub const KERN_IOV_MAX: c_int = 35;
-        pub const KERN_LOGSIGEXIT: c_int = 34;
-        pub const KERN_PROC_ARGS: c_int = 7;
-        pub const KERN_PROC_ENV: c_int = 35;
-        pub const KERN_PROC_GID: c_int = 11;
-        pub const KERN_PROC_RGID: c_int = 10;
-        pub const LOCAL_CONNWAIT: c_int = 4;
-        pub const LOCAL_CREDS: c_int = 2;
-        pub const MSG_NOTIFICATION: c_int = 0x00002000;
-        pub const NET_RT_IFLIST: c_int = 3;
-        pub const NI_NUMERICSCOPE: c_int = 0x00000020;
-        pub const PF_ARP: c_int = AF_ARP;
-        pub const PF_NATM: c_int = AF_NATM;
-        pub const pseudo_AF_HDRCMPLT: c_int = 31;
-        pub const SIOCGIFADDR: c_int = u32_cast_int(0xc0206921);
-        pub const SO_SETFIB: c_int = 0x1014;
-    }
-}
 
 pub const MAP_TYPE: c_int = 0x3;
 
@@ -2587,42 +2407,6 @@ safe_f! {
     }
 }
 
-cfg_if! {
-    if #[cfg(not(target_env = "nto71_iosock"))] {
-        extern "C" {
-            pub fn sendmmsg(
-                sockfd: c_int,
-                msgvec: *mut crate::mmsghdr,
-                vlen: c_uint,
-                flags: c_uint,
-            ) -> c_int;
-            pub fn recvmmsg(
-                sockfd: c_int,
-                msgvec: *mut crate::mmsghdr,
-                vlen: c_uint,
-                flags: c_uint,
-                timeout: *mut crate::timespec,
-            ) -> c_int;
-        }
-    } else {
-        extern "C" {
-            pub fn sendmmsg(
-                sockfd: c_int,
-                msgvec: *mut crate::mmsghdr,
-                vlen: size_t,
-                flags: c_int,
-            ) -> ssize_t;
-            pub fn recvmmsg(
-                sockfd: c_int,
-                msgvec: *mut crate::mmsghdr,
-                vlen: size_t,
-                flags: c_int,
-                timeout: *const crate::timespec,
-            ) -> ssize_t;
-        }
-    }
-}
-
 // Network related functions are provided by libsocket and regex
 // functions are provided by libregex.
 // In QNX <=7.0, libregex functions were included in libc itself.
@@ -3221,18 +3005,3 @@ impl siginfo_t {
         (*(self as *const siginfo_t).cast::<siginfo_si_status>()).si_status
     }
 }
-
-cfg_if! {
-    if #[cfg(target_arch = "x86_64")] {
-        mod x86_64;
-        pub use self::x86_64::*;
-    } else if #[cfg(target_arch = "aarch64")] {
-        mod aarch64;
-        pub use self::aarch64::*;
-    } else {
-        panic!("Unsupported arch");
-    }
-}
-
-mod neutrino;
-pub use self::neutrino::*;

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -17,30 +17,6 @@
 
 use crate::prelude::*;
 
-// Things that are QNX specific
-
-mod neutrino;
-pub use self::neutrino::*;
-
-// Things that are architecture specific
-
-mod arch;
-pub use self::arch::*;
-
-// Things that are network-stack specific
-
-cfg_if! {
-    if #[cfg(any(target_env = "nto70", target_env = "nto71"))] {
-        mod io_pkt;
-        pub use self::io_pkt::*;
-    } else if #[cfg(any(target_env = "nto71_iosock", target_env = "nto80"))] {
-        mod io_sock;
-        pub use self::io_sock::*;
-    } else {
-        panic!("Unsupported arch");
-    }
-}
-
 // QNX definitions of common UNIX things
 
 pub type clock_t = u32;
@@ -3003,5 +2979,29 @@ impl siginfo_t {
             si_status: c_int,
         }
         (*(self as *const siginfo_t).cast::<siginfo_si_status>()).si_status
+    }
+}
+
+// Things that are QNX specific
+
+mod neutrino;
+pub use self::neutrino::*;
+
+// Things that are architecture specific
+
+mod arch;
+pub use self::arch::*;
+
+// Things that are network-stack specific
+
+cfg_if! {
+    if #[cfg(any(target_env = "nto70", target_env = "nto71"))] {
+        mod io_pkt;
+        pub use self::io_pkt::*;
+    } else if #[cfg(any(target_env = "nto71_iosock", target_env = "nto80"))] {
+        mod io_sock;
+        pub use self::io_sock::*;
+    } else {
+        panic!("Unsupported arch");
     }
 }

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -1,4 +1,4 @@
-//! Definitions for QNX Neutrino and QNX OS
+//! Definitions for QNX Software Development Platform
 //!
 //! This module applies to:
 //!
@@ -12,8 +12,8 @@
 //! * `x86_64-pc-nto-qnx800`
 //!
 //! There are sub-modules for the target architecture, and sub-modules for the
-//! kind of networking library used. QNX Neutrino 7.0 uses `io-pkt`, QNX OS 8.0
-//! uses `io-sock`, and QNX Neutrino 7.1 can be configured to use either.
+//! kind of networking library used. QNX SDP 7.0 uses `io-pkt`, QNX SDP 8.0
+//! uses `io-sock`, and QNX SDP 7.1 comes with both (so you can pick).
 
 use crate::prelude::*;
 

--- a/src/unix/nto/neutrino.rs
+++ b/src/unix/nto/neutrino.rs
@@ -1,3 +1,5 @@
+//! APIs that are specific to QNX Neutrino and not found in other operating systems
+
 use crate::prelude::*;
 
 pub type nto_job_t = crate::sync_t;


### PR DESCRIPTION
# Description

As most of the differences are related to the change in network stack half-way through the life of QNX Neutrino 7.1, the definitions are now split into io-pkt (the older stack) and io-sock (the newer stack).

I didn't add any architecture definitions for x86 (as would be required for i686-pc-nto-qnx700) because I don't have access to QNX Neutrino 7.0 to verify what should go here. But there's a clear place to add it later.

I do have QNX Neutrino 7.1 and QNX OS 8.0 and I have verified each of the types in the io-pkt and io-sock modules against the relevant C header files. I have not verified the remaining types or functions - I assume they are correct.

This is an alternative to https://github.com/rust-lang/libc/pull/4615, which seems to have stalled.

# Sources

For io-sock, [QNX says](https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.io_sock/topic/socket_api.html):

> The io-sock networking stack supports all the routines that application programmers would expect, including (but not limited to) the functions listed below. The FreeBSD 13.5 manual pages at https://www.freebsd.org/cgi/man.cgi are the best guide to their use:

For io-pkt, you can refer to https://www.qnx.com/developers/docs/7.1/.

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
   - There aren't any for QNX
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
   - I left all the existing ones
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI
   - I tried running this locally and I got: *not implemented: Foreign functions are unlikely to have any other pattern.* I don't know if we normally run the tests for this target.

