### PR TITLE
Fix: Replace sighandler_t with sig_t for Apple and BSDs

### DIFF
--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -2195,6 +2195,7 @@ shmctl
 shmdt
 shmget
 shmid_ds
+sig_t
 sigaltstack
 sigevent
 siginfo_t

--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -2155,6 +2155,7 @@ shmctl
 shmdt
 shmget
 shmid_ds
+sig_t
 sigevent
 siginfo_t
 sigsuspend

--- a/libc-test/semver/dragonfly.txt
+++ b/libc-test/semver/dragonfly.txt
@@ -1606,6 +1606,7 @@ shmat
 shmctl
 shmdt
 shmget
+sig_t
 sigaltstack
 sigevent
 siginfo_t

--- a/libc-test/semver/dragonfly.txt
+++ b/libc-test/semver/dragonfly.txt
@@ -1667,6 +1667,7 @@ shmctl
 shmdt
 shmget
 shmid_ds
+sig_t
 sigaltstack
 sigevent
 siginfo_t

--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -2368,6 +2368,7 @@ shmctl
 shmdt
 shmget
 shmid_ds
+sig_t
 sigaltstack
 sigevent
 siginfo_t

--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -2430,6 +2430,7 @@ shmctl
 shmdt
 shmget
 shmid_ds
+sig_t
 sigaltstack
 sigevent
 siginfo_t

--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -1571,6 +1571,7 @@ shmctl
 shmdt
 shmget
 shmid_ds
+sig_t
 sigaltstack
 sigevent
 siginfo_t

--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -1598,6 +1598,7 @@ shmctl
 shmdt
 shmget
 shmid_ds
+sig_t
 sigaltstack
 sigevent
 siginfo_t

--- a/libc-test/semver/openbsd.txt
+++ b/libc-test/semver/openbsd.txt
@@ -1332,6 +1332,7 @@ shmctl
 shmdt
 shmget
 shmid_ds
+sig_t
 sigaltstack
 siginfo_t
 sigsuspend

--- a/libc-test/semver/openbsd.txt
+++ b/libc-test/semver/openbsd.txt
@@ -1385,6 +1385,7 @@ shmctl
 shmdt
 shmget
 shmid_ds
+sig_t
 sigaltstack
 siginfo_t
 sigsuspend

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -327,7 +327,7 @@ s! {
 
     pub struct sigaction {
         // FIXME(union): this field is actually a union
-        pub sa_sigaction: crate::sighandler_t,
+        pub sa_sigaction: crate::sig_t,
         pub sa_mask: sigset_t,
         pub sa_flags: c_int,
     }

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -326,9 +326,11 @@ s! {
         _pad: Padding<[usize; 9]>,
     }
 
+    // FIXME(1.0): This should not implement `PartialEq`
+    #[allow(unpredictable_function_pointer_comparisons)]
     pub struct sigaction {
         // FIXME(union): this field is actually a union
-        pub sa_sigaction: crate::sighandler_t,
+        pub sa_sigaction: crate::sig_t,
         pub sa_mask: sigset_t,
         pub sa_flags: c_int,
     }

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -164,7 +164,7 @@ s! {
     }
 
     pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
+        pub sa_sigaction: crate::sig_t,
         pub sa_flags: c_int,
         pub sa_mask: sigset_t,
     }

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -156,8 +156,10 @@ s! {
         _pad2: Padding<[c_int; 7]>,
     }
 
+    // FIXME(1.0): This should not implement `PartialEq`
+    #[allow(unpredictable_function_pointer_comparisons)]
     pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
+        pub sa_sigaction: crate::sig_t,
         pub sa_flags: c_int,
         pub sa_mask: sigset_t,
     }

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -11,6 +11,7 @@ pub type nfds_t = c_uint;
 pub type regoff_t = c_int;
 #[cfg(not(target_os = "dragonfly"))]
 pub type regoff_t = off_t;
+pub type sig_t = Option<unsafe extern "C" fn(crate::c_int)>;
 
 s! {
     pub struct sockaddr {

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -27,7 +27,7 @@ s! {
     }
 
     pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
+        pub sa_sigaction: crate::sig_t,
         pub sa_mask: crate::sigset_t,
         pub sa_flags: c_int,
     }

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -26,8 +26,10 @@ s! {
         pub sched_priority: c_int,
     }
 
+    // FIXME(1.0): This should not implement `PartialEq`
+    #[allow(unpredictable_function_pointer_comparisons)]
     pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
+        pub sa_sigaction: crate::sig_t,
         pub sa_mask: crate::sigset_t,
         pub sa_flags: c_int,
     }

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -18,6 +18,18 @@ pub type pid_t = i32;
 pub type in_addr_t = u32;
 pub type in_port_t = u16;
 pub type sighandler_t = size_t;
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos",
+    target_os = "visionos",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "openbsd",
+    target_os = "netbsd"
+))]
+pub type sig_t = sighandler_t;
 pub type cc_t = c_uchar;
 
 cfg_if! {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1336,7 +1336,23 @@ extern "C" {
     #[cfg_attr(gnu_file_offset_bits64, link_name = "ftruncate64")]
     pub fn ftruncate(fd: c_int, length: off_t) -> c_int;
 
+    #[cfg(not(any(
+        target_vendor = "apple",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
     pub fn signal(signum: c_int, handler: sighandler_t) -> sighandler_t;
+
+    #[cfg(any(
+        target_vendor = "apple",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    pub fn signal(signum: c_int, handler: sig_t) -> sig_t;
 
     #[cfg_attr(target_os = "netbsd", link_name = "__getrusage50")]
     #[cfg_attr(gnu_time_bits64, link_name = "__getrusage64")]


### PR DESCRIPTION
# Description

This PR tries to fix rust-lang/libc#1273.

> I am not able to evaluate whether `#[deprecated]` should be added.

# Sources

> Apple I checked at my local (Aarch MacOS 26.3.1)

- (Freebsd) https://github.com/freebsd/freebsd-src/blob/016570c4463d5908953355ee1cf9a385ad9601b4/sys/sys/signal.h
- (Dragonfly) https://github.com/DragonFlyBSD/DragonFlyBSD/blob/51591aff67978c86de99839e31d8c8fcc54bc316/sys/sys/signal.h
- https://www.gnu.org/software/gnulib/manual/html_node/signal_002eh.html
- The type `sighandler_t` (a GNU extension) is not defined on most non-glibc platforms: macOS 11.1
, FreeBSD 14.0, NetBSD 10.0, OpenBSD 7.5, AIX 5.1, HP-UX 11, Solaris 11.4, Cygwin, mingw, MSVC 14.

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
