### PR TITLE
feat(android): add timer_[create, delete, getoverrun, gettime, settime]

### DIFF
--- a/libc-test/semver/android.txt
+++ b/libc-test/semver/android.txt
@@ -4075,6 +4075,11 @@ tgkill
 time
 time_t
 timegm
+timer_create
+timer_delete
+timer_getoverrun
+timer_gettime
+timer_settime
 timerfd_create
 timerfd_gettime
 timerfd_settime

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -3501,6 +3501,20 @@ extern "C" {
         new_value: *const itimerspec,
         old_value: *mut itimerspec,
     ) -> c_int;
+    pub fn timer_create(
+        clockid: crate::clockid_t,
+        sevp: *mut crate::sigevent,
+        timerid: *mut crate::timer_t,
+    ) -> c_int;
+    pub fn timer_delete(timerid: crate::timer_t) -> c_int;
+    pub fn timer_getoverrun(timerid: crate::timer_t) -> c_int;
+    pub fn timer_gettime(timerid: crate::timer_t, curr_value: *mut crate::itimerspec) -> c_int;
+    pub fn timer_settime(
+        timerid: crate::timer_t,
+        flags: c_int,
+        new_value: *const crate::itimerspec,
+        old_value: *mut crate::itimerspec,
+    ) -> c_int;
     pub fn syscall(num: c_long, ...) -> c_long;
     pub fn sched_getaffinity(
         pid: crate::pid_t,


### PR DESCRIPTION
# Description

Add `timer_create`, `timer_delete`, `timer_getoverrun`, `timer_gettime`, and `timer_settime` to the Android extern block. These are standard POSIX per-process timer functions provided by Bionic but missing from the libc crate's Android bindings.

# Sources

* [timer_create](https://cs.android.com/android/platform/superproject/main/+/main:bionic/libc/bionic/posix_timers.cpp;l=121)
* [timer_delete](https://cs.android.com/android/platform/superproject/main/+/main:bionic/libc/bionic/posix_timers.cpp;l=205)
* [timer_getoverrun](https://cs.android.com/android/platform/superproject/main/+/main:bionic/libc/bionic/posix_timers.cpp;l=239)
* [timer_gettime](https://cs.android.com/android/platform/superproject/main/+/main:bionic/libc/bionic/posix_timers.cpp;l=224)
* [timer_settime](https://cs.android.com/android/platform/superproject/main/+/main:bionic/libc/bionic/posix_timers.cpp;l=233)

# Checklist

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated