### PR TITLE
WIP: Use a more type safe alternative for sigaction types

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -349,6 +349,13 @@ fn test_apple(target: &str) {
         }
     });
 
+    cfg.skip_union(move |u| {
+        match u.ident() {
+            "sighandler_t" => true,
+            _ => false,
+        }
+    });
+
     cfg.skip_const(move |constant| {
         match constant.ident() {
             // They're declared via `deprecated_mach` and we don't support it anymore.
@@ -367,6 +374,8 @@ fn test_apple(target: &str) {
 
             // FIXME(macos): bumped up on macOS 26, it's sizeof `vm_statistics64_data_t`
             "HOST_VM_INFO64_COUNT" => true,
+
+            "SIG_DFL" | "SIG_IGN" | "SIG_ERR" => true,
 
             _ => false,
         }
@@ -425,9 +434,6 @@ fn test_apple(target: &str) {
             .contains(&ty)
             .then_some(ty.to_string())
     });
-
-    // OSX calls this something else
-    cfg.rename_type(|ty| (ty == "sighandler_t").then_some("sig_t".to_string()));
 
     cfg.rename_struct_ty(|ty| ty.ends_with("_t").then_some(ty.to_string()));
     cfg.rename_union_ty(|ty| ty.ends_with("_t").then_some(ty.to_string()));

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -347,8 +347,8 @@ s! {
         _pad: Padding<[usize; 9]>,
     }
 
+    #[allow(unpredictable_function_pointer_comparisons)]
     pub struct sigaction {
-        // FIXME(union): this field is actually a union
         pub sa_sigaction: crate::sighandler_t,
         pub sa_mask: sigset_t,
         pub sa_flags: c_int,

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -129,6 +129,13 @@ impl siginfo_t {
     }
 }
 
+s_no_extra_traits! {
+    pub union sa_union_t {
+        pub sa_handler: crate::sighandler_t,
+        pub sa_sigaction: extern "C" fn(c_int, *mut crate::siginfo_t, *mut c_void),
+    }
+}
+
 s! {
     pub struct aiocb {
         pub aio_fildes: c_int,
@@ -161,7 +168,7 @@ s! {
     // FIXME(1.0): This should not implement `PartialEq`
     #[allow(unpredictable_function_pointer_comparisons)]
     pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
+        pub sa_sigaction: sa_union_t,
         pub sa_mask: crate::sigset_t,
         pub sa_flags: c_int,
         pub sa_restorer: Option<extern "C" fn()>,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -17,8 +17,18 @@ pub type ssize_t = isize;
 pub type pid_t = i32;
 pub type in_addr_t = u32;
 pub type in_port_t = u16;
-pub type sighandler_t = size_t;
 pub type cc_t = c_uchar;
+
+// All derivatives use sighandler_t to mean something which is either a
+// function pointer or a size_t. And this has implications for its size
+// (especially on CHERI architectures) compared to just blindly using size_t to
+// represent it.
+s_no_extra_traits! {
+    pub union sighandler_t {
+        pub sighandler_id: size_t,
+        pub sighandler_fn: extern "C" fn(c_int),
+    }
+}
 
 cfg_if! {
     if #[cfg(any(
@@ -229,9 +239,9 @@ s! {
 pub const INT_MIN: c_int = -2147483648;
 pub const INT_MAX: c_int = 2147483647;
 
-pub const SIG_DFL: sighandler_t = 0 as sighandler_t;
-pub const SIG_IGN: sighandler_t = 1 as sighandler_t;
-pub const SIG_ERR: sighandler_t = !0 as sighandler_t;
+pub const SIG_DFL: size_t = 0 as size_t;
+pub const SIG_IGN: size_t = 1 as size_t;
+pub const SIG_ERR: size_t = !0 as size_t;
 
 cfg_if! {
     if #[cfg(all(


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

We cannot safely rely on considering usize and pointers as interchangeable, especially on CHERI where the pointer size is larger than a usize. Using a union is a much safer option and it actually communicates the fact that we interpret these fields differently in different situations.

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

E.G: https://git.musl-libc.org/cgit/musl/tree/include/signal.h#n170

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->

This would be a disruptive change to crates currently using these types, however it (or something similar) is absolutely necessary in order for us to be compatible on targets where the size of a function pointer is not equal to a size_t. C is obviously less strict about things which appear to not be unions but that are treated as such, however on the C side, at least the type used in these declarations is the *maximum* of the two types (fn ptr > size_t), whereas we are just currently using size_t. For an example of the changes this implies to other crates, see https://github.com/lewis-belsten-revill/wait-timeout/commit/f5e017567ce942a344ec6262a1f0abe59ed8fed4