### PR TITLE
TEEOS: Change the definition of `time_t` to `i64`

### DIFF
--- a/src/teeos/mod.rs
+++ b/src/teeos/mod.rs
@@ -41,7 +41,7 @@ pub type pthread_spinlock_t = c_int;
 
 pub type off_t = i64;
 
-pub type time_t = c_long;
+pub type time_t = i64;
 
 pub type clock_t = c_long;
 


### PR DESCRIPTION
# Description

This PR aims to both discuss and (possibly) change the bit-width of the `time_t` type in TEEOS. At present, we expose a single `time_t` type whose bit-width relies on semantics specific to each target system, as `c_long` is likely to be 64-bit wide under platforms following LP64 and 32-bit wide under platforms following LLP64, but there's a few things that lead me to believe this may cause conflicts in TEEOS.

The first issue I would like to address is that if we're exposing the `time_t` definition in the OhOS SDK that TEEOS uses, our current definition is not completely correct. SDKs for all three of Darwin, Linux and Windows use the same definition as musl; Namely, `typedef _Int64 time_t`. In `libc`, though, we expose it as a `c_long`.

Just to be sure, though, I then looked at the TEEOS upstream kernel repo, and they define `time_t` in terms of either one of a 32-bit unsigned integer or a 64-bit unsigned integer, depending on the machine's word size. That implies this target OS likely supports running on both such types of machines, which means that our current definition is sort of OK on the bitwidth side but not on the signed integer side.

The proposed change in this PR switches the type to be an explicit 64-bit signed integer, though this has not taken into account the definition in the TEEOS kernel. That's why I would like to spark some discussion on this, or otherwise call it a day and learn something new.

## Sources

- A regex search through the downloadable OhOS SDK shows that all type definitions accross architectures follow musl's. For reference, I ran `ripgrep` across the SDKs for Darwin, Linux and Windows with the following command:

  > ```sh
  > rg -g "**/alltypes.h" -e "\btime_t\b"
  > ```

  I also ran it by more generally scoping the search to header files, but relevant results were the same.
- TEEOS kernel sources defining `time_t` as an unsigned integer.

  > <https://github.com/openharmony/tee_tee_os_kernel/blob/fc85968fa01f6503997a50f09f1fc11e832860d9/kernel/include/common/types.h#L50>

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI
