### PR TITLE
chore(cargo): remove deprecated package authors field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ keywords = ["libc", "ffi", "bindings", "operating", "system"]
 categories = ["external-ffi-bindings", "no-std", "os"]
 exclude = ["/ci/*", "/.github/*", "/triagebot.toml"]
 description = "Raw FFI bindings to platform libraries like libc."
-authors = ["The Rust Project Developers"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/libc"

--- a/ctest-test/Cargo.toml
+++ b/ctest-test/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ctest-test"
 version = "0.1.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 publish = false
 edition = "2021"
 

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -3,7 +3,6 @@ name = "libc-test"
 version = "0.1.0"
 description = "A test crate for the libc crate."
 publish = false
-authors = ["The Rust Project Developers"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/libc"


### PR DESCRIPTION
`package.authors` is deprecated: https://github.com/rust-lang/cargo/pull/15068