### PR TITLE
build: add `rust-toolchain.toml` file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
       # Here we use the latest stable Rust toolchain already installed by GitHub
       # Ideally we should run it for every target, but we cannot rely on unstable toolchains
       # due to Clippy not being consistent between them.
-      - run: cargo clippy --workspace --exclude libc-test --exclude ctest-test --all-targets -- -D warnings
+      - run: cargo +stable clippy --workspace --exclude libc-test --exclude ctest-test --all-targets -- -D warnings
 
   # This runs `cargo build --target ...` for all T1 and T2 targets`
   verify_build:
@@ -380,7 +380,7 @@ jobs:
     - name: Install Rust
       run: rustup update "$MSRV" --no-self-update && rustup default "$MSRV"
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-    - run: cargo build -p ctest
+    - run: cargo +"$MSRV" build -p ctest
 
   docs:
     name: Ensure docs build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Rust (rustup)
-        run: rustup update stable --no-self-update && rustup default stable
+        run: rustup update stable --no-self-update && rustup override set stable
       - name: Run release-plz
         uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db # v0.5.129
         env:

--- a/ci/install-rust.sh
+++ b/ci/install-rust.sh
@@ -26,6 +26,7 @@ fi
 rustup set profile minimal
 rustup update --force "$toolchain" --no-self-update
 rustup default "$toolchain"
+rustup override set "$toolchain"
 
 if [ -n "${TARGET:-}" ]; then
     echo "Install target"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
# Description

At present, one is either required to already have the `nightly` toolchain set as default in their
rustup set up, or otherwise configure a manual override with `rustup override set`. This makes it so
that stuff like autoformatting through `rustfmt` fails, as the `.rustfmt.toml` file is configured
with unstable features.

This commit adds a `rust-toolchain.toml` file that makes it so that the user will be reported as
requiring to add the corresponding component when calling, among others, `cargo fmt`, or otherwise
will silently perform the operation by switching to the `nightly` channel.

Because this has some slight consequences to some CI jobs, this patch includes changes there as
well.

Note it may be preferable to also add a list of components to make a single failed `cargo` command
automtically install all components the `libc` crate requires, but I've left that out for the time
being.

## Sources

None

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
