### PR TITLE
redox: fix blkcnt_t type

### DIFF
--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 pub type wchar_t = i32;
 
-pub type blkcnt_t = c_ulong;
+pub type blkcnt_t = c_longlong;
 pub type blksize_t = c_long;
 pub type clock_t = c_long;
 pub type clockid_t = c_int;


### PR DESCRIPTION
# Description

This fixes type for blkcnt_t in Redox OS as it's recently changed. 

# Sources

- https://gitlab.redox-os.org/redox-os/relibc/-/merge_requests/1036
- https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/platform/types.rs#L71

# Checklist

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
