### PR TITLE
Annotate unstable `*LAST` constants

### DIFF
--- a/src/solid/mod.rs
+++ b/src/solid/mod.rs
@@ -219,6 +219,9 @@ pub const LC_MONETARY: c_int = 3;
 pub const LC_NUMERIC: c_int = 4;
 pub const LC_TIME: c_int = 5;
 pub const LC_MESSAGES: c_int = 6;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const _LC_LAST: c_int = 7;
 
 pub const EPERM: c_int = 1;

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -947,7 +947,7 @@ pub const EOWNERDEAD: c_int = 94;
 pub const EPROTO: c_int = 95;
 
 /// This symbols is prone to change across releases upstream.
-/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const ELAST: c_int = 95;
 
 pub const F_DUPFD_CLOEXEC: c_int = 10;
@@ -1739,7 +1739,10 @@ pub const LC_NUMERIC_MASK: c_int = 1 << crate::LC_NUMERIC;
 pub const LC_TIME_MASK: c_int = 1 << crate::LC_TIME;
 pub const LC_MESSAGES_MASK: c_int = 1 << crate::LC_MESSAGES;
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 const _LC_LAST: c_int = 7;
+
 pub const LC_ALL_MASK: c_int = (1 << _LC_LAST) - 2;
 
 pub const LC_GLOBAL_LOCALE: crate::locale_t = -1isize as crate::locale_t;

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -1937,6 +1937,9 @@ pub const NF_BR_PRI_BRNF: c_int = 0;
 pub const NF_BR_PRI_NAT_DST_OTHER: c_int = 100;
 pub const NF_BR_PRI_FILTER_OTHER: c_int = 200;
 pub const NF_BR_PRI_NAT_SRC: c_int = 300;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NF_BR_PRI_LAST: c_int = crate::INT_MAX;
 
 // linux/netfilter_ipv4.h
@@ -1961,6 +1964,9 @@ pub const NF_IP_PRI_NAT_SRC: c_int = 100;
 pub const NF_IP_PRI_SELINUX_LAST: c_int = 225;
 pub const NF_IP_PRI_CONNTRACK_HELPER: c_int = 300;
 pub const NF_IP_PRI_CONNTRACK_CONFIRM: c_int = crate::INT_MAX;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NF_IP_PRI_LAST: c_int = crate::INT_MAX;
 
 // linux/netfilter_ipv6.h
@@ -1984,6 +1990,9 @@ pub const NF_IP6_PRI_SECURITY: c_int = 50;
 pub const NF_IP6_PRI_NAT_SRC: c_int = 100;
 pub const NF_IP6_PRI_SELINUX_LAST: c_int = 225;
 pub const NF_IP6_PRI_CONNTRACK_HELPER: c_int = 300;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NF_IP6_PRI_LAST: c_int = crate::INT_MAX;
 
 // linux/netfilter_ipv6/ip6_tables.h

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1905,6 +1905,9 @@ pub const NF_BR_PRI_BRNF: c_int = 0;
 pub const NF_BR_PRI_NAT_DST_OTHER: c_int = 100;
 pub const NF_BR_PRI_FILTER_OTHER: c_int = 200;
 pub const NF_BR_PRI_NAT_SRC: c_int = 300;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NF_BR_PRI_LAST: c_int = crate::INT_MAX;
 
 // linux/netfilter_ipv4.h
@@ -1929,6 +1932,9 @@ pub const NF_IP_PRI_NAT_SRC: c_int = 100;
 pub const NF_IP_PRI_SELINUX_LAST: c_int = 225;
 pub const NF_IP_PRI_CONNTRACK_HELPER: c_int = 300;
 pub const NF_IP_PRI_CONNTRACK_CONFIRM: c_int = crate::INT_MAX;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NF_IP_PRI_LAST: c_int = crate::INT_MAX;
 
 // linux/netfilter_ipv6.h
