### PR TITLE
l4re: change bit widths of file offset types

### DIFF
--- a/libc-test/build/main.rs
+++ b/libc-test/build/main.rs
@@ -4232,7 +4232,7 @@ fn test_linux(t: &Target) {
             "Ioctl" => Some("int".to_string()),
             // LFS64 types have been removed in musl 1.2.4+
             "off64_t" if musl => Some("off_t".to_string()),
-            "fsword_t" if uclibc => Some("__SWORD_TYPE".to_string()),
+            "__sword_type" if uclibc => Some("__SWORD_TYPE".to_string()),
             _ => None,
         }
     });
@@ -4288,6 +4288,10 @@ fn test_linux(t: &Target) {
             // For internal use only, to define architecture specific ioctl constants with a libc
             // specific type.
             "Ioctl" => true,
+
+            // This type was renamed to more closely match upstream's
+            // `__SWORD_TYPE`; It now goes by `__sword_type`.
+            "fsword_t" if uclibc => true,
 
             t => {
                 if musl {

--- a/src/unix/linux_like/l4re/mod.rs
+++ b/src/unix/linux_like/l4re/mod.rs
@@ -10,10 +10,6 @@ pub type pthread_t = *mut c_void;
 pub type dev_t = u64;
 pub type socklen_t = u32;
 pub type mode_t = u32;
-pub type ino64_t = u64;
-pub type off64_t = i64;
-pub type blkcnt64_t = i64;
-pub type rlim64_t = u64;
 pub type nfds_t = c_ulong;
 pub type nl_item = c_int;
 pub type idtype_t = c_uint;
@@ -21,6 +17,40 @@ pub type loff_t = c_longlong;
 pub type pthread_key_t = c_uint;
 pub type pthread_once_t = c_int;
 pub type pthread_spinlock_t = c_int;
+
+#[cfg_attr(
+    all(target_os = "l4re", target_pointer_width = "64"),
+    deprecated(
+        since = "0.2.190",
+        note = "Use `ino_t` instead. LFS is being phased out, see rust-lang/libc#4805."
+    )
+)]
+pub type ino64_t = u64;
+#[cfg_attr(
+    all(target_os = "l4re", target_pointer_width = "64"),
+    deprecated(
+        since = "0.2.190",
+        note = "Use `off_t` instead. LFS is being phased out, see rust-lang/libc#4805."
+    )
+)]
+pub type off64_t = i64;
+#[cfg_attr(
+    all(target_os = "l4re", target_pointer_width = "64"),
+    deprecated(
+        since = "0.2.190",
+        note = "Use `blkcnt_t` instead. LFS is being phased out, see
+                rust-lang/libc#4805."
+    )
+)]
+pub type blkcnt64_t = i64;
+#[cfg_attr(
+    all(target_os = "l4re", target_pointer_width = "64"),
+    deprecated(
+        since = "0.2.190",
+        note = "Use `rlim_t` instead. LFS is being phased out, see rust-lang/libc#4805."
+    )
+)]
+pub type rlim64_t = u64;
 
 s! {
     /// CPU sets.

--- a/src/unix/linux_like/l4re/mod.rs
+++ b/src/unix/linux_like/l4re/mod.rs
@@ -10,10 +10,6 @@ pub type pthread_t = *mut c_void;
 pub type dev_t = u64;
 pub type socklen_t = u32;
 pub type mode_t = u32;
-pub type ino64_t = u64;
-pub type off64_t = i64;
-pub type blkcnt64_t = i64;
-pub type rlim64_t = u64;
 pub type nfds_t = c_ulong;
 pub type nl_item = c_int;
 pub type idtype_t = c_uint;
@@ -21,6 +17,27 @@ pub type loff_t = c_longlong;
 pub type pthread_key_t = c_uint;
 pub type pthread_once_t = c_int;
 pub type pthread_spinlock_t = c_int;
+
+#[deprecated(
+    since = "0.2.190",
+    note = "Use `ino_t` instead. LFS is being phased out, see rust-lang/libc#4805."
+)]
+pub type ino64_t = u64;
+#[deprecated(
+    since = "0.2.190",
+    note = "Use `off_t` instead. LFS is being phased out, see rust-lang/libc#4805."
+)]
+pub type off64_t = i64;
+#[deprecated(
+    since = "0.2.190",
+    note = "Use `blkcnt_t` instead. LFS is being phased out, see rust-lang/libc#4805."
+)]
+pub type blkcnt64_t = i64;
+#[deprecated(
+    since = "0.2.190",
+    note = "Use `rlim_t` instead. LFS is being phased out, see rust-lang/libc#4805."
+)]
+pub type rlim64_t = u64;
 
 s! {
     /// CPU sets.

--- a/src/unix/linux_like/l4re/uclibc/mod.rs
+++ b/src/unix/linux_like/l4re/uclibc/mod.rs
@@ -1,4 +1,3 @@
-use crate::off64_t;
 use crate::prelude::*;
 
 pub type shmatt_t = c_ulong;
@@ -9,6 +8,12 @@ pub type __priority_which_t = c_uint;
 
 pub type _pthread_descr = *mut c_void;
 pub type __pthread_cond_align_t = c_long;
+
+#[cfg(target_pointer_width = "64")]
+pub type __sword_type = c_long;
+
+#[cfg(target_pointer_width = "32")]
+pub type __sword_type = c_int;
 
 cfg_if! {
     if #[cfg(doc)] {
@@ -44,48 +49,33 @@ s! {
     }
 
     pub struct statfs {
-        pub f_type: fsword_t,
-        pub f_bsize: fsword_t,
+        pub f_type: __sword_type,
+        pub f_bsize: __sword_type,
         pub f_blocks: crate::fsblkcnt_t,
         pub f_bfree: crate::fsblkcnt_t,
         pub f_bavail: crate::fsblkcnt_t,
         pub f_files: crate::fsfilcnt_t,
         pub f_ffree: crate::fsfilcnt_t,
         pub f_fsid: crate::fsid_t,
-        pub f_namelen: fsword_t,
-        pub f_frsize: fsword_t,
-        pub f_flags: fsword_t,
-        pub f_spare: [fsword_t; 4],
+        pub f_namelen: __sword_type,
+        pub f_frsize: __sword_type,
+        pub f_flags: __sword_type,
+        pub f_spare: [__sword_type; 4],
     }
 
     pub struct statfs64 {
-        pub f_type: fsword_t,
-        pub f_bsize: fsword_t,
+        pub f_type: __sword_type,
+        pub f_bsize: __sword_type,
         pub f_blocks: crate::fsblkcnt64_t,
         pub f_bfree: crate::fsblkcnt64_t,
         pub f_bavail: crate::fsblkcnt64_t,
         pub f_files: crate::fsfilcnt64_t,
         pub f_ffree: crate::fsfilcnt64_t,
         pub f_fsid: crate::fsid_t,
-        pub f_namelen: fsword_t,
-        pub f_frsize: fsword_t,
-        pub f_flags: fsword_t,
-        pub f_spare: [fsword_t; 4],
-    }
-
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsfilcnt64_t,
-        pub f_bfree: crate::fsfilcnt64_t,
-        pub f_bavail: crate::fsfilcnt64_t,
-        pub f_files: crate::fsfilcnt64_t,
-        pub f_ffree: crate::fsfilcnt64_t,
-        pub f_favail: crate::fsfilcnt64_t,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        pub __f_spare: [c_int; 6],
+        pub f_namelen: __sword_type,
+        pub f_frsize: __sword_type,
+        pub f_flags: __sword_type,
+        pub f_spare: [__sword_type; 4],
     }
 
     pub struct ipc_perm {
@@ -99,11 +89,11 @@ s! {
         #[cfg(target_pointer_width = "64")]
         pub mode: c_uint,
         #[cfg(target_pointer_width = "32")]
-        __pad1: c_ushort,
+        __pad1: Padding<c_ushort>,
         pub __seq: c_ushort,
-        __pad2: c_ushort,
-        __unused1: c_ulong,
-        __unused2: c_ulong,
+        __pad2: Padding<c_ushort>,
+        __unused1: Padding<c_ulong>,
+        __unused2: Padding<c_ulong>,
     }
 
     pub struct statvfs {
@@ -116,15 +106,30 @@ s! {
         pub f_files: crate::fsfilcnt_t,
         pub f_ffree: crate::fsfilcnt_t,
         pub f_favail: crate::fsfilcnt_t,
-        #[cfg(target_endian = "little")]
         pub f_fsid: c_ulong,
         #[cfg(target_pointer_width = "32")]
-        __f_unused: c_int,
-        #[cfg(target_endian = "big")]
-        pub f_fsid: c_ulong,
+        __f_unused: Padding<c_int>,
         pub f_flag: c_ulong,
         pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
+        __f_spare: Padding<[c_int; 6]>,
+    }
+
+    pub struct statvfs64 {
+        // Different than GNU!
+        pub f_bsize: c_ulong,
+        pub f_frsize: c_ulong,
+        pub f_blocks: crate::fsblkcnt64_t,
+        pub f_bfree: crate::fsblkcnt64_t,
+        pub f_bavail: crate::fsblkcnt64_t,
+        pub f_files: crate::fsfilcnt64_t,
+        pub f_ffree: crate::fsfilcnt64_t,
+        pub f_favail: crate::fsfilcnt64_t,
+        pub f_fsid: c_ulong,
+        #[cfg(target_pointer_width = "32")]
+        __f_unused: Padding<c_int>,
+        pub f_flag: c_ulong,
+        pub f_namemax: c_ulong,
+        __f_spare: Padding<[c_int; 6]>,
     }
 
     pub struct sysinfo {
@@ -300,8 +305,8 @@ s! {
         pub shm_cpid: crate::pid_t,
         pub shm_lpid: crate::pid_t,
         pub shm_nattch: crate::shmatt_t,
-        __unused4: c_ulong,
-        __unused5: c_ulong,
+        __unused4: Padding<c_ulong>,
+        __unused5: Padding<c_ulong>,
     }
 }
 
@@ -538,10 +543,26 @@ extern "C" {
         flags: c_int,
     ) -> c_int;
 
-    pub fn pwritev(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: off64_t) -> ssize_t;
-    pub fn preadv(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: off64_t) -> ssize_t;
+    pub fn pwritev(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: off_t) -> ssize_t;
+    pub fn preadv(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: off_t) -> ssize_t;
 
+    #[cfg_attr(
+        all(target_os = "l4re", target_pointer_width = "64"),
+        deprecated(
+            since = "0.2.190",
+            note = "Use `getrlimit` instead. LFS is being phased out, see rust-lang/libc#4805."
+        ),
+        allow(deprecated)
+    )]
     pub fn getrlimit64(resource: crate::__rlimit_resource_t, rlim: *mut crate::rlimit64) -> c_int;
+    #[cfg_attr(
+        all(target_os = "l4re", target_pointer_width = "64"),
+        deprecated(
+            since = "0.2.190",
+            note = "Use `setrlimit` instead. LFS is being phased out, see rust-lang/libc#4805."
+        ),
+        allow(deprecated)
+    )]
     pub fn setrlimit64(resource: crate::__rlimit_resource_t, rlim: *const crate::rlimit64)
         -> c_int;
     pub fn getrlimit(resource: crate::__rlimit_resource_t, rlim: *mut crate::rlimit) -> c_int;

--- a/src/unix/linux_like/l4re/uclibc/mod.rs
+++ b/src/unix/linux_like/l4re/uclibc/mod.rs
@@ -1,4 +1,3 @@
-use crate::off64_t;
 use crate::prelude::*;
 
 pub type shmatt_t = c_ulong;
@@ -9,6 +8,9 @@ pub type __priority_which_t = c_uint;
 
 pub type _pthread_descr = *mut c_void;
 pub type __pthread_cond_align_t = c_long;
+
+pub type statfs64 = statfs;
+pub type statvfs64 = statvfs;
 
 cfg_if! {
     if #[cfg(doc)] {
@@ -44,48 +46,18 @@ s! {
     }
 
     pub struct statfs {
-        pub f_type: fsword_t,
-        pub f_bsize: fsword_t,
+        pub f_type: c_long,
+        pub f_bsize: c_long,
         pub f_blocks: crate::fsblkcnt_t,
         pub f_bfree: crate::fsblkcnt_t,
         pub f_bavail: crate::fsblkcnt_t,
         pub f_files: crate::fsfilcnt_t,
         pub f_ffree: crate::fsfilcnt_t,
         pub f_fsid: crate::fsid_t,
-        pub f_namelen: fsword_t,
-        pub f_frsize: fsword_t,
-        pub f_flags: fsword_t,
-        pub f_spare: [fsword_t; 4],
-    }
-
-    pub struct statfs64 {
-        pub f_type: fsword_t,
-        pub f_bsize: fsword_t,
-        pub f_blocks: crate::fsblkcnt64_t,
-        pub f_bfree: crate::fsblkcnt64_t,
-        pub f_bavail: crate::fsblkcnt64_t,
-        pub f_files: crate::fsfilcnt64_t,
-        pub f_ffree: crate::fsfilcnt64_t,
-        pub f_fsid: crate::fsid_t,
-        pub f_namelen: fsword_t,
-        pub f_frsize: fsword_t,
-        pub f_flags: fsword_t,
-        pub f_spare: [fsword_t; 4],
-    }
-
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsfilcnt64_t,
-        pub f_bfree: crate::fsfilcnt64_t,
-        pub f_bavail: crate::fsfilcnt64_t,
-        pub f_files: crate::fsfilcnt64_t,
-        pub f_ffree: crate::fsfilcnt64_t,
-        pub f_favail: crate::fsfilcnt64_t,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        pub __f_spare: [c_int; 6],
+        pub f_namelen: c_long,
+        pub f_frsize: c_long,
+        pub f_flags: c_long,
+        pub f_spare: [c_long; 4],
     }
 
     pub struct ipc_perm {
@@ -99,11 +71,11 @@ s! {
         #[cfg(target_pointer_width = "64")]
         pub mode: c_uint,
         #[cfg(target_pointer_width = "32")]
-        __pad1: c_ushort,
+        __pad1: Padding<c_ushort>,
         pub __seq: c_ushort,
-        __pad2: c_ushort,
-        __unused1: c_ulong,
-        __unused2: c_ulong,
+        __pad2: Padding<c_ushort>,
+        __unused1: Padding<c_ulong>,
+        __unused2: Padding<c_ulong>,
     }
 
     pub struct statvfs {
@@ -116,15 +88,12 @@ s! {
         pub f_files: crate::fsfilcnt_t,
         pub f_ffree: crate::fsfilcnt_t,
         pub f_favail: crate::fsfilcnt_t,
-        #[cfg(target_endian = "little")]
         pub f_fsid: c_ulong,
         #[cfg(target_pointer_width = "32")]
-        __f_unused: c_int,
-        #[cfg(target_endian = "big")]
-        pub f_fsid: c_ulong,
+        __f_unused: Padding<c_int>,
         pub f_flag: c_ulong,
         pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
+        __f_spare: Padding<[c_int; 6]>,
     }
 
     pub struct sysinfo {
@@ -299,8 +268,8 @@ s! {
         pub shm_cpid: crate::pid_t,
         pub shm_lpid: crate::pid_t,
         pub shm_nattch: crate::shmatt_t,
-        __unused4: c_ulong,
-        __unused5: c_ulong,
+        __unused4: Padding<c_ulong>,
+        __unused5: Padding<c_ulong>,
     }
 }
 
@@ -535,10 +504,20 @@ extern "C" {
         flags: c_int,
     ) -> c_int;
 
-    pub fn pwritev(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: off64_t) -> ssize_t;
-    pub fn preadv(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: off64_t) -> ssize_t;
+    pub fn pwritev(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: off_t) -> ssize_t;
+    pub fn preadv(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: off_t) -> ssize_t;
 
+    #[deprecated(
+        since = "0.2.190",
+        note = "Use `getrlimit` instead. LFS is being phased out, see rust-lang/libc#4805."
+    )]
+    #[allow(deprecated)]
     pub fn getrlimit64(resource: crate::__rlimit_resource_t, rlim: *mut crate::rlimit64) -> c_int;
+    #[deprecated(
+        since = "0.2.190",
+        note = "Use `setrlimit` instead. LFS is being phased out, see rust-lang/libc#4805."
+    )]
+    #[allow(deprecated)]
     pub fn setrlimit64(resource: crate::__rlimit_resource_t, rlim: *const crate::rlimit64)
         -> c_int;
     pub fn getrlimit(resource: crate::__rlimit_resource_t, rlim: *mut crate::rlimit) -> c_int;

--- a/src/unix/linux_like/l4re/uclibc/x86_64/mod.rs
+++ b/src/unix/linux_like/l4re/uclibc/x86_64/mod.rs
@@ -11,13 +11,22 @@ pub type fsfilcnt_t = c_ulong;
 pub type ino_t = c_ulong;
 pub type nlink_t = c_ulong;
 pub type off_t = c_long;
+#[deprecated(since = "0.2.190", note = "Use `__sword_type` instead.")]
 pub type fsword_t = c_long;
 pub type suseconds_t = c_long;
 
 pub type blksize_t = c_long;
 pub type blkcnt_t = c_long;
 
+#[deprecated(
+    since = "0.2.190",
+    note = "Use `fsblkcnt_t` instead. LFS is being phased out, see rust-lang/libc#4805."
+)]
 pub type fsblkcnt64_t = c_ulong;
+#[deprecated(
+    since = "0.2.190",
+    note = "Use `fsfilcnt_t` instead. LFS is being phased out, see rust-lang/libc#4805."
+)]
 pub type fsfilcnt64_t = c_ulong;
 
 pub type __u32 = c_uint;
@@ -25,41 +34,39 @@ pub type __u64 = c_ulong;
 
 s! {
     pub struct stat {
-        pub st_dev: c_ulong,
+        pub st_dev: crate::dev_t,
         pub st_ino: crate::ino_t,
-        // According to uclibc/libc/sysdeps/linux/x86_64/bits/stat.h, order of
-        // nlink and mode are swapped on 64 bit systems.
         pub st_nlink: nlink_t,
         pub st_mode: crate::mode_t,
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
-        __pad0: c_int,
-        pub st_rdev: c_ulong,
+        __pad0: Padding<c_int>,
+        pub st_rdev: crate::dev_t,
         pub st_size: crate::off_t,
         pub st_blksize: crate::blksize_t,
-        pub st_blocks: crate::blkcnt64_t,
+        pub st_blocks: crate::blkcnt_t,
         pub st_atim: crate::timespec,
         pub st_mtim: crate::timespec,
         pub st_ctim: crate::timespec,
-        __uclibc_unused: [c_long; 3],
+        __uclibc_unused: Padding<[c_long; 3]>,
     }
 
     pub struct stat64 {
-        pub st_dev: c_ulong,
+        pub st_dev: crate::dev_t,
         pub st_ino: crate::ino_t,
         pub st_nlink: nlink_t,
         pub st_mode: crate::mode_t,
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
-        __pad0: c_int,
-        pub st_rdev: c_ulong,
+        __pad0: Padding<c_int>,
+        pub st_rdev: crate::dev_t,
         pub st_size: crate::off_t,
         pub st_blksize: crate::blksize_t,
-        pub st_blocks: crate::blkcnt64_t,
+        pub st_blocks: crate::blkcnt_t,
         pub st_atim: crate::timespec,
         pub st_mtim: crate::timespec,
         pub st_ctim: crate::timespec,
-        st_pad4: [c_long; 3],
+        __uclibc_unused: Padding<[c_long; 3]>,
     }
 
     #[allow(unpredictable_function_pointer_comparisons)]
@@ -89,6 +96,14 @@ s! {
     }
 
     pub struct flock {
+        pub l_type: c_short,
+        pub l_whence: c_short,
+        pub l_start: off_t,
+        pub l_len: off_t,
+        pub l_pid: crate::pid_t,
+    }
+
+    pub struct flock64 {
         pub l_type: c_short,
         pub l_whence: c_short,
         pub l_start: off_t,

--- a/src/unix/linux_like/l4re/uclibc/x86_64/mod.rs
+++ b/src/unix/linux_like/l4re/uclibc/x86_64/mod.rs
@@ -17,49 +17,40 @@ pub type suseconds_t = c_long;
 pub type blksize_t = c_long;
 pub type blkcnt_t = c_long;
 
+#[deprecated(
+    since = "0.2.190",
+    note = "Use `fsblkcnt_t` instead. LFS is being phased out, see rust-lang/libc#4805."
+)]
 pub type fsblkcnt64_t = c_ulong;
+#[deprecated(
+    since = "0.2.190",
+    note = "Use `fsfilcnt_t` instead. LFS is being phased out, see rust-lang/libc#4805."
+)]
 pub type fsfilcnt64_t = c_ulong;
 
 pub type __u32 = c_uint;
 pub type __u64 = c_ulong;
 
+pub type stat64 = stat;
+pub type flock64 = flock;
+
 s! {
     pub struct stat {
-        pub st_dev: c_ulong,
-        pub st_ino: crate::ino_t,
-        // According to uclibc/libc/sysdeps/linux/x86_64/bits/stat.h, order of
-        // nlink and mode are swapped on 64 bit systems.
-        pub st_nlink: nlink_t,
-        pub st_mode: crate::mode_t,
-        pub st_uid: crate::uid_t,
-        pub st_gid: crate::gid_t,
-        __pad0: c_int,
-        pub st_rdev: c_ulong,
-        pub st_size: crate::off_t,
-        pub st_blksize: crate::blksize_t,
-        pub st_blocks: crate::blkcnt64_t,
-        pub st_atim: crate::timespec,
-        pub st_mtim: crate::timespec,
-        pub st_ctim: crate::timespec,
-        __uclibc_unused: [c_long; 3],
-    }
-
-    pub struct stat64 {
-        pub st_dev: c_ulong,
+        pub st_dev: crate::dev_t,
         pub st_ino: crate::ino_t,
         pub st_nlink: nlink_t,
         pub st_mode: crate::mode_t,
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
-        __pad0: c_int,
-        pub st_rdev: c_ulong,
+        __pad0: Padding<c_int>,
+        pub st_rdev: crate::dev_t,
         pub st_size: crate::off_t,
         pub st_blksize: crate::blksize_t,
-        pub st_blocks: crate::blkcnt64_t,
+        pub st_blocks: crate::blkcnt_t,
         pub st_atim: crate::timespec,
         pub st_mtim: crate::timespec,
         pub st_ctim: crate::timespec,
-        st_pad4: [c_long; 3],
+        __uclibc_unused: Padding<[c_long; 3]>,
     }
 
     #[allow(unpredictable_function_pointer_comparisons)]

--- a/src/unix/linux_like/linux_l4re_shared.rs
+++ b/src/unix/linux_like/linux_l4re_shared.rs
@@ -1930,18 +1930,56 @@ extern "C" {
 cfg_if! {
     if #[cfg(not(any(target_env = "musl", target_env = "ohos")))] {
         extern "C" {
+            #[cfg_attr(
+                all(target_os = "l4re", target_pointer_width = "64",),
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `freopen` instead. LFS is being phased out, see \
+                            rust-lang/libc#4805."
+                )
+            )]
             pub fn freopen64(
                 filename: *const c_char,
                 mode: *const c_char,
                 file: *mut crate::FILE,
             ) -> *mut crate::FILE;
+            #[cfg_attr(
+                all(target_os = "l4re", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `fseeko` instead. LFS is being phased out, see rust-lang/libc#4805."
+                )
+            )]
             pub fn fseeko64(
                 stream: *mut crate::FILE,
+                #[cfg(any(
+                    not(target_os = "l4re"),
+                    all(target_os = "l4re", not(target_pointer_width = "64"))
+                ))]
                 offset: crate::off64_t,
+                #[cfg(all(target_os = "l4re", target_pointer_width = "64"))] offset: crate::off_t,
                 whence: c_int,
             ) -> c_int;
+            #[cfg_attr(
+                all(target_os = "l4re", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `fsetpos` instead. LFS is being phased out, see \
+                            rust-lang/libc#4805."
+                )
+            )]
             pub fn fsetpos64(stream: *mut crate::FILE, ptr: *const crate::fpos64_t) -> c_int;
+            #[cfg(any(
+                not(target_os = "l4re"),
+                all(target_os = "l4re", not(target_pointer_width = "64"))
+            ))]
             pub fn ftello64(stream: *mut crate::FILE) -> crate::off64_t;
+            #[cfg(all(target_os = "l4re", target_pointer_width = "64"))]
+            #[deprecated(
+                since = "0.2.190",
+                note = "Use `ftello` instead. LFS is being phased out, see rust-lang/libc#4805."
+            )]
+            pub fn ftello64(stream: *mut crate::FILE) -> crate::off_t;
         }
     }
 }

--- a/src/unix/linux_like/linux_l4re_shared.rs
+++ b/src/unix/linux_like/linux_l4re_shared.rs
@@ -275,6 +275,14 @@ s! {
         pub val: c_int,
     }
 
+    #[cfg_attr(
+        target_os = "l4re",
+        deprecated(
+            since = "0.2.190",
+            note = "Use `rlimit` instead. LFS is being phased out, see rust-lang/libc#4805."
+        ),
+        allow(deprecated)
+    )]
     pub struct rlimit64 {
         pub rlim_cur: crate::rlim64_t,
         pub rlim_max: crate::rlim64_t,
@@ -297,6 +305,14 @@ s! {
         pub d_name: [c_char; 256],
     }
 
+    #[cfg_attr(
+        target_os = "l4re",
+        deprecated(
+            since = "0.2.190",
+            note = "Use `dirent` instead. LFS is being phased out, see rust-lang/libc#4805."
+        ),
+        allow(deprecated)
+    )]
     pub struct dirent64 {
         pub d_ino: crate::ino64_t,
         pub d_off: crate::off64_t,
@@ -1925,18 +1941,49 @@ extern "C" {
 cfg_if! {
     if #[cfg(not(any(target_env = "musl", target_env = "ohos")))] {
         extern "C" {
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `freopen` instead. LFS is being phased out, see \
+                            rust-lang/libc#4805."
+                )
+            )]
             pub fn freopen64(
                 filename: *const c_char,
                 mode: *const c_char,
                 file: *mut crate::FILE,
             ) -> *mut crate::FILE;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `fseeko` instead. LFS is being phased out, see rust-lang/libc#4805."
+                )
+            )]
             pub fn fseeko64(
                 stream: *mut crate::FILE,
-                offset: crate::off64_t,
+                #[cfg(not(target_os = "l4re"))] offset: crate::off64_t,
+                #[cfg(target_os = "l4re")] offset: crate::off_t,
                 whence: c_int,
             ) -> c_int;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `fsetpos` instead. LFS is being phased out, see \
+                            rust-lang/libc#4805."
+                )
+            )]
             pub fn fsetpos64(stream: *mut crate::FILE, ptr: *const crate::fpos64_t) -> c_int;
+            #[cfg(not(all(target_os = "l4re")))]
             pub fn ftello64(stream: *mut crate::FILE) -> crate::off64_t;
+            #[cfg(all(target_os = "l4re"))]
+            #[deprecated(
+                since = "0.2.190",
+                note = "Use `ftello` instead. LFS is being phased out, see rust-lang/libc#4805."
+            )]
+            pub fn ftello64(stream: *mut crate::FILE) -> crate::off_t;
         }
     }
 }

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -560,6 +560,8 @@ pub const XATTR_REPLACE: c_int = 0x2;
 cfg_if! {
     if #[cfg(target_os = "android")] {
         pub const RLIM64_INFINITY: c_ulonglong = !0;
+    } else if #[cfg(all(target_os = "l4re", target_pointer_width = "64"))] {
+        pub const RLIM64_INFINITY: crate::rlim_t = !0;
     } else {
         pub const RLIM64_INFINITY: crate::rlim64_t = !0;
     }
@@ -2177,14 +2179,26 @@ cfg_if! {
                 flags: c_int,
             ) -> c_int;
             // FIXME(1.0,deprecate): lfs binding to be removed
+            #[cfg_attr(
+                all(target_os = "l4re", target_pointer_width = "64"),
+                allow(deprecated)
+            )]
             pub fn ftruncate64(fd: c_int, length: off64_t) -> c_int;
             // FIXME(1.0,deprecate): lfs binding to be removed
+            #[cfg_attr(
+                all(target_os = "l4re", target_pointer_width = "64"),
+                allow(deprecated)
+            )]
             pub fn lseek64(fd: c_int, offset: off64_t, whence: c_int) -> off64_t;
             #[cfg_attr(gnu_time_bits64, link_name = "__lstat64_time64")]
             #[cfg(not(target_os = "l4re"))]
             // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn lstat64(path: *const c_char, buf: *mut stat64) -> c_int;
             // FIXME(1.0,deprecate): lfs binding to be removed
+            #[cfg_attr(
+                all(target_os = "l4re", target_pointer_width = "64"),
+                allow(deprecated)
+            )]
             pub fn mmap64(
                 addr: *mut c_void,
                 len: size_t,
@@ -2198,6 +2212,10 @@ cfg_if! {
             // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn openat64(fd: c_int, path: *const c_char, oflag: c_int, ...) -> c_int;
             // FIXME(1.0,deprecate): lfs binding to be removed
+            #[cfg_attr(
+                all(target_os = "l4re", target_pointer_width = "64"),
+                allow(deprecated)
+            )]
             pub fn posix_fadvise64(
                 fd: c_int,
                 offset: off64_t,
@@ -2205,8 +2223,16 @@ cfg_if! {
                 advise: c_int,
             ) -> c_int;
             // FIXME(1.0,deprecate): lfs binding to be removed
+            #[cfg_attr(
+                all(target_os = "l4re", target_pointer_width = "64"),
+                allow(deprecated)
+            )]
             pub fn pread64(fd: c_int, buf: *mut c_void, count: size_t, offset: off64_t) -> ssize_t;
             // FIXME(1.0,deprecate): lfs binding to be removed
+            #[cfg_attr(
+                all(target_os = "l4re", target_pointer_width = "64"),
+                allow(deprecated)
+            )]
             pub fn pwrite64(
                 fd: c_int,
                 buf: *const c_void,
@@ -2226,6 +2252,10 @@ cfg_if! {
             // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn stat64(path: *const c_char, buf: *mut stat64) -> c_int;
             // FIXME(1.0,deprecate): lfs binding to be removed
+            #[cfg_attr(
+                all(target_os = "l4re", target_pointer_width = "64"),
+                allow(deprecated)
+            )]
             pub fn truncate64(path: *const c_char, length: off64_t) -> c_int;
         }
     }

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -555,6 +555,8 @@ pub const XATTR_REPLACE: c_int = 0x2;
 cfg_if! {
     if #[cfg(target_os = "android")] {
         pub const RLIM64_INFINITY: c_ulonglong = !0;
+    } else if #[cfg(target_os = "l4re")] {
+        pub const RLIM64_INFINITY: crate::rlim_t = !0;
     } else {
         pub const RLIM64_INFINITY: crate::rlim64_t = !0;
     }
@@ -2142,12 +2144,57 @@ cfg_if! {
         target_os = "emscripten",
     )))] {
         extern "C" {
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `fstatfs` instead. LFS is being phased out, see \
+                            rust-lang/libc#4805."
+                )
+            )]
             pub fn fstatfs64(fd: c_int, buf: *mut statfs64) -> c_int;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `statvfs` instead. LFS is being phased out, see \
+                            rust-lang/libc#4805."
+                )
+            )]
             pub fn statvfs64(path: *const c_char, buf: *mut statvfs64) -> c_int;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `fstatvfs` instead. LFS is being phased out, see \
+                            rust-lang/libc#4805."
+                )
+            )]
             pub fn fstatvfs64(fd: c_int, buf: *mut statvfs64) -> c_int;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `statfs` instead. LFS is being phased out, see rust-lang/libc#4805."
+                )
+            )]
             pub fn statfs64(path: *const c_char, buf: *mut statfs64) -> c_int;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `creat` instead. LFS is being phased out, see rust-lang/libc#4805."
+                )
+            )]
             pub fn creat64(path: *const c_char, mode: mode_t) -> c_int;
             #[cfg_attr(gnu_time_bits64, link_name = "__fstat64_time64")]
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `fstat` instead. LFS is being phased out, see rust-lang/libc#4805."
+                )
+            )]
             pub fn fstat64(fildes: c_int, buf: *mut stat64) -> c_int;
             #[cfg_attr(gnu_time_bits64, link_name = "__fstatat64_time64")]
             #[cfg(not(target_os = "l4re"))]
@@ -2157,11 +2204,36 @@ cfg_if! {
                 buf: *mut stat64,
                 flags: c_int,
             ) -> c_int;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `ftruncate` instead. LFS is being phased out, see \
+                            rust-lang/libc#4805."
+                ),
+                allow(deprecated)
+            )]
             pub fn ftruncate64(fd: c_int, length: off64_t) -> c_int;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `lseek` instead. LFS is being phased out, see rust-lang/libc#4805."
+                ),
+                allow(deprecated)
+            )]
             pub fn lseek64(fd: c_int, offset: off64_t, whence: c_int) -> off64_t;
             #[cfg_attr(gnu_time_bits64, link_name = "__lstat64_time64")]
             #[cfg(not(target_os = "l4re"))]
             pub fn lstat64(path: *const c_char, buf: *mut stat64) -> c_int;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `mmap` instead. LFS is being phased out, see rust-lang/libc#4805."
+                ),
+                allow(deprecated)
+            )]
             pub fn mmap64(
                 addr: *mut c_void,
                 len: size_t,
@@ -2170,22 +2242,79 @@ cfg_if! {
                 fd: c_int,
                 offset: off64_t,
             ) -> *mut c_void;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `open` instead. LFS is being phased out, see rust-lang/libc#4805."
+                )
+            )]
             pub fn open64(path: *const c_char, oflag: c_int, ...) -> c_int;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `openat` instead. LFS is being phased out, see rust-lang/libc#4805."
+                )
+            )]
             pub fn openat64(fd: c_int, path: *const c_char, oflag: c_int, ...) -> c_int;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `posix_fadvise` instead. LFS is being phased out, see \
+                            rust-lang/libc#4805."
+                ),
+                allow(deprecated)
+            )]
             pub fn posix_fadvise64(
                 fd: c_int,
                 offset: off64_t,
                 len: off64_t,
                 advise: c_int,
             ) -> c_int;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `pread` instead. LFS is being phased out, see rust-lang/libc#4805."
+                ),
+                allow(deprecated)
+            )]
             pub fn pread64(fd: c_int, buf: *mut c_void, count: size_t, offset: off64_t) -> ssize_t;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `pwrite` instead. LFS is being phased out, see rust-lang/libc#4805."
+                ),
+                allow(deprecated)
+            )]
             pub fn pwrite64(
                 fd: c_int,
                 buf: *const c_void,
                 count: size_t,
                 offset: off64_t,
             ) -> ssize_t;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `readdir` instead. LFS is being phased out, see \
+                            rust-lang/libc#4805."
+                ),
+                allow(deprecated)
+            )]
             pub fn readdir64(dirp: *mut crate::DIR) -> *mut crate::dirent64;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `readdir_r` instead. LFS is being phased out, see \
+                            rust-lang/libc#4805."
+                ),
+                allow(deprecated)
+            )]
             pub fn readdir64_r(
                 dirp: *mut crate::DIR,
                 entry: *mut crate::dirent64,
@@ -2194,6 +2323,15 @@ cfg_if! {
             #[cfg_attr(gnu_time_bits64, link_name = "__stat64_time64")]
             #[cfg(not(target_os = "l4re"))]
             pub fn stat64(path: *const c_char, buf: *mut stat64) -> c_int;
+            #[cfg_attr(
+                target_os = "l4re",
+                deprecated(
+                    since = "0.2.190",
+                    note = "Use `truncate` instead. LFS is being phased out, see \
+                            rust-lang/libc#4805."
+                ),
+                allow(deprecated)
+            )]
             pub fn truncate64(path: *const c_char, length: off64_t) -> c_int;
         }
     }


### PR DESCRIPTION
# Description

This PR deprecates a number of symbols from the `unix/linux_like/l4re` module. This has also come with further deprecations and modifications in other top-level modules.

At present, the definitions in upstream l4re-core are always 64-bit wide for the 64-bit targets we seem to support in this module. Though rustc only has support for x86_64 under this target OS.

## Sources

Sources on the uClibc changes are documented in rust-lang/libc#5165. A regex search of the affected symbols on l4re-core's `libc` directory reveals no modifications in their patches would necessitate changes in this patch.

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
