### PR TITLE
Annotate unstable `*MAX` constants

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -1592,6 +1592,8 @@ pub const LOCK_UN: c_int = 8;
 pub const SS_ONSTACK: c_int = 1;
 pub const SS_DISABLE: c_int = 2;
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PATH_MAX: c_int = 4096;
 
 pub const FD_SETSIZE: c_int = 1024;

--- a/src/new/linux_uapi/linux/can/j1939.rs
+++ b/src/new/linux_uapi/linux/can/j1939.rs
@@ -57,4 +57,6 @@ s! {
     }
 }
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const J1939_FILTER_MAX: c_int = 512;

--- a/src/new/linux_uapi/linux/can/raw.rs
+++ b/src/new/linux_uapi/linux/can/raw.rs
@@ -3,6 +3,9 @@
 pub use crate::linux::can::*;
 
 pub const SOL_CAN_RAW: c_int = SOL_CAN_BASE + CAN_RAW;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const CAN_RAW_FILTER_MAX: c_int = 512;
 
 // FIXME(cleanup): use `c_enum!`, which needs to be adapted to allow omitting a type.

--- a/src/new/qurt/limits.rs
+++ b/src/new/qurt/limits.rs
@@ -27,12 +27,24 @@ pub const USHRT_MAX: c_ushort = 65535;
 // POSIX Limits
 pub const ARG_MAX: c_int = 4096;
 pub const CHILD_MAX: c_int = 25;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const LINK_MAX: c_int = 8;
+
 pub const MAX_CANON: c_int = 255;
 pub const MAX_INPUT: c_int = 255;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NAME_MAX: c_int = 255;
+
 pub const OPEN_MAX: c_int = 20;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PATH_MAX: c_int = 260;
+
 pub const PIPE_BUF: c_int = 512;
 pub const STREAM_MAX: c_int = 20;
 pub const TZNAME_MAX: c_int = 50;

--- a/src/new/qurt/signal.rs
+++ b/src/new/qurt/signal.rs
@@ -51,6 +51,9 @@ pub const SIG_SETMASK: c_int = 3;
 pub const POSIX_MSG: c_int = 7;
 pub const POSIX_NOTIF: c_int = 8;
 pub const SIGRTMIN: c_int = 10;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SIGRTMAX: c_int = 32;
 
 // Notification types (from QuRT signal.h)

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -932,7 +932,11 @@ pub const RTAX_IFP: c_int = 4;
 pub const RTAX_IFA: c_int = 5;
 pub const RTAX_AUTHOR: c_int = 6;
 pub const RTAX_BRD: c_int = 7;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const RTAX_MAX: c_int = 8;
+
 pub const RTF_UP: c_int = 0x1;
 pub const RTF_GATEWAY: c_int = 0x2;
 pub const RTF_HOST: c_int = 0x4;
@@ -1445,7 +1449,11 @@ pub const L_GETPROCINFO: c_int = 7;
 pub const L_GETXINFO: c_int = 8;
 
 // sys/limits.h
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PATH_MAX: c_int = 1023;
+
 pub const PAGESIZE: c_int = 4096;
 pub const IOV_MAX: c_int = 16;
 pub const AIO_LISTIO_MAX: c_int = 4096;
@@ -1454,14 +1462,37 @@ pub const OPEN_MAX: c_int = 65534;
 pub const MAX_INPUT: c_int = 512;
 pub const MAX_CANON: c_int = 256;
 pub const ARG_MAX: c_int = 1048576;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const BC_BASE_MAX: c_int = 99;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const BC_DIM_MAX: c_int = 0x800;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const BC_SCALE_MAX: c_int = 99;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const BC_STRING_MAX: c_int = 0x800;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const CHARCLASS_NAME_MAX: c_int = 14;
+
 pub const CHILD_MAX: c_int = 128;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const COLL_WEIGHTS_MAX: c_int = 4;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const EXPR_NEST_MAX: c_int = 32;
+
 pub const NZERO: c_int = 20;
 
 // sys/lockf.h
@@ -1541,7 +1572,11 @@ pub const MAXPATHLEN: c_int = PATH_MAX + 1;
 pub const MAXSYMLINKS: c_int = 20;
 pub const MAXHOSTNAMELEN: c_int = 256;
 pub const MAXUPRC: c_int = 128;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NGROUPS_MAX: c_ulong = 2048;
+
 pub const NGROUPS: c_ulong = NGROUPS_MAX;
 pub const NOFILE: c_int = OPEN_MAX;
 
@@ -1739,7 +1774,11 @@ pub const SIGXCPU: c_int = 24;
 pub const SIGXFSZ: c_int = 25;
 pub const SIGTRAP: c_int = 5;
 pub const SIGCLD: c_int = 20;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SIGRTMAX: c_int = 57;
+
 pub const SIGRTMIN: c_int = 50;
 pub const SI_USER: c_int = 0;
 pub const SI_UNDEFINED: c_int = 8;
@@ -1817,7 +1856,11 @@ pub const AF_INET6: c_int = 24;
 pub const AF_INTF: c_int = 20;
 pub const AF_RIF: c_int = 21;
 pub const AF_NDD: c_int = 23;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const AF_MAX: c_int = 30;
+
 pub const PF_UNSPEC: c_int = AF_UNSPEC;
 pub const PF_UNIX: c_int = AF_UNIX;
 pub const PF_INET: c_int = AF_INET;
@@ -1843,7 +1886,11 @@ pub const PF_RIF: c_int = AF_RIF;
 pub const PF_INTF: c_int = AF_INTF;
 pub const PF_NDD: c_int = AF_NDD;
 pub const PF_INET6: c_int = AF_INET6;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PF_MAX: c_int = AF_MAX;
+
 pub const SF_CLOSE: c_int = 1;
 pub const SF_REUSE: c_int = 2;
 pub const SF_DONT_CACHE: c_int = 4;

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -2014,6 +2014,9 @@ pub const CPU_STATE_USER: c_int = 0;
 pub const CPU_STATE_SYSTEM: c_int = 1;
 pub const CPU_STATE_IDLE: c_int = 2;
 pub const CPU_STATE_NICE: c_int = 3;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const CPU_STATE_MAX: c_int = 4;
 
 pub const PROCESSOR_BASIC_INFO: c_int = 1;
@@ -3399,14 +3402,39 @@ pub const HW_TARGET: c_int = 26;
 pub const HW_PRODUCT: c_int = 27;
 pub const HW_MAXID: c_int = 28;
 pub const USER_CS_PATH: c_int = 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_BC_BASE_MAX: c_int = 2;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_BC_DIM_MAX: c_int = 3;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_BC_SCALE_MAX: c_int = 4;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_BC_STRING_MAX: c_int = 5;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_COLL_WEIGHTS_MAX: c_int = 6;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_EXPR_NEST_MAX: c_int = 7;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_LINE_MAX: c_int = 8;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_RE_DUP_MAX: c_int = 9;
+
 pub const USER_POSIX2_VERSION: c_int = 10;
 pub const USER_POSIX2_C_BIND: c_int = 11;
 pub const USER_POSIX2_C_DEV: c_int = 12;
@@ -3450,10 +3478,6 @@ pub const SIGEV_THREAD: c_int = 3;
 pub const AIO_CANCELED: c_int = 2;
 pub const AIO_NOTCANCELED: c_int = 4;
 pub const AIO_ALLDONE: c_int = 1;
-#[deprecated(
-    since = "0.2.64",
-    note = "Can vary at runtime.  Use sysconf(3) instead"
-)]
 pub const AIO_LISTIO_MAX: c_int = 16;
 pub const LIO_NOP: c_int = 0;
 pub const LIO_WRITE: c_int = 2;
@@ -3529,6 +3553,8 @@ pub const RTV_SSTHRESH: c_int = 0x20;
 pub const RTV_RTT: c_int = 0x40;
 pub const RTV_RTTVAR: c_int = 0x80;
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const RTAX_MAX: c_int = 8;
 
 pub const KERN_PROCARGS2: c_int = 49;

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -645,14 +645,39 @@ pub const HW_MACHINE_PLATFORM: c_int = 12;
 pub const HW_SENSORS: c_int = 13;
 pub const HW_MAXID: c_int = 14;
 pub const USER_CS_PATH: c_int = 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_BC_BASE_MAX: c_int = 2;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_BC_DIM_MAX: c_int = 3;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_BC_SCALE_MAX: c_int = 4;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_BC_STRING_MAX: c_int = 5;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_COLL_WEIGHTS_MAX: c_int = 6;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_EXPR_NEST_MAX: c_int = 7;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_LINE_MAX: c_int = 8;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_RE_DUP_MAX: c_int = 9;
+
 pub const USER_POSIX2_VERSION: c_int = 10;
 pub const USER_POSIX2_C_BIND: c_int = 11;
 pub const USER_POSIX2_C_DEV: c_int = 12;
@@ -1172,6 +1197,9 @@ pub const RTM_VERSION: c_int = 7;
 pub const RTAX_MPLS1: c_int = 8;
 pub const RTAX_MPLS2: c_int = 9;
 pub const RTAX_MPLS3: c_int = 10;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const RTAX_MAX: c_int = 11;
 
 const fn _CMSG_ALIGN(n: usize) -> usize {

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -2320,14 +2320,39 @@ pub const HW_MACHINE_ARCH: c_int = 11;
 pub const HW_REALMEM: c_int = 12;
 
 pub const USER_CS_PATH: c_int = 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_BC_BASE_MAX: c_int = 2;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_BC_DIM_MAX: c_int = 3;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_BC_SCALE_MAX: c_int = 4;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_BC_STRING_MAX: c_int = 5;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_COLL_WEIGHTS_MAX: c_int = 6;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_EXPR_NEST_MAX: c_int = 7;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_LINE_MAX: c_int = 8;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_RE_DUP_MAX: c_int = 9;
+
 pub const USER_POSIX2_VERSION: c_int = 10;
 pub const USER_POSIX2_C_BIND: c_int = 11;
 pub const USER_POSIX2_C_DEV: c_int = 12;
@@ -2444,6 +2469,9 @@ pub const SO_TS_BINTIME: c_int = 1;
 pub const SO_TS_REALTIME: c_int = 2;
 pub const SO_TS_MONOTONIC: c_int = 3;
 pub const SO_TS_DEFAULT: c_int = SO_TS_REALTIME_MICRO;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SO_TS_CLOCK_MAX: c_int = SO_TS_MONOTONIC;
 
 pub const LOCAL_CREDS: c_int = 2;
@@ -2729,6 +2757,8 @@ pub const IFNET_SLOWHZ: c_int = 1;
 pub const IFAN_ARRIVAL: c_int = 0;
 pub const IFAN_DEPARTURE: c_int = 1;
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const IFSTATMAX: c_int = 800;
 
 pub const RSS_FUNC_NONE: c_int = 0;
@@ -3066,6 +3096,9 @@ pub const TCP_PCAP_IN: c_int = 4096;
 pub const TCP_FUNCTION_BLK: c_int = 8192;
 pub const TCP_FUNCTION_ALIAS: c_int = 8193;
 pub const TCP_FASTOPEN_PSK_LEN: c_int = 16;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const TCP_FUNCTION_NAME_LEN_MAX: c_int = 32;
 
 pub const TCP_REUSPORT_LB_NUMA: c_int = 1026;
@@ -3432,71 +3465,111 @@ pub const KKST_STATE_SWAPPED: c_int = 1;
 pub const KKST_STATE_RUNNING: c_int = 2;
 
 // Constants about priority.
+
 pub const PRI_MIN: c_int = 0;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PRI_MAX: c_int = 255;
+
 pub const PRI_MIN_ITHD: c_int = PRI_MIN;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
-#[allow(deprecated)]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PRI_MAX_ITHD: c_int = PRI_MIN_REALTIME - 1;
+
 pub const PI_REALTIME: c_int = PRI_MIN_ITHD + 0;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PI_AV: c_int = PRI_MIN_ITHD + 4;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PI_NET: c_int = PRI_MIN_ITHD + 8;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PI_DISK: c_int = PRI_MIN_ITHD + 12;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PI_TTY: c_int = PRI_MIN_ITHD + 16;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PI_DULL: c_int = PRI_MIN_ITHD + 20;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PI_SOFT: c_int = PRI_MIN_ITHD + 24;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PRI_MIN_REALTIME: c_int = 48;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
-#[allow(deprecated)]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PRI_MAX_REALTIME: c_int = PRI_MIN_KERN - 1;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PRI_MIN_KERN: c_int = 80;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
-#[allow(deprecated)]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PRI_MAX_KERN: c_int = PRI_MIN_TIMESHARE - 1;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
-#[allow(deprecated)]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PSWP: c_int = PRI_MIN_KERN + 0;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
-#[allow(deprecated)]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PVM: c_int = PRI_MIN_KERN + 4;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
-#[allow(deprecated)]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PINOD: c_int = PRI_MIN_KERN + 8;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
-#[allow(deprecated)]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PRIBIO: c_int = PRI_MIN_KERN + 12;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
-#[allow(deprecated)]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PVFS: c_int = PRI_MIN_KERN + 16;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
-#[allow(deprecated)]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PZERO: c_int = PRI_MIN_KERN + 20;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
-#[allow(deprecated)]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PSOCK: c_int = PRI_MIN_KERN + 24;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
-#[allow(deprecated)]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PWAIT: c_int = PRI_MIN_KERN + 28;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
-#[allow(deprecated)]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PLOCK: c_int = PRI_MIN_KERN + 32;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
-#[allow(deprecated)]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PPAUSE: c_int = PRI_MIN_KERN + 36;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PRI_MIN_TIMESHARE: c_int = 120;
+
 pub const PRI_MAX_TIMESHARE: c_int = PRI_MIN_IDLE - 1;
-#[deprecated(since = "0.2.133", note = "Not stable across OS versions")]
-#[allow(deprecated)]
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PUSER: c_int = PRI_MIN_TIMESHARE;
+
 pub const PRI_MIN_IDLE: c_int = 224;
 pub const PRI_MAX_IDLE: c_int = PRI_MAX;
 
@@ -3512,6 +3585,7 @@ cfg_if! {
         pub const ARG_MAX: c_int = 2 * 256 * 1024;
     }
 }
+
 pub const CHILD_MAX: c_int = 40;
 /// max command name remembered
 pub const MAXCOMLEN: usize = 19;
@@ -3535,10 +3609,16 @@ pub const MAXHOSTNAMELEN: c_int = 256;
 pub const MAX_CANON: c_int = 255;
 /// max bytes in terminal input
 pub const MAX_INPUT: c_int = 255;
-/// max bytes in a file name
+/// Max bytes in a file name.
+///
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NAME_MAX: c_int = 255;
 pub const MAXSYMLINKS: c_int = 32;
-/// max supplemental group id's
+/// Max supplemental group IDs.
+///
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NGROUPS_MAX: c_int = 1023;
 /// max open files per process
 pub const OPEN_MAX: c_int = 64;
@@ -3552,23 +3632,58 @@ pub const _POSIX_PIPE_BUF: c_int = 512;
 pub const _POSIX_SSIZE_MAX: c_int = 32767;
 pub const _POSIX_STREAM_MAX: c_int = 8;
 
-/// max ibase/obase values in bc(1)
+/// Max ibase/obase values in bc(1).
+///
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const BC_BASE_MAX: c_int = 99;
-/// max array elements in bc(1)
+
+/// Max array elements in bc(1).
+///
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const BC_DIM_MAX: c_int = 2048;
-/// max scale value in bc(1)
+
+/// Max scale value in bc(1).
+///
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const BC_SCALE_MAX: c_int = 99;
-/// max const string length in bc(1)
+
+/// Max const string length in bc(1).
+///
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const BC_STRING_MAX: c_int = 1000;
-/// max character class name size
+
+/// Max character class name size.
+///
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const CHARCLASS_NAME_MAX: c_int = 14;
-/// max weights for order keyword
+
+/// Max weights for order keyword.
+///
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const COLL_WEIGHTS_MAX: c_int = 10;
-/// max expressions nested in expr(1)
+
+/// Max expressions nested in expr(1).
+///
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const EXPR_NEST_MAX: c_int = 32;
-/// max bytes in an input line
+
+/// Max bytes in an input line.
+///
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const LINE_MAX: c_int = 2048;
-/// max RE's in interval notation
+
+/// Max RE's in interval notation.
+///
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const RE_DUP_MAX: c_int = 255;
 
 pub const _POSIX2_BC_BASE_MAX: c_int = 99;
@@ -3976,6 +4091,8 @@ pub const RTF_FIXEDMTU: c_int = 0x80000;
 
 pub const RTM_VERSION: c_int = 5;
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const RTAX_MAX: c_int = 8;
 
 // sys/signal.h
@@ -4023,7 +4140,11 @@ pub const SCTP_PR_SCTP_TTL: c_int = 0x0001;
 pub const SCTP_PR_SCTP_PRIO: c_int = 0x0002;
 pub const SCTP_PR_SCTP_BUF: c_int = SCTP_PR_SCTP_PRIO;
 pub const SCTP_PR_SCTP_RTX: c_int = 0x0003;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SCTP_PR_SCTP_MAX: c_int = SCTP_PR_SCTP_RTX;
+
 pub const SCTP_PR_SCTP_ALL: c_int = 0x000f;
 
 pub const SCTP_INIT: c_int = 0x0001;
@@ -4105,6 +4226,9 @@ pub const SCTP_ASSOC_SUPPORTS_ASCONF: c_int = 0x03;
 pub const SCTP_ASSOC_SUPPORTS_MULTIBUF: c_int = 0x04;
 pub const SCTP_ASSOC_SUPPORTS_RE_CONFIG: c_int = 0x05;
 pub const SCTP_ASSOC_SUPPORTS_INTERLEAVING: c_int = 0x06;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SCTP_ASSOC_SUPPORTS_MAX: c_int = 0x06;
 
 pub const SCTP_ADDR_AVAILABLE: c_int = 0x0001;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -408,10 +408,6 @@ s! {
 // Non-public helper constant
 const SIZEOF_LONG: usize = size_of::<c_long>();
 
-#[deprecated(
-    since = "0.2.64",
-    note = "Can vary at runtime.  Use sysconf(3) instead"
-)]
 pub const AIO_LISTIO_MAX: c_int = 16;
 pub const AIO_CANCELED: c_int = 1;
 pub const AIO_NOTCANCELED: c_int = 2;

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -163,7 +163,10 @@ pub const FIOASYNC: c_ulong = 0x8004667d;
 pub const FIOSETOWN: c_ulong = 0x8004667c;
 pub const FIOGETOWN: c_ulong = 0x4004667b;
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PATH_MAX: c_int = 1024;
+
 pub const MAXPATHLEN: c_int = PATH_MAX;
 
 pub const IOV_MAX: c_int = 1024;

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1715,6 +1715,8 @@ pub const KVME_FLAG_PAGEABLE: c_int = 0x000000008;
 pub const KVME_FLAG_GROWS_UP: c_int = 0x000000010;
 pub const KVME_FLAG_GROWS_DOWN: c_int = 0x000000020;
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NGROUPS_MAX: c_int = 16;
 
 pub const KI_NGROUPS: c_int = 16;
@@ -1791,6 +1793,9 @@ pub const RTM_CHGADDR: c_int = 0x18;
 pub const RTA_TAG: c_int = 0x100;
 
 pub const RTAX_TAG: c_int = 8;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const RTAX_MAX: c_int = 9;
 
 // For eventfd

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1510,6 +1510,8 @@ pub const ISOFSMNT_EXTATT: c_int = 0x4; // enable extended attr
 pub const ISOFSMNT_NOJOLIET: c_int = 0x8; // disable Joliet Ext
 pub const ISOFSMNT_SESS: c_int = 0x10; // use iso_args.sess
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NFS_ARGSVERSION: c_int = 4; // change when nfs_args changes
 
 pub const NFSMNT_RESVPORT: c_int = 0; // always use reserved ports
@@ -1817,6 +1819,9 @@ pub const RTAX_BFD: c_int = 11;
 pub const RTAX_DNS: c_int = 12;
 pub const RTAX_STATIC: c_int = 13;
 pub const RTAX_SEARCH: c_int = 14;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const RTAX_MAX: c_int = 15;
 
 const fn _ALIGN(p: usize) -> usize {

--- a/src/unix/cygwin/mod.rs
+++ b/src/unix/cygwin/mod.rs
@@ -897,8 +897,15 @@ pub const ARG_MAX: c_int = 32000;
 pub const CHILD_MAX: c_int = 256;
 pub const IOV_MAX: c_int = 1024;
 pub const PTHREAD_STACK_MIN: size_t = 65536;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PATH_MAX: c_int = 4096;
+
 pub const PIPE_BUF: usize = 4096;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NGROUPS_MAX: c_int = 1024;
 
 pub const FILENAME_MAX: c_int = 4096;

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -902,6 +902,9 @@ pub const MINSIGSTKSZ: size_t = 8192;
 pub const SIGSTKSZ: size_t = 16384;
 
 pub const IOV_MAX: c_int = 1024;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PATH_MAX: c_int = 1024;
 
 pub const SA_NOCLDSTOP: c_int = 0x01;

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -1230,7 +1230,11 @@ pub const PF_IPX: c_int = 23;
 pub const PF_SIP: c_int = 24;
 pub const PF_PIP: c_int = 25;
 pub const PF_INET6: c_int = 26;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PF_MAX: c_int = 27;
+
 pub const AF_UNSPEC: c_int = 0;
 pub const AF_LOCAL: c_int = 1;
 pub const AF_UNIX: c_int = 1;
@@ -1260,7 +1264,11 @@ pub const AF_IPX: c_int = 23;
 pub const AF_SIP: c_int = 24;
 pub const pseudo_AF_PIP: c_int = 25;
 pub const AF_INET6: c_int = 26;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const AF_MAX: c_int = 27;
+
 pub const SOMAXCONN: c_int = 4096;
 pub const _SS_SIZE: usize = 128;
 pub const CMGROUP_MAX: usize = 16;
@@ -1526,8 +1534,15 @@ pub const _POSIX_QLIMIT: usize = 1;
 pub const _POSIX_HIWAT: usize = 512;
 pub const _POSIX_UIO_MAXIOV: usize = 16;
 pub const _POSIX_CLOCKRES_MIN: usize = 20000000;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NAME_MAX: usize = 255;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NGROUPS_MAX: usize = 256;
+
 pub const _POSIX_THREAD_KEYS_MAX: usize = 128;
 pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: usize = 4;
 pub const _POSIX_THREAD_THREADS_MAX: usize = 64;
@@ -3207,6 +3222,9 @@ pub const RTLD_DI_PROFILEOUT: c_int = 8;
 pub const RTLD_DI_TLS_MODID: c_int = 9;
 pub const RTLD_DI_TLS_DATA: c_int = 10;
 pub const RTLD_DI_PHDR: c_int = 11;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const RTLD_DI_MAX: c_int = 11;
 
 pub const SI_ASYNCIO: c_int = -4;

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -1681,6 +1681,9 @@ pub const NFQA_CFG_F_CONNTRACK: c_int = 0x0002;
 pub const NFQA_CFG_F_GSO: c_int = 0x0004;
 pub const NFQA_CFG_F_UID_GID: c_int = 0x0008;
 pub const NFQA_CFG_F_SECCTX: c_int = 0x0010;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NFQA_CFG_F_MAX: c_int = 0x0020;
 
 pub const NFQA_SKB_CSUMNOTREADY: c_int = 0x0001;
@@ -2001,7 +2004,11 @@ pub const NFT_REG_1: c_int = 1;
 pub const NFT_REG_2: c_int = 2;
 pub const NFT_REG_3: c_int = 3;
 pub const NFT_REG_4: c_int = 4;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const __NFT_REG_MAX: c_int = 5;
+
 pub const NFT_REG32_00: c_int = 8;
 pub const NFT_REG32_01: c_int = 9;
 pub const NFT_REG32_02: c_int = 10;
@@ -2050,6 +2057,9 @@ pub const NFT_MSG_NEWOBJ: c_int = 18;
 pub const NFT_MSG_GETOBJ: c_int = 19;
 pub const NFT_MSG_DELOBJ: c_int = 20;
 pub const NFT_MSG_GETOBJ_RESET: c_int = 21;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NFT_MSG_MAX: c_int = 25;
 
 pub const NFT_SET_ANONYMOUS: c_int = 0x1;
@@ -2181,31 +2191,77 @@ pub const NFT_NG_INCREMENTAL: c_int = 0;
 pub const NFT_NG_RANDOM: c_int = 1;
 
 // linux/input.h
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const FF_MAX: crate::__u16 = 0x7f;
+
 pub const FF_CNT: usize = FF_MAX as usize + 1;
 
 // linux/input-event-codes.h
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const INPUT_PROP_MAX: crate::__u16 = 0x1f;
+
 pub const INPUT_PROP_CNT: usize = INPUT_PROP_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const EV_MAX: crate::__u16 = 0x1f;
+
 pub const EV_CNT: usize = EV_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SYN_MAX: crate::__u16 = 0xf;
+
 pub const SYN_CNT: usize = SYN_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const KEY_MAX: crate::__u16 = 0x2ff;
+
 pub const KEY_CNT: usize = KEY_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const REL_MAX: crate::__u16 = 0x0f;
+
 pub const REL_CNT: usize = REL_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const ABS_MAX: crate::__u16 = 0x3f;
+
 pub const ABS_CNT: usize = ABS_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SW_MAX: crate::__u16 = 0x0f;
+
 pub const SW_CNT: usize = SW_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const MSC_MAX: crate::__u16 = 0x07;
+
 pub const MSC_CNT: usize = MSC_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const LED_MAX: crate::__u16 = 0x0f;
+
 pub const LED_CNT: usize = LED_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const REP_MAX: crate::__u16 = 0x01;
+
 pub const REP_CNT: usize = REP_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SND_MAX: crate::__u16 = 0x07;
+
 pub const SND_CNT: usize = SND_MAX as usize + 1;
 
 // linux/uinput.h
@@ -2835,7 +2891,11 @@ pub const PR_SCHED_CORE_GET: c_int = 0;
 pub const PR_SCHED_CORE_CREATE: c_int = 1;
 pub const PR_SCHED_CORE_SHARE_TO: c_int = 2;
 pub const PR_SCHED_CORE_SHARE_FROM: c_int = 3;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PR_SCHED_CORE_MAX: c_int = 4;
+
 pub const PR_SCHED_CORE_SCOPE_THREAD: c_int = 0;
 pub const PR_SCHED_CORE_SCOPE_THREAD_GROUP: c_int = 1;
 pub const PR_SCHED_CORE_SCOPE_PROCESS_GROUP: c_int = 2;
@@ -3137,7 +3197,11 @@ pub const KERN_S390_USER_DEBUG_LOGGING: c_int = 51;
 pub const KERN_CORE_USES_PID: c_int = 52;
 pub const KERN_TAINTED: c_int = 53;
 pub const KERN_CADPID: c_int = 54;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const KERN_PIDMAX: c_int = 55;
+
 pub const KERN_CORE_PATTERN: c_int = 56;
 pub const KERN_PANIC_ON_OOPS: c_int = 57;
 pub const KERN_HPPA_PWRSW: c_int = 58;
@@ -3145,7 +3209,11 @@ pub const KERN_HPPA_UNALIGNED: c_int = 59;
 pub const KERN_PRINTK_RATELIMIT: c_int = 60;
 pub const KERN_PRINTK_RATELIMIT_BURST: c_int = 61;
 pub const KERN_PTY: c_int = 62;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const KERN_NGROUPS_MAX: c_int = 63;
+
 pub const KERN_SPARC_SCONS_PWROFF: c_int = 64;
 pub const KERN_HZ_TIMER: c_int = 65;
 pub const KERN_UNKNOWN_NMI_PANIC: c_int = 66;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1493,7 +1493,11 @@ pub const SKF_AD_VLAN_TAG_PRESENT: c_int = 48;
 pub const SKF_AD_PAY_OFFSET: c_int = 52;
 pub const SKF_AD_RANDOM: c_int = 56;
 pub const SKF_AD_VLAN_TPID: c_int = 60;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SKF_AD_MAX: c_int = 64;
+
 pub const SKF_NET_OFF: c_int = -0x100000;
 pub const SKF_LL_OFF: c_int = -0x200000;
 pub const BPF_NET_OFF: c_int = SKF_NET_OFF;
@@ -1794,6 +1798,9 @@ pub const NFQA_CFG_F_CONNTRACK: c_int = 0x0002;
 pub const NFQA_CFG_F_GSO: c_int = 0x0004;
 pub const NFQA_CFG_F_UID_GID: c_int = 0x0008;
 pub const NFQA_CFG_F_SECCTX: c_int = 0x0010;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NFQA_CFG_F_MAX: c_int = 0x0020;
 
 pub const NFQA_SKB_CSUMNOTREADY: c_int = 0x0001;
@@ -2841,7 +2848,11 @@ pub const NFT_REG_1: c_int = 1;
 pub const NFT_REG_2: c_int = 2;
 pub const NFT_REG_3: c_int = 3;
 pub const NFT_REG_4: c_int = 4;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const __NFT_REG_MAX: c_int = 5;
+
 pub const NFT_REG32_00: c_int = 8;
 pub const NFT_REG32_01: c_int = 9;
 pub const NFT_REG32_02: c_int = 10;
@@ -2895,6 +2906,8 @@ cfg_if! {
     }
 }
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NFT_MSG_MAX: c_int = 34;
 
 pub const NFT_SET_ANONYMOUS: c_int = 0x1;
@@ -3025,7 +3038,10 @@ pub const NFT_NG_INCREMENTAL: c_int = 0;
 pub const NFT_NG_RANDOM: c_int = 1;
 
 // linux/input.h
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const FF_MAX: __u16 = 0x7f;
+
 pub const FF_CNT: usize = FF_MAX as usize + 1;
 
 // linux/input-event-codes.h
@@ -3036,27 +3052,71 @@ pub const INPUT_PROP_SEMI_MT: __u16 = 0x03;
 pub const INPUT_PROP_TOPBUTTONPAD: __u16 = 0x04;
 pub const INPUT_PROP_POINTING_STICK: __u16 = 0x05;
 pub const INPUT_PROP_ACCELEROMETER: __u16 = 0x06;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const INPUT_PROP_MAX: __u16 = 0x1f;
+
 pub const INPUT_PROP_CNT: usize = INPUT_PROP_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const EV_MAX: __u16 = 0x1f;
+
 pub const EV_CNT: usize = EV_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SYN_MAX: __u16 = 0xf;
+
 pub const SYN_CNT: usize = SYN_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const KEY_MAX: __u16 = 0x2ff;
+
 pub const KEY_CNT: usize = KEY_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const REL_MAX: __u16 = 0x0f;
+
 pub const REL_CNT: usize = REL_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const ABS_MAX: __u16 = 0x3f;
+
 pub const ABS_CNT: usize = ABS_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SW_MAX: __u16 = 0x10;
+
 pub const SW_CNT: usize = SW_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const MSC_MAX: __u16 = 0x07;
+
 pub const MSC_CNT: usize = MSC_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const LED_MAX: __u16 = 0x0f;