@@ -1952,6 +1958,9 @@ pub const NF_IP6_PRI_SECURITY: c_int = 50;
 pub const NF_IP6_PRI_NAT_SRC: c_int = 100;
 pub const NF_IP6_PRI_SELINUX_LAST: c_int = 225;
 pub const NF_IP6_PRI_CONNTRACK_HELPER: c_int = 300;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NF_IP6_PRI_LAST: c_int = crate::INT_MAX;
 
 // linux/netfilter_ipv6/ip6_tables.h
@@ -2029,9 +2038,15 @@ pub const SIOCGIWENCODEEXT: c_ulong = 0x8B35;
 pub const SIOCSIWPMKSA: c_ulong = 0x8B36;
 
 pub const SIOCIWFIRSTPRIV: c_ulong = 0x8BE0;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SIOCIWLASTPRIV: c_ulong = 0x8BFF;
 
 pub const SIOCIWFIRST: c_ulong = 0x8B00;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SIOCIWLAST: c_ulong = SIOCIWLASTPRIV;
 
 pub const IWEVTXDROP: c_ulong = 0x8C00;

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -152,6 +152,8 @@ pub const LOCK_EX: c_int = 2;
 pub const LOCK_NB: c_int = 4;
 pub const LOCK_UN: c_int = 8;
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const _PC_LAST: c_int = 101;
 
 pub const _CS_PATH: c_int = 65;

--- a/src/unix/solarish/solaris.rs
+++ b/src/unix/solarish/solaris.rs
@@ -132,6 +132,8 @@ pub const F_DUPFD_CLOFORK: c_int = 49;
 pub const F_DUP2FD_CLOEXEC: c_int = 48;
 pub const F_DUP2FD_CLOFORK: c_int = 50;
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const _PC_LAST: c_int = 102;
 
 pub const PRIV_PROC_SENSITIVE: c_uint = 0x0008;


### PR DESCRIPTION
# Description

This PR adds documentation. Some symbols are troublesome. They can change upstream. The Rust change is non-breaking. This requires annotating. It requires usage advice. This patch links to it.

## Notes

QNX is untouched. Sources were not found. Their SDK sign up is broken.

Solaris is mostly untouched. Sources were not found. Changes include generic symbols. These were sourced from Illumos.

## Sources

- FreeBSD manpage detailing how `UTXDB_LASTLOGIN` is *not* the type of constant we would want to deprecate.

  > <https://man.freebsd.org/cgi/man.cgi?query=getutxent&sektion=3>
- DragonFlyBSD sources showing how they define a `UTX_DB_LASTLOGX` symbol but not a `UTX_DB_LASTLOG` symbol as we do.

  > <https://github.com/DragonFlyBSD/DragonFlyBSD/blame/59b78e44f96799c5f46fb3d6d616c18d838a75d0/include/utmpx.h#L89>
- Android sources showing how they use the `NF_*_PRI_LAST` in much the same manner as the Linux sources (further below.)

  > <https://cs.android.com/search?q=NF_BR_PRI_LAST&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=NF_IP_PRI_LAST&sq=&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=NF_IP6_PRI_LAST&sq=&ss=android%2Fplatform%2Fsuperproject>
- Linux sources showing the use of `NF_*_PRI_LAST` constants as trailing enumeration constants defined in terms of large values.

  > <https://github.com/torvalds/linux/blob/eb3f4b7426cfd2b79d65b7d37155480b32259a11/include/uapi/linux/netfilter_bridge.h#L42>
  > <https://github.com/torvalds/linux/blob/eb3f4b7426cfd2b79d65b7d37155480b32259a11/include/uapi/linux/netfilter_ipv4.h#L44>
  > <https://github.com/torvalds/linux/blob/eb3f4b7426cfd2b79d65b7d37155480b32259a11/include/uapi/linux/netfilter_ipv6.h#L47>
- Illumos sources showing how `_PC_LAST` should be changed when adding new `_PC` constants.

  > <https://github.com/illumos/illumos-gate/blob/7124a0cccb6ebf2bcffdab36f9bdf8fe4c23d77f/usr/src/uts/common/sys/unistd.h#L336>
- OpenBSD sources showing how `_LC_LAST` serves as the "end" value for constants defined prior to it.

  > <https://github.com/search?q=repo%3Aopenbsd%2Fsrc%20_lc_last&type=code>

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated