### PR TITLE
newlib/espidf: Add espidf_picolibc cfg for picolibc O_* flag values

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,8 @@ use std::{
 // make sure to add it to this list as well.
 const ALLOWED_CFGS: &[&str] = &[
     "emscripten_old_stat_abi",
+    // Should be enabled by users if esp-idf (>=6.0) is build with picolibc instead of newlib.
+    "espidf_picolibc",
     "espidf_time32",
     "freebsd10",
     "freebsd11",

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -514,9 +514,17 @@ pub const F_DUPFD_CLOEXEC: c_int = 14;
 pub const O_RDONLY: c_int = 0;
 pub const O_WRONLY: c_int = 1;
 pub const O_RDWR: c_int = 2;
-pub const O_APPEND: c_int = 8;
-pub const O_CREAT: c_int = 512;
-pub const O_TRUNC: c_int = 1024;
+cfg_if! {
+    if #[cfg(espidf_picolibc)] {
+        pub const O_APPEND: c_int = 1024;
+        pub const O_CREAT: c_int = 64;
+        pub const O_TRUNC: c_int = 512;
+    } else {
+        pub const O_APPEND: c_int = 8;
+        pub const O_CREAT: c_int = 512;
+        pub const O_TRUNC: c_int = 1024;
+    }
+}
 pub const O_EXCL: c_int = 2048;
 pub const O_SYNC: c_int = 8192;
 pub const O_NONBLOCK: c_int = 16384;


### PR DESCRIPTION
# Description

ESP-IDF v6.0 switched from newlib to picolibc as default C library. Picolibc uses Linux-compatible O_APPEND/O_CREAT/O_TRUNC values which differ from newlib. Add espidf_picolibc cfg to select the correct values.

Technically, a picolibc might not belong in the newlib tree, and we could create a whole new picolibc tree structure, but these 3 values are the only ones that seem to be different, at least in esp-idf context.

Detected using a fork of SergioGasquez/libc-checks: https://github.com/drinkcat/libc-checks/actions/runs/23750132941/job/69189520202

# Sources

https://github.com/picolibc/picolibc/blob/f708b0107e1a51c952f5f5e296eb09528e76ebb3/libc/include/sys/_default_fcntl.h#L56

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated => no new symbol
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI => not applicable

@rustbot label +stable-nominated
