### PR TITLE
Linux: add `name_to_handle_at` and `open_by_handle_at`

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3671,6 +3671,7 @@ fn test_linux(target: &str) {
     }
 
     let arm = target.contains("arm");
+    let eabihf = target.contains("eabihf");
     let aarch64 = target.contains("aarch64");
     let i686 = target.contains("i686");
     let ppc = target.contains("powerpc");
@@ -4487,6 +4488,16 @@ fn test_linux(target: &str) {
             // FIXME(linux):  Requires >= 6.16 kernel headers.
             "PTRACE_SET_SYSCALL_INFO" => true,
 
+            // FIXME(linux): Requires >= 6.13 kernel headers.
+            "AT_HANDLE_CONNECTABLE" => true,
+
+            // FIXME(linux): Requires >= 6.12 kernel headers.
+            "AT_HANDLE_MNT_ID_UNIQUE" => true,
+
+            // FIXME(musl): This value is not yet in musl.
+            // eabihf targets are tested using an older version of glibc
+            "AT_HANDLE_FID" if musl || eabihf => true,
+
             _ => false,
         }
     });
@@ -4734,6 +4745,7 @@ fn test_linux(target: &str) {
             ("bcm_msg_head", "frames") => true,
             // FAM
             ("af_alg_iv", "iv") => true,
+            ("file_handle", "f_handle") if musl => true,
             // FIXME(ctest): ctest does not translate the rust code which computes the padding size
             ("pthread_cond_t", "__padding") if l4re => true,
             _ => false,

--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -167,6 +167,9 @@ AT_EXECVE_CHECK
 AT_FDCWD
 AT_FLAGS
 AT_GID
+AT_HANDLE_CONNECTABLE
+AT_HANDLE_FID
+AT_HANDLE_MNT_ID_UNIQUE
 AT_HWCAP
 AT_HWCAP2
 AT_HWCAP3
@@ -1705,6 +1708,7 @@ MAP_STACK
 MAP_TYPE
 MAXTTL
 MAX_ADDR_LEN
+MAX_HANDLE_SZ
 MAX_IPOPTLEN
 MAX_LINKS
 MCAST_BLOCK_SOURCE
@@ -4026,6 +4030,7 @@ ff_trigger
 fgetpos64
 fgetxattr
 file_clone_range
+file_handle
 flistxattr
 fmemopen
 fopen64
@@ -4189,6 +4194,7 @@ msgrcv
 msgsnd
 msqid_ds
 name_t
+name_to_handle_at
 newlocale
 nice
 nl_item
@@ -4203,6 +4209,7 @@ nlmsghdr
 nrand48
 off64_t
 open64
+open_by_handle_at
 open_how
 open_memstream
 openat

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1263,6 +1263,14 @@ s! {
         pub sched_deadline: crate::__u64,
         pub sched_period: crate::__u64,
     }
+
+    // linux/fcntl.h
+
+    pub struct file_handle {
+        pub handle_bytes: c_uint,
+        pub handle_type: c_int,
+        pub f_handle: [c_uchar; 0],
+    }
 }
 
 cfg_if! {
@@ -1397,6 +1405,11 @@ pub const IFF_ECHO: c_int = 0x40000;
 
 // linux/fcntl.h
 pub const AT_EXECVE_CHECK: c_int = 0x10000;
+
+pub const MAX_HANDLE_SZ: c_int = 128;
+pub const AT_HANDLE_FID: c_int = 0x200;
+pub const AT_HANDLE_MNT_ID_UNIQUE: c_int = 0x001;
+pub const AT_HANDLE_CONNECTABLE: c_int = 0x002;
 
 // linux/if_addr.h
 pub const IFA_UNSPEC: c_ushort = 0;
@@ -4366,6 +4379,15 @@ extern "C" {
     pub fn gethostid() -> c_long;
 
     pub fn klogctl(syslog_type: c_int, bufp: *mut c_char, len: c_int) -> c_int;
+
+    pub fn name_to_handle_at(
+        dirfd: c_int,
+        path: *const c_char,
+        handle: *mut file_handle,
+        mount_id: *mut c_int,
+        flags: c_int,
+    ) -> c_int;
+    pub fn open_by_handle_at(mount_fd: c_int, handle: *mut file_handle, flags: c_int) -> c_int;
 }
 
 // LFS64 extensions


### PR DESCRIPTION
# Description

Add file handle operations for Linux.

In particular I added:
- `name_to_handle_at()`
- `open_by_handle_at()`
- `file_handle`
- `MAX_HANDLE_SZ`
- `AT_HANDLE_MNT_ID_UNIQUE`
- `AT_HANDLE_FID`
- `AT_HANDLE_CONNECTABLE`

# Sources

- [`file_handle` struct (glibc)](https://github.com/bminor/glibc/blob/04e750e75b73957cf1c791535a3f4319534a52fc/sysdeps/unix/sysv/linux/bits/fcntl-linux.h#L364-L373)
- [Flags (glibc)](https://github.com/bminor/glibc/blob/04e750e75b73957cf1c791535a3f4319534a52fc/sysdeps/unix/sysv/linux/bits/fcntl-linux.h#L380-L387)
- [Functions (glibc)](https://github.com/bminor/glibc/blob/04e750e75b73957cf1c791535a3f4319534a52fc/sysdeps/unix/sysv/linux/bits/fcntl-linux.h#L455-L464)

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated