### PR TITLE
feat: add macro to declare unstable constants

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -402,6 +402,21 @@ macro_rules! offset_of {
     }};
 }
 
+/// Defines constants with an accompanying doc comment pointing out their
+/// instability, and links to the crate documentation for usage guidelines.
+macro_rules! ct {
+    ($($it:item)+) => {
+$(
+/// This constant, among others often used in C for the purposes of denoting the
+/// latest value or limit in a set of constants, is likely to change upstream.
+/// For correct usage, see the [crate-level documentation][docs].
+///
+/// [docs]: index.html#usage-recommendations
+$it
+)+
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use core::any::TypeId;


### PR DESCRIPTION
# Description

This PR adds a new macro that should align with the new usage guidelines in rust-lang/libc#5179.

This macro is meant to be used with constants that are likely to suffer from SemVer-breaking changes but which the new usage guidelines accept as being part of stable `libc` crate relases.

It has been used in rust-lang/libc#5118, rust-lang/libc#5119, rust-lang/libc#5120, rust-lang/libc#5121, rust-lang/libc#5122 and rust-lang/libc#5123.

While that PR gets merged, this PR will be left as a draft. The reason for that is that the link to the usage guidelines may change until rust-lang/libc#5179 is complete.

## Sources

Does not qualify.

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
