### PR TITLE
android: deprecate file offset types in targets with 64-bit abis

### DIFF
--- a/src/unix/linux_like/android/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/android/b64/aarch64/mod.rs
@@ -1,4 +1,3 @@
-use crate::off64_t;
 use crate::prelude::*;
 
 pub type wchar_t = u32;
@@ -15,7 +14,7 @@ s! {
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
         __pad1: Padding<c_ulong>,
-        pub st_size: off64_t,
+        pub st_size: crate::off_t,
         pub st_blksize: c_int,
         __pad2: Padding<c_int>,
         pub st_blocks: c_long,
@@ -29,6 +28,12 @@ s! {
         __unused5: Padding<c_uint>,
     }
 
+    #[deprecated(
+        since = "0.2.187",
+        note = "Use `stat` instead. Under 64-bit ABIs, Android aliases these types, and the `libc` \
+                crate is phasing out support for suffixed types in favor of a single, fixed-width unsuffixed type."
+    )]
+    #[allow(deprecated)]
     pub struct stat64 {
         pub st_dev: crate::dev_t,
         pub st_ino: crate::ino_t,
@@ -38,7 +43,7 @@ s! {
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
         __pad1: Padding<c_ulong>,
-        pub st_size: off64_t,
+        pub st_size: crate::off64_t,
         pub st_blksize: c_int,
         __pad2: Padding<c_int>,
         pub st_blocks: c_long,

--- a/src/unix/linux_like/android/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/android/b64/aarch64/mod.rs
@@ -27,6 +27,7 @@ s! {
         __unused5: Padding<c_uint>,
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct stat64 {
         pub st_dev: crate::dev_t,
         pub st_ino: crate::ino_t,

--- a/src/unix/linux_like/android/b64/mod.rs
+++ b/src/unix/linux_like/android/b64/mod.rs
@@ -4,8 +4,15 @@ use crate::prelude::*;
 // but may be wrong for mips64
 
 pub type mode_t = u32;
-pub type off64_t = i64;
 pub type socklen_t = u32;
+
+#[deprecated(
+    since = "0.2.187",
+    note = "Use `off_t` instead. Under 64-bit ABIs, Android just aliases these two types, and the \
+            `libc` crate is phasing out support for suffixed types in favor of exposing a single, \
+            fixed-width unsuffixed type."
+)]
+pub type off64_t = i64;
 
 s! {
     pub struct sigset_t {
@@ -21,6 +28,12 @@ s! {
         pub sa_restorer: Option<extern "C" fn()>,
     }
 
+    #[deprecated(
+        since = "0.2.187",
+        note = "Use `rlimit` instead. Under 64-bit ABIs, Android aliases these types, and the \
+                `libc` crate is phasing out support for suffixed variants in favor of a single, \
+                fixed-width suffixed type."
+    )]
     pub struct rlimit64 {
         pub rlim_cur: c_ulonglong,
         pub rlim_max: c_ulonglong,
@@ -78,6 +91,12 @@ s! {
         pub _f: [c_char; 0],
     }
 
+    #[deprecated(
+        since = "0.2.187",
+        note = "Use `statfs` instead. Under 64-bit ABIs, Android aliases these types, and the \
+               `libc` crate is phasing out support for suffixed types in favor of a single \
+               unsuffixed type with a fixed bit width."
+    )]
     pub struct statfs64 {
         pub f_type: u64,
         pub f_bsize: u64,
@@ -93,6 +112,12 @@ s! {
         pub f_spare: [u64; 4],
     }
 
+    #[deprecated(
+        since = "0.2.187",
+        note = "Use `statfs` instead. Under 64-bit ABIs, Android aliases these types, and the \
+               `libc` crate is phasing out support for suffixed types in favor of a single \
+               unsuffixed type with a fixed bit width."
+    )]
     pub struct statvfs64 {
         pub f_bsize: c_ulong,
         pub f_frsize: c_ulong,
@@ -135,6 +160,12 @@ s! {
         __reserved: Padding<[c_char; 36]>,
     }
 
+    #[deprecated(
+        since = "0.2.187",
+        note = "Use `sigset_t` instead. Under 64-bit ABIs, Android aliases these types, and the \
+                `libc` crate is phasing out support for suffixed variants in favor of a single, \
+                unsuffixed type with a fixed bit width."
+    )]
     pub struct sigset64_t {
         __bits: [c_ulong; 1],
     }

--- a/src/unix/linux_like/android/b64/mod.rs
+++ b/src/unix/linux_like/android/b64/mod.rs
@@ -4,6 +4,7 @@ use crate::prelude::*;
 // but may be wrong for mips64
 
 pub type mode_t = u32;
+// FIXME(1.0,deprecate): lfs binding to be removed
 pub type off64_t = i64;
 pub type socklen_t = u32;
 
@@ -21,6 +22,7 @@ s! {
         pub sa_restorer: Option<extern "C" fn()>,
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct rlimit64 {
         pub rlim_cur: c_ulonglong,
         pub rlim_max: c_ulonglong,
@@ -78,6 +80,7 @@ s! {
         pub _f: [c_char; 0],
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct statfs64 {
         pub f_type: u64,
         pub f_bsize: u64,
@@ -93,6 +96,7 @@ s! {
         pub f_spare: [u64; 4],
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct statvfs64 {
         pub f_bsize: c_ulong,
         pub f_frsize: c_ulong,
@@ -135,6 +139,7 @@ s! {
         __reserved: Padding<[c_char; 36]>,
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct sigset64_t {
         __bits: [c_ulong; 1],
     }

--- a/src/unix/linux_like/android/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/android/b64/riscv64/mod.rs
@@ -1,4 +1,3 @@
-use crate::off64_t;
 use crate::prelude::*;
 
 pub type wchar_t = u32;
@@ -16,7 +15,7 @@ s! {
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
         __pad1: Padding<c_ulong>,
-        pub st_size: off64_t,
+        pub st_size: crate::off_t,
         pub st_blksize: c_int,
         __pad2: Padding<c_int>,
         pub st_blocks: c_long,
@@ -30,6 +29,13 @@ s! {
         __unused5: Padding<c_uint>,
     }
 
+    #[deprecated(
+        since = "0.2.187",
+        note = "Use `stat` instead. Under 64-bit ABIs, Android aliases these types, and the `libc` \
+                crate is phasing out support for suffixed types in favor of a single unsuffixed \
+                type with a fixed bit width."
+    )]
+    #[allow(deprecated)]
     pub struct stat64 {
         pub st_dev: crate::dev_t,
         pub st_ino: crate::ino_t,
@@ -39,7 +45,7 @@ s! {
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
         __pad1: Padding<c_ulong>,
-        pub st_size: off64_t,
+        pub st_size: crate::off64_t,
         pub st_blksize: c_int,
         __pad2: Padding<c_int>,
         pub st_blocks: c_long,

--- a/src/unix/linux_like/android/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/android/b64/riscv64/mod.rs
@@ -28,6 +28,7 @@ s! {
         __unused5: Padding<c_uint>,
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct stat64 {
         pub st_dev: crate::dev_t,
         pub st_ino: crate::ino_t,

--- a/src/unix/linux_like/android/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/android/b64/x86_64/mod.rs
@@ -1,4 +1,3 @@
-use crate::off64_t;
 use crate::prelude::*;
 
 pub type wchar_t = i32;
@@ -15,7 +14,7 @@ s! {
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
-        pub st_size: off64_t,
+        pub st_size: crate::off_t,
         pub st_blksize: c_long,
         pub st_blocks: c_long,
         pub st_atime: c_long,
@@ -27,6 +26,13 @@ s! {
         __unused: Padding<[c_long; 3]>,
     }
 
+    #[deprecated(
+        since = "0.2.187",
+        note = "Use `stat` instead. Under 64-bit ABIs, Android aliases these types, and the `libc` \
+                crate is phasing out support for suffixed types in favor of a single, unsuffixed, \
+                fixed-width type."
+    )]
+    #[allow(deprecated)]
     pub struct stat64 {
         pub st_dev: crate::dev_t,
         pub st_ino: crate::ino_t,
@@ -35,7 +41,7 @@ s! {
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
-        pub st_size: off64_t,
+        pub st_size: crate::off64_t,
         pub st_blksize: c_long,
         pub st_blocks: c_long,
         pub st_atime: c_long,
@@ -156,6 +162,7 @@ s! {
 }
 
 s_no_extra_traits! {
+    #[allow(deprecated)]
     pub union __c_anonymous_uc_sigmask {
         uc_sigmask: crate::sigset_t,
         uc_sigmask64: crate::sigset64_t,

--- a/src/unix/linux_like/android/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/android/b64/x86_64/mod.rs
@@ -25,6 +25,7 @@ s! {
         __unused: Padding<[c_long; 3]>,
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct stat64 {
         pub st_dev: crate::dev_t,
         pub st_ino: crate::ino_t,

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -34,7 +34,6 @@ pub type nfds_t = c_uint;
 pub type rlim_t = c_ulong;
 pub type dev_t = c_ulong;
 pub type ino_t = c_ulong;
-pub type ino64_t = u64;
 pub type __CPU_BITTYPE = c_ulong;
 pub type idtype_t = c_int;
 pub type loff_t = c_longlong;
@@ -47,6 +46,17 @@ pub type __s16 = c_short;
 pub type __u32 = c_uint;
 pub type __s32 = c_int;
 pub type __be16 = __u16;
+
+#[cfg_attr(
+    target_pointer_width = "64",
+    deprecated(
+        since = "0.2.187",
+        note = "Use `ino_t` instead. Under 64-bit ABIs, Android aliases these types and the `libc` \
+                crate is phasing out support for suffixed variants in favor of a single, \
+                fixed-width unsuffixed type."
+    )
+)]
+pub type ino64_t = u64;
 
 // linux/elf.h
 
@@ -119,6 +129,15 @@ s! {
         pub l_pid: crate::pid_t,
     }
 
+    #[cfg_attr(
+        target_pointer_width = "64",
+        deprecated(
+            since = "0.2.187",
+            note = "Use `flock` instead. Under 64-bit ABIs, Android aliases these types, and the \
+                    `libc` crate is phasing out support for suffixed variants in favor of a single, \
+                    unsuffixed, fixed-width symbol."
+        )
+    )]
     pub struct flock64 {
         pub l_type: c_short,
         pub l_whence: c_short,
@@ -511,6 +530,12 @@ s! {
         pub d_name: [c_char; 256],
     }
 
+    #[deprecated(
+        since = "0.2.187",
+        note = "Use `dirent` instead. This type is defined as an alias to it and the `libc` crate \
+                is phasing out support for suffixed types in favor of a single, fixed-width \
+                unsuffixed type."
+    )]
     pub struct dirent64 {
         pub d_ino: u64,
         pub d_off: i64,
@@ -3397,7 +3422,27 @@ extern "C" {
     pub fn setgrent();
     pub fn endgrent();
     pub fn getgrent() -> *mut crate::group;
+    #[cfg_attr(
+        target_pointer_width = "64",
+        deprecated(
+            since = "0.2.187",
+            note = "Use `getrlimit` instead. Under 64-bit ABIs, Android aliases these types and the \
+                    `libc` crate is phasing out support for suffixed variants in favor of a single, \
+                    fixed-width, unsuffixed type."
+        ),
+        allow(deprecated)
+    )]
     pub fn getrlimit64(resource: c_int, rlim: *mut rlimit64) -> c_int;
+    #[cfg_attr(
+        target_pointer_width = "64",
+        deprecated(
+            since = "0.2.187",
+            note = "Use `setrlimit` instead. Under 64-bit ABIs, Android aliases these types and the \
+                    `libc` crate is phasing out support for suffixed variants in favor of a single, \
+                    fixed-width, unsuffixed type."
+        ),
+        allow(deprecated)
+    )]
     pub fn setrlimit64(resource: c_int, rlim: *const rlimit64) -> c_int;
     pub fn getrlimit(resource: c_int, rlim: *mut crate::rlimit) -> c_int;
     pub fn setrlimit(resource: c_int, rlim: *const crate::rlimit) -> c_int;
@@ -3407,6 +3452,16 @@ extern "C" {
         new_limit: *const crate::rlimit,
         old_limit: *mut crate::rlimit,
     ) -> c_int;
+    #[cfg_attr(
+        target_pointer_width = "64",
+        deprecated(
+            since = "0.2.187",
+            note = "Use `prlimit` instead. Under 64-bit ABIs, Android aliases these types and the \
+                    `libc` crate is phasing out support for suffixed variants in favor of a single, \
+                    fixed-width, unsuffixed type."
+        ),
+        allow(deprecated)
+    )]
     pub fn prlimit64(
         pid: crate::pid_t,
         resource: c_int,
@@ -3467,8 +3522,28 @@ extern "C" {
     pub fn seekdir(dirp: *mut crate::DIR, loc: c_long);
     pub fn telldir(dirp: *mut crate::DIR) -> c_long;
     pub fn fallocate(fd: c_int, mode: c_int, offset: off_t, len: off_t) -> c_int;
+    #[cfg_attr(
+        target_pointer_width = "64",
+        deprecated(
+            since = "0.2.187",
+            note = "Use `fallocate` instead. Under 64-bit ABIs, Android aliases these types and \
+                    the `libc` crate is phasing out support for suffixed variants in favor of a \
+                    fixed-width unsuffixed type."
+        ),
+        allow(deprecated)
+    )]
     pub fn fallocate64(fd: c_int, mode: c_int, offset: off64_t, len: off64_t) -> c_int;
     pub fn posix_fallocate(fd: c_int, offset: off_t, len: off_t) -> c_int;
+    #[cfg_attr(
+        target_pointer_width = "64",
+        deprecated(
+            since = "0.2.187",
+            note = "Use `posix_fallocate` instead. Under 64-bit ABIs, Android aliases these types \
+                    and the `libc` crate is phasing out support for suffixed variants in favor of \
+                    a fixed-width unsuffixed type."
+        ),
+        allow(deprecated)
+    )]
     pub fn posix_fallocate64(fd: c_int, offset: off64_t, len: off64_t) -> c_int;
     pub fn getxattr(
         path: *const c_char,
@@ -3625,6 +3700,16 @@ extern "C" {
         param: *const crate::sched_param,
     ) -> c_int;
     pub fn sendfile(out_fd: c_int, in_fd: c_int, offset: *mut off_t, count: size_t) -> ssize_t;
+    #[cfg_attr(
+        target_pointer_width = "64",
+        deprecated(
+            since = "0.2.187",
+            note = "Use `sendfile` instead. Under 64-bit ABIs, Android aliases these types and the \
+                    `libc` crate is phasing out support for suffixed variants in favor of a single \
+                    unsuffixed type with a fixed bit-width."
+        ),
+        allow(deprecated)
+    )]
     pub fn sendfile64(out_fd: c_int, in_fd: c_int, offset: *mut off64_t, count: size_t) -> ssize_t;
     pub fn setfsgid(gid: crate::gid_t) -> c_int;
     pub fn setfsuid(uid: crate::uid_t) -> c_int;

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -36,6 +36,7 @@ pub type nfds_t = c_uint;
 pub type rlim_t = c_ulong;
 pub type dev_t = c_ulong;
 pub type ino_t = c_ulong;
+// FIXME(1.0,deprecate): lfs binding to be removed
 pub type ino64_t = u64;
 pub type __CPU_BITTYPE = c_ulong;
 pub type idtype_t = c_int;
@@ -114,6 +115,7 @@ s! {
         pub l_pid: crate::pid_t,
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct flock64 {
         pub l_type: c_short,
         pub l_whence: c_short,
@@ -534,6 +536,7 @@ s! {
         pub d_name: [c_char; 256],
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct dirent64 {
         pub d_ino: u64,
         pub d_off: i64,
@@ -3512,7 +3515,9 @@ extern "C" {
     pub fn setgrent();
     pub fn endgrent();
     pub fn getgrent() -> *mut crate::group;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn getrlimit64(resource: c_int, rlim: *mut rlimit64) -> c_int;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn setrlimit64(resource: c_int, rlim: *const rlimit64) -> c_int;
     pub fn getrlimit(resource: c_int, rlim: *mut crate::rlimit) -> c_int;
     pub fn setrlimit(resource: c_int, rlim: *const crate::rlimit) -> c_int;
@@ -3522,6 +3527,7 @@ extern "C" {
         new_limit: *const crate::rlimit,
         old_limit: *mut crate::rlimit,
     ) -> c_int;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn prlimit64(
         pid: crate::pid_t,
         resource: c_int,
@@ -3582,8 +3588,10 @@ extern "C" {
     pub fn seekdir(dirp: *mut crate::DIR, loc: c_long);
     pub fn telldir(dirp: *mut crate::DIR) -> c_long;
     pub fn fallocate(fd: c_int, mode: c_int, offset: off_t, len: off_t) -> c_int;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn fallocate64(fd: c_int, mode: c_int, offset: off64_t, len: off64_t) -> c_int;
     pub fn posix_fallocate(fd: c_int, offset: off_t, len: off_t) -> c_int;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn posix_fallocate64(fd: c_int, offset: off64_t, len: off64_t) -> c_int;
     pub fn getxattr(
         path: *const c_char,
@@ -3740,6 +3748,7 @@ extern "C" {
         param: *const crate::sched_param,
     ) -> c_int;
     pub fn sendfile(out_fd: c_int, in_fd: c_int, offset: *mut off_t, count: size_t) -> ssize_t;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn sendfile64(out_fd: c_int, in_fd: c_int, offset: *mut off64_t, count: size_t) -> ssize_t;
     pub fn setfsgid(gid: crate::gid_t) -> c_int;
     pub fn setfsuid(uid: crate::uid_t) -> c_int;

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -2099,26 +2099,135 @@ cfg_if! {
         target_os = "emscripten",
     )))] {
         extern "C" {
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                ),
+                allow(deprecated)
+            )]
             pub fn fstatfs64(fd: c_int, buf: *mut statfs64) -> c_int;
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                ),
+                allow(deprecated)
+            )]
             pub fn statvfs64(path: *const c_char, buf: *mut statvfs64) -> c_int;
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                ),
+                allow(deprecated)
+            )]
             pub fn fstatvfs64(fd: c_int, buf: *mut statvfs64) -> c_int;
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                ),
+                allow(deprecated)
+            )]
             pub fn statfs64(path: *const c_char, buf: *mut statfs64) -> c_int;
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                )
+            )]
             pub fn creat64(path: *const c_char, mode: mode_t) -> c_int;
             #[cfg_attr(gnu_time_bits64, link_name = "__fstat64_time64")]
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                ),
+                allow(deprecated)
+            )]
             pub fn fstat64(fildes: c_int, buf: *mut stat64) -> c_int;
             #[cfg_attr(gnu_time_bits64, link_name = "__fstatat64_time64")]
             #[cfg(not(target_os = "l4re"))]
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                ),
+                allow(deprecated)
+            )]
             pub fn fstatat64(
                 dirfd: c_int,
                 pathname: *const c_char,
                 buf: *mut stat64,
                 flags: c_int,
             ) -> c_int;
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                ),
+                allow(deprecated)
+            )]
             pub fn ftruncate64(fd: c_int, length: off64_t) -> c_int;
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                ),
+                allow(deprecated)
+            )]
             pub fn lseek64(fd: c_int, offset: off64_t, whence: c_int) -> off64_t;
             #[cfg_attr(gnu_time_bits64, link_name = "__lstat64_time64")]
             #[cfg(not(target_os = "l4re"))]
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                ),
+                allow(deprecated)
+            )]
             pub fn lstat64(path: *const c_char, buf: *mut stat64) -> c_int;
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                ),
+                allow(deprecated)
+            )]
             pub fn mmap64(
                 addr: *mut c_void,
                 len: size_t,
@@ -2127,22 +2236,90 @@ cfg_if! {
                 fd: c_int,
                 offset: off64_t,
             ) -> *mut c_void;
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                )
+            )]
             pub fn open64(path: *const c_char, oflag: c_int, ...) -> c_int;
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                )
+            )]
             pub fn openat64(fd: c_int, path: *const c_char, oflag: c_int, ...) -> c_int;
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                ),
+                allow(deprecated)
+            )]
             pub fn posix_fadvise64(
                 fd: c_int,
                 offset: off64_t,
                 len: off64_t,
                 advise: c_int,
             ) -> c_int;
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                ),
+                allow(deprecated)
+            )]
             pub fn pread64(fd: c_int, buf: *mut c_void, count: size_t, offset: off64_t) -> ssize_t;
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                ),
+                allow(deprecated)
+            )]
             pub fn pwrite64(
                 fd: c_int,
                 buf: *const c_void,
                 count: size_t,
                 offset: off64_t,
             ) -> ssize_t;
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                )
+            )]
+            #[allow(deprecated)]
             pub fn readdir64(dirp: *mut crate::DIR) -> *mut crate::dirent64;
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                )
+            )]
+            #[allow(deprecated)]
             pub fn readdir64_r(
                 dirp: *mut crate::DIR,
                 entry: *mut crate::dirent64,
@@ -2150,7 +2327,27 @@ cfg_if! {
             ) -> c_int;
             #[cfg_attr(gnu_time_bits64, link_name = "__stat64_time64")]
             #[cfg(not(target_os = "l4re"))]
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                ),
+                allow(deprecated)
+            )]
             pub fn stat64(path: *const c_char, buf: *mut stat64) -> c_int;
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `ftruncate` instead. Under 64-bit ABIs, Android aliases these \
+                            routines, and the `libc` crate is phasing out support for suffixed \
+                            types in favor of a single unsuffixed type with a fixed bit width."
+                ),
+                allow(deprecated)
+            )]
             pub fn truncate64(path: *const c_char, length: off64_t) -> c_int;
         }
     }
@@ -2164,12 +2361,32 @@ cfg_if! {
         target_os = "emscripten",
     )))] {
         extern "C" {
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `preadv` instead. Under 64-bit ABIs, Android aliases these types, \
+                            and the `libc` crate is phasing out support for suffixed variants in \
+                            favor of a single fixed-width unsuffixed type."
+                ),
+                allow(deprecated)
+            )]
             pub fn preadv64(
                 fd: c_int,
                 iov: *const crate::iovec,
                 iovcnt: c_int,
                 offset: off64_t,
             ) -> ssize_t;
+            #[cfg_attr(
+                all(target_os = "android", target_pointer_width = "64"),
+                deprecated(
+                    since = "0.2.187",
+                    note = "Use `pwritev` instead. Under 64-bit ABIs, Android aliases these types, \
+                            and the `libc` crate is phasing out support for suffixed variants in \
+                            favor of a single fixed-width unsuffixed type."
+                ),
+                allow(deprecated)
+            )]
             pub fn pwritev64(
                 fd: c_int,
                 iov: *const crate::iovec,

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -2142,26 +2142,37 @@ cfg_if! {
         target_os = "emscripten",
     )))] {
         extern "C" {
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn fstatfs64(fd: c_int, buf: *mut statfs64) -> c_int;
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn statvfs64(path: *const c_char, buf: *mut statvfs64) -> c_int;
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn fstatvfs64(fd: c_int, buf: *mut statvfs64) -> c_int;
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn statfs64(path: *const c_char, buf: *mut statfs64) -> c_int;
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn creat64(path: *const c_char, mode: mode_t) -> c_int;
             #[cfg_attr(gnu_time_bits64, link_name = "__fstat64_time64")]
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn fstat64(fildes: c_int, buf: *mut stat64) -> c_int;
             #[cfg_attr(gnu_time_bits64, link_name = "__fstatat64_time64")]
             #[cfg(not(target_os = "l4re"))]
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn fstatat64(
                 dirfd: c_int,
                 pathname: *const c_char,
                 buf: *mut stat64,
                 flags: c_int,
             ) -> c_int;
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn ftruncate64(fd: c_int, length: off64_t) -> c_int;
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn lseek64(fd: c_int, offset: off64_t, whence: c_int) -> off64_t;
             #[cfg_attr(gnu_time_bits64, link_name = "__lstat64_time64")]
             #[cfg(not(target_os = "l4re"))]
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn lstat64(path: *const c_char, buf: *mut stat64) -> c_int;
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn mmap64(
                 addr: *mut c_void,
                 len: size_t,
@@ -2170,22 +2181,29 @@ cfg_if! {
                 fd: c_int,
                 offset: off64_t,
             ) -> *mut c_void;
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn open64(path: *const c_char, oflag: c_int, ...) -> c_int;
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn openat64(fd: c_int, path: *const c_char, oflag: c_int, ...) -> c_int;
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn posix_fadvise64(
                 fd: c_int,
                 offset: off64_t,
                 len: off64_t,
                 advise: c_int,
             ) -> c_int;
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn pread64(fd: c_int, buf: *mut c_void, count: size_t, offset: off64_t) -> ssize_t;
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn pwrite64(
                 fd: c_int,
                 buf: *const c_void,
                 count: size_t,
                 offset: off64_t,
             ) -> ssize_t;
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn readdir64(dirp: *mut crate::DIR) -> *mut crate::dirent64;
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn readdir64_r(
                 dirp: *mut crate::DIR,
                 entry: *mut crate::dirent64,
@@ -2193,7 +2211,9 @@ cfg_if! {
             ) -> c_int;
             #[cfg_attr(gnu_time_bits64, link_name = "__stat64_time64")]
             #[cfg(not(target_os = "l4re"))]
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn stat64(path: *const c_char, buf: *mut stat64) -> c_int;
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn truncate64(path: *const c_char, length: off64_t) -> c_int;
         }
     }
@@ -2207,12 +2227,14 @@ cfg_if! {
         target_os = "emscripten",
     )))] {
         extern "C" {
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn preadv64(
                 fd: c_int,
                 iov: *const crate::iovec,
                 iovcnt: c_int,
                 offset: off64_t,
             ) -> ssize_t;
+            // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn pwritev64(
                 fd: c_int,
                 iov: *const crate::iovec,


### PR DESCRIPTION
# Description

This PR deprecates symbols. Affected symbols include LFS64 bindings. Android is the target OS. 64-bit ABI architectures are affected. 32-bit ABI architectures are not.

Android aliases these types. This only applies to 64-bit ABI targets [[1].] Anybody using them should be unaffected. A warning should be all they get. 32-bit targets are unchanged.

[1]: https://android.googlesource.com/platform/bionic/+/main/docs/32-bit-abi.md

## Sources

- Upstream code search yielding results for suffixed variants of LFS64 routines existing as aliases to suffixed variants. Only a few examples are provided because others follow the same pattern.

  > <https://cs.android.com/search?q=case:y%20lang:c%20pcre:y%20symbol:%5Cbfstatfs64%5Cb>
  > <https://cs.android.com/search?q=case:y%20lang:c%20pcre:y%20symbol:%5Cbstatvfs64%5Cb%20function:%5Cbstatvfs64%5Cb>
  > <https://cs.android.com/search?q=case:y%20lang:c%20pcre:y%20function:%5Cbfstatvfs64%5Cb&sq=>
  > <https://cs.android.com/search?q=case:y%20lang:c%20pcre:y%20function:%5Cbstatfs64%5Cb>
- Upstream code search shows how `ino64_t` is defined in terms of its unsuffixed type in the vendored musl. Other libc implementations for targets with a 64-bit ABI follow that the effective bit width of the type is equivalent to that of the unsuffixed type. The "end" type to which all prior type aliases resolve to is a C `unsigned long` in 64-bit ABIs and a a C `unsigned long long` otherwise. This matches up with the 64-bit fixed width definition in the vendored musl, and thus serves the same aliasing purposes.

  > <https://cs.android.com/search?q=case:y%20lang:c%20pcre:y%20symbol:%5Cbino64_t%5Cb>
  > <https://cs.android.com/search?q=case:y%20lang:c%20pcre:y%20symbol:%5Cb__ino_t%5Cb>
  > <https://cs.android.com/search?q=case:y%20lang:c%20pcre:y%20symbol:%5Cb__kernel_ino_t%5Cb>
  > <https://cs.android.com/search?q=case:y%20lang:c%20pcre:y%20symbol:%5Cb__kernel_ulong_t%5Cb&sq=>
- Upstream code search shows how `flock64` has the same definition as `flock`. All its fields except those that are `off_t` are equivalent, and under 64-bit ABIs, `off_t` is also equivalent to `off64_t`.

  > <https://cs.android.com/search?q=case:y%20lang:c%7Ccc%20pcre:y%20symbol:%5Cbflock%5Cd*%5Cb&sq=>
- Upstream code search shows how `dirent64` has an equivalent definition to `dirent`. Its fields display the same pattern as the above type. Note that search result also contains irrelevant results, and one should look only at those where an actual record is defined. Some of the vendored libc implementations will `#define` one in terms of the other, while others will just check for the presence of the `__LARGEFILE64_SOURCE` feature test macro. We can safely assume that an internal Android-specific shim is already in charge of defining those when and if needed.

  > <https://cs.android.com/search?q=case:y%20lang:c%7Ccc%20pcre:y%20symbol:%5Cbdirent%5Cd*%5Cb>
- Upstream code search shows how `off64_t` has an equivalent definition to its unsuffixed variant. This follows the same pattern as the above types. Note how the source files where it is declared in terms of the unsuffixed type correspond to either 64-bit ABI targets, or are conditionally compiled for such platforms.

  > <https://cs.android.com/search?q=case:y%20lang:c%7Ccc%20pcre:y%20symbol:%5Cboff64_t%5Cb&sq=>
- Upstream code search shows how `rlim64_t` is defined in terms of `rlim_t`. `rlimit64` then follows with a definition that only varies from `rlimit` in whether it uses `rlim64_t` or `rlim_t` for its fields.

  > <https://cs.android.com/search?q=case:y%20lang:c%7Ccc%20pcre:y%20symbol:%5Cbrlim64_t%5Cb>
  > <https://cs.android.com/search?q=case:y%20lang:c%7Ccc%20pcre:y%20symbol:%5Cbrlimit64%5Cb>
- Upstream code search shows how `statfs64` has definitions with fields equivalent to those of the unsuffixed type. The latter further uses other type aliases for which sources are also provided, and for which the effective bit width is equivalent once conditionally compiled code resolves in targets with a 64-bit ABI.

  > <https://cs.android.com/search?q=case:y%20lang:c%7Ccc%20pcre:y%20symbol:%5Cbstatfs64%5Cb&sq=>
  > <https://cs.android.com/search?q=case:y%20lang:c%7Ccc%20pcre:y%20symbol:%5Cb__statfs_word%5Cb>
- Upstream code search showing how `statvfs64` has some fields which are conditionally defined as being 64-bit wide under the presence of certain feature test macros (or is altogether not defined under certain other macros.) Android requires not that the user `#define` these (required in vendored libc implementations,) so one can assume they are `#define`d in internal shims.

  > <https://cs.android.com/search?q=case:y%20lang:c%7Ccc%20pcre:y%20symbol:%5Cbstatvfs64%5Cb&sq=>
- Upstream code shows how the `sigset64_t` type is always defined in terms of `sigset_t`.

  > <https://cs.android.com/android/platform/superproject/+/android-latest-release:art/runtime/signal_set.h?q=case:y%20lang:c%7Ccc%20pcre:y%20symbol:%5Cbsigset64_t%5Cb>

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
