### PR TITLE
Add `sprintf`, `snprintf`, and the `scanf` family for Windows

### DIFF
--- a/libc-test/semver/windows.txt
+++ b/libc-test/semver/windows.txt
@@ -212,6 +212,7 @@ fputs
 fread
 free
 freopen
+fscanf
 fseek
 fsetpos
 fstat
@@ -286,6 +287,7 @@ remove
 rename
 rewind
 rmdir
+scanf
 sendto
 setbuf
 setlocale
@@ -294,9 +296,12 @@ setvbuf
 sighandler_t
 signal
 size_t
+snprintf
 sockaddr
 socket
+sprintf
 srand
+sscanf
 ssize_t
 stat
 strcat

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -260,6 +260,17 @@ cfg_if! {
         extern "C" {
             pub fn printf(format: *const c_char, ...) -> c_int;
             pub fn fprintf(stream: *mut FILE, format: *const c_char, ...) -> c_int;
+            pub fn snprintf(
+                buffer: *mut c_char,
+                count: size_t,
+                format: *const c_char,
+                ...
+            ) -> c_int;
+            pub fn sprintf(buffer: *mut c_char, format: *const c_char, ...) -> c_int;
+
+            pub fn scanf(format: *const c_char, ...) -> c_int;
+            pub fn sscanf(buffer: *const c_char, format: *const c_char, ...) -> c_int;
+            pub fn fscanf(stream: *mut FILE, format: *const c_char, ...) -> c_int;
         }
     }
 }


### PR DESCRIPTION
# Description

This adds declarations for the following functions for Windows:

* `sprintf`
* `snprintf`
* `scanf`
* `sscanf`
* `fscanf`

As noted in rust-lang/libc#2860, these are provided by `legacy_stdio_definitions.lib` in newer versions of Windows, so they're behind the same gate.

This fixes rust-lang/libc#4995.

# Sources

* https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/sprintf-sprintf-l-swprintf-swprintf-l-swprintf-l
* https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l
* https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/scanf-scanf-l-wscanf-wscanf-l
* https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/sscanf-sscanf-l-swscanf-swscanf-l
* https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fscanf-fscanf-l-fwscanf-fwscanf-l

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
