### PR TITLE
FreeBSD: Replace unstable env to set version with an unstable cfg

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -70,14 +70,22 @@ fn main() {
     let target_ptr_width = env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap_or_default();
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
 
+    // FIXME: this can be removed in 1-2 releases
+    println!("cargo:rerun-if-env-changed=RUST_LIBC_UNSTABLE_FREEBSD_VERSION");
+    if env::var("RUST_LIBC_UNSTABLE_FREEBSD_VERSION").is_ok() {
+        println!(
+            "cargo:warning=RUST_LIBC_UNSTABLE_FREEBSD_VERSION has been removed; set \
+            the cfg libc_unstable_freebsd_version via RUSTFLAGS instead"
+        );
+    }
+
     // The ABI of libc used by std is backward compatible with FreeBSD 12.
     // The ABI of libc from crates.io is backward compatible with FreeBSD 12.
     //
     // On CI, we detect the actual FreeBSD version and match its ABI exactly,
     // running tests to ensure that the ABI is correct.
-    println!("cargo:rerun-if-env-changed=RUST_LIBC_UNSTABLE_FREEBSD_VERSION");
     // Allow overriding the default version for testing
-    let which_freebsd = if let Ok(version) = env::var("RUST_LIBC_UNSTABLE_FREEBSD_VERSION") {
+    let which_freebsd = if let Ok(version) = env::var("CARGO_CFG_LIBC_UNSTABLE_FREEBSD_VERSION") {
         let vers = version.parse().unwrap();
         println!("cargo:warning=setting FreeBSD version to {vers}");
         vers

--- a/ci/verify-build.py
+++ b/ci/verify-build.py
@@ -442,16 +442,9 @@ def test_target(cfg: Cfg, target: Target) -> TargetResult:
     # if on nightly or stable
     if "freebsd" in tname and cfg.toolchain >= Toolchain.STABLE:
         for version in FREEBSD_VERSIONS:
-            run(
-                cmd,
-                env=env | {"RUST_LIBC_UNSTABLE_FREEBSD_VERSION": str(version)},
-                rustflags=rustflags,
-            )
-            run(
-                [*cmd, "--no-default-features"],
-                env=env | {"RUST_LIBC_UNSTABLE_FREEBSD_VERSION": str(version)},
-                rustflags=rustflags,
-            )
+            free_rustflags = f'{rustflags} --cfg=libc_unstable_freebsd_version="{version}"'
+            run(cmd, rustflags=free_rustflags)
+            run([*cmd, "--no-default-features"], rustflags=free_rustflags)
 
     if cfg.skip_semver:
         eprint("Skipping semver checks")

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -2299,7 +2299,16 @@ fn test_freebsd(target: &str) {
     assert!(target.contains("freebsd"));
     let mut cfg = ctest_cfg();
 
-    let freebsd_ver = if let Ok(version) = env::var("RUST_LIBC_UNSTABLE_FREEBSD_VERSION") {
+    // FIXME: this can be removed in 1-2 releases
+    println!("cargo:rerun-if-env-changed=RUST_LIBC_UNSTABLE_FREEBSD_VERSION");
+    if env::var("RUST_LIBC_UNSTABLE_FREEBSD_VERSION").is_ok() {
+        println!(
+            "cargo:warning=RUST_LIBC_UNSTABLE_FREEBSD_VERSION has been removed; set \
+            the cfg libc_unstable_freebsd_version via RUSTFLAGS instead"
+        );
+    }
+
+    let freebsd_ver = if let Ok(version) = env::var("CARGO_CFG_LIBC_UNSTABLE_FREEBSD_VERSION") {
         let vers = version.parse().unwrap();
         println!("cargo:warning=setting FreeBSD version to {vers}");
         Some(vers)


### PR DESCRIPTION
Environment variables affect builds for both the host and target, while cfg can be more accurately scoped with `RUSTFLAGS`.
