### PR TITLE
Fix the soundness bug in the representation of extern types

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,8 +107,10 @@ jobs:
         run: |
           set -eux
           if [ "${{ matrix.toolchain }}" = "1.65.0" ]; then
-              # Remove `-Dwarnings` at the MSRV since lints may be different
-              export RUSTFLAGS=""
+              # Remove `-Dwarnings` at the MSRV since lints may be different, and allow
+              # `improper_ctypes` since pointers to ZSTs got the warning prior to 1.72.
+              # FIXME(msrv): remove this flag when possible.
+              export RUSTFLAGS="-Aimproper_ctypes"
               # Remove `ctest` which uses the 2024 edition
               perl -i -ne 'print unless /"ctest(-test)?",/ || /"libc-test",/' Cargo.toml
           fi

--- a/ci/style.py
+++ b/ci/style.py
@@ -9,7 +9,6 @@ from difflib import unified_diff
 from glob import iglob
 from pathlib import Path
 
-
 FMT_DIRS = ["src", "ci"]
 IGNORE_FILES = [
     # Too much special syntax that we don't want to format
@@ -87,6 +86,9 @@ def fmt_one(fpath: Path, check_only: bool):
     # syntax. Replace it with a dummy name.
     text = re.sub(r"enum #anon\b", r"enum _fmt_anon", text)
 
+    # `extern_ty!` can be formatted as an extern block.
+    text = re.sub(r"extern_ty!", r'extern "extern-ty-macro"', text)
+
     # If enum variants are annotated with `pub`, rustfmt erases the visibility. To get
     # around this we first match on all enums to extract their bodies, then look for `pub`
     # visibility indicators. If found, these get stashed in a comment on the preceding
@@ -126,6 +128,7 @@ def fmt_one(fpath: Path, check_only: bool):
     text = re.sub(r"cfg_tmp!\(\[(.*?)\]\)", r"#[cfg(\1)]", text, flags=re.DOTALL)
     text = re.sub(r"enum _fmt_anon", r"enum #anon", text)
     text = re.sub(r"/\* FMT-VIS (.*) END-FMT-VIS \*/\n\s*", r"\1 ", text)
+    text = re.sub(r'extern "extern-ty-macro"', r"extern_ty!", text)
 
     # And write the formatted file back
     fpath.write_text(text)

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -325,6 +325,9 @@ fn test_apple(target: &str) {
 
     cfg.skip_struct(move |s| {
         match s.ident() {
+            // Extern types
+            "DIR" | "FILE" | "fpos_t" | "timezone" => true,
+
             // FIXME(macos): The size is changed in recent macOSes.
             "malloc_zone_t" => true,
             // it is a moving target, changing through versions
@@ -572,6 +575,15 @@ fn test_openbsd(target: &str) {
     cfg.rename_struct_ty(|ty| ty.ends_with("_t").then_some(ty.to_string()));
     cfg.rename_union_ty(|ty| ty.ends_with("_t").then_some(ty.to_string()));
 
+    cfg.skip_struct(move |struct_| {
+        match struct_.ident() {
+            // Extern types
+            "DIR" | "FILE" | "fpos_t" => true,
+
+            _ => false,
+        }
+    });
+
     cfg.skip_struct_field(move |struct_, field| {
         match (struct_.ident(), field.ident()) {
             // conflicting with `p_type` macro from <resolve.h>.
@@ -691,6 +703,15 @@ fn test_cygwin(target: &str) {
         "sighandler_t" => true,
 
         _ => false,
+    });
+
+    cfg.skip_struct(move |struct_| {
+        match struct_.ident() {
+            // Extern types
+            "DIR" | "FILE" | "fpos_t" => true,
+
+            _ => false,
+        }
     });
 
     cfg.rename_struct_field(move |struct_, field| {
@@ -828,6 +849,8 @@ fn test_windows(target: &str) {
         match struct_.ident() {
             // FIXME(windows): The size and alignment of this struct are incorrect
             "timespec" if gnu && i686 => true,
+            // Extern types
+            "FILE" | "fpos_t" | "timezone" => true,
             _ => false,
         }
     });
@@ -1089,13 +1112,16 @@ fn test_solarish(target: &str) {
         false
     });
     cfg.skip_struct(move |struct_| {
-        // the union handling is a mess
-        if struct_.ident().contains("door_desc_t_") {
-            return true;
-        }
         match struct_.ident() {
+            // the union handling is a mess
+            x if x.contains("door_desc_t_") => true,
+
             // a bunch of solaris-only fields
             "utmpx" if is_illumos => true,
+
+            // Extern types
+            "DIR" | "FILE" | "fpos_t" | "timezone" | "ucred_t" => true,
+
             _ => false,
         }
     });
@@ -1362,6 +1388,8 @@ fn test_netbsd(target: &str) {
             "ptrace_lwpinfo" => true,
             // ABI change in NetBSD10, with symbol versioning.
             "statvfs" if !netbsd9 => true,
+            // Extern types
+            "DIR" | "FILE" | "fpos_t" | "timezone" | "_cpuset" | "sem" => true,
             _ => false,
         }
     });
@@ -1647,6 +1675,9 @@ fn test_dragonflybsd(target: &str) {
             // structs.
             "termios2" => true,
 
+            // Extern types
+            "DIR" | "FILE" | "fpos_t" => true,
+
             _ => false,
         }
     });
@@ -1791,6 +1822,14 @@ fn test_wasi(target: &str) {
         "SO_BROADCAST" | "SO_LINGER" => true,
 
         _ => false,
+    });
+
+    cfg.skip_struct(move |struct_| {
+        match struct_.ident() {
+            // Extern types
+            "DIR" | "FILE" | "__locale_struct" => true,
+            _ => false,
+        }
     });
 
     cfg.skip_fn(|f| match f.ident() {
@@ -2040,6 +2079,9 @@ fn test_android(target: &str) {
             "inotify_event" => true,
             // FIXME(android): The field has been changed:
             "sockaddr_vm" => true,
+
+            // Extern types
+            "DIR" | "FILE" | "fpos_t" | "timezone" => true,
 
             _ => false,
         }
@@ -2846,6 +2888,9 @@ fn test_freebsd(target: &str) {
             // Those are introduced in FreeBSD 15.
             "xktls_session_onedir" | "xktls_session" if Some(15) > freebsd_ver => true,
 
+            // Extern types
+            "DIR" | "FILE" | "fpos_t" | "timezone" => true,
+
             _ => false,
         }
     });
@@ -3144,6 +3189,9 @@ fn test_emscripten(target: &str) {
             "pthread_condattr_t" => true,
             "pthread_mutexattr_t" => true,
 
+            // Extern types
+            "DIR" | "FILE" | "fpos_t" | "fpos64_t" | "timezone" => true,
+
             // No epoll support
             // https://github.com/emscripten-core/emscripten/issues/5033
             ty if ty.starts_with("epoll") => true,
@@ -3423,6 +3471,9 @@ fn test_neutrino(target: &str) {
 
             // union
             "_channel_connect_attr" => true,
+
+            // Extern types
+            "DIR" | "FILE" | "fpos_t" => true,
 
             _ => false,
         }
@@ -4221,9 +4272,10 @@ fn test_linux(target: &str) {
             // On 64 bits the size did not change, skip only for 32 bits.
             "ptrace_syscall_info" if pointer_width == 32 => true,
 
+            // not in sys/fanotify.h in uclibc
+            "fanotify_event_info_header" | "fanotify_event_info_fid" if uclibc => true,
+
             "canxl_frame"
-            | "fanotify_event_info_header" // not in sys/fanotify.h in uclibc
-            | "fanotify_event_info_fid"  // not in sys/fanotify.h in uclibc
             | "tls12_crypto_info_sm4_gcm"
             | "tls12_crypto_info_sm4_ccm"
             | "tls12_crypto_info_aria_gcm_128"
@@ -4232,6 +4284,9 @@ fn test_linux(target: &str) {
             {
                 true
             }
+
+            // Extern types
+            "DIR" | "FILE" | "fpos_t" | "timezone" => true,
 
             _ => false,
         }
@@ -5733,6 +5788,9 @@ fn test_aix(target: &str) {
             // These structures are guarded by the `_KERNEL` macro in the AIX
             // header.
             "fileops_t" | "file" => true,
+
+            // Extern types
+            "DIR" | "FILE" | "fpos_t" => true,
 
             _ => false,
         }

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -79,9 +79,9 @@ pub type fsfilcnt_t = c_ulonglong;
 pub type rlim_t = c_ulonglong;
 
 extern_ty! {
-    pub enum timezone {}
-    pub enum DIR {}
-    pub enum fpos64_t {} // FIXME(fuchsia): fill this out with a struct
+    pub type timezone;
+    pub type DIR;
+    pub type fpos64_t; // FIXME(fuchsia): fill this out with a struct
 }
 
 // PUB_STRUCT
@@ -3188,8 +3188,8 @@ fn __MHDR_END(mhdr: *const msghdr) -> *mut c_uchar {
 extern "C" {}
 
 extern_ty! {
-    pub enum FILE {}
-    pub enum fpos_t {} // FIXME(fuchsia): fill this out with a struct
+    pub type FILE;
+    pub type fpos_t; // FIXME(fuchsia): fill this out with a struct
 }
 
 extern "C" {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -246,17 +246,36 @@ macro_rules! s_no_extra_traits {
 macro_rules! extern_ty {
     ($(
         $(#[$attr:meta])*
-        pub enum $i:ident {}
+        pub type $i:ident;
     )*) => ($(
         $(#[$attr])*
-        // FIXME(1.0): the type is uninhabited so these traits are unreachable and could be
-        // removed.
+        /// This is an extern type ("opaque" or "incomplete" type in C).
+        ///
+        /// <div class="warning">
+        /// This type's current representation allows inspecting some properties, such as via
+        /// <code>size_of</code>, and it is technically possible to construct the type within
+        /// <code>MaybeUninit</code>, However, this <strong>MUST NOT</strong> be relied upon
+        /// because a future version of <code>libc</code> may switch to a proper
+        /// <a href="https://rust-lang.github.io/rfcs/1861-extern-types.html">extern type</a>
+        /// representation when available.
+        /// </div>
+        // ^ unfortunately warning blocks currently don't render markdown so we need to
+        // use raw HTML.
+        //
+        // Representation based on the Nomicon:
+        // <https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs>.
+        //
+        // FIXME(1.0): These traits are unreachable and should be removed.
         #[::core::prelude::v1::derive(
             ::core::clone::Clone,
             ::core::marker::Copy,
             ::core::fmt::Debug,
         )]
-        pub enum $i { }
+        #[repr(C)]
+        pub struct $i {
+            _data: (),
+            _marker: ::core::marker::PhantomData<(*mut u8, ::core::marker::PhantomPinned)>,
+        }
     )*);
 }
 

--- a/src/new/qurt/mod.rs
+++ b/src/new/qurt/mod.rs
@@ -63,7 +63,7 @@ pub type in_port_t = c_ushort;
 
 // Standard C library types
 extern_ty! {
-    pub enum FILE {}
+    pub type FILE;
 }
 pub type fpos_t = c_long;
 pub type clock_t = c_long;

--- a/src/solid/mod.rs
+++ b/src/solid/mod.rs
@@ -397,8 +397,8 @@ pub const SIGUSR2: c_int = 31;
 pub const SIGPWR: c_int = 32;
 
 extern_ty! {
-    pub enum FILE {}
-    pub enum fpos_t {}
+    pub type FILE;
+    pub type fpos_t;
 }
 
 extern "C" {

--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 
 // Define lock_data_instrumented as an empty enum
 extern_ty! {
-    pub enum lock_data_instrumented {}
+    pub type lock_data_instrumented;
 }
 
 s! {

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -176,7 +176,7 @@ pub type attrgroup_t = u32;
 pub type vol_capabilities_set_t = [u32; 4];
 
 extern_ty! {
-    pub enum timezone {}
+    pub type timezone;
 }
 
 c_enum! {

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -49,7 +49,7 @@ pub type vm_map_entry_t = *mut vm_map_entry;
 pub type pmap = __c_anonymous_pmap;
 
 extern_ty! {
-    pub enum sem {}
+    pub type sem;
 }
 
 c_enum! {

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -60,7 +60,7 @@ cfg_if! {
 // link.h
 
 extern_ty! {
-    pub enum timezone {}
+    pub type timezone;
 }
 
 impl siginfo_t {

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -17,8 +17,8 @@ pub type sem_t = *mut sem;
 pub type key_t = c_long;
 
 extern_ty! {
-    pub enum timezone {}
-    pub enum sem {}
+    pub type timezone;
+    pub type sem;
 }
 
 s! {

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -45,7 +45,7 @@ c_enum! {
 }
 
 extern_ty! {
-    pub enum _cpuset {}
+    pub type _cpuset;
 }
 
 cfg_if! {

--- a/src/unix/cygwin/mod.rs
+++ b/src/unix/cygwin/mod.rs
@@ -29,7 +29,7 @@ pub type suseconds_t = c_long;
 pub type useconds_t = c_ulong;
 
 extern_ty! {
-    pub enum timezone {}
+    pub type timezone;
 }
 
 pub type sigset_t = c_ulong;
@@ -71,7 +71,7 @@ pub type nfds_t = c_uint;
 pub type sem_t = *mut sem;
 
 extern_ty! {
-    pub enum sem {}
+    pub type sem;
 }
 
 pub type tcflag_t = c_uint;

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -81,7 +81,7 @@ pub type posix_spawnattr_t = *mut c_void;
 pub type posix_spawn_file_actions_t = *mut c_void;
 
 extern_ty! {
-    pub enum timezone {}
+    pub type timezone;
 }
 
 impl siginfo_t {

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -226,8 +226,8 @@ pub type nl_item = c_int;
 pub type iconv_t = *mut c_void;
 
 extern_ty! {
-    pub enum fpos64_t {} // FIXME(hurd): fill this out with a struct
-    pub enum timezone {}
+    pub type fpos64_t; // FIXME(hurd): fill this out with a struct
+    pub type timezone;
 }
 
 // structs

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -41,7 +41,7 @@ pub type statvfs64 = crate::statvfs;
 pub type dirent64 = crate::dirent;
 
 extern_ty! {
-    pub enum fpos64_t {} // FIXME(emscripten): fill this out with a struct
+    pub type fpos64_t; // FIXME(emscripten): fill this out with a struct
 }
 
 s! {

--- a/src/unix/linux_like/linux_l4re_shared.rs
+++ b/src/unix/linux_like/linux_l4re_shared.rs
@@ -35,7 +35,7 @@ pub type iconv_t = *mut c_void;
 cfg_if! {
     if #[cfg(not(target_env = "gnu"))] {
         extern_ty! {
-            pub enum fpos64_t {} // FIXME(linux): fill this out with a struct
+            pub type fpos64_t; // FIXME(linux): fill this out with a struct
         }
     }
 }

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -10,7 +10,7 @@ pub type key_t = c_int;
 pub type id_t = c_uint;
 
 extern_ty! {
-    pub enum timezone {}
+    pub type timezone;
 }
 
 s! {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -38,7 +38,7 @@ cfg_if! {
 }
 
 extern_ty! {
-    pub enum DIR {}
+    pub type DIR;
 }
 
 #[cfg(not(target_os = "nuttx"))]
@@ -606,13 +606,13 @@ cfg_if! {
 cfg_if! {
     if #[cfg(not(all(target_os = "linux", target_env = "gnu")))] {
         extern_ty! {
-            pub enum fpos_t {} // FIXME(unix): fill this out with a struct
+            pub type fpos_t; // FIXME(unix): fill this out with a struct
         }
     }
 }
 
 extern_ty! {
-    pub enum FILE {}
+    pub type FILE;
 }
 
 extern "C" {

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -73,7 +73,7 @@ pub type sem_t = sync_t;
 pub type nl_item = c_int;
 
 extern_ty! {
-    pub enum timezone {}
+    pub type timezone;
 }
 
 s! {

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -32,7 +32,7 @@ pub type uid_t = c_int;
 pub type gid_t = c_int;
 
 extern_ty! {
-    pub enum timezone {}
+    pub type timezone;
 }
 
 s! {

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -56,8 +56,8 @@ pub type posix_spawnattr_t = *mut c_void;
 pub type posix_spawn_file_actions_t = *mut c_void;
 
 extern_ty! {
-    pub enum timezone {}
-    pub enum ucred_t {}
+    pub type timezone;
+    pub type ucred_t;
 }
 
 s! {

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -3,7 +3,7 @@
 use crate::prelude::*;
 
 extern_ty! {
-    pub enum DIR {}
+    pub type DIR;
 }
 
 pub type intmax_t = i64;
@@ -93,7 +93,7 @@ pub type sa_family_t = c_uchar;
 pub type mqd_t = c_int;
 
 extern_ty! {
-    pub enum _Vx_semaphore {}
+    pub type _Vx_semaphore;
 }
 
 impl siginfo_t {
@@ -1433,8 +1433,8 @@ pub const TIOCGWINSZ: c_int = 0x1740087468;
 pub const TIOCSWINSZ: c_int = -0x7ff78b99;
 
 extern_ty! {
-    pub enum FILE {}
-    pub enum fpos_t {} // FIXME(vxworks): fill this out with a struct
+    pub type FILE;
+    pub type fpos_t; // FIXME(vxworks): fill this out with a struct
 }
 
 f! {

--- a/src/wasi/mod.rs
+++ b/src/wasi/mod.rs
@@ -45,15 +45,11 @@ s_no_extra_traits! {
     }
 }
 
-#[allow(missing_copy_implementations)]
-#[derive(Debug)]
-pub enum FILE {}
-#[allow(missing_copy_implementations)]
-#[derive(Debug)]
-pub enum DIR {}
-#[allow(missing_copy_implementations)]
-#[derive(Debug)]
-pub enum __locale_struct {}
+extern_ty! {
+    pub type FILE;
+    pub type DIR;
+    pub type __locale_struct;
+}
 
 s_paren! {
     // in wasi-libc clockid_t is const struct __clockid* (where __clockid is an opaque struct),

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -31,7 +31,7 @@ pub type dev_t = u32;
 pub type ino_t = u16;
 
 extern_ty! {
-    pub enum timezone {}
+    pub type timezone;
 }
 
 pub type time64_t = i64;
@@ -246,8 +246,8 @@ pub const L_tmpnam: c_uint = 260;
 pub const TMP_MAX: c_uint = 0x7fff_ffff;
 
 extern_ty! {
-    pub enum FILE {}
-    pub enum fpos_t {} // FIXME(windows): fill this out with a struct
+    pub type FILE;
+    pub type fpos_t; // FIXME(windows): fill this out with a struct
 }
 
 // Special handling for all print and scan type functions because of https://github.com/rust-lang/libc/issues/2860


### PR DESCRIPTION
Since the very first import dafaca90f095 ("Initial import of liblibc"), `libc` has used uninhabited enums to represent C's incomplete/opaque types. While this is, as far as I know, technically okay when working behind raw pointers, it means that using reference types like `&FILE` can lead to easy UB.

Resolve this by changing the representation to a `!Sync + !Send + !Unpin` ZST, as recommended by the nomicon [1]. The loss of auto traits technically makes this user-visible, but it is unlikely that anybody who is doing sound things was relying on these. 

I also used this as an opportunity to add a forward-compatibility note about intended use that should allow us to switch to real extern types once those are available.

[1]: https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs

Cc @RalfJung 