### PR TITLE
emscripten: fix pthread type sizes for wasm64 (MEMORY64)

### DIFF
--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -188,7 +188,8 @@ s! {
     }
 
     pub struct pthread_attr_t {
-        __size: [u32; 11],
+        // 11 pointer-width words: 44 bytes on wasm32, 88 on wasm64 (MEMORY64).
+        __size: [usize; 11],
     }
 
     pub struct sigset_t {
@@ -1064,8 +1065,14 @@ pub const SO_RXQ_OVFL: c_int = 40;
 pub const SO_PEEK_OFF: c_int = 42;
 pub const SO_BUSY_POLL: c_int = 46;
 
+#[cfg(target_pointer_width = "32")]
 pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 32;
+#[cfg(target_pointer_width = "64")]
+pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 56;
+#[cfg(target_pointer_width = "32")]
 pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 24;
+#[cfg(target_pointer_width = "64")]
+pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
 
 pub const O_DIRECT: c_int = 0x4000;
 pub const O_DIRECTORY: c_int = 0x10000;


### PR DESCRIPTION
On `wasm64-unknown-emscripten` (MEMORY64) several pthread types are larger than
the hardcoded wasm32 sizes used here, so `pthread_attr_init` overruns the
`pthread_attr_t` that `std` stack-allocates in `Thread::new`, corrupting the
result and making `std::thread::spawn` fail with a spurious error. This makes
the affected sizes pointer-width-aware.

The numbers are `sizeof()` from emscripten's own headers, compiled both ways:

```c
#include <pthread.h>
#include <stdio.h>
int main(void) {
    printf("attr=%zu mutex=%zu rwlock=%zu cond=%zu\n",
           sizeof(pthread_attr_t), sizeof(pthread_mutex_t),
           sizeof(pthread_rwlock_t), sizeof(pthread_cond_t));
}
```

```
emcc              -> attr=44 mutex=24 rwlock=32 cond=48
emcc -sMEMORY64=1 -> attr=88 mutex=40 rwlock=56 cond=48
```

- `pthread_attr_t` is exactly 11 pointer-width words (`44 = 11·4`, `88 = 11·8`),
  so `[usize; 11]` matches both with no `cfg` — and is identical to the previous
  `[u32; 11]` on wasm32.
- `pthread_mutex_t` / `pthread_rwlock_t` aren't a fixed multiple of the pointer
  width (musl sizes them as `int __i[N]` with a different `N` per width), so they
  need explicit per-width values.
- `pthread_cond_t` (48) and `pthread_t = c_ulong` (4/8 bytes) are already correct.

Found while bringing up `wasm64-unknown-emscripten` downstream (custom target
spec + `-Zbuild-std`): with the wasm32 sizes, `pthread_create` reports success at
the emscripten layer but `std` reads a corrupted result and panics
`failed to spawn thread`, so threads can't be spawned at all.

There's no `wasm64-unknown-emscripten` job in CI (it isn't a built-in target), so
this isn't exercised by `libc-test`; the sizes above are reproducible with the
snippet.