### PR TITLE
unix: annotate unstable `*COUNT` constants

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -3736,7 +3736,11 @@ pub const MNT_NOWAIT: c_int = 2;
 
 // <mach/thread_policy.h>
 pub const THREAD_STANDARD_POLICY: c_int = 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const THREAD_STANDARD_POLICY_COUNT: c_int = 0;
+
 pub const THREAD_EXTENDED_POLICY: c_int = 1;
 pub const THREAD_TIME_CONSTRAINT_POLICY: c_int = 2;
 pub const THREAD_PRECEDENCE_POLICY: c_int = 3;
@@ -3798,7 +3802,11 @@ pub const VM_PAGE_QUERY_PAGE_CS_NX: i32 = 0x400;
 
 // mach/task_info.h
 pub const TASK_THREAD_TIMES_INFO: u32 = 3;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const HOST_CPU_LOAD_INFO_COUNT: u32 = 4;
+
 pub const MACH_TASK_BASIC_INFO: u32 = 20;
 
 pub const MACH_PORT_NULL: i32 = 0;
@@ -3861,7 +3869,10 @@ pub const COPYFILE_STATE_DST_BSIZE: c_int = 12;
 pub const COPYFILE_STATE_BSIZE: c_int = 13;
 
 // <sys/attr.h>
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const ATTR_BIT_MAP_COUNT: c_ushort = 5;
+
 pub const FSOPT_NOFOLLOW: u32 = 0x1;
 pub const FSOPT_NOFOLLOW_ANY: u32 = 0x800;
 pub const FSOPT_REPORT_FULLSIZE: u32 = 0x4;
@@ -4032,36 +4043,73 @@ const fn __DARWIN_ALIGN32(p: usize) -> usize {
     (p + __DARWIN_ALIGNBYTES32) & !__DARWIN_ALIGNBYTES32
 }
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const THREAD_EXTENDED_POLICY_COUNT: mach_msg_type_number_t =
     (size_of::<thread_extended_policy_data_t>() / size_of::<integer_t>()) as mach_msg_type_number_t;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const THREAD_TIME_CONSTRAINT_POLICY_COUNT: mach_msg_type_number_t =
     (size_of::<thread_time_constraint_policy_data_t>() / size_of::<integer_t>())
         as mach_msg_type_number_t;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const THREAD_PRECEDENCE_POLICY_COUNT: mach_msg_type_number_t =
     (size_of::<thread_precedence_policy_data_t>() / size_of::<integer_t>())
         as mach_msg_type_number_t;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const THREAD_AFFINITY_POLICY_COUNT: mach_msg_type_number_t =
     (size_of::<thread_affinity_policy_data_t>() / size_of::<integer_t>()) as mach_msg_type_number_t;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const THREAD_BACKGROUND_POLICY_COUNT: mach_msg_type_number_t =
     (size_of::<thread_background_policy_data_t>() / size_of::<integer_t>())
         as mach_msg_type_number_t;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const THREAD_LATENCY_QOS_POLICY_COUNT: mach_msg_type_number_t =
     (size_of::<thread_latency_qos_policy_data_t>() / size_of::<integer_t>())
         as mach_msg_type_number_t;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const THREAD_THROUGHPUT_QOS_POLICY_COUNT: mach_msg_type_number_t =
     (size_of::<thread_throughput_qos_policy_data_t>() / size_of::<integer_t>())
         as mach_msg_type_number_t;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const THREAD_BASIC_INFO_COUNT: mach_msg_type_number_t =
     (size_of::<thread_basic_info_data_t>() / size_of::<integer_t>()) as mach_msg_type_number_t;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const THREAD_IDENTIFIER_INFO_COUNT: mach_msg_type_number_t =
     (size_of::<thread_identifier_info_data_t>() / size_of::<integer_t>()) as mach_msg_type_number_t;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const THREAD_EXTENDED_INFO_COUNT: mach_msg_type_number_t =
     (size_of::<thread_extended_info_data_t>() / size_of::<integer_t>()) as mach_msg_type_number_t;
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const TASK_THREAD_TIMES_INFO_COUNT: u32 =
     (size_of::<task_thread_times_info_data_t>() / size_of::<natural_t>()) as u32;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const MACH_TASK_BASIC_INFO_COUNT: u32 =
     (size_of::<mach_task_basic_info_data_t>() / size_of::<natural_t>()) as u32;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const HOST_VM_INFO64_COUNT: mach_msg_type_number_t =
     (size_of::<vm_statistics64_data_t>() / size_of::<integer_t>()) as mach_msg_type_number_t;
 

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -1569,6 +1569,9 @@ pub const NFNL_SUBSYS_CTNETLINK_TIMEOUT: c_int = 8;
 pub const NFNL_SUBSYS_CTHELPER: c_int = 9;
 pub const NFNL_SUBSYS_NFTABLES: c_int = 10;
 pub const NFNL_SUBSYS_NFT_COMPAT: c_int = 11;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NFNL_SUBSYS_COUNT: c_int = 12;
 
 pub const NFNL_MSG_BATCH_BEGIN: c_int = NLMSG_MIN_TYPE;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1678,6 +1678,9 @@ pub const NFNL_SUBSYS_CTHELPER: c_int = 9;
 pub const NFNL_SUBSYS_NFTABLES: c_int = 10;
 pub const NFNL_SUBSYS_NFT_COMPAT: c_int = 11;
 pub const NFNL_SUBSYS_HOOK: c_int = 12;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NFNL_SUBSYS_COUNT: c_int = 13;
 
 pub const NFNL_MSG_BATCH_BEGIN: c_int = crate::NLMSG_MIN_TYPE;

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -186,7 +186,10 @@ pub const PRIV_USER: c_uint = PRIV_DEBUG
     | PRIV_AWARE_RESET
     | PRIV_PFEXEC;
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const LGRP_RSRC_COUNT: crate::lgrp_rsrc_t = 2;
+
 pub const LGRP_RSRC_CPU: crate::lgrp_rsrc_t = 0;
 pub const LGRP_RSRC_MEM: crate::lgrp_rsrc_t = 1;
 


