### PR TITLE
linux(musl): deprecate LFS64 bindings

### DIFF
--- a/src/unix/linux_like/l4re/uclibc/mod.rs
+++ b/src/unix/linux_like/l4re/uclibc/mod.rs
@@ -284,6 +284,7 @@ s! {
         pub __wc: crate::wchar_t,
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct fpos64_t {
         pub __pos: crate::off64_t,
         pub __mbstate: __mbstate_t,

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -18,6 +18,7 @@ pub type dev_t = u64;
 pub type socklen_t = u32;
 pub type mode_t = u32;
 pub type ino64_t = u64;
+// FIXME(1.0,deprecate): lfs binding to be removed
 pub type off64_t = i64;
 pub type blkcnt64_t = i64;
 pub type rlim64_t = u64;
@@ -1014,6 +1015,7 @@ s! {
 cfg_if! {
     if #[cfg(not(target_env = "gnu"))] {
         extern_ty! {
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub type fpos64_t; // FIXME(linux): fill this out with a struct
         }
     }
@@ -3495,7 +3497,10 @@ extern "C" {
     pub fn fallocate(fd: c_int, mode: c_int, offset: off_t, len: off_t) -> c_int;
     #[cfg_attr(gnu_file_offset_bits64, link_name = "posix_fallocate64")]
     pub fn posix_fallocate(fd: c_int, offset: off_t, len: off_t) -> c_int;
+    #[cfg(not(any(target_env = "musl", target_env = "ohos")))]
     pub fn readahead(fd: c_int, offset: off64_t, count: size_t) -> ssize_t;
+    #[cfg(any(target_env = "musl", target_env = "ohos"))]
+    pub fn readahead(fd: c_int, offset: off_t, count: size_t) -> ssize_t;
     pub fn getxattr(
         path: *const c_char,
         name: *const c_char,
@@ -3583,7 +3588,10 @@ extern "C" {
 
     // Not available now on Android
     pub fn mkfifoat(dirfd: c_int, pathname: *const c_char, mode: mode_t) -> c_int;
+    #[cfg(not(any(target_env = "musl", target_env = "ohos")))]
     pub fn sync_file_range(fd: c_int, offset: off64_t, nbytes: off64_t, flags: c_uint) -> c_int;
+    #[cfg(any(target_env = "musl", target_env = "ohos"))]
+    pub fn sync_file_range(fd: c_int, offset: off_t, nbytes: off_t, flags: c_uint) -> c_int;
 
     pub fn posix_madvise(addr: *mut c_void, len: size_t, advice: c_int) -> c_int;
 

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -3,8 +3,6 @@ use crate::prelude::*;
 
 pub type wchar_t = u32;
 
-pub type stat64 = stat;
-
 s! {
     pub struct stat {
         pub st_dev: crate::dev_t,

--- a/src/unix/linux_like/linux/musl/b32/hexagon.rs
+++ b/src/unix/linux_like/linux/musl/b32/hexagon.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 
 pub type wchar_t = u32;
-pub type stat64 = crate::stat;
 
 s! {
     pub struct stat {

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -3,8 +3,6 @@ use crate::prelude::*;
 
 pub type wchar_t = c_int;
 
-pub type stat64 = stat;
-
 s! {
     pub struct stat {
         pub st_dev: crate::dev_t,
@@ -140,6 +138,7 @@ s! {
         pub f_spare: [c_ulong; 5],
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct statfs64 {
         pub f_type: c_ulong,
         pub f_bsize: c_ulong,

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -3,8 +3,6 @@ use crate::prelude::*;
 
 pub type wchar_t = i32;
 
-pub type stat64 = stat;
-
 s! {
     pub struct termios {
         pub c_iflag: crate::tcflag_t,

--- a/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
@@ -5,8 +5,6 @@ use crate::prelude::*;
 
 pub type wchar_t = c_int;
 
-pub type stat64 = stat;
-
 s! {
     pub struct stat {
         pub st_dev: crate::dev_t,

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -3,8 +3,6 @@ use crate::prelude::*;
 
 pub type wchar_t = i32;
 
-pub type stat64 = stat;
-
 s! {
     pub struct stat {
         pub st_dev: crate::dev_t,

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -5,8 +5,6 @@ pub type wchar_t = u32;
 pub type nlink_t = u32;
 pub type blksize_t = c_int;
 
-pub type stat64 = stat;
-
 s! {
     pub struct stat {
         pub st_dev: crate::dev_t,

--- a/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
@@ -8,8 +8,6 @@ pub type wchar_t = c_int;
 pub type nlink_t = c_uint;
 pub type blksize_t = c_int;
 
-pub type stat64 = stat;
-
 s! {
     pub struct stat {
         pub st_dev: crate::dev_t,

--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -5,8 +5,6 @@ pub type wchar_t = i32;
 pub type nlink_t = c_uint;
 pub type blksize_t = i64;
 
-pub type stat64 = stat;
-
 s! {
     pub struct stat {
         pub st_dev: crate::dev_t,
@@ -89,6 +87,7 @@ s! {
         pub f_spare: [c_ulong; 5],
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct statfs64 {
         pub f_type: c_ulong,
         pub f_bsize: c_ulong,

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -5,8 +5,6 @@ pub type wchar_t = i32;
 pub type nlink_t = u64;
 pub type blksize_t = c_long;
 
-pub type stat64 = stat;
-
 s! {
     pub struct termios {
         pub c_iflag: crate::tcflag_t,

--- a/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
@@ -8,8 +8,6 @@ pub type wchar_t = c_int;
 pub type nlink_t = c_uint;
 pub type blksize_t = c_int;
 
-pub type stat64 = stat;
-
 s! {
     pub struct stat {
         pub st_dev: crate::dev_t,

--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -5,8 +5,9 @@ pub type blksize_t = i64;
 pub type nlink_t = u64;
 pub type wchar_t = i32;
 pub type greg_t = u64;
+
+// FIXME(1.0,deprecate): lfs binding to be removed
 pub type statfs64 = statfs;
-pub type stat64 = stat;
 
 s! {
     pub struct ipc_perm {

--- a/src/unix/linux_like/linux/musl/b64/wasm32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/wasm32/mod.rs
@@ -7,8 +7,6 @@ pub type wchar_t = i32;
 pub type nlink_t = u64;
 pub type blksize_t = c_long;
 
-pub type stat64 = stat;
-
 s! {
     pub struct stat {
         pub st_dev: crate::dev_t,

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -6,8 +6,6 @@ pub type nlink_t = u64;
 pub type blksize_t = c_long;
 pub type greg_t = i64;
 
-pub type stat64 = stat;
-
 s! {
     pub struct stat {
         pub st_dev: crate::dev_t,

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -37,10 +37,15 @@ pub type shmatt_t = c_ulong;
 pub type msgqnum_t = c_ulong;
 pub type msglen_t = c_ulong;
 pub type fsblkcnt_t = c_ulonglong;
-pub type fsblkcnt64_t = c_ulonglong;
 pub type fsfilcnt_t = c_ulonglong;
-pub type fsfilcnt64_t = c_ulonglong;
 pub type rlim_t = c_ulonglong;
+
+// FIXME(1.0,deprecate): lfs binding to be removed
+pub type fsblkcnt64_t = c_ulonglong;
+// FIXME(1.0,deprecate): lfs binding to be removed
+pub type fsfilcnt64_t = c_ulonglong;
+// FIXME(1.0,deprecate): lfs binding to be removed
+pub type stat64 = stat;
 
 cfg_if! {
     if #[cfg(doc)] {
@@ -191,6 +196,7 @@ s! {
         __f_reserved: Padding<[c_int; 6]>,
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct statvfs64 {
         pub f_bsize: c_ulong,
         pub f_frsize: c_ulong,
@@ -232,6 +238,7 @@ s! {
         pub l_pid: crate::pid_t,
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct flock64 {
         pub l_type: c_short,
         pub l_whence: c_short,
@@ -398,6 +405,7 @@ s! {
     }
 
     // MIPS/s390x implementation is special (see arch folders)
+    // FIXME(1.0,deprecate): lfs binding to be removed
     #[cfg(not(any(target_arch = "mips", target_arch = "mips64", target_arch = "s390x")))]
     pub struct statfs64 {
         pub f_type: c_ulong,
@@ -887,6 +895,7 @@ extern "C" {
 }
 
 // Alias <foo> to <foo>64 to mimic glibc's LFS64 support
+// FIXME(1.0,deprecate): lfs binding to be removed
 mod lfs64;
 pub use self::lfs64::*;
 

--- a/src/unix/linux_like/linux_l4re_shared.rs
+++ b/src/unix/linux_like/linux_l4re_shared.rs
@@ -275,6 +275,7 @@ s! {
         pub val: c_int,
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct rlimit64 {
         pub rlim_cur: crate::rlim64_t,
         pub rlim_max: crate::rlim64_t,
@@ -297,6 +298,7 @@ s! {
         pub d_name: [c_char; 256],
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct dirent64 {
         pub d_ino: crate::ino64_t,
         pub d_off: crate::off64_t,
@@ -1911,12 +1913,22 @@ extern "C" {
         longindex: *mut c_int,
     ) -> c_int;
 
-    #[cfg(not(target_env = "uclibc"))]
+    #[cfg(not(any(target_env = "uclibc", target_env = "musl", target_env = "ohos")))]
     pub fn copy_file_range(
         fd_in: c_int,
         off_in: *mut crate::off64_t,
         fd_out: c_int,
         off_out: *mut crate::off64_t,
+        len: size_t,
+        flags: c_uint,
+    ) -> ssize_t;
+
+    #[cfg(any(target_env = "musl", target_env = "ohos"))]
+    pub fn copy_file_range(
+        fd_in: c_int,
+        off_in: *mut crate::off_t,
+        fd_out: c_int,
+        off_out: *mut crate::off_t,
         len: size_t,
         flags: c_uint,
     ) -> ssize_t;


### PR DESCRIPTION
# Description

This PR removes support for the exposed LFS64 bindings under Linux musl. This follows from the `libc` crate's attempts at providing a single, unsuffixed type with which to provide 64-bit functionality.

This follows from rust-lang/libc#5032, where I understood `libc` was meant to provide a single, unsuffixed type and not necessarily support aliases (much less conditional aliases.) Upstream musl also defines the LFS64 types routines in terms of the unsuffixed types and routines.

This patch ensures we deprecate these types and the whole `musl/lfs64` module in favor of using only the unsuffixed types and routines.

## Sources

No specific sources are provided. Running the following command with `rg` in the main worktree of latest musl should yield search results that show the uniform aliasing mentioned above across all header files.

```sh
rg -C 15 -s -uu -g "**/*.h" -e "\\b_LARGEFILE64_SOURCE\\b"
```

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI
