### PR TITLE
linux ptrace: Rename wrongly named field sval to rval

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -172,7 +172,7 @@ s! {
     }
 
     pub struct __c_anonymous_ptrace_syscall_info_exit {
-        pub sval: crate::__s64,
+        pub rval: crate::__s64,
         pub is_error: crate::__u8,
     }
 


### PR DESCRIPTION
Split from rust-lang/libc#4966 as suggested by @tgross35

# Description

`__c_anonymous_ptrace_syscall_info_exit` field was wrongly named `sval` instead of `rval`. Fix it by renaming the field.

This is a breaking change and should probably not be backported to 0.2.

# Sources

[ptrace.h](https://github.com/torvalds/linux/blob/72c395024dac5e215136cbff793455f065603b06/include/uapi/linux/ptrace.h#L83-L106)

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