### PR DESCRIPTION
# Description

This PR adds documentation. It links to usage advice. Some symbols need this. They can change between upstream releases. They are not considered SemVer-breaking.

I have some doubts. They are concerned with the GNU Hurd. The `DLFO_STRUCT_HAS_EH_COUNT` constant was not found. It has not suffered any changes.

## Sources

- Haiku sources showing how the `B_MEDIA_STALE_CHANGE_COUNT` is **not** the type of constant we would want to deprecate. The code upstream itself does not seem to use it as a delimitter value, as can be seen in the second search result of the below reference.

  > <https://github.com/search?q=repo%3Ahaiku%2Fhaiku%20B_MEDIA_STALE_CHANGE_COUNT&type=code>
- DragonFly BSD sources showing how the `CPUCTL_CPUID_COUNT` constant is **not** one we would want to deprecate, even though it may seem like it could be deprecated (because it appears as a `*COUNT` symbol after a bunch of other symbols.) This constant is actually used for literal CPU counts in
  <https://github.com/DragonFlyBSD/DragonFlyBSD/blob/master/sys/dev/misc/cpuctl/cpuctl.c#L145>.

  > <https://github.com/DragonFlyBSD/DragonFlyBSD/blob/master/sys/sys/cpuctl.h#L62>
- OpenBSD sources showing how the `KERN_TTYCOUNT` is actually used as a counter for TTY devices and not for other constants (just another enum-like "variant".) This does not qualify it for deprecation.

  > <https://github.com/search?q=repo%3Aopenbsd%2Fsrc%20KERN_TTYCOUNT&type=code>
- OpenBSD sources showing how the `KERN_EVCOUNT` is used as an event counter (with use akin to that of the above list item.) This does not qualify it for deprecation.

  > <https://github.com/search?q=repo%3Aopenbsd%2Fsrc%20KERN_EVCOUNT&type=code>
- NetBSD sources showing how the `DCCP_OPT_NDP_COUNT` constant is used as just a regular constant (not meant for deprecation.)

  > <https://github.com/NetBSD/src/blob/d28519920c966c62fedd65ccc0dbd8b628401da5/sys/netinet/dccp.h#L177>
- Linux sources showing how the `TIOCGICOUNT` constant seems to be used not as a counter for other symbols but as (possibly runtime) interrumpt counter (not meant to be deprecated.)

  > <https://github.com/torvalds/linux/blob/eb3f4b7426cfd2b79d65b7d37155480b32259a11/include/uapi/asm-generic/ioctls.h#L99>
- FreeBSD sources showing how the `IFMIB_IFCOUNT` constant is promptly liable to upstream changes as it denotes the number of configured interfaces.

  > <https://github.com/freebsd/freebsd-src/blob/f9f46294d6af2a937afa74938bd4bb6826cbb921/sys/net/if_mib.h#L60>
- XNU kernel sources showing how the `RTV_HOPCOUNT` is not the type of constant we would want to deprecate. It seems to be more of an enum "variant" among other similar constants.

  > <https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/net/route.h#L228>
- Illumos sources showing that the `IPV6_MINHOPCOUNT` is not dependent of other source code chagnes (and thus does not require deprecation.)

  > <https://github.com/illumos/illumos-gate/blob/7124a0cccb6ebf2bcffdab36f9bdf8fe4c23d77f/usr/src/uts/common/netinet/in.h#L1309>
- L4RE sources showing how the `SIOCGIFCOUNT` constant is more of an enum "variant" among other values, and thus not a targe of these deprecation efforts.

  > <https://github.com/search?q=repo%3Akernkonzept%2Fl4re-core%20SIOCGIFCOUNT&type=code>
- Illumos sources showing how the `LGRP_RSRC_COUNT` constant is meant to count the number of resource types, which for the time being are the two constants below it.

  > <https://github.com/search?q=repo%3Aillumos%2Fillumos-gate%20LGRP_RSRC_COUNT&type=code>
- Linux sources mentioning that the constants declared prior to the `NFNL_SUBSYS_COUNT` symbol could have been in an enumeration where the last value is the current "limit."

  > <https://github.com/search?q=repo%3Atorvalds%2Flinux%20NFNL_SUBSYS_COUNT&type=code>
- Android sources replicating similar behavior as in Linux.

  > <https://cs.android.com/search?q=NFNL_SUBSYS_COUNT&sq=&ss=android%2Fplatform%2Fsuperproject>

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated