### PR TITLE
Delete FreeBSD 13 CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -287,9 +287,6 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          # FIXME(#4740): FreeBSD 13 tests are extremely flaky and fail most of the time
-          # - release: "13.4"
-          #   target: x86_64-unknown-freebsd
           - release: "15.0"
             target: i686-unknown-freebsd
           - release: "14.4"


### PR DESCRIPTION
Because FreeBSD 13 is officially EoL as of today.

# Sources
https://www.freebsd.org/security/unsupported/

# Checklist

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated

