### PR TITLE
Update FreeBSD 14 CI image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ task:
         image: freebsd-15-0-release-amd64-ufs
     - name: nightly freebsd-14 x86_64
       freebsd_instance:
-        image: freebsd-14-3-release-amd64-ufs
+        image: freebsd-14-4-release-amd64-ufs
     - name: nightly freebsd-15 x86_64
       freebsd_instance:
         image: freebsd-15-0-release-amd64-ufs

--- a/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/x86_64/mod.rs
@@ -119,12 +119,12 @@ s! {
         pub mc_xfpustate: register_t,
         pub mc_xfpustate_len: register_t,
         // freebsd < 15
-        #[cfg(any(freebsd11, freebsd12, freebsd13, freebsd14))]
+        #[cfg(any(freebsd11, freebsd12, freebsd13))]
         pub mc_spare: [c_long; 4],
         // freebsd >= 15
-        #[cfg(not(any(freebsd11, freebsd12, freebsd13, freebsd14)))]
+        #[cfg(not(any(freebsd11, freebsd12, freebsd13)))]
         pub mc_tlsbase: register_t,
-        #[cfg(not(any(freebsd11, freebsd12, freebsd13, freebsd14)))]
+        #[cfg(not(any(freebsd11, freebsd12, freebsd13)))]
         pub mc_spare: [c_long; 3],
     }
 }


### PR DESCRIPTION
And update the definition of struct mcontext_t.  An additional field has
been added, and the spare field reduced accordingly.
    
No backwards-compatibility concerns, because we still build with a
FreeBSD 12 ABI by default.

Source:
https://github.com/freebsd/freebsd-src/commit/fa10e2fb88224b1b30abb6c94a9cf4c99ce5103f