### PR TITLE
change sa_flags in sigaction to c_int on redox

### DIFF
--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -153,7 +153,7 @@ s! {
     #[allow(unpredictable_function_pointer_comparisons)]
     pub struct sigaction {
         pub sa_sigaction: crate::sighandler_t,
-        pub sa_flags: c_ulong,
+        pub sa_flags: c_int,
         pub sa_restorer: Option<extern "C" fn()>,
         pub sa_mask: crate::sigset_t,
     }


### PR DESCRIPTION
# Description

Changes `sa_flags` in `sigaction` to `c_int` for redox as per POSIX specification.

# Sources

`sa_flags` in `sigaction` the rust signal header: https://gitlab.redox-os.org/redox-os/relibc/-/blob/ee6a6062cd6c6b57e7617559d988895d8a73ec64/src/header/signal/mod.rs#L56

`sa_flags` in `sigaction` in the C include file: https://gitlab.redox-os.org/redox-os/relibc/-/blob/28ffabebf629172a6c0c00ca56f73d72f25f7c6e/include/bits/signal.h#L19

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated

