### PR TITLE
apple: Make `bsdshortinfo.pbsi_rfu` nonpublic

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -629,7 +629,7 @@ s! {
         /// Current SVGID on process.
         pub pbsi_svgid: crate::gid_t,
         /// Reserved for future use.
-        pub pbsi_rfu: u32,
+        pbsi_rfu: u32,
     }
 
     pub struct proc_taskallinfo {


### PR DESCRIPTION
This has not yet made it to a release.