### PR TITLE
Revert "ci: Pin nightly to 2026-04-01"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,6 @@ env:
   RUST_BACKTRACE: full
   # Base branch for PRs or for merges, current ref for cron runs on a branch.
   TARGET_REF: ${{ github.base_ref || github.event.merge_group.base_ref || github.ref }}
-  # FIXME(ci): Unpin once <https://github.com/rust-lang/rust/issues/154878> is resolved.
-  TOOLCHAIN: nightly-2026-04-01
 
 defaults:
   run:


### PR DESCRIPTION
The relevant PR has been reverted in rust-lang/rust.

This reverts commit e26a0bd01d465c136043c1e23f71b106ceb0746f.