### PR TITLE
musl: add renameat2 binding

### DIFF
--- a/libc-test/semver/linux-musl.txt
+++ b/libc-test/semver/linux-musl.txt
@@ -86,6 +86,7 @@ pututxline
 pwritev2
 pwritev64
 reallocarray
+renameat2
 setutxent
 tcp_info
 timex

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -795,6 +795,13 @@ extern "C" {
         flags: c_int,
     ) -> ssize_t;
     pub fn getauxval(type_: c_ulong) -> c_ulong;
+    pub fn renameat2(
+        olddirfd: c_int,
+        oldpath: *const c_char,
+        newdirfd: c_int,
+        newpath: *const c_char,
+        flags: c_uint,
+    ) -> c_int;
 
     // Added in `musl` 1.1.20
     pub fn explicit_bzero(s: *mut c_void, len: size_t);


### PR DESCRIPTION
Add \`renameat2\` function binding for musl libc targets.

## Checklist

- [ ] Relevant tests in \`libc-test/semver\` have been updated
- [x] No placeholder or unstable values are included