### PR TITLE
enable musl32_time64 and musl_v1_2_3 for hexagon

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -52,7 +52,7 @@ const CHECK_CFG_EXTRA: &[(&str, &[&str])] = &[
 ];
 
 /// Musl architectures that set `#define _REDIR_TIME64 1`.
-const MUSL_REDIR_TIME64_ARCHES: &[&str] = &["arm", "mips", "powerpc", "x86"];
+const MUSL_REDIR_TIME64_ARCHES: &[&str] = &["arm", "hexagon", "mips", "powerpc", "x86"];
 
 fn main() {
     // Avoid unnecessary re-building.
@@ -110,8 +110,8 @@ fn main() {
     // OpenHarmony uses a fork of the musl libc
     let musl = target_env == "musl" || target_env == "ohos";
 
-    // loongarch64 and ohos only exist with recent musl
-    if target_arch == "loongarch64" || target_env == "ohos" {
+    // loongarch64, hexagon, and ohos only exist with recent musl
+    if target_arch == "loongarch64" || target_arch == "hexagon" || target_env == "ohos" {
         musl_v1_2_3 = true;
     }
 

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3685,6 +3685,7 @@ fn test_linux(target: &str) {
     let gnueabihf = target.contains("gnueabihf");
     let x86_64_gnux32 = target.contains("gnux32") && x86_64;
     let riscv64 = target.contains("riscv64");
+    let hexagon = target.contains("hexagon");
     let loongarch64 = target.contains("loongarch64");
     let wasm32 = target.contains("wasm32");
     let uclibc = target.contains("uclibc");
@@ -3699,9 +3700,9 @@ fn test_linux(target: &str) {
     let old_musl = musl && !musl_v1_2_3;
 
     let mut cfg = ctest_cfg();
-    if (musl_v1_2_3 || loongarch64) && musl {
+    if (musl_v1_2_3 || loongarch64 || hexagon) && musl {
         cfg.cfg("musl_v1_2_3", None);
-        if arm || ppc32 || x86_32 || mips32 {
+        if arm || hexagon || ppc32 || x86_32 || mips32 {
             cfg.cfg("musl32_time64", None);
             cfg.cfg("linux_time_bits64", None);
         }


### PR DESCRIPTION
Hexagon musl uses 64-bit time_t (__USE_TIME_BITS64), so add it to MUSL_REDIR_TIME64_ARCHES and force musl_v1_2_3 since hexagon only exists with recent musl. Without this, time_t is c_long (4 bytes) causing a 24-byte stack buffer overflow on fstat() calls.

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

# Sources

musl https://github.com/quic/musl/releases/tag/hexagon-v1.2.4-dec-2025

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
