### PR TITLE
linux: enable MFD_* constants on Linux uClibc targets

### DIFF
--- a/src/unix/linux_like/linux_l4re_shared.rs
+++ b/src/unix/linux_like/linux_l4re_shared.rs
@@ -1197,7 +1197,7 @@ pub const MFD_CLOEXEC: c_uint = 0x0001;
 pub const MFD_ALLOW_SEALING: c_uint = 0x0002;
 pub const MFD_HUGETLB: c_uint = 0x0004;
 cfg_if! {
-    if #[cfg(not(target_env = "uclibc"))] {
+    if #[cfg(not(all(target_os = "l4re", target_env = "uclibc")))] {
         pub const MFD_NOEXEC_SEAL: c_uint = 0x0008;
         pub const MFD_EXEC: c_uint = 0x0010;
         pub const MFD_HUGE_64KB: c_uint = 0x40000000;


### PR DESCRIPTION
Closes rust-lang/libc#5163

## What

Restrict the `not(target_env = "uclibc")` gate on the `MFD_*` block in
`src/unix/linux_like/linux_l4re_shared.rs` to
`not(all(target_os = "l4re", target_env = "uclibc"))`, so the `MFD_HUGE_*`,
`MFD_NOEXEC_SEAL` and `MFD_EXEC` constants are available on **Linux** uClibc
targets (e.g. `armv7-unknown-linux-uclibceabihf`).

## Why

These flags come from the kernel UAPI header `<linux/memfd.h>` and are valid on
Linux regardless of the C library, but the whole block was gated out for every
uClibc target. As a result crates that reference them fail to cross-compile for
Linux uClibc targets — e.g. `nix`'s `memfd` module uses `libc::MFD_HUGE_*`.

This mirrors the fix already applied to the `IP_`/`IPV6_` block in rust-lang/libc#5141
(issue rust-lang/libc#5140): the constants stay disabled only for the non-Linux
`x86_64-unknown-l4re-uclibc` target and are enabled for the Linux uClibc
targets. `linux_l4re_shared.rs` is compiled only for `target_os = "linux"` and
`target_os = "l4re"`, so the predicate covers exactly those two cases.

## Notes

The block also contains the newer `MFD_NOEXEC_SEAL` / `MFD_EXEC` (Linux 6.3+).
Like the newer `IPV6_*` constants enabled in rust-lang/libc#5141, these are kernel ABI
constants and are defined independently of a given uClibc's header vintage.
Happy to split the `cfg_if` to enable only `MFD_HUGE_*` if that is preferred.
