### PR TITLE
Feat(apple): Add the necessary for the `bsdshortinfo` API of libproc

### DIFF
--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -2071,6 +2071,7 @@ posix_spawnattr_t
 posix_spawnp
 preadv
 proc_bsdinfo
+proc_bsdshortinfo
 proc_kmsgbuf
 proc_libversion
 proc_listallpids

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -603,6 +603,35 @@ s! {
         pub pbi_start_tvusec: u64,
     }
 
+    pub struct proc_bsdshortinfo {
+        /// Process ID.
+        pub pbsi_pid: u32,
+        /// Process parent ID.
+        pub pbsi_ppid: u32,
+        /// Process perp ID.
+        pub pbsi_pgid: u32,
+        /// `p_stat` value: `SZOMB`, `SRUN`, etc.
+        pub pbsi_status: u32,
+        /// Up to 16 characters of process name.
+        pub pbsi_comm: [c_char; MAXCOMLEN],
+        /// 64bit, emulated, etc.
+        pub pbsi_flags: u32,
+        /// Current UID on process.
+        pub pbsi_uid: crate::uid_t,
+        /// Current GID on process.
+        pub pbsi_gid: crate::gid_t,
+        /// Current RUID on process.
+        pub pbsi_ruid: crate::uid_t,
+        /// Current RGID on process.
+        pub pbsi_rgid: crate::gid_t,
+        /// Current SVUID on process.
+        pub pbsi_svuid: crate::uid_t,
+        /// Current SVGID on process.
+        pub pbsi_svgid: crate::gid_t,
+        /// Reserved for future use.
+        pub pbsi_rfu: u32,
+    }
+
     pub struct proc_taskallinfo {
         pub pbsd: proc_bsdinfo,
         pub ptinfo: proc_taskinfo,
@@ -3506,6 +3535,7 @@ pub const PROC_PIDTBSDINFO: c_int = 3;
 pub const PROC_PIDTASKINFO: c_int = 4;
 pub const PROC_PIDTHREADINFO: c_int = 5;
 pub const PROC_PIDVNODEPATHINFO: c_int = 9;
+pub const PROC_PIDT_SHORTBSDINFO: c_int = 13;
 pub const PROC_PIDPATHINFO_MAXSIZE: c_int = 4096;
 
 pub const PROC_PIDLISTFDS: c_int = 1;


### PR DESCRIPTION
# Description

This adds the item necessary in order to get the "BSD short info" of processes by interacting with `proc_pidinfo`. Namely: `PROC_PIDT_SHORTBSDINFO` and `proc_bsdshortinfo`.

# Sources

 * [`PROC_PIDT_SHORTBSDINFO`](https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/sys/proc_info.h#L760);
 * [`proc_bsdshortinfo`](https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/sys/proc_info.h#L85);

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI.
  The concerned target is in tier 1 and I couldn't easily make my cross-compilation setup work for this.

@rustbot label +stable-nominated