### PR TITLE
linux: Qdd sockaddr_iucv

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3781,6 +3781,7 @@ fn test_linux(target: &str) {
         "netinet/ip.h",
         "netinet/tcp.h",
         "netinet/udp.h",
+        (gnu, "netiucv/iucv.h"),
         (l4re, "netpacket/packet.h"),
         "poll.h",
         "pthread.h",

--- a/src/unix/linux_like/linux/gnu/b64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mod.rs
@@ -98,6 +98,17 @@ s! {
         __glibc_reserved4: Padding<crate::__syscall_ulong_t>,
     }
 
+    // net/iucv/iucv.h
+
+    pub struct sockaddr_iucv {
+        pub siucv_family: crate::sa_family_t,
+        __siucv_port: Padding<u16>, // unused crate::in_port_t
+        __siucv_addr: Padding<u32>, // unused crate::in_addr_t
+        pub siucv_nodeid: [c_char; 8],
+        pub siucv_user_id: [c_char; 8],
+        pub siucv_name: [c_char; 8],
+    }
+
     pub struct timex {
         pub modes: c_uint,
         #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]


### PR DESCRIPTION
This adds the sockaddr_iucv define in netiucv/iucv. It is primarily used on the s390x platform when linux is running under z/VM, but is present on all the linux systems I've been able to test on.

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Adds support for sockaddr_iucv

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->
https://github.com/torvalds/linux/blob/5619b098e2fbf3a23bf13d91897056a1fe238c6d/include/net/iucv/iucv.h


# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI



@rustbot label +stable-nominated

