### PR TITLE
cygwin: Add missing TIOCM_DSR from termios.h

### DIFF
--- a/src/unix/cygwin/mod.rs
+++ b/src/unix/cygwin/mod.rs
@@ -1038,6 +1038,7 @@ pub const TIOCM_RTS: c_int = 0x004;
 pub const TIOCM_CTS: c_int = 0x020;
 pub const TIOCM_CAR: c_int = 0x040;
 pub const TIOCM_RNG: c_int = 0x080;
+pub const TIOCM_DSR: c_int = 0x100;
 pub const TIOCM_CD: c_int = TIOCM_CAR;
 pub const TIOCM_RI: c_int = TIOCM_RNG;
 pub const TCOOFF: c_int = 0;


### PR DESCRIPTION
# Description

Fixes missing `TIOCM_DSR` constant from `termios.h`

# Sources

https://github.com/msys2/msys2-runtime/blob/msys2-3.6.7/winsup/cygwin/include/sys/termios.h#L37

# Checklist

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated