### PR TITLE
ctest: probe optional compiler flags

### DIFF
--- a/ctest/src/generator.rs
+++ b/ctest/src/generator.rs
@@ -62,6 +62,7 @@ pub struct TestGenerator {
     pub(crate) includes: Vec<PathBuf>,
     out_dir: Option<PathBuf>,
     pub(crate) flags: Vec<String>,
+    pub(crate) flags_if_supported: Vec<String>,
     pub(crate) global_defines: Vec<(String, Option<String>)>,
     cfg: Vec<(String, Option<String>)>,
     mapped_names: Vec<MappedName>,
@@ -667,6 +668,15 @@ impl TestGenerator {
     /// ```
     pub fn flag(&mut self, flag: &str) -> &mut Self {
         self.flags.push(flag.to_string());
+        self
+    }
+
+    /// Add a flag to the C compiler invocation if the compiler supports it.
+    ///
+    /// This is useful for warning suppressions that are only available on some
+    /// compiler families or versions.
+    pub fn flag_if_supported(&mut self, flag: &str) -> &mut Self {
+        self.flags_if_supported.push(flag.to_string());
         self
     }
 

--- a/ctest/src/runner.rs
+++ b/ctest/src/runner.rs
@@ -38,6 +38,7 @@ pub fn generate_test(
     let mut cfg = cc::Build::new();
     cfg.file(output_file_path.with_extension(generator.language.extension()));
     cfg.host(&host);
+    cfg.target(&target);
 
     if target.contains("msvc") {
         cfg.flag("/W3")
@@ -63,10 +64,12 @@ pub fn generate_test(
             .flag("-Werror")
             .flag("-Wno-unused-parameter")
             .flag("-Wno-type-limits")
-            // allow taking address of packed struct members:
-            .flag("-Wno-address-of-packed-member")
-            .flag("-Wno-unknown-warning-option")
-            .flag("-Wno-deprecated-declarations"); // allow deprecated items
+            .flag("-Wno-deprecated-declarations") // allow deprecated items
+            // Probe support instead of assuming a compiler family. This keeps
+            // the suppression on newer GCC/Clang while avoiding regressions on
+            // older toolchains that reject these flags.
+            .flag_if_supported("-Wno-address-of-packed-member")
+            .flag_if_supported("-Wno-unknown-warning-option");
     }
 
     for p in &generator.includes {
@@ -77,6 +80,10 @@ pub fn generate_test(
         cfg.flag(flag);
     }
 
+    for flag in &generator.flags_if_supported {
+        cfg.flag_if_supported(flag);
+    }
+
     for (k, v) in &generator.global_defines {
         cfg.define(k, v.as_ref().map(|s| &s[..]));
     }
@@ -84,8 +91,7 @@ pub fn generate_test(
     cfg.cpp(matches!(generator.language, Language::CXX));
 
     let stem: &str = output_file_path.file_stem().unwrap().to_str().unwrap();
-    cfg.target(&target)
-        .out_dir(output_file_path.parent().unwrap())
+    cfg.out_dir(output_file_path.parent().unwrap())
         .compile(stem);
 
     Ok(output_file_path)


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

Add `TestGenerator::flag_if_supported` so ctest callers can request C compiler flags that should only be passed when the selected compiler supports them.

This also changes ctest’s built-in warning suppressions for `-Wno-address-of-packed-member` and `-Wno-unknown-warning-option` to use `cc::Build::flag_if_supported`. Some older toolchains (e.g. the default one on dragonfly) reject them when `-Werror` is enabled.

The generated test compiler setup now sets the target before probing flags, so support checks use the same target configuration as the actual compile.

# Sources

Not applicable.

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
