### PR TITLE
musl: add renameat2 binding

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4633,6 +4633,8 @@ fn test_linux(target: &str) {
             "preadv2" | "pwritev2" if musl => true,
             // FIXME(musl): Supported in new musl but we don't have a new enough version in CI.
             "statx" if musl => true,
+            // FIXME(musl): Supported since musl 1.2.6 but not yet in CI.
+            "renameat2" if musl => true,
 
             // Needs glibc 2.33 or later.
             "mallinfo2" => true,

--- a/libc-test/semver/linux-musl.txt
+++ b/libc-test/semver/linux-musl.txt
@@ -86,6 +86,7 @@ pututxline
 pwritev2
 pwritev64
 reallocarray
+renameat2
 setutxent
 tcp_info
 timex

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -795,6 +795,13 @@ extern "C" {
         flags: c_int,
     ) -> ssize_t;
     pub fn getauxval(type_: c_ulong) -> c_ulong;
+    pub fn renameat2(
+        olddirfd: c_int,
+        oldpath: *const c_char,
+        newdirfd: c_int,
+        newpath: *const c_char,
+        flags: c_uint,
+    ) -> c_int;
 
     // Added in `musl` 1.1.20
     pub fn explicit_bzero(s: *mut c_void, len: size_t);


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

This PR adds the renameat2 function binding for musl targets. musl supports renameat2 since version 1.2.6.
Closes: https://github.com/rust-lang/libc/issues/4478

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

https://musl.libc.org/releases.html

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
