### PR TITLE
freebsd: annotate unstable `RAND_MAX`

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
@@ -258,11 +258,14 @@ s! {
     }
 }
 
-/// This symbols is prone to change across releases upstream.
+/// This symbol is prone to change across releases upstream.
 /// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const ELAST: c_int = 96;
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const RAND_MAX: c_int = 0x7fff_fffd;
+
 pub const KI_NSPARE_PTR: usize = 6;
 pub const MINCORE_SUPER: c_int = 0x20;
 /// max length of devicename

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -303,9 +303,11 @@ s! {
     }
 }
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const RAND_MAX: c_int = 0x7fff_fffd;
 
-/// This symbols is prone to change across releases upstream.
+/// This symbol is prone to change across releases upstream.
 /// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const ELAST: c_int = 97;
 

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -316,9 +316,11 @@ s! {
     }
 }
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const RAND_MAX: c_int = 0x7fff_ffff;
 
-/// This symbols is prone to change across releases upstream.
+/// This symbol is prone to change across releases upstream.
 /// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const ELAST: c_int = 97;
 

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -318,9 +318,11 @@ s! {
     }
 }
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const RAND_MAX: c_int = 0x7fff_ffff;
 
-/// This symbols is prone to change across releases upstream.
+/// This symbol is prone to change across releases upstream.
 /// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const ELAST: c_int = 97;
 

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
@@ -320,9 +320,11 @@ s! {
     }
 }
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const RAND_MAX: c_int = 0x7fff_ffff;
 
-/// This symbols is prone to change across releases upstream.
+/// This symbol is prone to change across releases upstream.
 /// See the [usage guidelines](crate::#usage-guidelines) for details and use.
 pub const ELAST: c_int = 97;
 


### PR DESCRIPTION
# Description

This PR adds documentation. It annotates one symbol. This symbol has changed recently. It needs usage advice. It's a numerical limit. It should not need annotating. FreeBSD has changed it recently.

## Sources

- FreeBSD tree in `libc` where the constant was added to specific FreeBSD releases as it changed between FreeBSD 12 and FreeBSD 13.

  > <https://github.com/rust-lang/libc/blob/main/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs#L323>
- C standard library documentation (unofficial) mentioning the purpose of the constant as a "limit" value `rand`.

  > <https://en.cppreference.com/c/numeric/random/RAND_MAX>

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated