### PR TITLE
chore(ci): upgrade macOS runner to 26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
     name: Clippy on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-15, windows-2025]
+        os: [ubuntu-24.04, macos-26, windows-2025]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
@@ -118,7 +118,7 @@ jobs:
       matrix:
         include:
           - target: aarch64-apple-darwin
-            os: macos-15
+            os: macos-26
           - target: aarch64-pc-windows-msvc
             os: windows-11-arm
           - target: aarch64-unknown-linux-gnu
@@ -217,7 +217,7 @@ jobs:
           - target: wasm32-wasip1
           - target: wasm32-wasip2
           - target: x86_64-apple-darwin
-            os: macos-15-intel
+            os: macos-26-intel
           - target: x86_64-linux-android
           # FIXME: Exec format error (os error 8)
           # - target: x86_64-unknown-linux-gnux32

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -332,6 +332,9 @@ fn test_apple(target: &str) {
 
             // FIXME(macos): The size is changed in recent macOSes.
             "malloc_introspection_t" if x86_64 => true,
+
+            // FIXME(macos): The size is changed in macOS 26.
+            "vm_statistics64" => true,
             _ => false,
         }
     });
@@ -346,6 +349,21 @@ fn test_apple(target: &str) {
             // https://github.com/apple-oss-distributions/xnu/commit/e6231be02a03711ca404e5121a151b24afbff733
             "TIOCREMOTE" => true,
 
+            // FIXME(macos): bumped up on macOS 26
+            // https://github.com/apple-oss-distributions/xnu/commit/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea
+            "ELAST" => true,
+
+            // FIXME(macos): bumped up on macOS 26, it's sizeof `vm_statistics64_data_t`
+            "HOST_VM_INFO64_COUNT" => true,
+
+            _ => false,
+        }
+    });
+
+    cfg.skip_alias(move |ty| {
+        match ty.ident() {
+            // FIXME(macos): The size is changed in macOS 26.
+            "vm_statistics64_data_t" => true,
             _ => false,
         }
     });


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

SSIA


# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
