### PR TITLE
android: Add getpwent/setpwent/endpwent

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2232,6 +2232,9 @@ fn test_android(target: &str) {
             "endgrent" => true,
 
             // Added in API level 26, but some tests use level 24.
+            "getpwent" | "setpwent" | "endpwent" => true,
+
+            // Added in API level 26, but some tests use level 24.
             "getdomainname" | "setdomainname" => true,
 
             // FIXME(android): bad function pointers:

--- a/libc-test/semver/android.txt
+++ b/libc-test/semver/android.txt
@@ -3437,6 +3437,7 @@ dup
 dup2
 duplocale
 endgrent
+endpwent
 endservent
 epoll_create
 epoll_create1
@@ -3568,6 +3569,7 @@ getppid
 getpriority
 getprotobyname
 getprotobynumber
+getpwent
 getpwnam
 getpwnam_r
 getpwuid
@@ -3955,6 +3957,7 @@ setlogmask
 setns
 setpgid
 setpriority
+setpwent
 setregid
 setresgid
 setresuid

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -3381,6 +3381,9 @@ safe_f! {
 }
 
 extern "C" {
+    pub fn setpwent();
+    pub fn endpwent();
+    pub fn getpwent() -> *mut passwd;
     pub fn setgrent();
     pub fn endgrent();
     pub fn getgrent() -> *mut crate::group;


### PR DESCRIPTION
Closes rust-lang/libc#3014
Supersedes rust-lang/libc#3015

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

This pull request adds support for `getpwent`, `setpwent` and `endpwent` for Android targets. I have no idea how to gate them behind API >= 26, and previous PR didn't do this either so I assume it's fine

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->
https://cs.android.com/android/platform/superproject/main/+/main:bionic/libc/include/pwd.h;l=89;drc=02ce401d1e2b31586c94c8b6999364bbbce27388

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

Tried testing locally on `x86_64-unknown-linux-gnu` (NixOS) host with:
- [cross (git)](https://github.com/cross-rs/cross), `cross test --target aarch64-linux-android` (NDK r25b, API 28, Android 9.0.0_r1, from their a bit dated [Dockerfile](https://github.com/cross-rs/cross/blob/29d00c7803f221f1b3f35e561b03792368fb8339/docker/Dockerfile.aarch64-linux-android#L17)): failed to compile, errors on `IFF_NO_CARRIER`, `TUN_F_*`, `PR_*` and several others.
- `cargo zigbuild --tests --target aarch64-linux-android` (zig 0.16.0): failed due to missing include `sys/param.h`

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:
-->
@rustbot label +stable-nominated

