### PR TITLE
linux(uclibc): remove redundant records and explicit linking to `libutil`

### DIFF
--- a/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
@@ -661,7 +661,6 @@ pub const SYS_process_mrelease: c_long = 4000 + 448;
 pub const SYS_futex_waitv: c_long = 4000 + 449;
 pub const SYS_set_mempolicy_home_node: c_long = 4000 + 450;
 
-#[link(name = "util")]
 extern "C" {
     pub fn sysctl(
         name: *mut c_int,

--- a/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
@@ -234,19 +234,6 @@ s! {
         pub _f: [c_char; 0],
     }
 
-    pub struct glob_t {
-        // FIXME(ulibc)
-        pub gl_pathc: size_t,
-        pub gl_pathv: *mut *mut c_char,
-        pub gl_offs: size_t,
-        pub gl_flags: c_int,
-        __unused1: Padding<*mut c_void>,
-        __unused2: Padding<*mut c_void>,
-        __unused3: Padding<*mut c_void>,
-        __unused4: Padding<*mut c_void>,
-        __unused5: Padding<*mut c_void>,
-    }
-
     pub struct cpu_set_t {
         // FIXME(ulibc)
         #[cfg(target_pointer_width = "32")]
@@ -273,16 +260,6 @@ s! {
         pub cmsg_len: size_t,
         pub cmsg_level: c_int,
         pub cmsg_type: c_int,
-    }
-}
-
-s_no_extra_traits! {
-    pub struct dirent {
-        pub d_ino: crate::ino64_t,
-        pub d_off: off64_t,
-        pub d_reclen: u16,
-        pub d_type: u8,
-        pub d_name: [c_char; 256],
     }
 }
 


### PR DESCRIPTION
# Description

This PR consists of a small clean up over the `linux/uclibc` module. It removes
some records that were already declared in top-level modules. It also removes an
explicit linking directive to `libutil` as part of ongoing efforts in rust-lang/libc#5265.

## Sources

None. The records that were removed were already declared in top-level modules,
but the combination of target architecture, OS and libc implementation does not
currently exist as an officially supported Rust target.

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] Commit messages permalink to headers for added or changed API
- [x] Placeholder or unstable values like `*LAST` or `*MAX` have the standard
  doc comment
- [ ] Tested locally (`cargo test -p libc-test --target mytarget`); especially
  relevant for platforms that may not be checked in CI
