### PR TITLE
Correct the definition of `pthread_t` on Darwin

### DIFF
--- a/libc-test/build/main.rs
+++ b/libc-test/build/main.rs
@@ -262,7 +262,7 @@ fn test_apple(t: &Target) {
     cfg.skip_struct(move |s| {
         match s.ident() {
             // Extern types
-            "DIR" | "FILE" | "fpos_t" | "timezone" => true,
+            "DIR" | "FILE" | "fpos_t" | "timezone" | "_opaque_pthread_t" => true,
 
             // FIXME(macos): The size is changed in recent macOSes.
             "malloc_zone_t" => true,

--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -1798,6 +1798,7 @@ __PTHREAD_RWLOCKATTR_SIZE__
 __PTHREAD_RWLOCK_SIZE__
 __darwin_mcontext64
 __error
+_opaque_pthread_t
 abs
 acct
 aio_cancel

--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -1943,6 +1943,7 @@ __PTHREAD_RWLOCK_SIZE__
 __c_anonymous_bfl_u
 __darwin_mcontext64
 __error
+_opaque_pthread_t
 abs
 acct
 aio_cancel

--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -1943,7 +1943,6 @@ __PTHREAD_RWLOCK_SIZE__
 __c_anonymous_bfl_u
 __darwin_mcontext64
 __error
-_opaque_pthread_t
 abs
 acct
 aio_cancel

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -5,7 +5,22 @@ pub type useconds_t = u32;
 pub type blkcnt_t = i64;
 pub type socklen_t = u32;
 pub type sa_family_t = u8;
-pub type pthread_t = crate::uintptr_t;
+
+cfg_if! {
+    if #[cfg(target_vendor = "apple")] {
+        extern_ty! {
+            pub type _opaque_pthread_t;
+        }
+
+        type __darwin_pthread_t = *mut _opaque_pthread_t;
+
+        pub type pthread_t = __darwin_pthread_t;
+    } else {
+        // FIXME(1.0): verify other BSDs? Glancing around, other BSDs also look like a pointer
+        pub type pthread_t = crate::uintptr_t;
+    }
+}
+
 pub type nfds_t = c_uint;
 #[cfg(target_os = "dragonfly")]
 pub type regoff_t = c_int;

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -5,7 +5,22 @@ pub type useconds_t = u32;
 pub type blkcnt_t = i64;
 pub type socklen_t = u32;
 pub type sa_family_t = u8;
-pub type pthread_t = crate::uintptr_t;
+
+cfg_if! {
+    if #[cfg(target_vendor = "apple")] {
+        extern_ty! {
+            pub type _opaque_pthread_t;
+        }
+
+        type __darwin_pthread_t = *mut _opaque_pthread_t;
+
+        pub type pthread_t = __darwin_pthread_t;
+    } else {
+        // FIXME(1.0): verify other BSDs? Glancing around, other BSDs also look like a pointer
+        pub type pthread_t = crate::uintptr_t;
+    }
+}
+
 pub type nfds_t = c_uint;
 pub type regoff_t = off_t;
 

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -9,6 +9,9 @@ pub type sa_family_t = u8;
 cfg_if! {
     if #[cfg(target_vendor = "apple")] {
         extern_ty! {
+            // Internal definition that must be public because it appears in `pthread_t`, but is
+            // not meant to be user-facing.
+            #[doc(hidden)]
             pub type _opaque_pthread_t;
         }
 


### PR DESCRIPTION
# Description

This PR fixes rust-lang/libc#2903. This PR picks up the work started by @highjeans in rust-lang/libc#4336 (close rust-lang/libc#4336) which had stalled. I just followed up the comments from @tgross35 in the PR and tried to finish it.

> Thanks for leaving a great start point to study this crate.

Closes: https://github.com/rust-lang/libc/pull/4336

# Sources

- https://github.com/apple-oss-distributions/xnu/blob/8d741a5de7ff4191bf97d57b9f54c2f6d4a15585/EXTERNAL_HEADERS/sys/_pthread/_pthread_types.h#L103
- https://github.com/apple-oss-distributions/libpthread/blob/main/include/sys/_pthread/_pthread_t.h#L31

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI