### PR TITLE
hexagon: decouple time64 types from musl symbol redirects

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,8 +28,10 @@ const ALLOWED_CFGS: &[&str] = &[
     // Corresponds to `__USE_TIME_BITS64` in UAPI
     "linux_time_bits64",
     "musl_v1_2_3",
-    // Corresponds to `_REDIR_TIME64` in musl
+    // musl v1.2.3+ && 32-bit: time_t is i64, struct layouts change
     "musl32_time64",
+    // Corresponds to `_REDIR_TIME64` in musl: symbol redirects to __*_time64
+    "musl_redir_time64",
     "vxworks_lt_25_09",
 ];
 
@@ -51,8 +53,9 @@ const CHECK_CFG_EXTRA: &[(&str, &[&str])] = &[
     ),
 ];
 
-/// Musl architectures that set `#define _REDIR_TIME64 1`.
-const MUSL_REDIR_TIME64_ARCHES: &[&str] = &["arm", "hexagon", "mips", "powerpc", "x86"];
+/// Musl architectures that define `_REDIR_TIME64` (i.e. those that transitioned
+/// from 32-bit to 64-bit `time_t` and need `__*_time64` symbol redirects).
+const MUSL_REDIR_TIME64_ARCHES: &[&str] = &["arm", "mips", "powerpc", "x86"];
 
 fn main() {
     // Avoid unnecessary re-building.
@@ -117,9 +120,12 @@ fn main() {
 
     if musl && musl_v1_2_3 {
         set_cfg("musl_v1_2_3");
-        if MUSL_REDIR_TIME64_ARCHES.contains(&target_arch.as_str()) {
+        if target_ptr_width == "32" {
             set_cfg("musl32_time64");
             set_cfg("linux_time_bits64");
+        }
+        if MUSL_REDIR_TIME64_ARCHES.contains(&target_arch.as_str()) {
+            set_cfg("musl_redir_time64");
         }
     }
 

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3723,12 +3723,17 @@ fn test_linux(target: &str) {
     }
     let old_musl = musl && !musl_v1_2_3;
 
+    let b32 = arm || target.contains("hexagon") || mips32 || ppc32 || x86_32;
+
     let mut cfg = ctest_cfg();
     if (musl_v1_2_3 || loongarch64 || hexagon) && musl {
         cfg.cfg("musl_v1_2_3", None);
-        if arm || hexagon || ppc32 || x86_32 || mips32 {
+        if b32 {
             cfg.cfg("musl32_time64", None);
             cfg.cfg("linux_time_bits64", None);
+        }
+        if arm || ppc32 || x86_32 || mips32 {
+            cfg.cfg("musl_redir_time64", None);
         }
     }
     cfg.define("_GNU_SOURCE", None)
@@ -4215,6 +4220,7 @@ fn test_linux(target: &str) {
                 || name.starts_with("STATX_")
                 || name.starts_with("SW_")
                 || name.starts_with("SYS_")
+                || name.starts_with("SYS3264_")
                 || name.starts_with("TCP_")
                 || name.starts_with("UINPUT_")
                 || name.starts_with("VMADDR_")

--- a/src/new/common/posix/pthread.rs
+++ b/src/new/common/posix/pthread.rs
@@ -195,7 +195,7 @@ extern "C" {
 
     #[cfg(any(target_os = "android", target_os = "l4re", target_os = "linux"))]
     #[cfg_attr(gnu_time_bits64, link_name = "__pthread_mutex_timedlock64")]
-    #[cfg_attr(musl32_time64, link_name = "__pthread_mutex_timedlock_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__pthread_mutex_timedlock_time64")]
     pub fn pthread_mutex_timedlock(
         lock: *mut crate::pthread_mutex_t,
         abstime: *const crate::timespec,

--- a/src/new/musl/sys/socket.rs
+++ b/src/new/musl/sys/socket.rs
@@ -41,7 +41,7 @@ extern "C" {
         vlen: c_uint,
         flags: c_uint,
     ) -> c_int;
-    #[cfg_attr(musl32_time64, link_name = "__recvmmsg_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__recvmmsg_time64")]
     pub fn recvmmsg(
         sockfd: c_int,
         msgvec: *mut crate::mmsghdr,

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -4010,7 +4010,7 @@ cfg_if! {
                 msg_prio: *mut c_uint,
             ) -> ssize_t;
             #[cfg_attr(
-                any(gnu_time_bits64, musl32_time64),
+                any(gnu_time_bits64, musl_redir_time64),
                 link_name = "__mq_timedreceive_time64"
             )]
             pub fn mq_timedreceive(
@@ -4027,7 +4027,7 @@ cfg_if! {
                 msg_prio: c_uint,
             ) -> c_int;
             #[cfg_attr(
-                any(gnu_time_bits64, musl32_time64),
+                any(gnu_time_bits64, musl_redir_time64),
                 link_name = "__mq_timedsend_time64"
             )]
             pub fn mq_timedsend(
@@ -4053,7 +4053,7 @@ extern "C" {
     pub fn lcong48(p: *mut c_ushort);
 
     #[cfg_attr(gnu_time_bits64, link_name = "__lutimes64")]
-    #[cfg_attr(musl32_time64, link_name = "__lutimes_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__lutimes_time64")]
     pub fn lutimes(file: *const c_char, times: *const crate::timeval) -> c_int;
 
     pub fn shm_open(name: *const c_char, oflag: c_int, mode: mode_t) -> c_int;
@@ -4129,9 +4129,15 @@ extern "C" {
     pub fn fremovexattr(filedes: c_int, name: *const c_char) -> c_int;
     pub fn signalfd(fd: c_int, mask: *const crate::sigset_t, flags: c_int) -> c_int;
     pub fn timerfd_create(clockid: crate::clockid_t, flags: c_int) -> c_int;
-    #[cfg_attr(any(gnu_time_bits64, musl32_time64), link_name = "__timerfd_gettime64")]
+    #[cfg_attr(
+        any(gnu_time_bits64, musl_redir_time64),
+        link_name = "__timerfd_gettime64"
+    )]
     pub fn timerfd_gettime(fd: c_int, curr_value: *mut crate::itimerspec) -> c_int;
-    #[cfg_attr(any(gnu_time_bits64, musl32_time64), link_name = "__timerfd_settime64")]
+    #[cfg_attr(
+        any(gnu_time_bits64, musl_redir_time64),
+        link_name = "__timerfd_settime64"
+    )]
     pub fn timerfd_settime(
         fd: c_int,
         flags: c_int,
@@ -4148,7 +4154,7 @@ extern "C" {
     ) -> c_int;
     pub fn dup3(oldfd: c_int, newfd: c_int, flags: c_int) -> c_int;
     #[cfg_attr(gnu_time_bits64, link_name = "__sigtimedwait64")]
-    #[cfg_attr(musl32_time64, link_name = "__sigtimedwait_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__sigtimedwait_time64")]
     pub fn sigtimedwait(
         set: *const sigset_t,
         info: *mut siginfo_t,
@@ -4211,7 +4217,7 @@ extern "C" {
     pub fn eventfd_write(fd: c_int, value: eventfd_t) -> c_int;
 
     #[cfg_attr(gnu_time_bits64, link_name = "__sched_rr_get_interval64")]
-    #[cfg_attr(musl32_time64, link_name = "__sched_rr_get_interval_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__sched_rr_get_interval_time64")]
     pub fn sched_rr_get_interval(pid: crate::pid_t, tp: *mut crate::timespec) -> c_int;
     pub fn sched_setparam(pid: crate::pid_t, param: *const crate::sched_param) -> c_int;
     pub fn setns(fd: c_int, nstype: c_int) -> c_int;
@@ -4229,7 +4235,7 @@ extern "C" {
     ) -> c_int;
     pub fn sched_getscheduler(pid: crate::pid_t) -> c_int;
     #[cfg_attr(
-        any(gnu_time_bits64, musl32_time64),
+        any(gnu_time_bits64, musl_redir_time64),
         link_name = "__clock_nanosleep_time64"
     )]
     pub fn clock_nanosleep(

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -765,7 +765,7 @@ extern "C" {
         new_limit: *const crate::rlimit,
         old_limit: *mut crate::rlimit,
     ) -> c_int;
-    #[cfg_attr(musl32_time64, link_name = "__gettimeofday_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__gettimeofday_time64")]
     pub fn gettimeofday(tp: *mut crate::timeval, tz: *mut c_void) -> c_int;
     pub fn ptrace(request: c_int, ...) -> c_long;
     pub fn getpriority(which: c_int, who: crate::id_t) -> c_int;
@@ -801,9 +801,9 @@ extern "C" {
     // Added in `musl` 1.2.2
     pub fn reallocarray(ptr: *mut c_void, nmemb: size_t, size: size_t) -> *mut c_void;
 
-    #[cfg_attr(musl32_time64, link_name = "__adjtimex_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__adjtimex_time64")]
     pub fn adjtimex(buf: *mut crate::timex) -> c_int;
-    #[cfg_attr(musl32_time64, link_name = "__clock_adjtime64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__clock_adjtime64")]
     pub fn clock_adjtime(clk_id: crate::clockid_t, buf: *mut crate::timex) -> c_int;
 
     pub fn ctermid(s: *mut c_char) -> *mut c_char;
@@ -871,7 +871,7 @@ extern "C" {
     pub fn utmpxname(file: *const c_char) -> c_int;
     pub fn pthread_tryjoin_np(thread: crate::pthread_t, retval: *mut *mut c_void) -> c_int;
     #[cfg_attr(
-        all(musl32_time64, target_pointer_width = "32"),
+        all(musl_redir_time64, target_pointer_width = "32"),
         link_name = "__pthread_timedjoin_np_time64"
     )]
     pub fn pthread_timedjoin_np(

--- a/src/unix/linux_like/linux_l4re_shared.rs
+++ b/src/unix/linux_like/linux_l4re_shared.rs
@@ -976,7 +976,7 @@ pub const IPC_NOWAIT: c_int = 0o4000;
 
 pub const IPC_RMID: c_int = 0;
 pub const IPC_SET: c_int = 1;
-pub const IPC_STAT: c_int = if cfg!(musl32_time64) { 0x102 } else { 2 };
+pub const IPC_STAT: c_int = if cfg!(musl_redir_time64) { 0x102 } else { 2 };
 pub const IPC_INFO: c_int = 3;
 
 pub const SHM_R: c_int = 0o400;
@@ -1660,7 +1660,7 @@ cfg_if! {
             #[cfg_attr(gnu_file_offset_bits64, link_name = "aio_return64")]
             pub fn aio_return(aiocbp: *mut crate::aiocb) -> ssize_t;
             #[cfg_attr(
-                any(musl32_time64, gnu_time_bits64),
+                any(musl_redir_time64, gnu_time_bits64),
                 link_name = "__aio_suspend_time64"
             )]
             pub fn aio_suspend(
@@ -1725,7 +1725,7 @@ cfg_if! {
                 flags: c_ulong,
             ) -> isize;
             #[cfg_attr(gnu_time_bits64, link_name = "__futimes64")]
-            #[cfg_attr(musl32_time64, link_name = "__futimes_time64")]
+            #[cfg_attr(musl_redir_time64, link_name = "__futimes_time64")]
             pub fn futimes(fd: c_int, times: *const crate::timeval) -> c_int;
         }
     }
@@ -1827,10 +1827,10 @@ extern "C" {
     ) -> c_int;
     pub fn sched_get_priority_max(policy: c_int) -> c_int;
     #[cfg_attr(gnu_time_bits64, link_name = "__settimeofday64")]
-    #[cfg_attr(musl32_time64, link_name = "__settimeofday_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__settimeofday_time64")]
     pub fn settimeofday(tv: *const crate::timeval, tz: *const crate::timezone) -> c_int;
     #[cfg_attr(gnu_time_bits64, link_name = "__sem_timedwait64")]
-    #[cfg_attr(musl32_time64, link_name = "__sem_timedwait_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__sem_timedwait_time64")]
     pub fn sem_timedwait(sem: *mut crate::sem_t, abstime: *const crate::timespec) -> c_int;
     pub fn sem_getvalue(sem: *mut crate::sem_t, sval: *mut c_int) -> c_int;
     pub fn mount(
@@ -1843,7 +1843,7 @@ extern "C" {
     #[cfg_attr(gnu_time_bits64, link_name = "__prctl_time64")]
     pub fn prctl(option: c_int, ...) -> c_int;
     #[cfg_attr(gnu_time_bits64, link_name = "__ppoll64")]
-    #[cfg_attr(musl32_time64, link_name = "__ppoll_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__ppoll_time64")]
     pub fn ppoll(
         fds: *mut crate::pollfd,
         nfds: crate::nfds_t,
@@ -1934,9 +1934,15 @@ extern "C" {
     pub fn timer_delete(timerid: crate::timer_t) -> c_int;
     #[cfg(not(target_os = "l4re"))]
     pub fn timer_getoverrun(timerid: crate::timer_t) -> c_int;
-    #[cfg_attr(any(gnu_time_bits64, musl32_time64), link_name = "__timer_gettime64")]
+    #[cfg_attr(
+        any(gnu_time_bits64, musl_redir_time64),
+        link_name = "__timer_gettime64"
+    )]
     pub fn timer_gettime(timerid: crate::timer_t, curr_value: *mut crate::itimerspec) -> c_int;
-    #[cfg_attr(any(gnu_time_bits64, musl32_time64), link_name = "__timer_settime64")]
+    #[cfg_attr(
+        any(gnu_time_bits64, musl_redir_time64),
+        link_name = "__timer_settime64"
+    )]
     pub fn timer_settime(
         timerid: crate::timer_t,
         flags: c_int,

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1922,20 +1922,26 @@ extern "C" {
     pub fn mincore(addr: *mut c_void, len: size_t, vec: *mut c_uchar) -> c_int;
 
     #[cfg_attr(gnu_time_bits64, link_name = "__clock_getres64")]
-    #[cfg_attr(musl32_time64, link_name = "__clock_getres_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__clock_getres_time64")]
     pub fn clock_getres(clk_id: crate::clockid_t, tp: *mut crate::timespec) -> c_int;
-    #[cfg_attr(any(gnu_time_bits64, musl32_time64), link_name = "__clock_gettime64")]
+    #[cfg_attr(
+        any(gnu_time_bits64, musl_redir_time64),
+        link_name = "__clock_gettime64"
+    )]
     pub fn clock_gettime(clk_id: crate::clockid_t, tp: *mut crate::timespec) -> c_int;
-    #[cfg_attr(any(gnu_time_bits64, musl32_time64), link_name = "__clock_settime64")]
+    #[cfg_attr(
+        any(gnu_time_bits64, musl_redir_time64),
+        link_name = "__clock_settime64"
+    )]
     pub fn clock_settime(clk_id: crate::clockid_t, tp: *const crate::timespec) -> c_int;
     #[cfg(not(target_os = "l4re"))]
     pub fn clock_getcpuclockid(pid: crate::pid_t, clk_id: *mut crate::clockid_t) -> c_int;
 
     #[cfg_attr(gnu_time_bits64, link_name = "__getitimer64")]
-    #[cfg_attr(musl32_time64, link_name = "__getitimer_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__getitimer_time64")]
     pub fn getitimer(which: c_int, curr_value: *mut crate::itimerval) -> c_int;
     #[cfg_attr(gnu_time_bits64, link_name = "__setitimer64")]
-    #[cfg_attr(musl32_time64, link_name = "__setitimer_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__setitimer_time64")]
     pub fn setitimer(
         which: c_int,
         new_value: *const crate::itimerval,
@@ -1956,11 +1962,11 @@ extern "C" {
     #[cfg_attr(gnu_file_offset_bits64, link_name = "posix_fadvise64")]
     pub fn posix_fadvise(fd: c_int, offset: off_t, len: off_t, advise: c_int) -> c_int;
     #[cfg_attr(gnu_time_bits64, link_name = "__futimens64")]
-    #[cfg_attr(musl32_time64, link_name = "__futimens_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__futimens_time64")]
     #[cfg(not(target_os = "l4re"))]
     pub fn futimens(fd: c_int, times: *const crate::timespec) -> c_int;
     #[cfg_attr(gnu_time_bits64, link_name = "__utimensat64")]
-    #[cfg_attr(musl32_time64, link_name = "__utimensat_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__utimensat_time64")]
     pub fn utimensat(
         dirfd: c_int,
         path: *const c_char,
@@ -2007,7 +2013,7 @@ extern "C" {
     pub fn setresgid(rgid: crate::gid_t, egid: crate::gid_t, sgid: crate::gid_t) -> c_int;
     #[cfg(not(target_os = "l4re"))]
     pub fn setresuid(ruid: crate::uid_t, euid: crate::uid_t, suid: crate::uid_t) -> c_int;
-    #[cfg_attr(any(gnu_time_bits64, musl32_time64), link_name = "__wait4_time64")]
+    #[cfg_attr(any(gnu_time_bits64, musl_redir_time64), link_name = "__wait4_time64")]
     #[cfg(not(target_os = "l4re"))]
     pub fn wait4(
         pid: crate::pid_t,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -912,7 +912,7 @@ extern "C" {
         all(not(gnu_time_bits64), gnu_file_offset_bits64),
         link_name = "fstat64"
     )]
-    #[cfg_attr(musl32_time64, link_name = "__fstat_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__fstat_time64")]
     pub fn fstat(fildes: c_int, buf: *mut stat) -> c_int;
 
     pub fn mkdir(path: *const c_char, mode: mode_t) -> c_int;
@@ -931,7 +931,7 @@ extern "C" {
         all(not(gnu_time_bits64), gnu_file_offset_bits64),
         link_name = "stat64"
     )]
-    #[cfg_attr(musl32_time64, link_name = "__stat_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__stat_time64")]
     pub fn stat(path: *const c_char, buf: *mut stat) -> c_int;
 
     pub fn pclose(stream: *mut crate::FILE) -> c_int;
@@ -1026,7 +1026,7 @@ extern "C" {
         link_name = "fstatat64"
     )]
     #[cfg(not(target_os = "l4re"))]
-    #[cfg_attr(musl32_time64, link_name = "__fstatat_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__fstatat_time64")]
     pub fn fstatat(dirfd: c_int, pathname: *const c_char, buf: *mut stat, flags: c_int) -> c_int;
     #[cfg(not(target_os = "l4re"))]
     pub fn linkat(
@@ -1131,7 +1131,7 @@ extern "C" {
     )]
     #[cfg_attr(target_os = "netbsd", link_name = "__nanosleep50")]
     #[cfg_attr(gnu_time_bits64, link_name = "__nanosleep64")]
-    #[cfg_attr(musl32_time64, link_name = "__nanosleep_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__nanosleep_time64")]
     pub fn nanosleep(rqtp: *const timespec, rmtp: *mut timespec) -> c_int;
     pub fn tcgetpgrp(fd: c_int) -> pid_t;
     pub fn tcsetpgrp(fd: c_int, pgrp: crate::pid_t) -> c_int;
@@ -1176,7 +1176,7 @@ extern "C" {
     pub fn umask(mask: mode_t) -> mode_t;
 
     #[cfg_attr(target_os = "netbsd", link_name = "__utime50")]
-    #[cfg_attr(any(gnu_time_bits64, musl32_time64), link_name = "__utime64")]
+    #[cfg_attr(any(gnu_time_bits64, musl_redir_time64), link_name = "__utime64")]
     pub fn utime(file: *const c_char, buf: *const utimbuf) -> c_int;
 
     #[cfg_attr(
@@ -1231,7 +1231,7 @@ extern "C" {
         all(not(gnu_time_bits64), gnu_file_offset_bits64),
         link_name = "lstat64"
     )]
-    #[cfg_attr(musl32_time64, link_name = "__lstat_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__lstat_time64")]
     pub fn lstat(path: *const c_char, buf: *mut stat) -> c_int;
 
     #[cfg_attr(
@@ -1263,7 +1263,7 @@ extern "C" {
 
     #[cfg_attr(target_os = "netbsd", link_name = "__getrusage50")]
     #[cfg_attr(gnu_time_bits64, link_name = "__getrusage64")]
-    #[cfg_attr(musl32_time64, link_name = "__getrusage_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__getrusage_time64")]
     pub fn getrusage(resource: c_int, usage: *mut rusage) -> c_int;
 
     #[cfg_attr(
@@ -1346,7 +1346,7 @@ extern "C" {
         link_name = "pthread_cond_timedwait$UNIX2003"
     )]
     #[cfg_attr(gnu_time_bits64, link_name = "__pthread_cond_timedwait64")]
-    #[cfg_attr(musl32_time64, link_name = "__pthread_cond_timedwait_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__pthread_cond_timedwait_time64")]
     pub fn pthread_cond_timedwait(
         cond: *mut crate::pthread_cond_t,
         lock: *mut crate::pthread_mutex_t,
@@ -1415,11 +1415,11 @@ extern "C" {
 
     #[cfg_attr(target_os = "netbsd", link_name = "__utimes50")]
     #[cfg_attr(gnu_time_bits64, link_name = "__utimes64")]
-    #[cfg_attr(musl32_time64, link_name = "__utimes_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__utimes_time64")]
     pub fn utimes(filename: *const c_char, times: *const crate::timeval) -> c_int;
     pub fn dlopen(filename: *const c_char, flag: c_int) -> *mut c_void;
     pub fn dlerror() -> *mut c_char;
-    #[cfg_attr(musl32_time64, link_name = "__dlsym_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__dlsym_time64")]
     pub fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
     pub fn dlclose(handle: *mut c_void) -> c_int;
 
@@ -1470,42 +1470,42 @@ extern "C" {
     #[cfg_attr(target_os = "netbsd", link_name = "__gmtime_r50")]
     #[cfg_attr(gnu_time_bits64, link_name = "__gmtime64_r")]
     #[cfg_attr(not(musl32_time64), allow(deprecated))]
-    #[cfg_attr(musl32_time64, link_name = "__gmtime64_r")]
+    #[cfg_attr(musl_redir_time64, link_name = "__gmtime64_r")]
     pub fn gmtime_r(time_p: *const time_t, result: *mut tm) -> *mut tm;
     #[cfg_attr(target_os = "netbsd", link_name = "__localtime_r50")]
     #[cfg_attr(gnu_time_bits64, link_name = "__localtime64_r")]
     #[cfg_attr(not(musl32_time64), allow(deprecated))]
-    #[cfg_attr(musl32_time64, link_name = "__localtime64_r")]
+    #[cfg_attr(musl_redir_time64, link_name = "__localtime64_r")]
     pub fn localtime_r(time_p: *const time_t, result: *mut tm) -> *mut tm;
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86"),
         link_name = "mktime$UNIX2003"
     )]
     #[cfg_attr(target_os = "netbsd", link_name = "__mktime50")]
-    #[cfg_attr(any(gnu_time_bits64, musl32_time64), link_name = "__mktime64")]
+    #[cfg_attr(any(gnu_time_bits64, musl_redir_time64), link_name = "__mktime64")]
     #[cfg_attr(not(musl32_time64), allow(deprecated))]
     pub fn mktime(tm: *mut tm) -> time_t;
     #[cfg_attr(target_os = "netbsd", link_name = "__time50")]
-    #[cfg_attr(any(gnu_time_bits64, musl32_time64), link_name = "__time64")]
+    #[cfg_attr(any(gnu_time_bits64, musl_redir_time64), link_name = "__time64")]
     #[cfg_attr(not(musl32_time64), allow(deprecated))]
     pub fn time(time: *mut time_t) -> time_t;
     #[cfg_attr(target_os = "netbsd", link_name = "__gmtime50")]
-    #[cfg_attr(any(gnu_time_bits64, musl32_time64), link_name = "__gmtime64")]
+    #[cfg_attr(any(gnu_time_bits64, musl_redir_time64), link_name = "__gmtime64")]
     #[cfg_attr(not(musl32_time64), allow(deprecated))]
     pub fn gmtime(time_p: *const time_t) -> *mut tm;
     #[cfg_attr(target_os = "netbsd", link_name = "__locatime50")]
-    #[cfg_attr(any(gnu_time_bits64, musl32_time64), link_name = "__localtime64")]
+    #[cfg_attr(any(gnu_time_bits64, musl_redir_time64), link_name = "__localtime64")]
     #[cfg_attr(not(musl32_time64), allow(deprecated))]
     pub fn localtime(time_p: *const time_t) -> *mut tm;
     #[cfg_attr(target_os = "netbsd", link_name = "__difftime50")]
-    #[cfg_attr(any(gnu_time_bits64, musl32_time64), link_name = "__difftime64")]
+    #[cfg_attr(any(gnu_time_bits64, musl_redir_time64), link_name = "__difftime64")]
     #[cfg_attr(not(musl32_time64), allow(deprecated))]
     pub fn difftime(time1: time_t, time0: time_t) -> c_double;
     #[cfg(not(target_os = "aix"))]
     #[cfg_attr(target_os = "netbsd", link_name = "__timegm50")]
     #[cfg_attr(gnu_time_bits64, link_name = "__timegm64")]
     #[cfg_attr(not(musl32_time64), allow(deprecated))]
-    #[cfg_attr(musl32_time64, link_name = "__timegm_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__timegm_time64")]
     pub fn timegm(tm: *mut crate::tm) -> time_t;
 
     #[cfg_attr(target_os = "netbsd", link_name = "__mknod50")]
@@ -1566,7 +1566,7 @@ extern "C" {
     #[cfg_attr(target_os = "netbsd", link_name = "__select50")]
     #[cfg_attr(target_os = "aix", link_name = "__fd_select")]
     #[cfg_attr(gnu_time_bits64, link_name = "__select64")]
-    #[cfg_attr(musl32_time64, link_name = "__select_time64")]
+    #[cfg_attr(musl_redir_time64, link_name = "__select_time64")]
     pub fn select(
         nfds: c_int,
         readfds: *mut fd_set,
@@ -2131,7 +2131,7 @@ cfg_if! {
     )))] {
         extern "C" {
             #[cfg_attr(target_os = "netbsd", link_name = "__adjtime50")]
-            #[cfg_attr(any(gnu_time_bits64, musl32_time64), link_name = "__adjtime64")]
+            #[cfg_attr(any(gnu_time_bits64, musl_redir_time64), link_name = "__adjtime64")]
             pub fn adjtime(delta: *const timeval, olddelta: *mut timeval) -> c_int;
         }
     } else if #[cfg(target_os = "solaris")] {
@@ -2309,7 +2309,7 @@ cfg_if! {
             )]
             #[cfg_attr(target_os = "netbsd", link_name = "__pselect50")]
             #[cfg_attr(gnu_time_bits64, link_name = "__pselect64")]
-            #[cfg_attr(musl32_time64, link_name = "__pselect_time64")]
+            #[cfg_attr(musl_redir_time64, link_name = "__pselect_time64")]
             pub fn pselect(
                 nfds: c_int,
                 readfds: *mut fd_set,


### PR DESCRIPTION
Hexagon was added to musl after the time64 transition and never had a 32-bit time_t ABI, so its libc exports `clock_gettime` (not `__clock_gettime64`) and has no `__*time64` redirect symbols. Remove hexagon from MUSL_REDIR_TIME64_ARCHES to stop applying ~45 link_name redirects that cause undefined symbol errors at link time.

The correct 64-bit time_t/suseconds_t types and timespec padding are preserved via direct target_arch = "hexagon" conditions, and linux_time_bits64 is set separately for input_event layout.

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
