### PR TITLE
bsd: Annotate `ELAST` constants as unstable

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -2143,6 +2143,9 @@ pub const ENOTRECOVERABLE: c_int = 104;
 pub const EOWNERDEAD: c_int = 105;
 pub const EQFULL: c_int = 106;
 pub const ENOTCAPABLE: c_int = 107;
+
+/// This symbols is prone to change across releases upstream.
+/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const ELAST: c_int = 107;
 
 pub const EAI_AGAIN: c_int = 2;

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -548,7 +548,11 @@ pub const ENOMEDIUM: c_int = 93;
 pub const ENOTRECOVERABLE: c_int = 94;
 pub const EOWNERDEAD: c_int = 95;
 pub const EASYNC: c_int = 99;
+
+/// This symbols is prone to change across releases upstream.
+/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const ELAST: c_int = 99;
+
 pub const RLIMIT_POSIXLOCKS: c_int = 11;
 #[deprecated(since = "0.2.64", note = "Not stable across OS versions")]
 pub const RLIM_NLIMITS: crate::rlim_t = 12;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
@@ -258,7 +258,10 @@ s! {
     }
 }
 
+/// This symbols is prone to change across releases upstream.
+/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const ELAST: c_int = 96;
+
 pub const RAND_MAX: c_int = 0x7fff_fffd;
 pub const KI_NSPARE_PTR: usize = 6;
 pub const MINCORE_SUPER: c_int = 0x20;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -304,6 +304,9 @@ s! {
 }
 
 pub const RAND_MAX: c_int = 0x7fff_fffd;
+
+/// This symbols is prone to change across releases upstream.
+/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const ELAST: c_int = 97;
 
 /// max length of devicename

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -317,6 +317,9 @@ s! {
 }
 
 pub const RAND_MAX: c_int = 0x7fff_ffff;
+
+/// This symbols is prone to change across releases upstream.
+/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const ELAST: c_int = 97;
 
 pub const KF_TYPE_EVENTFD: c_int = 13;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -319,6 +319,9 @@ s! {
 }
 
 pub const RAND_MAX: c_int = 0x7fff_ffff;
+
+/// This symbols is prone to change across releases upstream.
+/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const ELAST: c_int = 97;
 
 pub const KF_TYPE_EVENTFD: c_int = 13;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
@@ -321,6 +321,9 @@ s! {
 }
 
 pub const RAND_MAX: c_int = 0x7fff_ffff;
+
+/// This symbols is prone to change across releases upstream.
+/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const ELAST: c_int = 97;
 
 pub const KF_TYPE_EVENTFD: c_int = 13;

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -945,6 +945,9 @@ pub const EBADMSG: c_int = 92;
 pub const ENOTRECOVERABLE: c_int = 93;
 pub const EOWNERDEAD: c_int = 94;
 pub const EPROTO: c_int = 95;
+
+/// This symbols is prone to change across releases upstream.
+/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const ELAST: c_int = 95;
 
 pub const F_DUPFD_CLOEXEC: c_int = 10;


### PR DESCRIPTION
# Description

This set of constants had already been discussed to cause some issues in rust-lang/libc#3131. This patch deprecates such bug-prone and latest-error symbols such that the interface to the `libc` crate is not prone to SemVer-breakage as often as the values change upstream.

Note the NetBSD constant was left unmodified as it already had been annotated with a deprecation attribute.

If you yourself want to help out in the deprecation effort for this type of constants across the `libc` crate, maybe try out the [`libc-constant-deprecator`][deprecator] crate. It's been the tool used to perform the changes that have been submitted in this PR, and it very much welcomes bug reports.

[deprecator]: https://github.com/dybucc/libc-constant-deprecator

## Sources

- Upstream source code for the FreeBSD `ELAST` macro declaration, mentioning its use as a "limit" value for other `errno` values.

  > <https://github.com/freebsd/freebsd-src/blob/bd15d6ef126ee4c0eac931117f6bbbf6f9a3fc72/sys/sys/errno.h#L184>
- Upstream source code for the OpenBSD equivalent macro declaration.

  > <https://github.com/openbsd/src/blob/58ff4898d99200dea776fa757004330318255d45/sys/sys/errno.h#L175>
- Upstream source code for the XNU kernel equivalent macro declaration.

  > <https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/sys/errno.h#L270>
- Upstream source code for the DragonFlyBSD equivalent macro declaration.

  > <https://github.com/DragonFlyBSD/DragonFlyBSD/blob/7b7fb99bddde8ded0bee8f43df4026ca02be0938/sys/sys/errno.h#L206>

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI
