### PR TITLE
vxworks: add `cfg` to definition of `off64_t` and `off_t`

### DIFF
--- a/src/new/vxworks/mod.rs
+++ b/src/new/vxworks/mod.rs
@@ -1,4 +1,7 @@
 //! VxWorks libc.
+//!
+//! VxWorks allows compiling different types of programs. The `libc` crate only
+//! supports RTPs. Refer to the RTP definitions in case of discrepancy.
 // FIXME(vxworks): link to headers needed.
 
 pub(crate) mod unistd;

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -58,7 +58,12 @@ pub type pthread_key_t = c_ulong;
 
 // From b_off_t.h
 pub type off_t = c_longlong;
-pub type off64_t = off_t;
+
+#[deprecated(
+    since = "0.2.187",
+    note = "Kernel mode definitions are unsupported. Use `off_t` instead."
+)]
+pub type off64_t = c_longlong;
 
 // From b_BOOL.h
 pub type BOOL = c_int;
@@ -2412,14 +2417,6 @@ safe_f! {
     pub const fn WSTOPSIG(status: c_int) -> c_int {
         (status >> 16) & 0xFF
     }
-}
-
-pub unsafe fn pread(_fd: c_int, _buf: *mut c_void, _count: size_t, _offset: off64_t) -> ssize_t {
-    -1
-}
-
-pub unsafe fn pwrite(_fd: c_int, _buf: *const c_void, _count: size_t, _offset: off64_t) -> ssize_t {
-    -1
 }
 
 pub unsafe fn posix_memalign(memptr: *mut *mut c_void, align: size_t, size: size_t) -> c_int {


### PR DESCRIPTION
# Description

This PR improves the definition of `off_t`. This applies to targets whose operating system is VxWorks.

The `libc` crate defines `off_t` as a `c_longlong`. This is only correct in programs compiled as RTPs. Programs compiled as VxWorks kernels are different. They expose `off_t` as a `c_long`.

The `off64_` type is not present in RTP processes.

Automatic detection of this does not seem possible in Rust. A specific flag is issued to gcc to expose the feature test macro. This patch adds an equivalent `cfg`. The crate user must manually set it.

Two redundant routines were removed. These are explicitly out of the shipped SDK. It seems like the `libc` crate had polyfills set up. These would always return an error value.

## Sources

- Lines 23-33 of file `sysroot/usr/h/public/base/b_off_t.h`. This was found in the VxWorks downloadable SDK for QEMU x86_64.
- File `usr/3pp/develop/usr/include/python3.9/pyconfig.h`. This was found in the same as SDK as quoted above. This defines certain included features. `pread` and `pwrite` are not defined.

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