+
 pub const LED_CNT: usize = LED_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const REP_MAX: __u16 = 0x01;
+
 pub const REP_CNT: usize = REP_MAX as usize + 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SND_MAX: __u16 = 0x07;
+
 pub const SND_CNT: usize = SND_MAX as usize + 1;
 
 // linux/uinput.h
@@ -3290,7 +3350,11 @@ pub const SCTP_PR_SCTP_NONE: c_int = 0x0000;
 pub const SCTP_PR_SCTP_TTL: c_int = 0x0010;
 pub const SCTP_PR_SCTP_RTX: c_int = 0x0020;
 pub const SCTP_PR_SCTP_PRIO: c_int = 0x0030;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SCTP_PR_SCTP_MAX: c_int = SCTP_PR_SCTP_PRIO;
+
 pub const SCTP_PR_SCTP_MASK: c_int = 0x0030;
 pub const SCTP_ENABLE_RESET_STREAM_REQ: c_int = 0x01;
 pub const SCTP_ENABLE_RESET_ASSOC_REQ: c_int = 0x02;
@@ -3398,7 +3462,11 @@ pub const KERN_S390_USER_DEBUG_LOGGING: c_int = 51;
 pub const KERN_CORE_USES_PID: c_int = 52;
 pub const KERN_TAINTED: c_int = 53;
 pub const KERN_CADPID: c_int = 54;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const KERN_PIDMAX: c_int = 55;
+
 pub const KERN_CORE_PATTERN: c_int = 56;
 pub const KERN_PANIC_ON_OOPS: c_int = 57;
 pub const KERN_HPPA_PWRSW: c_int = 58;
@@ -3406,7 +3474,11 @@ pub const KERN_HPPA_UNALIGNED: c_int = 59;
 pub const KERN_PRINTK_RATELIMIT: c_int = 60;
 pub const KERN_PRINTK_RATELIMIT_BURST: c_int = 61;
 pub const KERN_PTY: c_int = 62;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const KERN_NGROUPS_MAX: c_int = 63;
+
 pub const KERN_SPARC_SCONS_PWROFF: c_int = 64;
 pub const KERN_HZ_TIMER: c_int = 65;
 pub const KERN_UNKNOWN_NMI_PANIC: c_int = 66;

--- a/src/unix/linux_like/linux/musl/b32/hexagon.rs
+++ b/src/unix/linux_like/linux/musl/b32/hexagon.rs
@@ -103,7 +103,11 @@ s! {
 
 pub const AF_FILE: c_int = 1;
 pub const AF_KCM: c_int = 41;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const AF_MAX: c_int = 43;
+
 pub const AF_QIPCRTR: c_int = 42;
 pub const EADDRINUSE: c_int = 98;
 pub const EADDRNOTAVAIL: c_int = 99;
@@ -236,7 +240,11 @@ pub const O_SYNC: c_int = 1052672;
 pub const O_RSYNC: c_int = 1052672;
 pub const PF_FILE: c_int = 1;
 pub const PF_KCM: c_int = 41;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PF_MAX: c_int = 43;
+
 pub const PF_QIPCRTR: c_int = 42;
 pub const SA_ONSTACK: c_int = 0x08000000;
 pub const SA_SIGINFO: c_int = 0x00000004;

--- a/src/unix/linux_like/linux_l4re_shared.rs
+++ b/src/unix/linux_like/linux_l4re_shared.rs
@@ -1160,7 +1160,11 @@ pub const PR_SCHED_CORE_GET: c_int = 0;
 pub const PR_SCHED_CORE_CREATE: c_int = 1;
 pub const PR_SCHED_CORE_SHARE_TO: c_int = 2;
 pub const PR_SCHED_CORE_SHARE_FROM: c_int = 3;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PR_SCHED_CORE_MAX: c_int = 4;
+
 pub const PR_SCHED_CORE_SCOPE_THREAD: c_int = 0;
 pub const PR_SCHED_CORE_SCOPE_THREAD_GROUP: c_int = 1;
 pub const PR_SCHED_CORE_SCOPE_PROCESS_GROUP: c_int = 2;
@@ -1313,6 +1317,9 @@ pub const RT_CLASS_UNSPEC: u8 = 0;
 pub const RT_CLASS_DEFAULT: u8 = 253;
 pub const RT_CLASS_MAIN: u8 = 254;
 pub const RT_CLASS_LOCAL: u8 = 255;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const RT_CLASS_MAX: u8 = 255;
 
 pub const MAX_ADDR_LEN: usize = 7;

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1043,7 +1043,12 @@ pub const LOCK_UN: c_int = 8;
 pub const SS_ONSTACK: c_int = 1;
 pub const SS_DISABLE: c_int = 2;
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const NAME_MAX: c_int = 255;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PATH_MAX: c_int = 4096;
 
 pub const UIO_MAXIOV: c_int = 1024;

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -151,6 +151,9 @@ pub const EAI_SYSTEM: c_int = 11;
 pub const EAI_BADHINTS: c_int = 12;
 pub const EAI_PROTOCOL: c_int = 13;
 pub const EAI_OVERFLOW: c_int = 14;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const EAI_MAX: c_int = 15;
 
 pub const AF_UNIX: c_int = 1;

--- a/src/unix/newlib/rtems/mod.rs
+++ b/src/unix/newlib/rtems/mod.rs
@@ -56,7 +56,11 @@ pub const SIGWINCH: c_int = 24;
 pub const SIGUSR1: c_int = 25;
 pub const SIGUSR2: c_int = 26;
 pub const SIGRTMIN: c_int = 27;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SIGRTMAX: c_int = 31;
+
 pub const SIGXCPU: c_int = 24;
 pub const SIGXFSZ: c_int = 25;
 pub const SIGVTALRM: c_int = 26;

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -1154,6 +1154,8 @@ pub const LOCK_UN: c_int = 0x8;
 pub const SS_ONSTACK: c_int = 1;
 pub const SS_DISABLE: c_int = 2;
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PATH_MAX: c_int = 1024;
 
 pub const UIO_MAXIOV: c_int = 1024;
@@ -2340,14 +2342,39 @@ pub const TIOCSTOP: c_int = 29807;
 pub const TIOCSWINSZ: c_int = -2146929561;
 
 pub const USER_CS_PATH: c_int = 1;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_BC_BASE_MAX: c_int = 2;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_BC_DIM_MAX: c_int = 3;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_BC_SCALE_MAX: c_int = 4;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_BC_STRING_MAX: c_int = 5;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_COLL_WEIGHTS_MAX: c_int = 6;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_EXPR_NEST_MAX: c_int = 7;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_LINE_MAX: c_int = 8;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const USER_RE_DUP_MAX: c_int = 9;
+
 pub const USER_POSIX2_VERSION: c_int = 10;
 pub const USER_POSIX2_C_BIND: c_int = 11;
 pub const USER_POSIX2_C_DEV: c_int = 12;

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -333,6 +333,8 @@ cfg_if! {
 }
 
 // limits.h
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PATH_MAX: c_int = 4096;
 
 // fcntl.h

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -109,7 +109,11 @@ pub const FD_CLOFORK: c_int = 2;
 pub const FIL_ATTACH: c_int = 0x1;
 pub const FIL_DETACH: c_int = 0x2;
 pub const FIL_LIST: c_int = 0x3;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const FILNAME_MAX: c_int = 32;
+
 pub const FILF_PROG: c_int = 0x1;
 pub const FILF_AUTO: c_int = 0x2;
 pub const FILF_BYPASS: c_int = 0x4;

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -823,6 +823,8 @@ pub const NOEXPR: crate::nl_item = 57;
 pub const _DATE_FMT: crate::nl_item = 58;
 pub const MAXSTRMSG: crate::nl_item = 58;
 
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PATH_MAX: c_int = 1024;
 
 pub const SA_ONSTACK: c_int = 0x00000001;

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -702,6 +702,9 @@ pub const PTHREAD_MUTEX_ERRORCHECK: c_int = 1;
 pub const PTHREAD_MUTEX_RECURSIVE: c_int = 2;
 pub const PTHREAD_MUTEX_DEFAULT: c_int = PTHREAD_MUTEX_NORMAL;
 pub const PTHREAD_STACK_MIN: usize = 4096;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const _PTHREAD_SHARED_SEM_NAME_MAX: usize = 30;
 
 //sched.h
@@ -1041,6 +1044,9 @@ pub const AF_SOCKDEV: c_int = 31;
 pub const AF_TIPC: c_int = 33;
 pub const AF_MIPC: c_int = 34;
 pub const AF_MIPC_SAFE: c_int = 35;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const AF_MAX: c_int = 39;
 
 // termios.h
@@ -1171,7 +1177,10 @@ pub const FIOGETNAME: c_int = 18;
 pub const FIONBIO: c_int = 0x90040010;
 
 // limits.h
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const PATH_MAX: c_int = _PARM_PATH_MAX;
+
 pub const _POSIX_PATH_MAX: c_int = 256;
 
 // Some poll stuff
@@ -1315,7 +1324,12 @@ pub const AT_REMOVEDIR: c_int = 0x200;
 pub const AT_SYMLINK_FOLLOW: c_int = 0x400;
 
 // vxParams.h definitions
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const _PARM_NAME_MAX: c_int = 255;
+
+/// This symbol is prone to change across releases upstream.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const _PARM_PATH_MAX: c_int = 1024;
 
 // WAIT STUFF


### PR DESCRIPTION
# Description

This PR adds documentation. This affects certain symbols. These are often not stable upstream. This causes SemVer-breaking issues. Users may need advice. This patch links to such advice.

Some constants have been ignored. They are issued to `sysconf`.

POSIX defines clases of constants. They are part of `limits.h`. Some are runtime invariant. Others are not. Numerical limits have been skipped. Runtime invariant values have been skipped. Pathname variable values have been annotated. Runtime increasable values have been annotated.

POSIX-compliance has been assumed. This is sometimes broken. NetBSD is an example. They define `AIO_LIST_MAX` as variable [[1].] This should be a runtime invariant value. This PR does not handle this.

QNX sources have not been found. Its module has been barely modified. Only some symbols have been taken into consideration. Those correspond with the above POSIX-defined symbols.

[1]: https://man.freebsd.org/cgi/man.cgi?query=sysctl&apropos=0&sektion=7&manpath=NetBSD+10.1&arch=default&format=html

## Sources

- `ELIBMAX` is **not** the type of constant we would want to deprecate. This is just another enum-like "variant" for `errno` values. A concise defintion of its purpose is given in the below source, though this is not exclusive to Hermit.

  > <https://github.com/hermit-os/kernel/blob/38bff4ca8ca172039d1f6bee28cc0baa5183dd7c/src/errno.rs#L414>
- Hexagon sources show that `SIGRTMAX` may be the type of constant we want to deprecate (sources can be found on the downloadable SDK.) This constant exists for the purposes of keeping a higher limit on the number of realtime signals that the system can issue. In theory, this is not defined in `limits.h`, and very much seems like a fitting "limit" value to be deprecated, but I have my doubts. Either way, this patch deprecates it.
- Linux sources show that the `J1939_FILTER_MAX` constant may be the type of symbol we would want to deprecate. Even though there's other `_MAX`-suffixed symbols in that module, the comment left alongside this one in the source code seems fitting of a "limit" value. This constant is documented in the kernel as being an upper limit on the number of filters that the J1939 protocol over CAN can configure. Considering the protocol is a higher-level abstraction, I am not sure if we can assume a certain degree of stability here, so I've deprecated it. But then again, I have my doubts.

  > <https://github.com/torvalds/linux/blob/8fde5d1d47f69db6082dfa34500c27f8485389a5/include/uapi/linux/can/j1939.h#L106>
  > <https://www.kernel.org/doc/html/latest/networking/j1939.html>
- NetBSD sources show that the `MOD_PPSMAX` constant is likely not one we would want to deprecate, as judging solely by the inline comment left alongside the symbol definition, it is meant to be used as an identifier to set an upper limit on some system config.

  > <https://github.com/search?q=repo%3ANetBSD%2Fsrc%20MOD_PPSMAX&type=code>
- Linux sources show that, much like the above limit on filters for the J1939 protocol over CAN, the `CAN_RAW_FILTER_MAX` constant may be worth deprecating, as it seems to set the upper bound on the number of filters that one can set over raw CAN with a `struct can_filter`.

  > <https://github.com/search?q=repo%3Atorvalds%2Flinux%20CAN_RAW_FILTER_MAX&type=code>
  > <https://docs.kernel.org/networking/can.html>
- Hexagon sources show that the `TMP_MAX` and `FOPEN_MAX` constants are very similar to those symbols I decided not to deprecate in the `limits.h` header file of each target system's implementation. Their documentation in the downloadable SDK use the same wording and express the same purpose as other constants in `limits.h`, so I decided against deprecating those. These are actually part of SUSv2 (though `FOPEN_MAX` prevails in current versions of the standard,) and are supposed to be runtime invariant, so a user does not really risk anything by reading them through the value exposed in `limits.h` or otherwise through the `sysconf` library routine with the corresponding `_SC`-prefixed constants.
- All of the TeeOS `_MAX`-suffixed constants are part of those defined as the implementation limits for POSIX-defined constants, so those have not been modified. The same applies to a bunch of other implementations, such as those declared by the QuRT in their `limits.h` header file. At the moment, though, this only applies to those constants that have been known to be runtime invariant by any one of the SUSv2, SUSv3 or the latest POSIX standard specifications.
- The `RLIM_SAVED_MAX` constant, even though not quite the same as the other limits, is documented in The Linux Programming Interface, by Michael Kerrisk, as being a similar resource limit for applications where, say, one may have launched a process on some machine where a 64-bit resource limit is inherited but the process is being run in 32-bit mode (e.g. x86_32) is only capable of holding a potentially smaller resource limit. I believe this is not the type of constant we would want to deprecate.
- The BSD folks seem to do things a bit differently when it comes to limits that are used for kernel-relative requests to `sysctl`, but that does not mean the constants defined analogously to those in the `limits.h` header file have a different purpose (for the most part.) That's why I've decided against deprecating those we expose in the `libc` crate; Namely, `KERN_IOV_MAX` and `KERN_ARGMAX`. One exception to this is the `KERN_SBMAX` constant, which is not defined in terms of a constant in the POSIX standard, but the accompanying comments in the NetBSD source mentions as being used for the maximum size of a socket buffer; I've thus left it undeprecated.

  The same applies to some of the `USER_`- and `CTL_`-prefixed symbols. In this group, we do expose some constants that without the prefix actually match runtime increasable symbols specified in the POSIX standards.

  > <https://github.com/DragonFlyBSD/DragonFlyBSD/blob/59b78e44f96799c5f46fb3d6d616c18d838a75d0/sys/sys/sysctl.h#L531>
  > <https://github.com/search?q=repo%3ANetBSD%2Fsrc%20kern_sbmax&type=code>
- The `FILENAME_MAX` constant has not been deprecated, as that one seems to be part of the C standard library and seems to denote the largest supported character in an array of C `char`s. This likely makes it something folks can just read up, as there's no `sysconf` or (more appropiately, in this instance) `pathconf` constant to issue to these library routines to check the sure limit at runtime.
- The `RTAX_MAX` constant, unlike those mentioned above for the BSDs, is the type of limit we would want to deprecate, as it really only gives a size limit for arrays that are meant to hold all of the `sockaddr` values that are declared before it in the sources.

  > <https://github.com/search?q=repo%3ADragonFlyBSD%2FDragonFlyBSD+RTAX_MAX&type=code>
  > <https://github.com/search?q=repo%3Aopenbsd%2Fsrc%20rtax_max&type=code>
- The `NFSMNT_ACREGMAX` and `NFSMNT_ACDIRMAX` constants are likely not the type of symbols we would want to deprecate, as those provide information in OpenBSD to fix the values of the last fields of the `struct nfs_args`. Though while looking into the source, I noticed we also expose from the `libc` crate the `NFS_ARGSVERSION` constant, which is documented as changing whenever the afore mentioned record changes. This is quite definetely worth deprecating, and this patch does so.

  > <https://github.com/openbsd/src/blob/42d9a1e328839c7e55d698ee9b8c6ce4dbb4628d/sys/sys/mount.h#L110-L162>
- The FreeBSD sources show that the `CMGROUP_MAX` constant is likely not meant for deprecation, as the comment alongside its definition mentions that it's meant to be a limit on an actual resource and (to some extent) has historical significance. I believe this is not the type of constant that would be prone to fast changes, so I haven't deprecated it.

  > <https://github.com/freebsd/freebsd-src/blob/283959bbe0863917c4fc3200a92d1055a4c89bdc/sys/sys/socket.h#L506>
- I am not completely sure of the `RTP_PRIO_MAX` constant in FreeBSD. It seems to denote the type of range fitting the constants we are deprecating, but it does seem to be used across the codebase to fix values relating to the `rtprio` family of functions. For the time being, I've left it undeprecated.

  > <https://github.com/search?q=repo%3Afreebsd%2Ffreebsd-src%20rtp_prio_max&type=code>
- The `MOD_PPSMAX` constant is not fit for deprecation, as it's used as a "variant" for setter routine in the FreeBSD source.

  > <https://github.com/search?q=repo%3Afreebsd%2Ffreebsd-src+mod_ppsmax&type=code>
- The `SYS_`-prefixed constants in Android are not meant for deprecation either. Those are used as "variants" to be issued to `syscall()` such that they may serve as identifiers for some other piece of functionality.

  > <https://cs.android.com/search?q=SYS_sched_get_priority_max&sq=&ss=android%2Fplatform%2Fsuperproject>
- I'm having doubts about the `PRIO_MAX` constant in the Fuchsia and GNU Hurd trees. At first, I thought it would be part of constants defined in the POSIX standard like `MQ_PRIO_MAX`, where I decided against their deprecation so long as they were noted as runtime invariant in the spec. But looking at the Fuchsia source code, I am not so sure; It seems to be defined for compatibility with the Android Bionic source code judging by the file hierarchy, but it is not declared alongside other constants I would rather not deprecate. I would like some input on this from somebody else.

  > <https://cs.opensource.google/search?q=prio_max&sq=&ss=fuchsia>
- I couldn't get hold of the AIX sources, but I assumed the same of the `RTAX_MAX` constant as I did in the BSDs, and went ahead and deprecated it. I could be wrong, though, as I've not had access to the upstream code. The same can be said of the `BC_`- and `COL_`-prefixed constants, both of which exist under the BSDs with an additional `USER_` prefix. See the comments on those above. This also applies to the `SIGRTMAX` constant, which I did deprecate, as commented with the Hexagon sources above, and as explained in The Linux Programming Interface book.
- The `AF_MAX` and `PF_MAX` constants have been deprecated across all targets, as they seem to be used to denote the current limit on the procol and adress families after all other `AF_`- and `PF_`-prefixed constants.
- A constant that had breen previously marked as deprecated, `AIO_LISTIO_MAX`, has been undeprecated in favor of keeping deprecated solely the set of constants that are not runtime invariant according to the POSIX standard. This was discussed in the *Notes* section above.
- The `SO_TS_CLOCK_MAX` constant has been deprecated though it may just be that it should not be deprecated. This constant appears to me in the FreeBSD source code as being used solely for the purposes of denoting the largest of the constants defined prior to it, except for `SO_TS_DEFAULT`, which itself also takes on the values of one of the constants defined before it. I've taken this to mean that it's a "limit" value of the type we seek to deprecate. There's no mention of it in the POSIX standards either, so I've had to take a desision here that may have been the wrong one.

  > <https://github.com/freebsd/freebsd-src/blob/3118f1b99f23431235c202d9aadbe3d183bcc259/sys/sys/socket.h#L185>
- The `CPU_STATE_MAX` constant in the XNU kernel was deprecated as it seems to be used as the maximum value that the possible CPU states can take on. Below its definition, the actual states are declared, with its own definition rounding up the size for, say, an array of such states.

  > <https://github.com/search?q=repo%3Aapple-oss-distributions%2Fxnu%20cpu_state_max&type=code>
- The `SCOPE6_ID_MAX` constant in the XNU kernel has not been deprecated because it does not seem like it is a limit of any sort. There's neither any documentation on it beyond the comment left alongside its definition, which does not imply such use.
- I couldn't get any information on the `SC_SPCM_MAX` constant, because that is declared solely in AIX, and I can't get my hands on any AIX source code.
- I couldn't pinpoint the `PR_SME_VL_LEN_MAX` constant in the glibc repo, but I've decided against its depreaction because of the context that the kernel docs provide on similar constants (apparently related to vectored matrix operations on AArch64.) From my read on some of the sections (especially Section 6,) I believe this constant to be used as the maximum length of the SME vector length. This does not strike me like the type of "limit" we're trying to deprecate.

  > <https://docs.kernel.org/arch/arm64/sme.html>
- After looking into the `IN_CLASSA_MAX` and `IN_CLASSB_MAX` constants in the GNU Hurd, I couldn't find those to be constants that we would want to deprecate, though in this particular instance, I would greatly appreciate if somebody else checked things out.

  > <https://cgit.git.savannah.gnu.org/cgit/hurd/glibc.git/tree/inet/netinet/in.h?h=t/sysvshm#n170>
- I am not sure about deprecating the `__SIGRTMAX` constant in the GNU Hurd. This constant should be deprecated if we follow the same reasoning as explained in one of the above items. But this symbol is documented in the upstream source code as not being something users should call from application code. They should instead use `SIGRTMAX` as defined in `signal.h`. That one definition, though, we do not expose in the `libc` crate. I don't think the solution goes through adding that one constant and immediately deprecating it.

  > <https://cgit.git.savannah.gnu.org/cgit/hurd/glibc.git/tree/bits/signum-generic.h?h=t/sysvshm#n97>
- I couldn't locate the `TCP_COOKIE_MAX` in the GNU Hurd codebase, so I've left it unmodified as I can't quite determine whether it should be deprecated or not without further context, and it does not seem to appear in any other supported target system.
- The `RTLD_DI_MAX` constant got deprecated, even though I couldn't locate it in the GNU Hurd source code, because that one has documentation on the constants that are declared right before it in the Linux manpages. I then assumed that the fact it takes on the largest value of such enum-like constants was enough to represent a "limit" constant prone to SemVer breakage.
- The following Android and Linux constants:
  - `NFQA_CFG_F_MAX`,
  - `__NFT_REG_MAX`,
  - `NFT_MSG_MAX`,
  - `INPUT_PROP_MAX`,
  - `FF_MAX`,
  - `EV_MAX`,
  - `SYN_MAX`,
  - `KEY_MAX`,
  - `REL_MAX`,
  - `ABS_MAX`,
  - `SW_MAX`
  - `MSC_MAX`,
  - `LED_MAX`,
  - `REP_MAX`,
  - `SND_MAX`,
  - `PR_SCHED_CORE_MAX`,
  - `KERN_PIDMAX`,
  - `KERN_NGROUPS_MAX` (no source because it's part of the runtime increasable values in POSIX)
  got deprecated following from the fact each of them are used as trailing enum values for the largest value of the constants whose suffix is not `MAX`.

  > <https://cs.android.com/search?q=NFQA_CFG_F_MAX&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=nft_reg_max&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=nft_msg_max&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=ff_max&sq=&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=input_prop_max&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=ev_max&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=syn_max&sq=&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=key_max&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=rel_max&sq=&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=rel_max&sq=&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=sw_max&sq=&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=msc_max&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=led_max&sq=&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=rep_max&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=rep_max&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=pr_sched_core_max&sq=&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/search?q=kern_pidmax&ss=android%2Fplatform%2Fsuperproject>
- The `PROP_VALUE_MAX` constant in the Android source code did not get deprecated, as that seems to be meant for a limit on the length of some higher-level abstraction (judging by the comments left in the comments alongside it.) A related constant, `PROP_NAME_MAX`, serves a similar purpose and has not been deprecated, but may just be fit for deprecation as the Android sources themselves mention so in an accompanying comment.

  > <https://cs.android.com/search?q=prop_value_max&ss=android%2Fplatform%2Fsuperproject>
  > <https://cs.android.com/android/platform/superproject/+/android-latest-release:bionic/libc/include/sys/system_properties.h;l=116?q=prop_name_max&ss=android%2Fplatform%2Fsuperproject>
- The `KERN_SHMMAX` constant in the Android source tree is likely not meant to be deprecated. Even though not explicitly included among the runtime invariant values specified in POSIX, its use upstream does not seem like that of a "limit" value. If anything, it seems like an Android-speficic extension of constants similar to those specified as runtime invariant in SUS.

  > <https://cs.android.com/search?q=kern_shmmax&sq=&ss=android%2Fplatform%2Fsuperproject>
- The `M_MMAP_MAX` and `M_ARENA_MAX` Linux constants were not found in the Linux source tree, so I have decided against their deprecation. I looked under `include/uapi/linux/personality.h` and didn't find anything. Then I looked into the glibc repo, and could neither find anything.
- The `IFSTATMAX` and `TCP_FUNCTION_NAME_LEN_MAX` constants in the FreeBSD source tree have been deprecated as the comments and context in their upstream definitions mention them as being used for character array sizes in fields of records declared near them. I believe this fits the type of "limit" value we're looking to deprecate.

  > <https://github.com/freebsd/freebsd-src/blob/2fa4bdd7f9e99698a6652db405c3165fdcd41c1d/sys/net/if.h#L550>
  > <https://github.com/freebsd/freebsd-src/blob/2fa4bdd7f9e99698a6652db405c3165fdcd41c1d/sys/netinet/tcp.h#L472>
- The `TCP_BBR_PACE_SEG_MAX` constant in FreeBSD has been left unmodified, because I couldn't find any context nor explanation on its purpose. The source code itself defines it as an unused constant.

  > <https://github.com/freebsd/freebsd-src/blob/2fa4bdd7f9e99698a6652db405c3165fdcd41c1d/sys/netinet/tcp.h#L271>
- The `PRI_MAX` constant in FreeBSD has been deprecated, though I am not very sure of this one. It seems as if the range could change by the comment that precedes it and other related constants, but that may not be the case. One could interpret that the range bound to change is that of idle user threads, but I'm not sure. Outside input on this would be greatly appreciated.

  > <https://github.com/freebsd/freebsd-src/blob/2fa4bdd7f9e99698a6652db405c3165fdcd41c1d/sys/sys/priority.h#L87>
- The `SCTP_PR_SCTP_MAX` and `SCTP_ASSOC_SUPPORTS_MAX` constants in FreeBSD (the former also in Linux) have been deprecated as they are used to denote the largest value among constants defined prior to them in an enum-like manner. This seems to fit the type of "limit" value we are looking to deprecate.

  > <https://github.com/freebsd/freebsd-src/blob/2fa4bdd7f9e99698a6652db405c3165fdcd41c1d/sys/netinet/sctp_uio.h#L262>
  > <https://github.com/freebsd/freebsd-src/blob/2fa4bdd7f9e99698a6652db405c3165fdcd41c1d/sys/netinet/sctp_uio.h#L325>
- The `EAI_MAX` constant in the Newlib tree has been deprecated because it also fits the trailing enum-like largest value mentioned in prior items.

  > <https://github.com/cygwin/cygwin/blob/6926523688bab730ae1b56f24ad6fb203b7350af/newlib/libc/sys/rtems/include/netdb.h#L184>
- The `_PTHREAD_SHARED_SEM_NAME_MAX` constant in VxWorks got deprecated as the comment alongside its declaration implies it is used solely as a limit to character arrays for synchronization utilities. This seems like it fits the type of "limit" we would want to deprecate. Sources can be found in the VxWorks SDK for QEMU on x86_64.
- The `_PARM_NAME_MAX` and `_PARM_PATH_MAX` constants in VxWorks got deprecated because they seem to attempt to replicate the analogous, POSIX-compliant `_POSIX_NAME_MAX` and `_POSIX_PATH_MAX`, but using non-standard-compliant parameters set by them. The POSIX constants don't get deprecated because they're meant to provide a guarantee on the on the lower/upper bound of the constant they're referring, but these VxWorks-specific bounds do not seem to be backed by a standard, so I went ahead and deprecated them. Sources can be found in the downloadable SDKs for QEMU on x86_64.
- Much like in Android (as noted in one of the above items,) the `PR_SCHED_CORE_MAX` constant is used as a trailing maximum value for a set of constants delcared right before it in the Linux kernel's UAPI. This constant has thus been deprecated.

  > <https://github.com/torvalds/linux/blob/f5e5d3509bffb95c6648eb9795f7f236852ae62d/include/uapi/linux/prctl.h#L290>
- I couldn't find the `RT_CLASS_MAX` constant in neither of the Linux nor L4RE upstream repos, but I still decided to deprecate it as in our own sources (the `libc` crate) it appears to be a trailing enum-like value for the largest of some constants defined prior to it.

  > <https://github.com/rust-lang/libc/blob/2364caf83be0f55ead8bd34dfb82cce66a17c387/src/unix/linux_like/linux_l4re_shared.rs#L1368>
- The `SKF_AD_MAX` constant in Linux has been deprecated as is used as trailing enum-like value denoting the largest of the "variants" declared before it.

  > <https://github.com/torvalds/linux/blob/f5e5d3509bffb95c6648eb9795f7f236852ae62d/include/uapi/linux/filter.h#L82>
- The following constants in Linux:
  - `IW_ENCODING_TOKEN_MAX`,
  - `IW_POWER_MAX`,
  - `IW_RETRY_MAX`,
  - `IW_CUSTOM_MAX`,
  - `IW_GENERIC_IE_MAX`,
  - `KERN_RTSIGMAX`,
  - `KERN_SHMMAX`,
  - `KERN_MSGMAX`,
  - `SCHED_FLAG_UTIL_CLAMP_MAX`
  have not been deprecated because they seem to be used as genuine maximum values unlikely to be changed, though I'm judging solely by the comments left alongside them and the overall context in the source code.

  > <https://github.com/torvalds/linux/blob/f5e5d3509bffb95c6648eb9795f7f236852ae62d/include/uapi/linux/wireless.h>
  > <https://github.com/torvalds/linux/blob/f5e5d3509bffb95c6648eb9795f7f236852ae62d/include/uapi/linux/sysctl.h#L109-L112>
  > <https://github.com/search?q=repo%3Atorvalds%2Flinux%20SCHED_FLAG_UTIL_CLAMP_MAX&type=code>
- The `FILNAME_MAX` constant on Illumos has been deprecated as it was used as the array size for a field of a record declared right after it.

  > <https://github.com/illumos/illumos-gate/blob/6f3c184c6edfea99545c770c275f7d8680f05426/usr/src/uts/common/sys/socket.h#L219>
- The `TCP_RTO_MAX` and `PPS_SHIFTMAX` in for Solarish-like systems constants were left undeprecated, as they denote a limit but they don't quite strike me like the types of values that would easily break SemVer.

  > <https://github.com/search?q=repo%3Aillumos%2Fillumos-gate%20TCP_RTO_MAX&type=code>
  > <https://github.com/search?q=repo%3Aillumos%2Fillumos-gate+PPS_SHIFTMAX&type=code>

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated