### PR TITLE
linux(uclibc): move definition of `time_t`

### DIFF
--- a/src/unix/linux_like/linux/uclibc/arm/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/arm/mod.rs
@@ -3,17 +3,6 @@ use crate::prelude::*;
 
 pub type wchar_t = c_uint;
 
-cfg_if! {
-    // Set cfg(libc_unstable_uclibc_time64) in rustflags if your uclibc has 64-bit time
-    if #[cfg(linux_time_bits64)] {
-        pub type time_t = c_longlong;
-        pub type suseconds_t = c_longlong;
-    } else {
-        pub type time_t = c_long;
-        pub type suseconds_t = c_long;
-    }
-}
-
 pub type clock_t = c_long;
 pub type fsblkcnt_t = c_ulong;
 pub type fsfilcnt_t = c_ulong;

--- a/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
@@ -2,8 +2,6 @@ use crate::off64_t;
 use crate::prelude::*;
 
 pub type clock_t = i32;
-pub type time_t = i32;
-pub type suseconds_t = i32;
 pub type wchar_t = i32;
 pub type off_t = i32;
 pub type ino_t = u32;

--- a/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
@@ -8,8 +8,6 @@ pub type fsfilcnt_t = c_ulong;
 pub type ino_t = u64;
 pub type nlink_t = u64;
 pub type off_t = i64;
-pub type suseconds_t = i64;
-pub type time_t = i64;
 pub type wchar_t = i32;
 
 s! {

--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -13,6 +13,17 @@ pub type __rlimit_resource_t = c_ulong;
 pub type __priority_which_t = c_uint;
 
 cfg_if! {
+    // Set `--cfg=libc_unstable_uclibc_time64` in RUSTFLAGS if your uClibc has 64-bit `time_t`.
+    if #[cfg(linux_time_bits64)] {
+        pub type time_t = i64;
+        pub type suseconds_t = i64;
+    } else {
+        pub type time_t = c_long;
+        pub type suseconds_t = c_long;
+    }
+}
+
+cfg_if! {
     if #[cfg(doc)] {
         // Used in `linux::arch` to define ioctl constants.
         pub(crate) type Ioctl = c_ulong;

--- a/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
@@ -14,8 +14,6 @@ pub type nlink_t = c_uint;
 pub type off_t = c_long;
 // [uClibc docs] Note stat64 has the same shape as stat for x86-64.
 pub type stat64 = stat;
-pub type suseconds_t = c_long;
-pub type time_t = c_int;
 pub type wchar_t = c_int;
 pub type pthread_t = c_ulong;
 


### PR DESCRIPTION
# Description

This PR extends the changes in rust-lang/libc#5046 to the entirety of the `uclibc` module.

That patch introduced a `cfg` option for compatibility with the uClibc build option to get a 64-bit `time_t`. In that patch, though, the option was only used in 32-bit arm targets.

This patch extends that to all uClibc targets. The "configuration" macro upstream is meant for all targets, irrespective of machine word size.

## Sources

- Upstream uclibc-ng sources showing the `types.h` header with the definition of the type that `time_t` is defined as and the fragment from which that "nested" defintion stems from. Note the comment above the latter source below, where some developer left a note on the explicit GCC "bit-width configurations" uclibc-ng supports.

  > <https://gogs.waldemar-brodkorb.de/oss/uclibc-ng/src/master/libc/sysdeps/linux/common/bits/types.h#L152>
  > <https://gogs.waldemar-brodkorb.de/oss/uclibc-ng/src/master/libc/sysdeps/linux/common/bits/types.h#L102-L128>
- Upstream uclibc-ng sources showing the use of the `__UCLIBC_USE_TIME64__` macro to ensure the type of the type with which `time_t` is ultimately defined is either 64 bits or a C `long`.

  > <https://gogs.waldemar-brodkorb.de/oss/uclibc-ng/src/master/libc/sysdeps/linux/common/bits/typesizes.h#L50-L54>

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI
