### PR TITLE
fix(newlib): update stat struct to match official headers

### DIFF
--- a/src/unix/newlib/generic.rs
+++ b/src/unix/newlib/generic.rs
@@ -1,5 +1,5 @@
 //! Common types used by most newlib platforms
-
+use crate::off_t;
 #[allow(unused_imports)] // needed for platforms that don't use the prelude here
 use crate::prelude::*;
 
@@ -9,7 +9,6 @@ s! {
         __val: u32,
     }
 
-    #[cfg(all(not(target_os = "vita"), not(target_os = "horizon")))]
     pub struct stat {
         pub st_dev: crate::dev_t,
         pub st_ino: crate::ino_t,
@@ -18,13 +17,10 @@ s! {
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
-        pub st_size: crate::off_t,
-        pub st_atime: crate::time_t,
-        pub st_spare1: c_long,
-        pub st_mtime: crate::time_t,
-        pub st_spare2: c_long,
-        pub st_ctime: crate::time_t,
-        pub st_spare3: c_long,
+        pub st_size: off_t,
+        pub st_atim: crate::timespec,
+        pub st_mtim: crate::timespec,
+        pub st_ctim: crate::timespec,
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
         pub st_spare4: [c_long; 2usize],

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -1,6 +1,5 @@
 //! ARMv6K Nintendo 3DS C Newlib definitions
 
-use crate::off_t;
 use crate::prelude::*;
 
 pub type wchar_t = c_uint;
@@ -67,23 +66,6 @@ s! {
 
     pub struct sched_param {
         pub sched_priority: c_int,
-    }
-
-    pub struct stat {
-        pub st_dev: crate::dev_t,
-        pub st_ino: crate::ino_t,
-        pub st_mode: crate::mode_t,
-        pub st_nlink: crate::nlink_t,
-        pub st_uid: crate::uid_t,
-        pub st_gid: crate::gid_t,
-        pub st_rdev: crate::dev_t,
-        pub st_size: off_t,
-        pub st_atim: crate::timespec,
-        pub st_mtim: crate::timespec,
-        pub st_ctim: crate::timespec,
-        pub st_blksize: crate::blksize_t,
-        pub st_blocks: crate::blkcnt_t,
-        pub st_spare4: [c_long; 2usize],
     }
 }
 

--- a/src/unix/newlib/vita/mod.rs
+++ b/src/unix/newlib/vita/mod.rs
@@ -1,4 +1,3 @@
-use crate::off_t;
 use crate::prelude::*;
 
 pub type clock_t = c_long;
@@ -59,23 +58,6 @@ s! {
 
     pub struct sched_param {
         pub sched_priority: c_int,
-    }
-
-    pub struct stat {
-        pub st_dev: crate::dev_t,
-        pub st_ino: crate::ino_t,
-        pub st_mode: crate::mode_t,
-        pub st_nlink: crate::nlink_t,
-        pub st_uid: crate::uid_t,
-        pub st_gid: crate::gid_t,
-        pub st_rdev: crate::dev_t,
-        pub st_size: off_t,
-        pub st_atime: crate::time_t,
-        pub st_mtime: crate::time_t,
-        pub st_ctime: crate::time_t,
-        pub st_blksize: crate::blksize_t,
-        pub st_blocks: crate::blkcnt_t,
-        pub st_spare4: [c_long; 2usize],
     }
 
     #[repr(align(8))]


### PR DESCRIPTION
# Description

This PR fixes rust-lang/libc#2795

> Note: If any platforms that meet the above criteria are added, they would need to create their own definition and use that (maybe a `cfg_if!`) - by ian-h-chamberlain

> ps. thank @zetanumbers for investigating targets' compatibility

# Sources

- https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/include/sys/stat.h;h=6525272dd40123d6ea4e7355a8e6f3a3f3d0dbb8;hb=HEAD

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
