### PR TITLE
redox: Add *at and dirent functions

### DIFF
--- a/libc-test/semver/redox.txt
+++ b/libc-test/semver/redox.txt
@@ -4,7 +4,12 @@ ATF_COM
 ATF_PERM
 ATF_PUBL
 ATF_USETRAILERS
+AT_EACCESS
+AT_EMPTY_PATH
 AT_FDCWD
+AT_REMOVEDIR
+AT_SYMLINK_FOLLOW
+AT_SYMLINK_NOFOLLOW
 B1000000
 B1152000
 B1500000
@@ -140,6 +145,7 @@ O_NOCTTY
 O_PATH
 O_SHLOCK
 O_SYMLINK
+O_SYNC
 PTHREAD_MUTEX_DEFAULT
 PTHREAD_MUTEX_ERRORCHECK
 PTHREAD_MUTEX_ROBUST
@@ -199,6 +205,8 @@ TCSETS
 TIOCGPGRP
 TIOCSCTTY
 TIOCSPGRP
+UTIME_NOW
+UTIME_OMIT
 UTSLENGTH
 VDISCARD
 VLNEXT
@@ -291,6 +299,8 @@ __errno_location
 bsearch
 chroot
 clearerr
+clock_getres
+clock_gettime
 difftime
 dirfd
 endgrent
@@ -302,7 +312,9 @@ epoll_ctl
 epoll_event
 epoll_wait
 explicit_bzero
+faccessat
 fchdir
+fdopendir
 fmemopen
 getdtablesize
 getgrent
@@ -325,11 +337,14 @@ lockf
 login_tty
 madvise
 memalign
+mkdirat
+mknodat
 mkostemp
 mkostemps
 nice
 open_memstream
 open_wmemstream
+openat
 openpty
 pipe2
 pthread_condattr_setclock
@@ -337,6 +352,7 @@ qsort
 reallocarray
 renameat2
 rlim_t
+seekdir
 sem_clockwait
 sem_destroy
 sem_getvalue
@@ -363,3 +379,4 @@ strncasecmp
 strndup
 strsignal
 ttyname_r
+utimensat

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -975,6 +975,15 @@ extern "C" {
     )]
     #[cfg_attr(target_os = "netbsd", link_name = "__opendir30")]
     pub fn opendir(dirname: *const c_char) -> *mut crate::DIR;
+    #[cfg_attr(
+        all(target_os = "macos", target_arch = "x86_64"),
+        link_name = "fdopendir$INODE64"
+    )]
+    #[cfg_attr(
+        all(target_os = "macos", target_arch = "x86"),
+        link_name = "fdopendir$INODE64$UNIX2003"
+    )]
+    pub fn fdopendir(fd: c_int) -> *mut crate::DIR;
 
     #[cfg_attr(
         all(target_os = "macos", not(target_arch = "aarch64")),
@@ -1012,6 +1021,8 @@ extern "C" {
         group: crate::gid_t,
         flags: c_int,
     ) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "openat64")]
+    pub fn openat(dirfd: c_int, pathname: *const c_char, flags: c_int, ...) -> c_int;
     #[cfg_attr(
         all(target_os = "macos", not(target_arch = "aarch64")),
         link_name = "fstatat$INODE64"
@@ -1036,6 +1047,8 @@ extern "C" {
         newpath: *const c_char,
         flags: c_int,
     ) -> c_int;
+    #[cfg(not(target_os = "l4re"))]
+    pub fn mkdirat(dirfd: c_int, pathname: *const c_char, mode: mode_t) -> c_int;
     #[cfg(not(target_os = "l4re"))]
     pub fn renameat(
         olddirfd: c_int,
@@ -2214,22 +2227,6 @@ cfg_if! {
                 link_name = "pause$UNIX2003"
             )]
             pub fn pause() -> c_int;
-
-            #[cfg(not(target_os = "l4re"))]
-            pub fn mkdirat(dirfd: c_int, pathname: *const c_char, mode: mode_t) -> c_int;
-            #[cfg_attr(gnu_file_offset_bits64, link_name = "openat64")]
-            pub fn openat(dirfd: c_int, pathname: *const c_char, flags: c_int, ...) -> c_int;
-
-            #[cfg_attr(
-                all(target_os = "macos", target_arch = "x86_64"),
-                link_name = "fdopendir$INODE64"
-            )]
-            #[cfg_attr(
-                all(target_os = "macos", target_arch = "x86"),
-                link_name = "fdopendir$INODE64$UNIX2003"
-            )]
-            pub fn fdopendir(fd: c_int) -> *mut crate::DIR;
-
             #[cfg_attr(
                 all(target_os = "macos", not(target_arch = "aarch64")),
                 link_name = "readdir_r$INODE64"

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -345,6 +345,11 @@ pub const F_TLOCK: c_int = 2;
 pub const F_TEST: c_int = 3;
 
 pub const AT_FDCWD: c_int = -100;
