### PR TITLE
newlib/espidf: Move DT_* to espidf/mod.rs

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -252,7 +252,11 @@ pub const SIG_IGN: sighandler_t = 1 as sighandler_t;
 pub const SIG_ERR: sighandler_t = !0 as sighandler_t;
 
 cfg_if! {
-    if #[cfg(all(not(target_os = "nto"), not(target_os = "aix")))] {
+    if #[cfg(all(
+        not(target_os = "nto"),
+        not(target_os = "aix"),
+        not(target_os = "espidf")
+    ))] {
         pub const DT_UNKNOWN: u8 = 0;
         pub const DT_FIFO: u8 = 1;
         pub const DT_CHR: u8 = 2;

--- a/src/unix/newlib/espidf/mod.rs
+++ b/src/unix/newlib/espidf/mod.rs
@@ -99,6 +99,17 @@ pub const NSIG: size_t = 32;
 
 pub const SOMAXCONN: c_int = 128;
 
+pub const DT_UNKNOWN: u8 = 0;
+pub const DT_REG: u8 = 1;
+pub const DT_DIR: u8 = 2;
+// Not used by esp-idf, but still defined in headers.
+pub const DT_CHR: u8 = 4;
+pub const DT_BLK: u8 = 6;
+pub const DT_FIFO: u8 = 8;
+pub const DT_LNK: u8 = 10;
+pub const DT_SOCK: u8 = 12;
+pub const DT_WHT: u8 = 14;
+
 extern "C" {
     pub fn pthread_create(
         native: *mut crate::pthread_t,


### PR DESCRIPTION
# Description

The values for `DT_*` in espidf are different from standard newlib.

Detected using a fork of SergioGasquez/libc-checks: https://github.com/drinkcat/libc-checks/actions/runs/23748047229/job/69181969328

# Sources

https://github.com/espressif/newlib-esp32/blob/67537d91e601c40e2b52b9b865518abb7eecc85b/newlib/libc/sys/esp/include/sys/dirent.h#L32

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated => There are not new symbols, just renamed.
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI => Not applicable

@rustbot label +stable-nominated