### PR TITLE
fix: replace raw pointer casts with pointer::cast

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -4226,7 +4226,7 @@ f! {
     }
 
     pub fn uname(buf: *mut crate::utsname) -> c_int {
-        __xuname(256, buf as *mut c_void)
+        __xuname(256, buf.cast())
     }
 
     pub fn CPU_ZERO(cpuset: &mut cpuset_t) -> () {

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -495,7 +495,7 @@ pub const RTAX_BRD: c_int = 7;
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const crate::msghdr) -> *mut cmsghdr {
         if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
-            (*mhdr).msg_control.cast::<cmsghdr>()
+            (*mhdr).msg_control.cast()
         } else {
             core::ptr::null_mut()
         }

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -83,7 +83,7 @@ impl siginfo_t {
             __pad1: Padding<c_int>,
             _pid: crate::pid_t,
         }
-        (*(self as *const siginfo_t as *const siginfo_timer))._pid
+        (*(self as *const siginfo_t).cast::<siginfo_timer>())._pid
     }
 
     pub unsafe fn si_uid(&self) -> crate::uid_t {
@@ -97,7 +97,7 @@ impl siginfo_t {
             _pid: crate::pid_t,
             _uid: crate::uid_t,
         }
-        (*(self as *const siginfo_t as *const siginfo_timer))._uid
+        (*(self as *const siginfo_t).cast::<siginfo_timer>())._uid
     }
 
     pub unsafe fn si_value(&self) -> crate::sigval {
@@ -112,7 +112,7 @@ impl siginfo_t {
             _uid: crate::uid_t,
             value: crate::sigval,
         }
-        (*(self as *const siginfo_t as *const siginfo_timer)).value
+        (*(self as *const siginfo_t).cast::<siginfo_timer>()).value
     }
 
     pub unsafe fn si_status(&self) -> c_int {
@@ -127,7 +127,7 @@ impl siginfo_t {
             _uid: crate::uid_t,
             status: c_int,
         }
-        (*(self as *const siginfo_t as *const siginfo_timer)).status
+        (*(self as *const siginfo_t).cast::<siginfo_timer>()).status
     }
 }
 

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -865,7 +865,7 @@ impl siginfo_t {
             _stime: crate::clock_t,
             _status: crate::c_int,
         }
-        (*(self as *const siginfo_t as *const siginfo_proc))._status
+        (*(self as *const siginfo_t).cast::<siginfo_proc>())._status
     }
 }
 

--- a/src/unix/cygwin/mod.rs
+++ b/src/unix/cygwin/mod.rs
@@ -534,7 +534,7 @@ impl siginfo_t {
             _si_errno: c_int,
             si_addr: *mut c_void,
         }
-        (*(self as *const siginfo_t as *const siginfo_si_addr)).si_addr
+        (*(self as *const siginfo_t).cast::<siginfo_si_addr>()).si_addr
     }
 
     pub unsafe fn si_status(&self) -> c_int {
@@ -547,7 +547,7 @@ impl siginfo_t {
             _si_errno: c_int,
             si_status: c_int,
         }
-        (*(self as *const siginfo_t as *const siginfo_sigchld)).si_status
+        (*(self as *const siginfo_t).cast::<siginfo_sigchld>()).si_status
     }
 
     pub unsafe fn si_pid(&self) -> pid_t {
@@ -568,7 +568,7 @@ impl siginfo_t {
             _si_errno: c_int,
             si_value: sigval,
         }
-        (*(self as *const siginfo_t as *const siginfo_si_value)).si_value
+        (*(self as *const siginfo_t).cast::<siginfo_si_value>()).si_value
     }
 }
 

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -1383,7 +1383,7 @@ const fn CMSG_ALIGN(len: usize) -> usize {
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
         if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
-            (*mhdr).msg_control as *mut cmsghdr
+            (*mhdr).msg_control.cast()
         } else {
             core::ptr::null_mut::<cmsghdr>()
         }

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -3363,7 +3363,7 @@ const fn CMSG_ALIGN(len: usize) -> usize {
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
         if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
-            (*mhdr).msg_control.cast::<cmsghdr>()
+            (*mhdr).msg_control.cast()
         } else {
             core::ptr::null_mut::<cmsghdr>()
         }
