### PR TITLE
feat: add back support for GNU Windows x86 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,15 +125,13 @@ jobs:
             os: windows-11-arm
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
-          # FIXME: It currently causes segfaults.
-          #- target: i686-pc-windows-gnu
-          #  env: { ARCH_BITS: 32, ARCH: i686 }
+          - target: i686-pc-windows-gnu
+            os: windows-2025
           - target: i686-pc-windows-msvc
             os: windows-2025
           - target: i686-unknown-linux-gnu
           - target: x86_64-pc-windows-gnu
             os: windows-2025
-            env: { ARCH_BITS: 64, ARCH: x86_64 }
           - target: x86_64-pc-windows-msvc
             os: windows-2025
           - target: x86_64-unknown-linux-gnu

--- a/ci/install-rust.sh
+++ b/ci/install-rust.sh
@@ -38,23 +38,11 @@ if [ -n "${INSTALL_RUST_SRC:-}" ]; then
 fi
 
 if [ "$os" = "windows" ]; then
-    if [ "${ARCH_BITS:-}" = "i686" ]; then
-        echo "Install MinGW32"
-        choco install mingw --x86 --force
-    fi
-
     echo "Find GCC libraries"
     gcc -print-search-dirs
-    /usr/bin/find "C:\ProgramData\Chocolatey" -name "crt2*"
-    /usr/bin/find "C:\ProgramData\Chocolatey" -name "dllcrt2*"
-    /usr/bin/find "C:\ProgramData\Chocolatey" -name "libmsvcrt*"
-
-    if [ -n "${ARCH_BITS:-}" ]; then
-        echo "Fix MinGW"
-        for i in crt2.o dllcrt2.o libmingwex.a libmsvcrt.a; do
-            cp -f "/C/ProgramData/Chocolatey/lib/mingw/tools/install/mingw$ARCH_BITS/$ARCH-w64-mingw32/lib/$i" "$(rustc --print sysroot)/lib/rustlib/$TARGET/lib"
-        done
-    fi
+    /usr/bin/find "C:\ProgramData\chocolatey" -name "crt2*"
+    /usr/bin/find "C:\ProgramData\chocolatey" -name "dllcrt2*"
+    /usr/bin/find "C:\ProgramData\chocolatey" -name "libmsvcrt*"
 fi
 
 echo "Query rust and cargo versions"

--- a/src/windows/gnu/mod.rs
+++ b/src/windows/gnu/mod.rs
@@ -1,5 +1,7 @@
 use crate::prelude::*;
 
+// The below configuration for machines with 32-bit word size aligns with the
+// declaration in the `mingw-w64` headers.
 cfg_if! {
     if #[cfg(target_pointer_width = "64")] {
         s_no_extra_traits! {
@@ -10,9 +12,9 @@ cfg_if! {
         }
     } else if #[cfg(target_pointer_width = "32")] {
         s_no_extra_traits! {
-            #[repr(align(16))]
+            #[repr(align(8))]
             pub struct max_align_t {
-                priv_: [i64; 6],
+                priv_: [i64; 3],
             }
         }
     }


### PR DESCRIPTION
# Description

After having tested out GNU on Windows x86, it seemed like the only issue was
related to a wrongly aligned/sized `max_align_t`. This has been fixed, and the
test suite seems to be running just fine in CI now for the above
platform/environment.

There were also some environment variables in CI that seemed to be set for the
purposes of changing the Mingw toolchain set up, but that weren't truly being
used as the job that ran the script that used those was being triggered earlier
in the CI pipeline. Because CI logs seem to reveal this has been the case for
some time, this has also been altogether removed.

# Sources

- Mingw source code outlining the structure layout of `max_align_t`
  https://github.com/mingw-w64/mingw-w64/blob/9b3dd0125792fe94d16cacdc596dbd42fca1b369/mingw-w64-headers/crt/stddef.h#L424-L427

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated