### PR TITLE
build: Delete config via `RUST_LIBC_UNSTABLE_LINUX_TIME_BITS64`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -136,11 +136,6 @@ fn main() {
         set_cfg("linux_time_bits64");
     }
 
-    let linux_time_bits64 = env::var("RUST_LIBC_UNSTABLE_LINUX_TIME_BITS64").is_ok();
-    println!("cargo:rerun-if-env-changed=RUST_LIBC_UNSTABLE_LINUX_TIME_BITS64");
-    if linux_time_bits64 {
-        set_cfg("linux_time_bits64");
-    }
     println!("cargo:rerun-if-env-changed=RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS");
     println!("cargo:rerun-if-env-changed=RUST_LIBC_UNSTABLE_GNU_TIME_BITS");
     if target_env == "gnu"


### PR DESCRIPTION
The internal config `linux_time_bits64` already gets set via the musl or glibc config, so it isn't useful to be able to set it on its own. Delete the env option since it isn't used anyway.