### PR TITLE
NetBSD: `_lwp_park`: `ts` pointer is mutable

### DIFF
--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2233,7 +2233,7 @@ extern "C" {
     pub fn _lwp_park(
         clock: crate::clockid_t,
         flags: c_int,
-        ts: *const crate::timespec,
+        ts: *mut crate::timespec,
         unpark: crate::lwpid_t,
         hint: *const c_void,
         unparkhint: *mut c_void,


### PR DESCRIPTION
# Description

NetBSD 9.0 changed the pointer type of the `timespec` argument to `_lwp_park` to a mutable pointer, since it now returns the remaining time for relative timeouts through that pointer. Taking a `*const timespec` causes `std` to be very subtly unsound under stacked-borrows, since it passes a `&mut timespec`, but that is implicitly reborrowed with a read-only tag upon coercion to a `*const timespec` (I noticed this while adding NetBSD shims to miri):
https://github.com/rust-lang/rust/blob/b5d46ecb51c3e4134b82570cfe718f093daa6390/library/std/src/sys/pal/unix/thread_parking.rs#L34-L43

# Sources

* Current version: https://github.com/NetBSD/src/blob/3bea51a26c6e426303801042b20f9553d7e26485/include/lwp.h#L57
* Pre-9.0: https://github.com/NetBSD/src/blob/3760f161e6dd25c683ad32f20d1ce281f87658db/include/lwp.h#L57

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
Even though it is a breaking change, but perhaps we can get away with this? It currently causes `std` to be unsound under stacked borrows.