### PR TITLE
[ctest] support r#keyword

### DIFF
--- a/ctest/src/ast/field.rs
+++ b/ctest/src/ast/field.rs
@@ -13,4 +13,69 @@ impl Field {
     pub fn ident(&self) -> &str {
         &self.ident
     }
+
+    /// Return the identifier escaped for Rust source output when needed.
+    pub fn rust_ident(&self) -> String {
+        if is_rust_keyword(&self.ident) {
+            format!("r#{}", self.ident)
+        } else {
+            self.ident.to_string()
+        }
+    }
+}
+
+fn is_rust_keyword(ident: &str) -> bool {
+    matches!(
+        ident,
+        "as" | "break"
+            | "const"
+            | "continue"
+            | "crate"
+            | "else"
+            | "enum"
+            | "extern"
+            | "false"
+            | "fn"
+            | "for"
+            | "if"
+            | "impl"
+            | "in"
+            | "let"
+            | "loop"
+            | "match"
+            | "mod"
+            | "move"
+            | "mut"
+            | "pub"
+            | "ref"
+            | "return"
+            | "self"
+            | "Self"
+            | "static"
+            | "struct"
+            | "super"
+            | "trait"
+            | "true"
+            | "type"
+            | "unsafe"
+            | "use"
+            | "where"
+            | "while"
+            | "async"
+            | "await"
+            | "dyn"
+            | "abstract"
+            | "become"
+            | "box"
+            | "do"
+            | "final"
+            | "macro"
+            | "override"
+            | "priv"
+            | "typeof"
+            | "unsized"
+            | "virtual"
+            | "yield"
+            | "try"
+    )
 }

--- a/ctest/src/ffi_items.rs
+++ b/ctest/src/ffi_items.rs
@@ -96,10 +96,17 @@ fn collect_fields(fields: &Punctuated<syn::Field, syn::Token![,]>) -> Vec<Field>
     fields
         .iter()
         .filter_map(|field| {
-            field.ident.as_ref().map(|ident| Field {
-                public: is_visible(&field.vis),
-                ident: ident.to_string().into_boxed_str(),
-                ty: field.ty.clone(),
+            field.ident.as_ref().map(|ident| {
+                let ident = ident.to_string();
+                Field {
+                    public: is_visible(&field.vis),
+                    ident: ident
+                        .strip_prefix("r#")
+                        .unwrap_or(&ident)
+                        .to_string()
+                        .into_boxed_str(),
+                    ty: field.ty.clone(),
+                }
             })
         })
         .collect()

--- a/ctest/templates/test.rs
+++ b/ctest/templates/test.rs
@@ -188,19 +188,19 @@ mod generated_tests {
         let uninit_ty = uninit_ty.as_ptr();
 
         {# /* SAFETY: we assume the field access doesn't wrap */ #}
-        let ty_ptr = unsafe { &raw const (*uninit_ty).{{ item.field.ident() }}   };
+        let ty_ptr = unsafe { &raw const (*uninit_ty).{{ item.field.rust_ident() }}   };
         {# /* SAFETY: we assume that all zeros is a valid bitpattern for `ty_ptr`, otherwise the
             * test should be skipped. */ #}
         let val = unsafe { ty_ptr.read_unaligned() };
 
         {# /* SAFETY: FFI call with no preconditions */ #}
         let ctest_field_offset = unsafe { ctest_offset_of__{{ item.id }}__{{ item.field.ident() }}() };
-        check_same(offset_of!({{ item.id }}, {{ item.field.ident() }}) as u64, ctest_field_offset,
-            "field offset `{{ item.field.ident() }}` of `{{ item.id }}`");
+        check_same(offset_of!({{ item.id }}, {{ item.field.rust_ident() }}) as u64, ctest_field_offset,
+            "field offset `{{ item.field.rust_ident() }}` of `{{ item.id }}`");
         {# /* SAFETY: FFI call with no preconditions */ #}
         let ctest_field_size = unsafe { ctest_size_of__{{ item.id }}__{{ item.field.ident() }}() };
         check_same(size_of_val(&val) as u64, ctest_field_size,
-            "field size `{{ item.field.ident() }}` of `{{ item.id }}`");
+            "field size `{{ item.field.rust_ident() }}` of `{{ item.id }}`");
     }
 {%- endfor +%}
 
@@ -217,12 +217,12 @@ mod generated_tests {
         let ty_ptr = uninit_ty.as_ptr();
         // SAFETY: We don't read `field_ptr`, only compare the pointer itself.
         // The assumption is made that this does not wrap the address space.
-        let field_ptr = unsafe { &raw const ((*ty_ptr).{{ item.field.ident() }}) };
+        let field_ptr = unsafe { &raw const ((*ty_ptr).{{ item.field.rust_ident() }}) };
 
         // SAFETY: FFI call with no preconditions
         let ctest_field_ptr = unsafe { ctest_field_ptr__{{ item.id }}__{{ item.field.ident() }}(ty_ptr) };
         check_same(field_ptr.cast(), ctest_field_ptr,
-            "field pointer access `{{ item.field.ident() }}` of `{{ item.id }}`");
+            "field pointer access `{{ item.field.rust_ident() }}` of `{{ item.id }}`");
     }
 
 {%- endfor +%}
@@ -254,11 +254,11 @@ mod generated_tests {
         let bar = bar.as_ptr();
         {%- for field in item.fields +%}
 
-        let ty_ptr = unsafe { &raw const ((*bar).{{ field.ident() }}) };
+        let ty_ptr = unsafe { &raw const ((*bar).{{ field.rust_ident() }}) };
         let val = unsafe { ty_ptr.read_unaligned() };
 
         let size = size_of_val(&val);
-        let off = offset_of!({{ item.id }}, {{ field.ident() }});
+        let off = offset_of!({{ item.id }}, {{ field.rust_ident() }});
         v.push((off, size));
         {%- endfor +%}
         {# /* This vector contains `true` if the byte is padding and `false` if the byte is not

--- a/ctest/tests/basic.rs
+++ b/ctest/tests/basic.rs
@@ -174,3 +174,38 @@ fn test_entrypoint_invalid_syntax() {
 
     assert!(fails)
 }
+
+#[test]
+fn test_raw_identifier_field() {
+    let include_path = PathBuf::from("tests/input");
+    let crate_path = include_path.join("raw_ident.rs");
+    let library_path = "raw_ident.out.a";
+
+    let (mut gen_, out_dir) = default_generator(1, Some("raw_ident.h")).unwrap();
+    gen_.rename_struct_ty(|ty| Some(ty.to_string()));
+    let output_file = gen_.generate_files(&crate_path, library_path).unwrap();
+
+    let rust_output = fs::read_to_string(output_file.with_extension("rs")).unwrap();
+    let c_output = fs::read_to_string(output_file.with_extension("c")).unwrap();
+
+    assert!(rust_output.contains("(*uninit_ty).r#type"));
+    assert!(rust_output.contains("offset_of!(RawIdent, r#type)"));
+    assert!(rust_output.contains("ctest_offset_of__RawIdent__type"));
+    assert!(rust_output.contains("ctest_field_ptr__RawIdent__type"));
+
+    assert!(c_output.contains(", type)"));
+    assert!(c_output.contains("->type"));
+    assert!(!c_output.contains("r#type"));
+    assert!(c_output.contains("ctest_offset_of__RawIdent__type"));
+    assert!(c_output.contains("ctest_field_ptr__RawIdent__type"));
+
+    if env::var("TARGET_PLATFORM") == env::var("HOST_PLATFORM") {
+        generate_test(&mut gen_, &crate_path, library_path).unwrap();
+        let test_binary = __compile_test(&out_dir, crate_path, library_path).unwrap();
+        let result = __run_test(test_binary);
+        if let Err(err) = &result {
+            eprintln!("Test failed: {err:?}");
+        }
+        assert!(result.is_ok());
+    }
+}

--- a/ctest/tests/input/raw_ident.h
+++ b/ctest/tests/input/raw_ident.h
@@ -1,0 +1,5 @@
+#include <stdint.h>
+
+typedef struct {
+    int32_t type;
+} RawIdent;

--- a/ctest/tests/input/raw_ident.rs
+++ b/ctest/tests/input/raw_ident.rs
@@ -1,0 +1,4 @@
+#[repr(C)]
+pub struct RawIdent {
+    pub r#type: i32,
+}


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Add rust keywork escape pattern `r#<keyword>` like `r#type`.

This change is not for libc usage, but will be useful as an independent ctest library.

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

probably not applicable to ctest changes.

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

<!--
- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
-->

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
