### PR TITLE
VxWorks: Adding structs and defines

### DIFF
--- a/libc-test/semver/vxworks.txt
+++ b/libc-test/semver/vxworks.txt
@@ -241,12 +241,15 @@ ONLCR
 OPOST
 O_ACCMODE
 O_APPEND
+O_ASYNC
 O_CLOEXEC
 O_CREAT
+O_DSYNC
 O_EXCL
 O_NONBLOCK
 O_RDONLY
 O_RDWR
+O_SYNC
 O_TRUNC
 O_WRONLY
 PARENB
@@ -468,6 +471,7 @@ connect
 creat
 dev_t
 dirent
+dirfd
 dladdr
 dlclose
 dlerror
@@ -482,7 +486,9 @@ fchown
 fchownat
 fclose
 fcntl
+fdatasync
 fdopen
+fdopendir
 feof
 ferror
 fflush
@@ -506,6 +512,7 @@ fscanf
 fseek
 fseeko
 fsetpos
+fsid_t
 fstat
 fsync
 ftell
@@ -586,6 +593,7 @@ memcpy
 memmove
 memset
 mkdir
+mkdirat
 mkdtemp
 mkfifo
 mkstemp
@@ -604,6 +612,7 @@ nfds_t
 nlink_t
 off_t
 open
+openat
 opendir
 openlog
 pathconf
@@ -676,6 +685,7 @@ raise
 read
 readdir
 readlink
+readlinkat
 readv
 realloc
 realpath
@@ -736,6 +746,7 @@ sprintf
 sscanf
 ssize_t
 stat
+statfs
 strcat
 strchr
 strcmp

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -241,6 +241,22 @@ s! {
         st_reserved4: Padding<c_int>,
     }
 
+    pub struct fsid_t {
+        val: [c_long; 2],
+    }
+
+    pub struct statfs {
+        pub f_type: c_long,
+        pub f_bsize: c_long,
+        pub f_blocks: c_long,
+        pub f_bfree: c_long,
+        pub f_bavail: c_long,
+        pub f_files: c_long,
+        pub f_ffree: c_long,
+        pub f_fsid: crate::fsid_t,
+        f_spare: Padding<[c_long; 7]>,
+    }
+
     //b_struct__Timespec.h
     pub struct _Timespec {
         pub tv_sec: crate::time_t,
@@ -1385,6 +1401,9 @@ pub const O_ACCMODE: c_int = 3;
 pub const O_CLOEXEC: c_int = 0x100000; // fcntlcom
 pub const O_EXCL: c_int = 0x0800;
 pub const O_CREAT: c_int = 0x0200;
+pub const O_SYNC: c_int = 0x2000;
+pub const O_ASYNC: c_int = 0x0040;
+pub const O_DSYNC: c_int = 0x10000;
 pub const O_TRUNC: c_int = 0x0400;
 pub const O_APPEND: c_int = 0x0008;
 pub const O_RDWR: c_int = 0x0002;
@@ -1571,6 +1590,15 @@ extern "C" {
         flags: c_int,
     ) -> c_int;
 
+    pub fn mkdirat(dirfd: c_int, pathname: *const c_char, mode: mode_t) -> c_int;
+
+    pub fn readlinkat(
+        dirfd: c_int,
+        pathname: *const c_char,
+        buf: *mut c_char,
+        bufsiz: size_t,
+    ) -> ssize_t;
+
     pub fn unlinkat(dirfd: c_int, pathname: *const c_char, flags: c_int) -> c_int;
 
     // netdb.h
@@ -1617,6 +1645,7 @@ extern "C" {
     pub fn pause() -> c_int;
     pub fn seteuid(uid: uid_t) -> c_int;
     pub fn setegid(gid: gid_t) -> c_int;
+    pub fn statfs(path: *const c_char, buf: *mut statfs) -> c_int;
     pub fn sleep(secs: c_uint) -> c_uint;
     pub fn ttyname(fd: c_int) -> *mut c_char;
     pub fn wait(status: *mut c_int) -> pid_t;
@@ -1829,6 +1858,9 @@ extern "C" {
     // stat.h
     pub fn fstat(fildes: c_int, buf: *mut stat) -> c_int;
 
+    // sys/statfs.h
+    pub fn fstatfs(fd: c_int, buf: *mut statfs) -> c_int;
+
     // stat.h
     pub fn lstat(path: *const c_char, buf: *mut stat) -> c_int;
 
@@ -1845,9 +1877,18 @@ extern "C" {
     // dirent.h
     pub fn readdir(pDir: *mut crate::DIR) -> *mut crate::dirent;
 
+    // dirent.h
+    pub fn fdopendir(fd: c_int) -> *mut crate::DIR;
+
+    // dirent.h
+    pub fn dirfd(dirp: *mut crate::DIR) -> c_int;
+
     // fcntl.h or
     // ioLib.h
     pub fn open(path: *const c_char, oflag: c_int, ...) -> c_int;
+
+    // fcntl.h
+    pub fn openat(dirfd: c_int, pathname: *const c_char, flags: c_int, ...) -> c_int;
 
     // poll.h
     pub fn poll(fds: *mut pollfd, nfds: nfds_t, timeout: c_int) -> c_int;
@@ -2185,6 +2226,9 @@ extern "C" {
 
     // unistd.h
     pub fn fsync(fd: c_int) -> c_int;
+
+    // unistd.h
+    pub fn fdatasync(fd: c_int) -> c_int;
 
     // dirent.h
     pub fn closedir(ptr: *mut crate::DIR) -> c_int;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->
In particular I have added:

- struct statfs
- O_SYNC
- O_ASYNC
- O_DSYNC
- mkdirat()
- readlinkat()
- statfs()
- fstatfs()
- fopendir()
- dirfd()
- openat()
- fdatasync()
for VxWorks.

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
