### PR TITLE
Fix constants accidentally removed for Linux uClibc targets

### DIFF
--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -805,11 +805,11 @@ pub const IP_TRANSPARENT: c_int = 19;
 pub const IP_ORIGDSTADDR: c_int = 20;
 pub const IP_RECVORIGDSTADDR: c_int = IP_ORIGDSTADDR;
 pub const IP_MINTTL: c_int = 21;
-#[cfg(not(target_env = "uclibc"))]
+#[cfg(not(all(target_os = "l4re", target_env = "uclibc")))]
 pub const IP_NODEFRAG: c_int = 22;
-#[cfg(not(target_env = "uclibc"))]
+#[cfg(not(all(target_os = "l4re", target_env = "uclibc")))]
 pub const IP_CHECKSUM: c_int = 23;
-#[cfg(not(target_env = "uclibc"))]
+#[cfg(not(all(target_os = "l4re", target_env = "uclibc")))]
 pub const IP_BIND_ADDRESS_NO_PORT: c_int = 24;
 pub const IP_MULTICAST_IF: c_int = 32;
 pub const IP_MULTICAST_TTL: c_int = 33;
@@ -831,9 +831,9 @@ pub const IP_PMTUDISC_DONT: c_int = 0;
 pub const IP_PMTUDISC_WANT: c_int = 1;
 pub const IP_PMTUDISC_DO: c_int = 2;
 pub const IP_PMTUDISC_PROBE: c_int = 3;
-#[cfg(not(target_env = "uclibc"))]
+#[cfg(not(all(target_os = "l4re", target_env = "uclibc")))]
 pub const IP_PMTUDISC_INTERFACE: c_int = 4;
-#[cfg(not(target_env = "uclibc"))]
+#[cfg(not(all(target_os = "l4re", target_env = "uclibc")))]
 pub const IP_PMTUDISC_OMIT: c_int = 5;
 
 // IPPROTO_IP defined in src/unix/mod.rs
@@ -943,16 +943,16 @@ pub const IPV6_RECVRTHDR: c_int = 56;
 pub const IPV6_RTHDR: c_int = 57;
 pub const IPV6_RECVDSTOPTS: c_int = 58;
 pub const IPV6_DSTOPTS: c_int = 59;
-#[cfg(not(target_env = "uclibc"))]
+#[cfg(not(all(target_os = "l4re", target_env = "uclibc")))]
 pub const IPV6_RECVPATHMTU: c_int = 60;
-#[cfg(not(target_env = "uclibc"))]
+#[cfg(not(all(target_os = "l4re", target_env = "uclibc")))]
 pub const IPV6_PATHMTU: c_int = 61;
-#[cfg(not(target_env = "uclibc"))]
+#[cfg(not(all(target_os = "l4re", target_env = "uclibc")))]
 pub const IPV6_DONTFRAG: c_int = 62;
 pub const IPV6_RECVTCLASS: c_int = 66;
 pub const IPV6_TCLASS: c_int = 67;
 cfg_if! {
-    if #[cfg(not(target_env = "uclibc"))] {
+    if #[cfg(not(all(target_os = "l4re", target_env = "uclibc")))] {
         pub const IPV6_AUTOFLOWLABEL: c_int = 70;
         pub const IPV6_ADDR_PREFERENCES: c_int = 72;
         pub const IPV6_MINHOPCOUNT: c_int = 73;
@@ -1220,7 +1220,7 @@ pub const __WALL: c_int = 0x40000000;
 pub const __WCLONE: c_int = 0x80000000;
 
 cfg_if! {
-    if #[cfg(not(target_env = "uclibc"))] {
+    if #[cfg(not(all(target_os = "l4re", target_env = "uclibc")))] {
         pub const SPLICE_F_MOVE: c_uint = 0x01;
         pub const SPLICE_F_NONBLOCK: c_uint = 0x02;
         pub const SPLICE_F_MORE: c_uint = 0x04;


### PR DESCRIPTION
# Description

This PR fixes constants that were, probably accidentally, removed by commit 2fe1d91 for uClibc in all operating systems. However, based on the commit message, the commit was supposed to fix things for L4Re, not break things for other operating systems.

So this PR limits the uClibc exclusions introduced in 2fe1d91 to apply only if the target OS is L4Re. This also fixes rust-lang/libc#5140.

# Sources

I believe no links to sources are necessary here. The affected constants were previously available for all linux-like operating systems and environments. This PR simply reverts things to the previous state for all operating systems except L4Re.

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI

# Notes

There was nothing to update in `libc-test/semver`. The constants are already present in `linux.txt`.

I'm unable to run the tests locally though. After building custom `rustc` and `rust-std` for `armv7-unknown-linux-uclibceabihf`, I'm able to initiate the build of `libc-test` but it fails because the following header files are missing in my case:

* `linux/can/j1939.h`
* `linux/mount.h`
* `linux/openat2.h`

I guess they require a more up to date Linux headers then I currently have in my toolchain. When I comment out the header files, I get a ton of missing symbol errors. I'll try to re-run the test with a more recent toolchain.

@rustbot label +stable-nominated