@@ -3392,7 +3392,7 @@ f! {
         {
             core::ptr::null_mut::<cmsghdr>()
         } else {
-            next.cast::<cmsghdr>()
+            next.cast()
         }
     }
 

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -3285,7 +3285,7 @@ f! {
         if (next.offset(1)) as usize > max {
             core::ptr::null_mut::<cmsghdr>()
         } else {
-            next as *mut cmsghdr
+            next.cast()
         }
     }
 
@@ -3747,7 +3747,7 @@ impl siginfo_t {
             _si_code: c_int,
             si_addr: *mut c_void,
         }
-        (*(self as *const siginfo_t as *const siginfo_sigfault)).si_addr
+        (*(self as *const siginfo_t).cast::<siginfo_sigfault>()).si_addr
     }
 
     pub unsafe fn si_value(&self) -> crate::sigval {
@@ -3760,13 +3760,13 @@ impl siginfo_t {
             _si_overrun: c_int,
             si_sigval: crate::sigval,
         }
-        (*(self as *const siginfo_t as *const siginfo_timer)).si_sigval
+        (*(self as *const siginfo_t).cast::<siginfo_timer>()).si_sigval
     }
 }
 
 impl siginfo_t {
     unsafe fn sifields(&self) -> &sifields {
-        &(*(self as *const siginfo_t as *const siginfo_f)).sifields
+        &(*(self as *const siginfo_t).cast::<siginfo_f>()).sifields
     }
 
     pub unsafe fn si_pid(&self) -> crate::pid_t {

--- a/src/unix/linux_like/emscripten/lfs64.rs
+++ b/src/unix/linux_like/emscripten/lfs64.rs
@@ -10,7 +10,7 @@ pub unsafe extern "C" fn creat64(path: *const c_char, mode: crate::mode_t) -> c_
 
 #[inline]
 pub unsafe extern "C" fn fgetpos64(stream: *mut crate::FILE, pos: *mut crate::fpos64_t) -> c_int {
-    crate::fgetpos(stream, pos as *mut _)
+    crate::fgetpos(stream, pos.cast())
 }
 
 #[inline]
@@ -38,12 +38,12 @@ pub unsafe extern "C" fn fseeko64(
 
 #[inline]
 pub unsafe extern "C" fn fsetpos64(stream: *mut crate::FILE, pos: *const crate::fpos64_t) -> c_int {
-    crate::fsetpos(stream, pos as *mut _)
+    crate::fsetpos(stream, pos.cast())
 }
 
 #[inline]
 pub unsafe extern "C" fn fstat64(fildes: c_int, buf: *mut crate::stat64) -> c_int {
-    crate::fstat(fildes, buf as *mut _)
+    crate::fstat(fildes, buf.cast())
 }
 
 #[inline]
@@ -53,17 +53,17 @@ pub unsafe extern "C" fn fstatat64(
     buf: *mut crate::stat64,
     flag: c_int,
 ) -> c_int {
-    crate::fstatat(fd, path, buf as *mut _, flag)
+    crate::fstatat(fd, path, buf.cast(), flag)
 }
 
 #[inline]
 pub unsafe extern "C" fn fstatfs64(fd: c_int, buf: *mut crate::statfs64) -> c_int {
-    crate::fstatfs(fd, buf as *mut _)
+    crate::fstatfs(fd, buf.cast())
 }
 
 #[inline]
 pub unsafe extern "C" fn fstatvfs64(fd: c_int, buf: *mut crate::statvfs64) -> c_int {
-    crate::fstatvfs(fd, buf as *mut _)
+    crate::fstatvfs(fd, buf.cast())
 }
 
 #[inline]
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn ftruncate64(fd: c_int, length: off64_t) -> c_int {
 
 #[inline]
 pub unsafe extern "C" fn getrlimit64(resource: c_int, rlim: *mut crate::rlimit64) -> c_int {
-    crate::getrlimit(resource, rlim as *mut _)
+    crate::getrlimit(resource, rlim.cast())
 }
 
 #[inline]
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn lseek64(fd: c_int, offset: off64_t, whence: c_int) -> o
 
 #[inline]
 pub unsafe extern "C" fn lstat64(path: *const c_char, buf: *mut crate::stat64) -> c_int {
-    crate::lstat(path, buf as *mut _)
+    crate::lstat(path, buf.cast())
 }
 
 #[inline]
@@ -171,7 +171,7 @@ pub unsafe extern "C" fn pwritev64(
 
 #[inline]
 pub unsafe extern "C" fn readdir64(dirp: *mut crate::DIR) -> *mut crate::dirent64 {
-    crate::readdir(dirp) as *mut _
+    crate::readdir(dirp).cast()
 }
 
 #[inline]
@@ -180,27 +180,27 @@ pub unsafe extern "C" fn readdir64_r(
     entry: *mut crate::dirent64,
     result: *mut *mut crate::dirent64,
 ) -> c_int {
-    crate::readdir_r(dirp, entry as *mut _, result as *mut _)
+    crate::readdir_r(dirp, entry.cast(), result.cast())
 }
 
 #[inline]
 pub unsafe extern "C" fn setrlimit64(resource: c_int, rlim: *const crate::rlimit64) -> c_int {
-    crate::setrlimit(resource, rlim as *mut _)
+    crate::setrlimit(resource, rlim.cast())
 }
 
 #[inline]
 pub unsafe extern "C" fn stat64(pathname: *const c_char, statbuf: *mut crate::stat64) -> c_int {
-    crate::stat(pathname, statbuf as *mut _)
+    crate::stat(pathname, statbuf.cast())
 }
 
 #[inline]
 pub unsafe extern "C" fn statfs64(pathname: *const c_char, buf: *mut crate::statfs64) -> c_int {
-    crate::statfs(pathname, buf as *mut _)
+    crate::statfs(pathname, buf.cast())
 }
 
 #[inline]
 pub unsafe extern "C" fn statvfs64(path: *const c_char, buf: *mut crate::statvfs64) -> c_int {
-    crate::statvfs(path, buf as *mut _)
+    crate::statvfs(path, buf.cast())
 }
 
 #[inline]

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1260,7 +1260,7 @@ f! {
         if (next.offset(1)) as usize >= max {
             core::ptr::null_mut::<cmsghdr>()
         } else {
-            next as *mut cmsghdr
+            next.cast()
         }
     }
 

--- a/src/unix/linux_like/linux/musl/lfs64.rs
+++ b/src/unix/linux_like/linux/musl/lfs64.rs
@@ -18,7 +18,7 @@ pub unsafe extern "C" fn fallocate64(
 
 #[inline]
 pub unsafe extern "C" fn fgetpos64(stream: *mut crate::FILE, pos: *mut crate::fpos64_t) -> c_int {
-    crate::fgetpos(stream, pos as *mut _)
+    crate::fgetpos(stream, pos.cast())
 }
 
 #[inline]
@@ -46,12 +46,12 @@ pub unsafe extern "C" fn fseeko64(
 
 #[inline]
 pub unsafe extern "C" fn fsetpos64(stream: *mut crate::FILE, pos: *const crate::fpos64_t) -> c_int {
-    crate::fsetpos(stream, pos as *mut _)
+    crate::fsetpos(stream, pos.cast())
 }
 
 #[inline]
 pub unsafe extern "C" fn fstat64(fildes: c_int, buf: *mut crate::stat64) -> c_int {
-    crate::fstat(fildes, buf as *mut _)
+    crate::fstat(fildes, buf.cast())
 }
 
 #[inline]
@@ -61,17 +61,17 @@ pub unsafe extern "C" fn fstatat64(
     buf: *mut crate::stat64,
     flag: c_int,
 ) -> c_int {
-    crate::fstatat(fd, path, buf as *mut _, flag)
+    crate::fstatat(fd, path, buf.cast(), flag)
 }
 
 #[inline]
 pub unsafe extern "C" fn fstatfs64(fd: c_int, buf: *mut crate::statfs64) -> c_int {
-    crate::fstatfs(fd, buf as *mut _)
+    crate::fstatfs(fd, buf.cast())
 }
 
 #[inline]
 pub unsafe extern "C" fn fstatvfs64(fd: c_int, buf: *mut crate::statvfs64) -> c_int {
-    crate::fstatvfs(fd, buf as *mut _)
+    crate::fstatvfs(fd, buf.cast())
 }
 
 #[inline]
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn ftruncate64(fd: c_int, length: off64_t) -> c_int {
 
 #[inline]
 pub unsafe extern "C" fn getrlimit64(resource: c_int, rlim: *mut crate::rlimit64) -> c_int {
-    crate::getrlimit(resource, rlim as *mut _)
+    crate::getrlimit(resource, rlim.cast())
 }
 
 #[inline]
@@ -96,7 +96,7 @@ pub unsafe extern "C" fn lseek64(fd: c_int, offset: off64_t, whence: c_int) -> o
 
 #[inline]
 pub unsafe extern "C" fn lstat64(path: *const c_char, buf: *mut crate::stat64) -> c_int {
-    crate::lstat(path, buf as *mut _)
+    crate::lstat(path, buf.cast())
 }
 
 #[inline]
@@ -164,7 +164,7 @@ pub unsafe extern "C" fn prlimit64(
     new_limit: *const crate::rlimit64,
     old_limit: *mut crate::rlimit64,
 ) -> c_int {
-    crate::prlimit(pid, resource, new_limit as *mut _, old_limit as *mut _)
+    crate::prlimit(pid, resource, new_limit.cast(), old_limit.cast())
 }
 
 #[inline]
@@ -189,7 +189,7 @@ pub unsafe extern "C" fn pwritev64(
 
 #[inline]
 pub unsafe extern "C" fn readdir64(dirp: *mut crate::DIR) -> *mut crate::dirent64 {
-    crate::readdir(dirp) as *mut _
+    crate::readdir(dirp).cast()
 }
 
 #[inline]
@@ -198,7 +198,7 @@ pub unsafe extern "C" fn readdir64_r(
     entry: *mut crate::dirent64,
     result: *mut *mut crate::dirent64,
 ) -> c_int {
-    crate::readdir_r(dirp, entry as *mut _, result as *mut _)
+    crate::readdir_r(dirp, entry.cast(), result.cast())
 }
 
 #[inline]
@@ -213,22 +213,22 @@ pub unsafe extern "C" fn sendfile64(
 
 #[inline]
 pub unsafe extern "C" fn setrlimit64(resource: c_int, rlim: *const crate::rlimit64) -> c_int {
-    crate::setrlimit(resource, rlim as *mut _)
+    crate::setrlimit(resource, rlim.cast())
 }
 
 #[inline]
 pub unsafe extern "C" fn stat64(pathname: *const c_char, statbuf: *mut crate::stat64) -> c_int {
-    crate::stat(pathname, statbuf as *mut _)
+    crate::stat(pathname, statbuf.cast())
 }
 
 #[inline]
 pub unsafe extern "C" fn statfs64(pathname: *const c_char, buf: *mut crate::statfs64) -> c_int {
-    crate::statfs(pathname, buf as *mut _)
+    crate::statfs(pathname, buf.cast())
 }
 
 #[inline]
 pub unsafe extern "C" fn statvfs64(path: *const c_char, buf: *mut crate::statvfs64) -> c_int {
-    crate::statvfs(path, buf as *mut _)
+    crate::statvfs(path, buf.cast())
 }
 
 #[inline]

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -61,7 +61,7 @@ impl siginfo_t {
             _si_code: c_int,
             si_addr: *mut c_void,
         }
-        (*(self as *const siginfo_t as *const siginfo_sigfault)).si_addr
+        (*(self as *const siginfo_t).cast::<siginfo_sigfault>()).si_addr
     }
 
     pub unsafe fn si_value(&self) -> crate::sigval {
@@ -74,7 +74,7 @@ impl siginfo_t {
             _si_overrun: c_int,
             si_value: crate::sigval,
         }
-        (*(self as *const siginfo_t as *const siginfo_si_value)).si_value
+        (*(self as *const siginfo_t).cast::<siginfo_si_value>()).si_value
     }
 }
 
@@ -105,7 +105,7 @@ s_no_extra_traits! {
 
 impl siginfo_t {
     unsafe fn sifields(&self) -> &sifields {
-        &(*(self as *const siginfo_t as *const siginfo_f)).sifields
+        &(*(self as *const siginfo_t).cast::<siginfo_f>()).sifields
     }
 
     pub unsafe fn si_pid(&self) -> crate::pid_t {

--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -164,7 +164,7 @@ impl siginfo_t {
             _si_code: c_int,
             si_addr: *mut c_void,
         }
-        (*(self as *const siginfo_t as *const siginfo_sigfault)).si_addr
+        (*(self as *const siginfo_t).cast::<siginfo_sigfault>()).si_addr
     }
 
     pub unsafe fn si_value(&self) -> crate::sigval {
@@ -177,7 +177,7 @@ impl siginfo_t {
             _si_overrun: c_int,
             si_value: crate::sigval,
         }
-        (*(self as *const siginfo_t as *const siginfo_si_value)).si_value
+        (*(self as *const siginfo_t).cast::<siginfo_si_value>()).si_value
     }
 }
 
@@ -208,7 +208,7 @@ s_no_extra_traits! {
 
 impl siginfo_t {
     unsafe fn sifields(&self) -> &sifields {
-        &(*(self as *const siginfo_t as *const siginfo_f)).sifields
+        &(*(self as *const siginfo_t).cast::<siginfo_f>()).sifields
     }
 
     pub unsafe fn si_pid(&self) -> crate::pid_t {

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1789,7 +1789,7 @@ const fn CMSG_ALIGN(len: usize) -> usize {
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const crate::msghdr) -> *mut crate::cmsghdr {
         if (*mhdr).msg_controllen as usize >= size_of::<crate::cmsghdr>() {
-            (*mhdr).msg_control.cast::<crate::cmsghdr>()
+            (*mhdr).msg_control.cast()
         } else {
             core::ptr::null_mut::<crate::cmsghdr>()
         }

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -2427,7 +2427,7 @@ const fn _ALIGN(p: usize, b: usize) -> usize {
 f! {
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
         if (*mhdr).msg_controllen as usize >= size_of::<cmsghdr>() {
-            (*mhdr).msg_control as *mut cmsghdr
+            (*mhdr).msg_control.cast()
         } else {
             core::ptr::null_mut::<cmsghdr>()
         }
@@ -3155,7 +3155,7 @@ impl siginfo_t {
             _pad: Padding<[u8; 32]>,
             si_addr: *mut c_void,
         }
-        (*(self as *const siginfo_t as *const siginfo_si_addr)).si_addr
+        (*(self as *const siginfo_t).cast::<siginfo_si_addr>()).si_addr
     }
 
     pub unsafe fn si_value(&self) -> crate::sigval {
@@ -3164,7 +3164,7 @@ impl siginfo_t {
             _pad: Padding<[u8; 32]>,
             si_value: crate::sigval,
         }
-        (*(self as *const siginfo_t as *const siginfo_si_value)).si_value
+        (*(self as *const siginfo_t).cast::<siginfo_si_value>()).si_value
     }
 
     pub unsafe fn si_pid(&self) -> crate::pid_t {
@@ -3173,7 +3173,7 @@ impl siginfo_t {
             _pad: Padding<[u8; 16]>,
             si_pid: crate::pid_t,
         }
-        (*(self as *const siginfo_t as *const siginfo_si_pid)).si_pid
+        (*(self as *const siginfo_t).cast::<siginfo_si_pid>()).si_pid
     }
 
     pub unsafe fn si_uid(&self) -> crate::uid_t {
@@ -3182,7 +3182,7 @@ impl siginfo_t {
             _pad: Padding<[u8; 24]>,
             si_uid: crate::uid_t,
         }
-        (*(self as *const siginfo_t as *const siginfo_si_uid)).si_uid
+        (*(self as *const siginfo_t).cast::<siginfo_si_uid>()).si_uid
     }
 
     pub unsafe fn si_status(&self) -> c_int {
@@ -3191,7 +3191,7 @@ impl siginfo_t {
             _pad: Padding<[u8; 28]>,
             si_status: c_int,
         }
-        (*(self as *const siginfo_t as *const siginfo_si_status)).si_status
+        (*(self as *const siginfo_t).cast::<siginfo_si_status>()).si_status
     }
 }
 

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2222,7 +2222,7 @@ f! {
         if ((*mhdr).msg_controllen as usize) < size_of::<cmsghdr>() {
             core::ptr::null_mut::<cmsghdr>()
         } else {
-            (*mhdr).msg_control as *mut cmsghdr
+            (*mhdr).msg_control.cast::<cmsghdr>()
         }
     }
 

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -1458,7 +1458,7 @@ f! {
 
     pub fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
         if (*mhdr).msg_controllen as usize > 0 {
-            (*mhdr).msg_control as *mut cmsghdr
+            (*mhdr).msg_control.cast()
         } else {
             core::ptr::null_mut::<cmsghdr>()
         }


### PR DESCRIPTION
Replace some raw pointer casts equivalent to [`clippy::ptr_as_ptr`](https://rust-lang.github.io/rust-clippy/master/#ptr_as_ptr).