### PR TITLE
[main] Increase the MSRV from 1.63 to 1.65

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
     name: Verify build
     strategy:
       matrix:
-        toolchain: [stable, 1.63.0]
+        toolchain: [stable, 1.65.0]
         include:
           # Nightly has a lot of targets, so split it in half
           - toolchain: nightly
@@ -67,7 +67,7 @@ jobs:
           - toolchain: beta
             only: '(aarch64|x86_64)' # just a spot check for beta
           - toolchain: stable
-          - toolchain: 1.63.0 # msrv
+          - toolchain: 1.65.0 # msrv
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     env:
@@ -97,7 +97,7 @@ jobs:
       - name: Execute build check
         run: |
           set -eux
-          if [ "${{ matrix.toolchain }}" = "1.63.0" ]; then
+          if [ "${{ matrix.toolchain }}" = "1.65.0" ]; then
               # Remove `-Dwarnings` at the MSRV since lints may be different
               export RUSTFLAGS=""
               # Remove `ctest` which uses the 2024 edition

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["The Rust Project Developers"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/libc"
-rust-version = "1.63"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 features = ["extra_traits"]

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ libc = "0.2"
 
 ## Rust version support
 
-The minimum supported Rust toolchain version is currently **Rust 1.63**.
+The minimum supported Rust toolchain version is currently **Rust 1.65**.
 
 Increases to the MSRV are allowed to change without a major (i.e. semver-
 breaking) release in order to avoid a ripple effect in the ecosystem. A policy


### PR DESCRIPTION
Perform a small MSRV bump by two versions. The main thing this gets is access to the C types in `core::ffi`, which means the ecosystem can start harmonizing around those aliases instead of using e.g. `core::ffi::c_int` in some cases and `libc::c_int` in others.

1.65 is selected as a small bump over 1.64 because it comes with some small "nice" things like workspace-level lints and `cast_mut`. It has been over a year since the last MSRV bump to 1.63 (in 93052d1542de, "Document the MSRV of the stable channel as 1.63") so we could probably bump higher yet, but there isn't anything else on the list at [1] as useful as `core::ffi`.

[1]: https://github.com/rust-lang/libc/issues/4626

(apply <https://github.com/rust-lang/libc/pull/4972> to main)
(cherry picked from commit 50cc5db8ae544ef7bc5f8ddbd7f21ef365a3075e)