### PR TITLE
linux: add ifinfomsg struct from rtnetlink.h

### DIFF
--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -4095,6 +4095,7 @@ if_freenameindex
 if_nameindex
 ifaddrs
 ifconf
+ifinfomsg
 ifreq
 in6_ifreq
 in6_pktinfo

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1253,6 +1253,16 @@ s! {
         pub handle_type: c_int,
         pub f_handle: [c_uchar; 0],
     }
+
+    // include/uapi/linux/rtnetlink.h
+    pub struct ifinfomsg {
+        pub ifi_family: c_uchar,
+        __ifi_pad: Padding<c_uchar>,
+        pub ifi_type: c_ushort,
+        pub ifi_index: c_int,
+        pub ifi_flags: c_uint,
+        pub ifi_change: c_uint,
+    }
 }
 
 cfg_if! {


### PR DESCRIPTION
# Description

Add ifinfomsg struct which is required to query netlink device information.

# Sources

https://github.com/torvalds/linux/blob/0257f64bdac7fdca30fa3cae0df8b9ecbec7733a/tools/include/uapi/linux/rtnetlink.h

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated

