### PR TITLE
horizon: Change POLL constants from c_short to c_int

### DIFF
--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -150,16 +150,16 @@ pub const SOL_CONFIG: c_uint = 65534;
 pub const PTHREAD_STACK_MIN: size_t = 4096;
 pub const WNOHANG: c_int = 1;
 
-pub const POLLIN: c_short = 0x0001;
-pub const POLLPRI: c_short = 0x0002;
-pub const POLLOUT: c_short = 0x0004;
-pub const POLLRDNORM: c_short = 0x0040;
-pub const POLLWRNORM: c_short = POLLOUT;
-pub const POLLRDBAND: c_short = 0x0080;
-pub const POLLWRBAND: c_short = 0x0100;
-pub const POLLERR: c_short = 0x0008;
-pub const POLLHUP: c_short = 0x0010;
-pub const POLLNVAL: c_short = 0x0020;
+pub const POLLIN: c_int = 0x0001;
+pub const POLLPRI: c_int = 0x0002;
+pub const POLLOUT: c_int = 0x0004;
+pub const POLLRDNORM: c_int = 0x0040;
+pub const POLLWRNORM: c_int = POLLOUT;
+pub const POLLRDBAND: c_int = 0x0080;
+pub const POLLWRBAND: c_int = 0x0100;
+pub const POLLERR: c_int = 0x0008;
+pub const POLLHUP: c_int = 0x0010;
+pub const POLLNVAL: c_int = 0x0020;
 
 pub const EAI_AGAIN: c_int = 2;
 pub const EAI_BADFLAGS: c_int = 3;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

This change modifies constants to match the definition of the types in pollfd
https://github.com/rust-lang/libc/blob/b6ab1fbc3946975593d3b3ef3b733ed97ae64146/src/unix/newlib/horizon/mod.rs#L31

# Sources

This struct is meant to match the libctru pollfd which also uses ints for all the struct members.
https://github.com/devkitPro/libctru/blob/36fe1ada5b7ebe53ba4decda36d764a55f8fefb6/libctru/include/poll.h#L12

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
