### PR TITLE
redox: fix signal action constant types

### DIFF
--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -665,14 +665,14 @@ pub const SIGPWR: c_int = 30;
 pub const SIGSYS: c_int = 31;
 pub const NSIG: c_int = 32;
 
-pub const SA_NOCLDWAIT: c_ulong = 0x0000_0002;
-pub const SA_RESTORER: c_ulong = 0x0000_0004; // FIXME(redox): remove after relibc removes it
-pub const SA_SIGINFO: c_ulong = 0x0200_0000;
-pub const SA_ONSTACK: c_ulong = 0x0400_0000;
-pub const SA_RESTART: c_ulong = 0x0800_0000;
-pub const SA_NODEFER: c_ulong = 0x1000_0000;
-pub const SA_RESETHAND: c_ulong = 0x2000_0000;
-pub const SA_NOCLDSTOP: c_ulong = 0x4000_0000;
+pub const SA_NOCLDWAIT: c_int = 0x0000_0002;
+pub const SA_RESTORER: c_int = 0x0000_0004; // FIXME(redox): remove after relibc removes it
+pub const SA_SIGINFO: c_int = 0x0200_0000;
+pub const SA_ONSTACK: c_int = 0x0400_0000;
+pub const SA_RESTART: c_int = 0x0800_0000;
+pub const SA_NODEFER: c_int = 0x1000_0000;
+pub const SA_RESETHAND: c_int = 0x2000_0000;
+pub const SA_NOCLDSTOP: c_int = 0x4000_0000;
 
 // sys/file.h
 pub const LOCK_SH: c_int = 1;


### PR DESCRIPTION
Change `SA_` constant types to `c_int` to fix a redox build error.

Follow-up to https://github.com/rust-lang/libc/pull/4986

@rustbot label +stable-nominated