### PR TITLE
linux: Move `mount.h` constants to `src/new`

### DIFF
--- a/src/new/linux_uapi/linux/mod.rs
+++ b/src/new/linux_uapi/linux/mod.rs
@@ -5,5 +5,6 @@
 pub(crate) mod can;
 pub(crate) mod keyctl;
 pub(crate) mod membarrier;
+pub(crate) mod mount;
 pub(crate) mod netlink;
 pub(crate) mod pidfd;

--- a/src/new/linux_uapi/linux/mount.rs
+++ b/src/new/linux_uapi/linux/mount.rs
@@ -1,0 +1,68 @@
+//! Header: `uapi/linux/mount.h`
+
+use crate::prelude::*;
+
+pub const MS_RMT_MASK: c_ulong = crate::MS_RDONLY
+    | crate::MS_SYNCHRONOUS
+    | crate::MS_MANDLOCK
+    | crate::MS_I_VERSION
+    | crate::MS_LAZYTIME;
+
+pub const OPEN_TREE_CLONE: c_uint = 0x01;
+pub const OPEN_TREE_NAMESPACE: c_uint = 0x02;
+pub const OPEN_TREE_CLOEXEC: c_uint = crate::O_CLOEXEC as c_uint;
+
+pub const MOVE_MOUNT_F_SYMLINKS: c_uint = 0x00000001;
+pub const MOVE_MOUNT_F_AUTOMOUNTS: c_uint = 0x00000002;
+pub const MOVE_MOUNT_F_EMPTY_PATH: c_uint = 0x00000004;
+pub const MOVE_MOUNT_T_SYMLINKS: c_uint = 0x00000010;
+pub const MOVE_MOUNT_T_AUTOMOUNTS: c_uint = 0x00000020;
+pub const MOVE_MOUNT_T_EMPTY_PATH: c_uint = 0x00000040;
+pub const MOVE_MOUNT_SET_GROUP: c_uint = 0x00000100;
+pub const MOVE_MOUNT_BENEATH: c_uint = 0x00000200;
+
+pub const FSOPEN_CLOEXEC: c_uint = 0x00000001;
+
+pub const FSPICK_CLOEXEC: c_uint = 0x00000001;
+pub const FSPICK_SYMLINK_NOFOLLOW: c_uint = 0x00000002;
+pub const FSPICK_NO_AUTOMOUNT: c_uint = 0x00000004;
+pub const FSPICK_EMPTY_PATH: c_uint = 0x00000008;
+
+c_enum! {
+    pub enum fsconfig_command {
+        pub FSCONFIG_SET_FLAG,
+        pub FSCONFIG_SET_STRING,
+        pub FSCONFIG_SET_BINARY,
+        pub FSCONFIG_SET_PATH,
+        pub FSCONFIG_SET_PATH_EMPTY,
+        pub FSCONFIG_SET_FD,
+        pub FSCONFIG_CMD_CREATE,
+        pub FSCONFIG_CMD_RECONFIGURE,
+        pub FSCONFIG_CMD_CREATE_EXCL,
+    }
+}
+
+pub const FSMOUNT_CLOEXEC: c_uint = 0x00000001;
+
+pub const MOUNT_ATTR_RDONLY: u64 = 0x00000001;
+pub const MOUNT_ATTR_NOSUID: u64 = 0x00000002;
+pub const MOUNT_ATTR_NODEV: u64 = 0x00000004;
+pub const MOUNT_ATTR_NOEXEC: u64 = 0x00000008;
+pub const MOUNT_ATTR__ATIME: u64 = 0x00000070;
+pub const MOUNT_ATTR_RELATIME: u64 = 0x00000000;
+pub const MOUNT_ATTR_NOATIME: u64 = 0x00000010;
+pub const MOUNT_ATTR_STRICTATIME: u64 = 0x00000020;
+pub const MOUNT_ATTR_NODIRATIME: u64 = 0x00000080;
+pub const MOUNT_ATTR_IDMAP: u64 = 0x00100000;
+pub const MOUNT_ATTR_NOSYMFOLLOW: u64 = 0x00200000;
+
+s! {
+    pub struct mount_attr {
+        pub attr_set: crate::__u64,
+        pub attr_clr: crate::__u64,
+        pub propagation: crate::__u64,
+        pub userns_fd: crate::__u64,
+    }
+}
+
+pub const MOUNT_ATTR_SIZE_VER0: c_int = 32;

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -182,6 +182,7 @@ cfg_if! {
         pub use linux::can::raw::*;
         pub use linux::keyctl::*;
         pub use linux::membarrier::*;
+        pub use linux::mount::*;
         pub use linux::netlink::*;
         pub use linux::pidfd::*;
         #[cfg(target_env = "gnu")]

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -546,8 +546,6 @@ pub const PRIO_PROCESS: crate::__priority_which_t = 0;
 pub const PRIO_PGRP: crate::__priority_which_t = 1;
 pub const PRIO_USER: crate::__priority_which_t = 2;
 
-pub const MS_RMT_MASK: c_ulong = 0x02800051;
-
 pub const __UT_LINESIZE: usize = 32;
 pub const __UT_NAMESIZE: usize = 32;
 pub const __UT_HOSTSIZE: usize = 256;
@@ -826,16 +824,6 @@ pub const M_ARENA_TEST: c_int = -7;
 pub const M_ARENA_MAX: c_int = -8;
 
 pub const SOMAXCONN: c_int = 4096;
-
-// linux/mount.h
-pub const MOVE_MOUNT_F_SYMLINKS: c_uint = 0x00000001;
-pub const MOVE_MOUNT_F_AUTOMOUNTS: c_uint = 0x00000002;
-pub const MOVE_MOUNT_F_EMPTY_PATH: c_uint = 0x00000004;
-pub const MOVE_MOUNT_T_SYMLINKS: c_uint = 0x00000010;
-pub const MOVE_MOUNT_T_AUTOMOUNTS: c_uint = 0x00000020;
-pub const MOVE_MOUNT_T_EMPTY_PATH: c_uint = 0x00000040;
-pub const MOVE_MOUNT_SET_GROUP: c_uint = 0x00000100;
-pub const MOVE_MOUNT_BENEATH: c_uint = 0x00000200;
 
 // sys/timex.h
 pub const ADJ_OFFSET: c_uint = 0x0001;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -993,15 +993,6 @@ s! {
         pub csum_offset: __u16,
     }
 
-    // linux/mount.h
-
-    pub struct mount_attr {
-        pub attr_set: crate::__u64,
-        pub attr_clr: crate::__u64,
-        pub propagation: crate::__u64,
-        pub userns_fd: crate::__u64,
-    }
-
     // linux/nsfs.h
     pub struct mnt_ns_info {
         pub size: crate::__u32,
@@ -3104,34 +3095,6 @@ pub const IN_ALL_EVENTS: u32 = IN_ACCESS
 pub const IN_CLOEXEC: c_int = O_CLOEXEC;
 pub const IN_NONBLOCK: c_int = O_NONBLOCK;
 
-// uapi/linux/mount.h
-pub const OPEN_TREE_CLONE: c_uint = 0x01;
-pub const OPEN_TREE_NAMESPACE: c_uint = 0x02;
-pub const OPEN_TREE_CLOEXEC: c_uint = O_CLOEXEC as c_uint;
-
-pub const FSOPEN_CLOEXEC: c_uint = 0x00000001;
-
-pub const FSPICK_CLOEXEC: c_uint = 0x00000001;
-pub const FSPICK_SYMLINK_NOFOLLOW: c_uint = 0x00000002;
-pub const FSPICK_NO_AUTOMOUNT: c_uint = 0x00000004;
-pub const FSPICK_EMPTY_PATH: c_uint = 0x00000008;
-
-pub const FSMOUNT_CLOEXEC: c_uint = 0x00000001;
-
-c_enum! {
-    pub enum fsconfig_command {
-        pub FSCONFIG_SET_FLAG,
-        pub FSCONFIG_SET_STRING,
-        pub FSCONFIG_SET_BINARY,
-        pub FSCONFIG_SET_PATH,
-        pub FSCONFIG_SET_PATH_EMPTY,
-        pub FSCONFIG_SET_FD,
-        pub FSCONFIG_CMD_CREATE,
-        pub FSCONFIG_CMD_RECONFIGURE,
-        pub FSCONFIG_CMD_CREATE_EXCL,
-    }
-}
-
 // uapi/linux/netfilter/nf_tables.h
 pub const NFT_TABLE_MAXNAMELEN: c_int = 256;
 pub const NFT_CHAIN_MAXNAMELEN: c_int = 256;
@@ -3897,21 +3860,6 @@ pub const XDP_TXMD_FLAGS_CHECKSUM: crate::__u32 = 1 << 1;
 pub const XDP_TX_METADATA: crate::__u32 = 1 << 1;
 
 pub const SOL_XDP: c_int = 283;
-
-// linux/mount.h
-pub const MOUNT_ATTR_RDONLY: crate::__u64 = 0x00000001;
-pub const MOUNT_ATTR_NOSUID: crate::__u64 = 0x00000002;
-pub const MOUNT_ATTR_NODEV: crate::__u64 = 0x00000004;
-pub const MOUNT_ATTR_NOEXEC: crate::__u64 = 0x00000008;
-pub const MOUNT_ATTR__ATIME: crate::__u64 = 0x00000070;
-pub const MOUNT_ATTR_RELATIME: crate::__u64 = 0x00000000;
-pub const MOUNT_ATTR_NOATIME: crate::__u64 = 0x00000010;
-pub const MOUNT_ATTR_STRICTATIME: crate::__u64 = 0x00000020;
-pub const MOUNT_ATTR_NODIRATIME: crate::__u64 = 0x00000080;
-pub const MOUNT_ATTR_IDMAP: crate::__u64 = 0x00100000;
-pub const MOUNT_ATTR_NOSYMFOLLOW: crate::__u64 = 0x00200000;
-
-pub const MOUNT_ATTR_SIZE_VER0: c_int = 32;
 
 pub const SCHED_FLAG_KEEP_ALL: c_int = SCHED_FLAG_KEEP_POLICY | SCHED_FLAG_KEEP_PARAMS;
 

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -509,8 +509,6 @@ pub const MAP_HUGE_1GB: c_int = 30 << MAP_HUGE_SHIFT;
 pub const MAP_HUGE_2GB: c_int = 31 << MAP_HUGE_SHIFT;
 pub const MAP_HUGE_16GB: c_int = 34 << MAP_HUGE_SHIFT;
 
-pub const MS_RMT_MASK: c_ulong = 0x02800051;
-
 // include/utmpx.h
 pub const EMPTY: c_short = 0;
 pub const RUN_LVL: c_short = 1;

--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -288,10 +288,6 @@ pub const LC_MESSAGES: c_int = 5;
 pub const LC_ALL: c_int = 6;
 // end different section
 
-// MS_ flags for mount(2)
-pub const MS_RMT_MASK: c_ulong =
-    crate::MS_RDONLY | crate::MS_SYNCHRONOUS | crate::MS_MANDLOCK | crate::MS_I_VERSION;
-
 pub const ENOTSUP: c_int = EOPNOTSUPP;
 
 pub const IPV6_JOIN_GROUP: c_int = 20;

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -598,6 +598,7 @@ pub const MS_NODIRATIME: c_ulong = 0x0800;
 pub const MS_BIND: c_ulong = 0x1000;
 pub const MS_MOVE: c_ulong = 0x2000;
 pub const MS_REC: c_ulong = 0x4000;
+// MS_VERBOSE is deprecated
 pub const MS_SILENT: c_ulong = 0x8000;
 pub const MS_POSIXACL: c_ulong = 0x010000;
 pub const MS_UNBINDABLE: c_ulong = 0x020000;


### PR DESCRIPTION
This has the effect of making `MOVE_MOUNT_*` constants available on all Linux platforms, not just glibc.

Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/mount.h?h=028ef9c96e96197026887c0f092424679298aae8