### PR TITLE
fix(android/aarch64): use `libc::ucontext_t` from Android NDK

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2248,8 +2248,6 @@ fn test_android(target: &str) {
             // These are tested as part of the linux_fcntl tests since there are
             // header conflicts when including them with all the other structs.
             "termios2" => true,
-            // uc_sigmask and uc_sigmask64 of ucontext_t are an anonymous union
-            "ucontext_t" => true,
             // 'private' type
             "prop_info" => true,
 

--- a/libc-test/build/main.rs
+++ b/libc-test/build/main.rs
@@ -2176,8 +2176,6 @@ fn test_android(t: &Target) {
             // These are tested as part of the linux_fcntl tests since there are
             // header conflicts when including them with all the other structs.
             "termios2" => true,
-            // uc_sigmask and uc_sigmask64 of ucontext_t are an anonymous union
-            "ucontext_t" => true,
             // 'private' type
             "prop_info" => true,
 
@@ -2444,6 +2442,9 @@ fn test_android(t: &Target) {
             ("siginfo_t", "_pad") => true,
             ("ifreq", "ifr_ifru") => true,
             ("ifconf", "ifc_ifcu") => true,
+
+            // uc_sigmask and uc_sigmask64 are an anonymous union
+            ("ucontext_t", "uc_sigmask" | "uc_sigmask64" | "uc_sigmask__c_anonymous_union") => true,
 
             _ => false,
         }

--- a/src/unix/linux_like/android/b32/arm.rs
+++ b/src/unix/linux_like/android/b32/arm.rs
@@ -31,7 +31,7 @@ s! {
 
     pub struct __c_anonymous_uc_sigmask_with_padding {
         pub uc_sigmask: crate::sigset_t,
-        /* Android has a wrong (smaller) sigset_t on x86. */
+        /* Android has a wrong (smaller) sigset_t on ARM. */
         __padding_rt_sigset: Padding<u32>,
     }
 

--- a/src/unix/linux_like/android/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/android/b64/aarch64/mod.rs
@@ -62,6 +62,9 @@ s! {
         pub uc_link: *mut ucontext_t,
         pub uc_stack: crate::stack_t,
         pub uc_sigmask: crate::sigset_t,
+        /* The kernel adds extra padding after uc_sigmask to match
+         * glibc sigset_t on ARM64. */
+        __padding: Padding<[c_char; 128 - size_of::<crate::sigset_t>()]>,
         pub uc_mcontext: mcontext_t,
     }
 

--- a/src/unix/linux_like/android/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/android/b64/aarch64/mod.rs
@@ -63,6 +63,9 @@ s! {
         pub uc_link: *mut ucontext_t,
         pub uc_stack: crate::stack_t,
         pub uc_sigmask: crate::sigset_t,
+        /* The kernel adds extra padding after uc_sigmask to match
+         * glibc sigset_t on ARM64. */
+        __padding: Padding<[c_char; 128 - size_of::<crate::sigset_t>()]>,
         pub uc_mcontext: mcontext_t,
     }
 


### PR DESCRIPTION
Resolves rust-lang/libc#5159

https://android.googlesource.com/platform/bionic/+/refs/tags/ndk-r29/libc/include/sys/ucontext.h#102

It would be good to backport this to `libc-0.2`

r? @tgross35
