### PR TITLE
FreeBSD: Added `xfile` structure and file descriptor types

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2747,6 +2747,9 @@ fn test_freebsd(target: &str) {
             // Added in FreeBSD 15
             "AT_HWCAP3" | "AT_HWCAP4" if Some(15) > freebsd_ver => true,
 
+            // Added in FreeBSD 15
+            "DTYPE_INOTIFY" | "DTYPE_JAILDESC" if Some(15) > freebsd_ver => true,
+
             _ => false,
         }
     });

--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -2425,4 +2425,5 @@ vmtotal
 wait4
 waitid
 xallocx
+xfile
 xucred

--- a/src/new/freebsd/mod.rs
+++ b/src/new/freebsd/mod.rs
@@ -3,4 +3,5 @@
 //! * Headers: <https://github.com/freebsd/freebsd-src/blob/main/sys/riscv/include/ucontext.h>
 //! * Symbol map: <https://github.com/freebsd/freebsd-src/blob/main/lib/libc/gen/Symbol.map>
 
+pub(crate) mod sys;
 pub(crate) mod unistd;

--- a/src/new/freebsd/sys/file.rs
+++ b/src/new/freebsd/sys/file.rs
@@ -1,0 +1,46 @@
+//! Header: `sys/file.h`
+//!
+//! https://github.com/freebsd/freebsd-src/blob/main/sys/sys/file.h
+
+use crate::prelude::*;
+
+pub const DTYPE_NONE: c_int = 0;
+pub const DTYPE_VNODE: c_int = 1;
+pub const DTYPE_SOCKET: c_int = 2;
+pub const DTYPE_PIPE: c_int = 3;
+pub const DTYPE_FIFO: c_int = 4;
+pub const DTYPE_KQUEUE: c_int = 5;
+pub const DTYPE_CRYPTO: c_int = 6;
+pub const DTYPE_MQUEUE: c_int = 7;
+pub const DTYPE_SHM: c_int = 8;
+pub const DTYPE_SEM: c_int = 9;
+pub const DTYPE_PTS: c_int = 10;
+pub const DTYPE_DEV: c_int = 11;
+pub const DTYPE_PROCDESC: c_int = 12;
+pub const DTYPE_EVENTFD: c_int = 13;
+pub const DTYPE_TIMERFD: c_int = 14;
+pub const DTYPE_INOTIFY: c_int = 15;
+pub const DTYPE_JAILDESC: c_int = 16;
+
+s! {
+    #[cfg(not(any(freebsd10, freebsd11)))]
+    pub struct xfile {
+        pub xf_size: crate::ksize_t,
+        pub xf_pid: crate::pid_t,
+        pub xf_uid: crate::uid_t,
+        pub xf_fd: c_int,
+        _xf_int_pad1: Padding<c_int>,
+        pub xf_file: crate::kvaddr_t,
+        pub xf_type: c_short,
+        _xf_short_pad1: Padding<c_short>,
+        pub xf_count: c_int,
+        pub xf_msgcount: c_int,
+        _xf_int_pad2: Padding<c_int>,
+        pub xf_offset: crate::off_t,
+        pub xf_data: crate::kvaddr_t,
+        pub xf_vnode: crate::kvaddr_t,
+        pub xf_flag: c_uint,
+        _xf_int_pad3: Padding<c_int>,
+        _xf_int64_pad: Padding<[i64; 6]>,
+    }
+}

--- a/src/new/freebsd/sys/mod.rs
+++ b/src/new/freebsd/sys/mod.rs
@@ -1,0 +1,5 @@
+//! Directory: `sys/`
+//!
+//! https://github.com/freebsd/freebsd-src/tree/main/sys/sys'
+
+pub(crate) mod file;

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -210,6 +210,8 @@ cfg_if! {
     } else if #[cfg(target_os = "nto")] {
         pub use net::bpf::*;
         pub use net::if_::*;
+    } else if #[cfg(target_os = "freebsd")] {
+        pub use sys::file::*;
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->


# Description

Added binding for `xfile` structure from `sys/file.h` and descriptor types.

<!-- Add a short description about what this change does -->

# Sources

#### FreeBSD 15
- [xfile](https://github.com/freebsd/freebsd-src/blob/b17655c95c4cb313355de1ffd74cb8a4dcc1a053/sys/sys/file.h#L243)
- [descriptors](https://github.com/freebsd/freebsd-src/blob/b17655c95c4cb313355de1ffd74cb8a4dcc1a053/sys/sys/file.h#L59)

#### FreeBSD 14
- [xfile](https://github.com/freebsd/freebsd-src/blob/e0e1e9e083097383bcebf0b6cf65af46653e2f73/sys/sys/file.h#L234)
- [descriptors](https://github.com/freebsd/freebsd-src/blob/e0e1e9e083097383bcebf0b6cf65af46653e2f73/sys/sys/file.h#L58)

#### FreeBSD 13
- [xfile](https://github.com/freebsd/freebsd-src/blob/55eff489d9cdae5620bf60bb79d996a059404ed2/sys/sys/file.h#L224)
- [descriptors](https://github.com/freebsd/freebsd-src/blob/55eff489d9cdae5620bf60bb79d996a059404ed2/sys/sys/file.h#L58)

#### ~~FreeBSD 12~~
- ~~[xfile](https://github.com/freebsd/freebsd-src/blob/9aed7107bbfbe9f919b547d68e9cd228a1a1852c/sys/sys/file.h#L217)~~
- ~~[descriptors](https://github.com/freebsd/freebsd-src/blob/9aed7107bbfbe9f919b547d68e9cd228a1a1852c/sys/sys/file.h#L58)~~

#### ~~FreeBSD 11~~
- ~~[xfile](https://github.com/freebsd/freebsd-src/blob/5ed7eb0d97ba4436218e810f61bd059acba984c2/sys/sys/file.h#L209)~~
- ~~[descriptors](https://github.com/freebsd/freebsd-src/blob/5ed7eb0d97ba4436218e810f61bd059acba984c2/sys/sys/file.h#L56)~~

#### ~~FreeBSD 10~~
- ~~[xfile](https://github.com/freebsd/freebsd-src/blob/28cce1d5b5f5636459f6fa4b99d32139af8ecd2b/sys/sys/file.h#L198)~~
- ~~[descriptors](https://github.com/freebsd/freebsd-src/blob/28cce1d5b5f5636459f6fa4b99d32139af8ecd2b/sys/sys/file.h#L56)~~

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:


-->

@rustbot label +stable-nominated
