### PR TITLE
fix: remove conflicting items in L4Re uClibc

### DIFF
--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -297,64 +297,6 @@ pub const ENOTSUP: c_int = EOPNOTSUPP;
 pub const IPV6_JOIN_GROUP: c_int = 20;
 pub const IPV6_LEAVE_GROUP: c_int = 21;
 
-// These are different from GNU
-pub const ABDAY_1: crate::nl_item = 0x300;
-pub const ABDAY_2: crate::nl_item = 0x301;
-pub const ABDAY_3: crate::nl_item = 0x302;
-pub const ABDAY_4: crate::nl_item = 0x303;
-pub const ABDAY_5: crate::nl_item = 0x304;
-pub const ABDAY_6: crate::nl_item = 0x305;
-pub const ABDAY_7: crate::nl_item = 0x306;
-pub const DAY_1: crate::nl_item = 0x307;
-pub const DAY_2: crate::nl_item = 0x308;
-pub const DAY_3: crate::nl_item = 0x309;
-pub const DAY_4: crate::nl_item = 0x30A;
-pub const DAY_5: crate::nl_item = 0x30B;
-pub const DAY_6: crate::nl_item = 0x30C;
-pub const DAY_7: crate::nl_item = 0x30D;
-pub const ABMON_1: crate::nl_item = 0x30E;
-pub const ABMON_2: crate::nl_item = 0x30F;
-pub const ABMON_3: crate::nl_item = 0x310;
-pub const ABMON_4: crate::nl_item = 0x311;
-pub const ABMON_5: crate::nl_item = 0x312;
-pub const ABMON_6: crate::nl_item = 0x313;
-pub const ABMON_7: crate::nl_item = 0x314;
-pub const ABMON_8: crate::nl_item = 0x315;
-pub const ABMON_9: crate::nl_item = 0x316;
-pub const ABMON_10: crate::nl_item = 0x317;
-pub const ABMON_11: crate::nl_item = 0x318;
-pub const ABMON_12: crate::nl_item = 0x319;
-pub const MON_1: crate::nl_item = 0x31A;
-pub const MON_2: crate::nl_item = 0x31B;
-pub const MON_3: crate::nl_item = 0x31C;
-pub const MON_4: crate::nl_item = 0x31D;
-pub const MON_5: crate::nl_item = 0x31E;
-pub const MON_6: crate::nl_item = 0x31F;
-pub const MON_7: crate::nl_item = 0x320;
-pub const MON_8: crate::nl_item = 0x321;
-pub const MON_9: crate::nl_item = 0x322;
-pub const MON_10: crate::nl_item = 0x323;
-pub const MON_11: crate::nl_item = 0x324;
-pub const MON_12: crate::nl_item = 0x325;
-pub const AM_STR: crate::nl_item = 0x326;
-pub const PM_STR: crate::nl_item = 0x327;
-pub const D_T_FMT: crate::nl_item = 0x328;
-pub const D_FMT: crate::nl_item = 0x329;
-pub const T_FMT: crate::nl_item = 0x32A;
-pub const T_FMT_AMPM: crate::nl_item = 0x32B;
-pub const ERA: crate::nl_item = 0x32C;
-pub const ERA_D_FMT: crate::nl_item = 0x32E;
-pub const ALT_DIGITS: crate::nl_item = 0x32F;
-pub const ERA_D_T_FMT: crate::nl_item = 0x330;
-pub const ERA_T_FMT: crate::nl_item = 0x331;
-pub const CODESET: crate::nl_item = 10;
-pub const CRNCYSTR: crate::nl_item = 0x215;
-pub const RADIXCHAR: crate::nl_item = 0x100;
-pub const THOUSEP: crate::nl_item = 0x101;
-pub const NOEXPR: crate::nl_item = 0x501;
-pub const YESSTR: crate::nl_item = 0x502;
-pub const NOSTR: crate::nl_item = 0x503;
-
 // Different than Gnu.
 pub const FILENAME_MAX: c_uint = 4095;
 
@@ -418,7 +360,6 @@ pub const SOCK_PACKET: c_int = 10;
 pub const TCP_COOKIE_TRANSACTIONS: c_int = 15;
 pub const UDP_GRO: c_int = 104;
 pub const UDP_SEGMENT: c_int = 103;
-pub const YESEXPR: c_int = ((5) << 8) | (0);
 
 extern "C" {
     pub fn gettimeofday(tp: *mut crate::timeval, tz: *mut crate::timezone) -> c_int;

--- a/src/unix/linux_like/linux_l4re_shared.rs
+++ b/src/unix/linux_like/linux_l4re_shared.rs
@@ -455,7 +455,7 @@ cfg_if! {
         pub const YESSTR: crate::nl_item = 0x50002;
         pub const NOSTR: crate::nl_item = 0x50003;
     } else if #[cfg(target_env = "uclibc")] {
-        pub const CODESET: crate::nl_item = 10;
+        pub const CODESET: crate::nl_item = 329;
         pub const CRNCYSTR: crate::nl_item = 0x215;
         pub const RADIXCHAR: crate::nl_item = 0x100;
         pub const THOUSEP: crate::nl_item = 0x101;


### PR DESCRIPTION
# Description

This PR removes duplicate definitions of `langinfo.h` constants in L4Re uClibc that cause builds to
fail. This is unrelated to the broken L4Re support in Rust std (more on that below.)

A few of these constants were special-cased in the `uclibc` module. These definitions actually
mismatched those of upstream uclibc-ng. The `linux_l4re_shared` module also specialized these
definitions when the target environment was determined to be uClibc, but this module got the values
right.

This patch altogether removes the symbols from the `uclibc` child module, instead relying on the
ones in the `linux_l4re_shared` module.

This change has been marked stable because the fix does not affect the availability of symbols. It
doesn't really affect the values of those symbols either. Anyone who had been using the `libc` crate
with the affected target triple (`x86_64-unknown-l4re-uclibc`) should not have been capable of even
building their programs lest they patched the `libc` crate themselves.

Building std still fails in L4Re, and [[1]] seems to have already tracked that. No further fixes
have been provided to L4Re becaues it seems the same new maintainer is the one that made the changes
in the `libc` crate that make std not build anymore (like not exposing the `lstat64` routine.) They
probably know best, and they seem to have a working build of std, as per [[2]]. This has made
testing impossible, beyond attempting to build the `libc` crate.

[1]: https://github.com/rust-lang/rust/issues/149198
[2]: https://github.com/rust-lang/rust/issues/149198#issuecomment-3566991950

## Sources

- Upstream uclibc-ng sources showing the enum where the constants we expose are declared. The entire
  file has been included because there are a bunch of variants affected across the entire
  enumeration, which starts at the top level. Note that there are also quite a few variants upstream
  that are straight up disabled.

  > <https://gogs.waldemar-brodkorb.de/oss/uclibc-ng/src/master/include/langinfo.h>

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
