### PR TITLE
cygwin: fix off-by-one in utsname.sysname length

### DIFF
--- a/libc-test/tests/cygwin_utsname.rs
+++ b/libc-test/tests/cygwin_utsname.rs
@@ -1,0 +1,72 @@
+//! Verify that `libc::uname()` populates the `utsname` struct with each field
+//! starting at the correct C offset on Cygwin.
+//!
+//! Cygwin's `<sys/utsname.h>` declares all six fields as 65 bytes
+//! (`_UTSNAME_LENGTH`). If any field is mis-sized in the Rust declaration,
+//! every subsequent field shifts in the struct and `CStr::from_ptr` reads
+//! that field starting at the wrong byte. The most observable consequence
+//! is that `nodename` no longer matches `gethostname()`, so this test is
+//! the smallest behavioural check that catches such a regression.
+
+#![cfg(target_os = "cygwin")]
+
+use std::ffi::CStr;
+use std::mem::MaybeUninit;
+
+#[test]
+fn uname_nodename_matches_gethostname() {
+    let mut uts = MaybeUninit::<libc::utsname>::uninit();
+    let mut host = [0u8; 256];
+
+    unsafe {
+        assert_ne!(
+            libc::uname(uts.as_mut_ptr()),
+            -1,
+            "uname() failed",
+        );
+        assert_ne!(
+            libc::gethostname(host.as_mut_ptr() as *mut libc::c_char, host.len()),
+            -1,
+            "gethostname() failed",
+        );
+
+        let uts = uts.assume_init();
+        let nodename = CStr::from_ptr(uts.nodename.as_ptr())
+            .to_str()
+            .expect("uname.nodename is not valid UTF-8");
+        let hostname = CStr::from_ptr(host.as_ptr() as *const libc::c_char)
+            .to_str()
+            .expect("gethostname() returned non-UTF-8");
+
+        assert_eq!(
+            nodename, hostname,
+            "uname.nodename and gethostname() must agree",
+        );
+    }
+}
+
+#[test]
+fn uname_fields_are_non_empty() {
+    let mut uts = MaybeUninit::<libc::utsname>::uninit();
+
+    unsafe {
+        assert_ne!(libc::uname(uts.as_mut_ptr()), -1, "uname() failed");
+        let uts = uts.assume_init();
+
+        let read = |buf: &[libc::c_char], name: &str| -> String {
+            CStr::from_ptr(buf.as_ptr())
+                .to_str()
+                .unwrap_or_else(|_| panic!("uname.{name} is not valid UTF-8"))
+                .to_owned()
+        };
+
+        // Every variable-length field must read as a non-empty string.
+        // A leading-zero byte here would mean the field is being read
+        // from a misaligned offset (the bug this test guards against).
+        assert!(!read(&uts.sysname, "sysname").is_empty());
+        assert!(!read(&uts.nodename, "nodename").is_empty());
+        assert!(!read(&uts.release, "release").is_empty());
+        assert!(!read(&uts.version, "version").is_empty());
+        assert!(!read(&uts.machine, "machine").is_empty());
+    }
+}

--- a/src/unix/cygwin/mod.rs
+++ b/src/unix/cygwin/mod.rs
@@ -447,7 +447,7 @@ s! {
     }
 
     pub struct utsname {
-        pub sysname: [c_char; 66],
+        pub sysname: [c_char; 65],
         pub nodename: [c_char; 65],
         pub release: [c_char; 65],
         pub version: [c_char; 65],


### PR DESCRIPTION
# Description

`libc` declares the Cygwin `utsname` struct's `sysname` field as `[c_char; 66]`, but Cygwin's `<sys/utsname.h>` declares all six fields as `_UTSNAME_LENGTH` = 65 bytes. The over-declaration shifts every subsequent field one byte forward in Rust's view of the struct, so `CStr::from_ptr` reads `nodename`, `release`, `version`, `machine`, and `domainname` starting at byte 1 instead of byte 0 — silently dropping the first character of each.

This PR changes a single character (`66` → `65`) and adds a runtime regression test.

Empirical effect on a Cygwin x86_64 host where `uname -a` reports `CYGWIN_NT-10.0-26200 xps-ne 3.6.7-1.x86_64 ...`:

| Field    | Before fix             | Expected               |
|----------|------------------------|------------------------|
| sysname  | `CYGWIN_NT-10.0-26200` | `CYGWIN_NT-10.0-26200` |
| nodename | `ps-ne`                | `xps-ne`               |
| release  | `.6.7-1.x86_64`        | `3.6.7-1.x86_64`       |
| machine  | `86_64`                | `x86_64`               |

`sysname` reads correctly because field 0 starts at offset 0 either way; subsequent fields each begin one byte too late.

Downstream this propagates to `platform-info`, `uutils/coreutils`'s `uname -m`, and `maturin`'s wheel-tag formatter — which produces `*-cygwin_86_64.whl` (instead of `cygwin_x86_64`) that Cygwin Python's `pip` then refuses with `is not a supported wheel on this platform.`

# Sources

Cygwin's `<sys/utsname.h>` in the newlib-cygwin tree:

https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=winsup/cygwin/include/sys/utsname.h

```c
#define _UTSNAME_LENGTH 65

struct utsname
{
  char sysname[_UTSNAME_LENGTH];
  char nodename[_UTSNAME_LENGTH];
  char release[_UTSNAME_LENGTH];
  char version[_UTSNAME_LENGTH];
  char machine[_UTSNAME_LENGTH];
#if __GNU_VISIBLE
  char domainname[_UTSNAME_LENGTH];
#else
  char __domainname[_UTSNAME_LENGTH];
#endif
};
```

# Checklist

- [ ] Relevant tests in `libc-test/semver` have been updated — N/A; correcting layout of an existing struct field, not adding/removing symbols.
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included
- [x] Tested locally — `cargo test --target x86_64-pc-cygwin` passes on `libc-0.2` with this fix; passes on `main` with this fix plus the cpuset_t typo fix from companion PR rust-lang/libc#5098. The added regression test verifies `uname.nodename == gethostname()` and that all variable-length fields read non-empty.

Note: this PR is independent but `main` does not currently build on `x86_64-pc-cygwin` due to a separate `cpuset_t` typo, addressed in companion PR rust-lang/libc#5098. The fix here was verified end-to-end on both the `libc-0.2` branch (which builds cleanly) and on `main` with both fixes stacked.

@rustbot label +stable-nominated