### PR TITLE
nuttx: Add _SC_HOST_NAME_MAX constant

### DIFF
--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -512,6 +512,7 @@ pub const FIONBIO: i32 = 0x30a;
 pub const _SC_PAGESIZE: i32 = 0x36;
 pub const _SC_THREAD_STACK_MIN: i32 = 0x58;
 pub const _SC_GETPW_R_SIZE_MAX: i32 = 0x25;
+pub const _SC_HOST_NAME_MAX: i32 = 0x26;
 
 // signal.h
 pub const SIGHUP: c_int = 1;


### PR DESCRIPTION
# Description
Add the missing `_SC_HOST_NAME_MAX` sysconf constant for the NuttX platform. This constant is used with `sysconf()` to get the maximum length of a host name.
# Sources
* NuttX unistd.h: https://github.com/apache/nuttx/blob/master/include/unistd.h#L170
# Checklist
<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->
- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
