### PR TITLE
redox: Add semaphore functions

### DIFF
--- a/libc-test/semver/redox.txt
+++ b/libc-test/semver/redox.txt
@@ -337,6 +337,14 @@ qsort
 reallocarray
 renameat2
 rlim_t
+sem_clockwait
+sem_destroy
+sem_getvalue
+sem_init
+sem_post
+sem_timedwait
+sem_trywait
+sem_wait
 setgrent
 setpwent
 setresgid

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -1309,6 +1309,17 @@ extern "C" {
         result: *mut *mut passwd,
     ) -> c_int;
 
+    // semaphore.h
+    pub fn sem_destroy(sem: *mut sem_t) -> c_int;
+    pub fn sem_init(sem: *mut sem_t, pshared: c_int, value: c_uint) -> c_int;
+    pub fn sem_clockwait(
+        sem: *mut sem_t,
+        clock_id: clockid_t,
+        abstime: *const crate::timespec,
+    ) -> c_int;
+    pub fn sem_timedwait(sem: *mut sem_t, abstime: *const crate::timespec) -> c_int;
+    pub fn sem_getvalue(sem: *mut sem_t, sval: *mut c_int) -> c_int;
+
     // signal.h
     pub fn pthread_sigmask(
         how: c_int,


### PR DESCRIPTION
# Description

This adds more `semaphore.h` functions to Redox. These functions existed since years ago and tested months ago for Golang thread synchronization. Now these are added to fix compilation related to new `ctrlc` crate.

Added in `redox.rs`
+ sem_clockwait
+ sem_destroy
+ sem_getvalue
+ sem_init
+ sem_timedwait

Already in `unix.rs`
+ sem_post
+ sem_trywait
+ sem_wait

# Sources

- [Relibc Source](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/semaphore/mod.rs)
- [libc crate backport to fix ctrlc crate](https://gitlab.redox-os.org/redox-os/redox/-/merge_requests/2053/diffs)

# Checklist

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated

