### PR TITLE
emscripten: deprecate file offset types

### DIFF
--- a/libc-test/semver/emscripten.txt
+++ b/libc-test/semver/emscripten.txt
@@ -7,4 +7,3 @@ getgrnam_r
 getpwnam_r
 getpwuid_r
 in6_pktinfo
-posix_fallocate64

--- a/libc-test/semver/emscripten.txt
+++ b/libc-test/semver/emscripten.txt
@@ -8,4 +8,3 @@ getgrnam_r
 getpwnam_r
 getpwuid_r
 in6_pktinfo
-posix_fallocate64

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -28,19 +28,38 @@ pub type fsfilcnt_t = u32;
 pub type rlim_t = u64;
 pub type nlink_t = u32;
 
-pub type ino64_t = crate::ino_t;
+#[deprecated(since = "0.2.187", note = "Use `ino_t` instead. See #5142.")]
+pub type ino64_t = ino_t;
+
+#[deprecated(since = "0.2.187", note = "Use `off_t` instead. See #5142.")]
 pub type off64_t = off_t;
+
+#[deprecated(since = "0.2.187", note = "Use `blkcnt_t` instead. See #5142.")]
 pub type blkcnt64_t = crate::blkcnt_t;
+
+#[deprecated(since = "0.2.187", note = "Use `rlim_t` instead. See #5142.")]
 pub type rlim64_t = crate::rlim_t;
 
+#[deprecated(since = "0.2.187", note = "Use `rlimit` instead. See #5142.")]
 pub type rlimit64 = crate::rlimit;
+
+#[deprecated(since = "0.2.187", note = "Use `flock` instead. See #5142.")]
 pub type flock64 = crate::flock;
+
+#[deprecated(since = "0.2.187", note = "Use `stat` instead. See #5142.")]
 pub type stat64 = crate::stat;
+
+#[deprecated(since = "0.2.187", note = "Use `statfs` instead. See #5142.")]
 pub type statfs64 = crate::statfs;
+
+#[deprecated(since = "0.2.187", note = "Use `statvfs` instead. See #5142.")]
 pub type statvfs64 = crate::statvfs;
+
+#[deprecated(since = "0.2.187", note = "Use `dirent` instead. See #5142.")]
 pub type dirent64 = crate::dirent;
 
 extern_ty! {
+    #[deprecated(since = "0.2.187", note = "Use `fpos_t` instead. See #5142.")]
     pub type fpos64_t; // FIXME(emscripten): fill this out with a struct
 }
 
@@ -1461,5 +1480,16 @@ extern "C" {
 }
 
 // Alias <foo> to <foo>64 to mimic glibc's LFS64 support
+#[deprecated(
+    since = "0.2.187",
+    note = "Use \"64\"-unsuffixed routines instead. See #5142."
+)]
+#[allow(deprecated)]
 mod lfs64;
+
+#[deprecated(
+    since = "0.2.187",
+    note = "Use \"64\"-unsuffixed routines instead. See #5142."
+)]
+#[allow(deprecated)]
 pub use self::lfs64::*;

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -28,20 +28,39 @@ pub type fsfilcnt_t = u32;
 pub type rlim_t = u64;
 pub type nlink_t = u32;
 
-pub type ino64_t = crate::ino_t;
-pub type off64_t = off_t;
-pub type blkcnt64_t = crate::blkcnt_t;
-pub type rlim64_t = crate::rlim_t;
+// FIXME(1.0,deprecate): lfs binding to be removed
+pub type ino64_t = ino_t;
 
+// FIXME(1.0,deprecate): lfs binding to be removed
+pub type off64_t = off_t;
+
+//FIXME(1.0,deprecate): lfs binding to be removed
+pub type blkcnt64_t = blkcnt_t;
+
+//FIXME(1.0,deprecate): lfs binding to be removed
+pub type rlim64_t = rlim_t;
+
+//FIXME(1.0,deprecate): lfs binding to be removed
 pub type rlimit64 = crate::rlimit;
-pub type flock64 = crate::flock;
-pub type stat64 = crate::stat;
-pub type statfs64 = crate::statfs;
-pub type statvfs64 = crate::statvfs;
-pub type dirent64 = crate::dirent;
+
+//FIXME(1.0,deprecate): lfs binding to be removed
+pub type flock64 = flock;
+
+//FIXME(1.0,deprecate): lfs binding to be removed
+pub type stat64 = stat;
+
+//FIXME(1.0,deprecate): lfs binding to be removed
+pub type statfs64 = statfs;
+
+//FIXME(1.0,deprecate): lfs binding to be removed
+pub type statvfs64 = statvfs;
+
+//FIXME(1.0,deprecate): lfs binding to be removed
+pub type dirent64 = dirent;
 
 extern_ty! {
-    pub type fpos64_t; // FIXME(emscripten): fill this out with a struct
+    //FIXME(1.0,deprecate): lfs binding to be removed
+    pub type fpos64_t;
 }
 
 s! {
@@ -1466,4 +1485,6 @@ extern "C" {
 
 // Alias <foo> to <foo>64 to mimic glibc's LFS64 support
 mod lfs64;
+
+// FIXME(1.0,deprecate): lfs bindings to be removed
 pub use self::lfs64::*;

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -544,6 +544,7 @@ cfg_if! {
     if #[cfg(target_os = "android")] {
         pub const RLIM64_INFINITY: c_ulonglong = !0;
     } else {
+        #[cfg_attr(target_os = "emscripten", allow(deprecated))]
         pub const RLIM64_INFINITY: crate::rlim64_t = !0;
     }
 }


### PR DESCRIPTION
# Description

This PR deprecates all LFS64 types and routines in emscripten. This target follows quite closely the musl upstream. The changes they make are not concerned with file offset types. The only exception to this is the `blkcnt_t` type. This type is always 32-bits wide no matter the target machine.

All other types have received the same treatment as in rust-lang/libc#5170.

## Sources

- Upstream emscripten sources showing both the final `alltypes.h` header with the `off_t` definition and the input to the `sed` script that generates it.

  > <https://github.com/emscripten-core/emscripten/blob/1637a13961ab1d6f9595db4db26bfc16a68e6ad8/system/lib/libc/musl/arch/emscripten/bits/alltypes.h#L221>
  > <https://github.com/emscripten-core/musl/blob/85e0e3519655220688e757b9d5bfd314923548bd/include/alltypes.h.in#L29>

- Upstream emscripten fork of musl showing what has been assumed to be the "main" definition of `off64_t` and related types when both the `_GNU_SOURCE` and `_LARGEFILE64_SOURCE` feature test
  macros are present.

  > <https://github.com/emscripten-core/musl/blob/85e0e3519655220688e757b9d5bfd314923548bd/include/sys/types.h#L79>

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI
