### PR TITLE
Add SOMAXCONN to ESP-IDF

### DIFF
--- a/libc-test/semver/espidf.txt
+++ b/libc-test/semver/espidf.txt
@@ -31,6 +31,7 @@ SIGQUIT
 SIGSEGV
 SIGTERM
 SOL_SOCKET
+SOMAXCONN
 cmsghdr
 dirent
 eventfd

--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -97,6 +97,8 @@ pub const SIGHUP: c_int = 1;
 pub const SIGQUIT: c_int = 3;
 pub const NSIG: size_t = 32;
 
+pub const SOMAXCONN: c_int = 128;
+
 extern "C" {
     pub fn pthread_create(
         native: *mut crate::pthread_t,


### PR DESCRIPTION
# Description

Adds the SOMAXCONN constant for ESP-IDF.

# Sources

Only source I could find for this: https://sourcevu.sysprogs.com/espressif/esp-idf/macros/SOMAXCONN. But 128 is commonly used value

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated