### PR TITLE
unix: add preadv2 and pwritev2 to android

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2403,7 +2403,13 @@ fn test_android(target: &str) {
             "SOF_TIMESTAMPING_OPT_RX_FILTER" => true,
 
             // FIXME(android): Requires >= 6.9 kernel headers.
-            "AT_HWCAP3" | "AT_HWCAP4" => true,
+            "AT_HWCAP3" | "AT_HWCAP4" | "RWF_NOAPPEND" => true,
+
+            // FIXME(android): Requires >= 6.11 kernel headers.
+            "RWF_ATOMIC" => true,
+
+            // FIXME(android): Requires >= 6.14 kernel headers.
+            "RWF_DONTCACHE" => true,
 
             _ => false,
         }
@@ -2436,6 +2442,9 @@ fn test_android(target: &str) {
 
             // Added in API level 30, but tests use level 28.
             "memfd_create" | "mlock2" | "renameat2" | "statx" | "statx_timestamp" => true,
+
+            // Added in API level 33, but tests use level 28.
+            "preadv2" | "pwritev2" => true,
 
             // Added in glibc 2.25.
             "getentropy" => true,

--- a/libc-test/semver/android.txt
+++ b/libc-test/semver/android.txt
@@ -2364,6 +2364,14 @@ RT_TABLE_MAIN
 RT_TABLE_UNSPEC
 RUSAGE_CHILDREN
 RUSAGE_SELF
+RWF_APPEND
+RWF_ATOMIC
+RWF_DONTCACHE
+RWF_DSYNC
+RWF_HIPRI
+RWF_NOAPPEND
+RWF_NOWAIT
+RWF_SYNC
 R_OK
 SA_NOCLDSTOP
 SA_NOCLDWAIT
@@ -3770,6 +3778,7 @@ prctl
 pread
 pread64
 preadv
+preadv2
 preadv64
 printf
 prlimit
@@ -3873,6 +3882,7 @@ puts
 pwrite
 pwrite64
 pwritev
+pwritev2
 pwritev64
 qsort
 raise

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -3404,6 +3404,16 @@ pub const AT_MINSIGSTKSZ: c_ulong = 51;
 pub const SI_DETHREAD: c_int = -7;
 pub const TRAP_PERF: c_int = 6;
 
+// Flags for preadv2/pwritev2
+pub const RWF_HIPRI: c_int = 0x00000001;
+pub const RWF_DSYNC: c_int = 0x00000002;
+pub const RWF_SYNC: c_int = 0x00000004;
+pub const RWF_NOWAIT: c_int = 0x00000008;
+pub const RWF_APPEND: c_int = 0x00000010;
+pub const RWF_NOAPPEND: c_int = 0x00000020;
+pub const RWF_ATOMIC: c_int = 0x00000040;
+pub const RWF_DONTCACHE: c_int = 0x00000080;
+
 // Most `*_SUPER_MAGIC` constants are defined at the `linux_like` level; the
 // following are only available on newer Linux versions than the versions
 // currently used in CI in some configurations, so we define them here.
@@ -3878,6 +3888,20 @@ extern "C" {
         newpath: *const c_char,
         flags: c_uint,
     ) -> c_int;
+    pub fn preadv2(
+        fd: c_int,
+        iov: *const crate::iovec,
+        iovcnt: c_int,
+        offset: off_t,
+        flags: c_int,
+    ) -> ssize_t;
+    pub fn pwritev2(
+        fd: c_int,
+        iov: *const crate::iovec,
+        iovcnt: c_int,
+        offset: off_t,
+        flags: c_int,
+    ) -> ssize_t;
 }
 
 cfg_if! {


### PR DESCRIPTION
Add preadv2 and pwrite2 to linux and Android, making majority of linux_like based systems have support, to allow using the new flags introduced in https://github.com/rust-lang/libc/pull/4452. Move definitions to linux_like/mod.rs instead of each separate system alone.

- [X] Relevant tests in `libc-test/semver` have been updated - no tests to modify
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [~] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

Getting error while testing locally due to different linux version and mismatch of SW_MAX and MS_NOUSER. Modifying those to match local system (0x11 and 0x80000000) shows passing tests using `cargo test`.

Unable to test other systems, need to run CI

Android source for preadv2 and pwritev2 support: https://android.googlesource.com/platform/bionic/+/cf59e19e22fc7c4795fd955eeecd1f457d79eba0/libc/include/sys/uio.h#117

<!-- @rustbot label +stable-nominated -->
