### PR TITLE
fix : incorrect POLLOUT def on horizonOS/armv6k-nintendo-3ds

### DIFF
--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -134,12 +134,14 @@ pub const WNOHANG: c_int = 1;
 
 pub const POLLIN: c_int = 0x0001;
 pub const POLLPRI: c_int = 0x0002;
-pub const POLLOUT: c_int = 0x0004;
+pub const POLLOUT: c_int = 0x0008;
 pub const POLLRDNORM: c_int = 0x0040;
 pub const POLLWRNORM: c_int = POLLOUT;
 pub const POLLRDBAND: c_int = 0x0080;
 pub const POLLWRBAND: c_int = 0x0100;
+/// POLLERR behavior on 3DS+HorizonOS is unclear, and it may be unsupported.
 pub const POLLERR: c_int = 0x0008;
+/// POLLHUP behavior on 3DS+HorizonOS is unclear, and it may be unsupported.
 pub const POLLHUP: c_int = 0x0010;
 pub const POLLNVAL: c_int = 0x0020;
 


### PR DESCRIPTION
# Description

Current definition for POLLOUT is incorrect - as described [here](https://www.3dbrew.org/wiki/SOCU:poll), it should be 0x08.

Unfortunately, it seems like the current definition for POLLERR is overlapping as 0x08. According to the linked docs, POLLERR is actually not a supported operation on this target (neither is POLLHUP, which is also currently defined). 

I'm not super clear on what the best procedure would be here - should POLLERR & POLLHUP be deleted as definitions? 

# Sources

- https://www.3dbrew.org/wiki/SOCU:poll

# Checklist

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI 
(libc-test does not currently support horizonOS, as far as I can tell?)