+pub const AT_SYMLINK_NOFOLLOW: c_int = 0x200;
+pub const AT_REMOVEDIR: c_int = 0x200;
+pub const AT_SYMLINK_FOLLOW: c_int = 0x2000;
+pub const AT_EMPTY_PATH: c_int = 0x4000;
+pub const AT_EACCESS: c_int = 0x400;
 
 // FIXME(redox): relibc {
 pub const RTLD_DEFAULT: *mut c_void = ptr::null_mut();
@@ -516,6 +521,7 @@ pub const O_SHLOCK: c_int = 0x0010_0000;
 pub const O_EXLOCK: c_int = 0x0020_0000;
 pub const O_ASYNC: c_int = 0x0040_0000;
 pub const O_FSYNC: c_int = 0x0080_0000;
+pub const O_SYNC: c_int = O_FSYNC;
 pub const O_CLOEXEC: c_int = 0x0100_0000;
 pub const O_CREAT: c_int = 0x0200_0000;
 pub const O_TRUNC: c_int = 0x0400_0000;
@@ -725,6 +731,8 @@ pub const S_IRWXO: c_int = 0o0007;
 pub const S_IROTH: c_int = 0o0004;
 pub const S_IWOTH: c_int = 0o0002;
 pub const S_IXOTH: c_int = 0o0001;
+pub const UTIME_NOW: c_long = 0xffffffff;
+pub const UTIME_OMIT: c_long = 0xfffffffe;
 
 // stdlib.h
 pub const EXIT_SUCCESS: c_int = 0;
@@ -1204,8 +1212,10 @@ extern "C" {
 
     // dirent.h
     pub fn dirfd(dirp: *mut crate::DIR) -> c_int;
+    pub fn seekdir(dirp: *mut crate::DIR, loc: c_long);
 
     // unistd.h
+    pub fn faccessat(dirfd: c_int, pathname: *const c_char, mode: c_int, flags: c_int) -> c_int;
     pub fn pipe2(fds: *mut c_int, flags: c_int) -> c_int;
     pub fn getdtablesize() -> c_int;
     pub fn getresgid(
@@ -1406,6 +1416,13 @@ extern "C" {
 
     // sys/stat.h
     pub fn futimens(fd: c_int, times: *const crate::timespec) -> c_int;
+    pub fn mknodat(dirfd: c_int, pathname: *const c_char, mode: mode_t, dev: dev_t) -> c_int;
+    pub fn utimensat(
+        dirfd: c_int,
+        path: *const c_char,
+        times: *const crate::timespec,
+        flag: c_int,
+    ) -> c_int;
 
     // sys/uio.h
     pub fn preadv(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: off_t) -> ssize_t;
@@ -1418,6 +1435,7 @@ extern "C" {
 
     // time.h
     pub fn gettimeofday(tp: *mut crate::timeval, tz: *mut crate::timezone) -> c_int;
+    pub fn clock_getres(clk_id: crate::clockid_t, tp: *mut crate::timespec) -> c_int;
     pub fn clock_gettime(clk_id: crate::clockid_t, tp: *mut crate::timespec) -> c_int;
     pub fn strftime(
         s: *mut c_char,


### PR DESCRIPTION
# Description

This adds a family of `*at` and `dirent` functions. These are part of functions that is used by `wasmtime`.

# Sources

- [AT_* constants](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/fcntl/redox.rs#L62-78)
- [O_SYNC](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/fcntl/redox.rs#L26)
- [UTIME_NOW/UTIME_OMIT](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/sys_stat/mod.rs#L75-76)
- [faccessat](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/unistd/mod.rs#L145)
- [mkdirat](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/sys_stat/mod.rs#L193)
- [mknodat](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/sys_stat/mod.rs#L232)
- [utimensat](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/sys_stat/mod.rs#L260)
- [openat](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/fcntl/mod.rs#L114)
- [fdopendir](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/dirent/mod.rs#L255)
- [seekdir](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/dirent/mod.rs#L383)
- [clock_getres](https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/time/mod.rs#L272)


# Checklist

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
