### PR TITLE
nuttx: add SO_KEEPALIVE and TCP keepalive constants

### DIFF
--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -501,9 +501,13 @@ pub const SO_LINGER: i32 = 6;
 pub const SO_RCVTIMEO: i32 = 0xa;
 pub const SO_SNDTIMEO: i32 = 0xe;
 pub const SO_BROADCAST: i32 = 1;
+pub const SO_KEEPALIVE: i32 = 5;
 
 // netinet/tcp.h
 pub const TCP_NODELAY: i32 = 0x10;
+pub const TCP_KEEPIDLE: i32 = 0x11;
+pub const TCP_KEEPINTVL: i32 = 0x12;
+pub const TCP_KEEPCNT: i32 = 0x13;
 
 // nuttx/fs/ioctl.h
 pub const FIONBIO: i32 = 0x30a;


### PR DESCRIPTION
   # Description
   https://github.com/rust-lang/rust/issues/156790

   Add `SO_KEEPALIVE` socket option and `TCP_KEEPIDLE`, `TCP_KEEPINTVL`, `TCP_KEEPCNT`
   TCP-level keepalive constants for the NuttX target.



   # Sources

   * `SO_KEEPALIVE = 5`: https://github.com/apache/nuttx/blob/master/include/sys/socket.h
   * `TCP_KEEPIDLE`, `TCP_KEEPINTVL`, `TCP_KEEPCNT`: https://github.com/apache/nuttx/blob/master/include/netinet/tcp.h

   # Checklist

   - [x] Relevant tests in `libc-test/semver` have been updated
   - [x] No placeholder or unstable values like `*LAST` or `*MAX` are included
   - [x] Tested locally

@rustbot label +stable-nominated
