### PR TITLE
ctest: check incompatible pointer types for public fields.

### DIFF
--- a/ctest/src/generator.rs
+++ b/ctest/src/generator.rs
@@ -103,6 +103,8 @@ pub enum GenerationError {
     OsError(std::io::Error),
     #[error("one of {0} environment variable(s) not set")]
     EnvVarNotFound(String),
+    #[error("unable to compile C tests {0}")]
+    CompileError(cc::Error),
 }
 
 impl TestGenerator {

--- a/ctest/src/runner.rs
+++ b/ctest/src/runner.rs
@@ -92,7 +92,8 @@ pub fn generate_test(
 
     let stem: &str = output_file_path.file_stem().unwrap().to_str().unwrap();
     cfg.out_dir(output_file_path.parent().unwrap())
-        .compile(stem);
+        .try_compile(stem)
+        .map_err(GenerationError::CompileError)?;
 
     Ok(output_file_path)
 }

--- a/ctest/templates/test.c
+++ b/ctest/templates/test.c
@@ -104,6 +104,14 @@ CTEST_EXTERN uint64_t ctest_size_of__{{ item.id }}__{{ item.field.ident() }}(voi
 typedef {{ item.volatile_keyword }}{{ item.field_return_type }};
 CTEST_EXTERN ctest_field_ty__{{ item.id }}__{{ item.field.ident() }}
 ctest_field_ptr__{{ item.id }}__{{ item.field.ident() }}({{ item.c_ty }} *b) {
+    {#
+        // In order to trigger -Wincompatible-pointer-types, we need to attempt to create a
+        // pointer to the given struct or field type, but using the type translated from Rust.
+    #}
+    ctest_field_ty__{{ item.id }}__{{ item.field.ident() }} ptr;
+    ptr = &b->{{ item.c_field }};
+    (void)ptr; {# avoid unused warnings #}
+
     return &b->{{ item.c_field }};
 }
 {%- endfor +%}

--- a/ctest/tests/basic.rs
+++ b/ctest/tests/basic.rs
@@ -209,3 +209,35 @@ fn test_raw_identifier_field() {
         assert!(result.is_ok());
     }
 }
+
+#[test]
+fn test_mismatched_union_field_ty() {
+    let include_path = PathBuf::from("tests/input");
+    let crate_path = include_path.join("mismatched_union_field_ty.rs");
+    let library_path = "mismatched_union_field_ty.out.a";
+
+    let (mut gen_, _out_dir) = default_generator(1, Some("mismatched_union_field_ty.h")).unwrap();
+
+    if env::var("TARGET_PLATFORM") == env::var("HOST_PLATFORM") {
+        let result = generate_test(&mut gen_, &crate_path, library_path);
+        assert!(result.is_err());
+        // As cc prints its warning/error messages to stderr, we cannot access them from cc::Error,
+        // and so cannot assert that the error was actually due to -Wincompatible-pointer-types.
+    }
+}
+
+#[test]
+fn test_mismatched_struct_field_ty() {
+    let include_path = PathBuf::from("tests/input");
+    let crate_path = include_path.join("mismatched_struct_field_ty.rs");
+    let library_path = "mismatched_struct_field_ty.out.a";
+
+    let (mut gen_, _out_dir) = default_generator(1, Some("mismatched_struct_field_ty.h")).unwrap();
+
+    if env::var("TARGET_PLATFORM") == env::var("HOST_PLATFORM") {
+        let result = generate_test(&mut gen_, &crate_path, library_path);
+        assert!(result.is_err());
+        // FIXME(ctest): As cc prints its warning/error messages to stderr, we cannot access them from cc::Error,
+        // and so cannot assert that the error was actually due to -Wincompatible-pointer-types.
+    }
+}

--- a/ctest/tests/input/macro.out.c
+++ b/ctest/tests/input/macro.out.c
@@ -90,6 +90,11 @@ CTEST_EXTERN uint64_t ctest_size_of__VecU16__y(void) {
 typedef uint8_t *ctest_field_ty__VecU8__x;
 CTEST_EXTERN ctest_field_ty__VecU8__x
 ctest_field_ptr__VecU8__x(struct VecU8 *b) {
+    
+    ctest_field_ty__VecU8__x ptr;
+    ptr = &b->x;
+    (void)ptr; 
+
     return &b->x;
 }
 
@@ -97,6 +102,11 @@ ctest_field_ptr__VecU8__x(struct VecU8 *b) {
 typedef uint8_t *ctest_field_ty__VecU8__y;
 CTEST_EXTERN ctest_field_ty__VecU8__y
 ctest_field_ptr__VecU8__y(struct VecU8 *b) {
+    
+    ctest_field_ty__VecU8__y ptr;
+    ptr = &b->y;
+    (void)ptr; 
+
     return &b->y;
 }
 
@@ -104,6 +114,11 @@ ctest_field_ptr__VecU8__y(struct VecU8 *b) {
 typedef uint16_t *ctest_field_ty__VecU16__x;
 CTEST_EXTERN ctest_field_ty__VecU16__x
 ctest_field_ptr__VecU16__x(struct VecU16 *b) {
+    
+    ctest_field_ty__VecU16__x ptr;
+    ptr = &b->x;
+    (void)ptr; 
+
     return &b->x;
 }
 
@@ -111,6 +126,11 @@ ctest_field_ptr__VecU16__x(struct VecU16 *b) {
 typedef uint16_t *ctest_field_ty__VecU16__y;
 CTEST_EXTERN ctest_field_ty__VecU16__y
 ctest_field_ptr__VecU16__y(struct VecU16 *b) {
+    
+    ctest_field_ty__VecU16__y ptr;
+    ptr = &b->y;
+    (void)ptr; 
+
     return &b->y;
 }
 

--- a/ctest/tests/input/macro.out.edition-2024.c
+++ b/ctest/tests/input/macro.out.edition-2024.c
@@ -90,6 +90,11 @@ CTEST_EXTERN uint64_t ctest_size_of__VecU16__y(void) {
 typedef uint8_t *ctest_field_ty__VecU8__x;
 CTEST_EXTERN ctest_field_ty__VecU8__x
 ctest_field_ptr__VecU8__x(struct VecU8 *b) {
+    
+    ctest_field_ty__VecU8__x ptr;
+    ptr = &b->x;
+    (void)ptr; 
+
     return &b->x;
 }
 
@@ -97,6 +102,11 @@ ctest_field_ptr__VecU8__x(struct VecU8 *b) {
 typedef uint8_t *ctest_field_ty__VecU8__y;
 CTEST_EXTERN ctest_field_ty__VecU8__y
 ctest_field_ptr__VecU8__y(struct VecU8 *b) {
+    
+    ctest_field_ty__VecU8__y ptr;
+    ptr = &b->y;
+    (void)ptr; 
+
     return &b->y;
 }
 
@@ -104,6 +114,11 @@ ctest_field_ptr__VecU8__y(struct VecU8 *b) {
 typedef uint16_t *ctest_field_ty__VecU16__x;
 CTEST_EXTERN ctest_field_ty__VecU16__x
 ctest_field_ptr__VecU16__x(struct VecU16 *b) {
+    
+    ctest_field_ty__VecU16__x ptr;
+    ptr = &b->x;
+    (void)ptr; 
+
     return &b->x;
 }
 
@@ -111,6 +126,11 @@ ctest_field_ptr__VecU16__x(struct VecU16 *b) {
 typedef uint16_t *ctest_field_ty__VecU16__y;
 CTEST_EXTERN ctest_field_ty__VecU16__y
 ctest_field_ptr__VecU16__y(struct VecU16 *b) {
+    
+    ctest_field_ty__VecU16__y ptr;
+    ptr = &b->y;
+    (void)ptr; 
+
     return &b->y;
 }
 

--- a/ctest/tests/input/mismatched_struct_field_ty.h
+++ b/ctest/tests/input/mismatched_struct_field_ty.h
@@ -1,0 +1,18 @@
+#include <stdint.h>
+
+// The struct and union must match the size and alignment of the Rust side,
+// otherwise different warnings are emitted that hide -Wincompatible-pointer-types.
+struct Bar {
+    int16_t x;
+    int16_t y;
+};
+
+union Baz {
+    int32_t x;
+    float y;
+};
+
+struct Foo {
+    struct Bar a;
+    union Baz b;
+};

--- a/ctest/tests/input/mismatched_struct_field_ty.rs
+++ b/ctest/tests/input/mismatched_struct_field_ty.rs
@@ -1,0 +1,6 @@
+#[repr(C)]
+pub struct Foo {
+    // We use a 4 byte type with 4 byte alignment.
+    pub a: i32,
+    pub b: i32,
+}

--- a/ctest/tests/input/mismatched_union_field_ty.h
+++ b/ctest/tests/input/mismatched_union_field_ty.h
@@ -1,0 +1,8 @@
+#include <stdint.h>
+
+// The union must match the size and alignment of the Rust side,
+// otherwise different warnings are emitted that hide -Wincompatible-pointer-types.
+union Bar {
+    int64_t x;
+    int32_t y;
+};

--- a/ctest/tests/input/mismatched_union_field_ty.rs
+++ b/ctest/tests/input/mismatched_union_field_ty.rs
@@ -1,0 +1,8 @@
+use core::ffi::c_float;
+
+// Union size is 8 bytes.
+#[repr(C)]
+union Bar {
+    pub x: i64,
+    pub y: c_float,
+}

--- a/ctest/tests/input/simple.out.with-renames.c
+++ b/ctest/tests/input/simple.out.with-renames.c
@@ -155,6 +155,11 @@ CTEST_EXTERN uint64_t ctest_size_of__Word__byte(void) {
 typedef const char **ctest_field_ty__Person__name;
 CTEST_EXTERN ctest_field_ty__Person__name
 ctest_field_ptr__Person__name(struct Person *b) {
+    
+    ctest_field_ty__Person__name ptr;
+    ptr = &b->name;
+    (void)ptr; 
+
     return &b->name;
 }
 
@@ -162,6 +167,11 @@ ctest_field_ptr__Person__name(struct Person *b) {
 typedef uint8_t *ctest_field_ty__Person__age;
 CTEST_EXTERN ctest_field_ty__Person__age
 ctest_field_ptr__Person__age(struct Person *b) {
+    
+    ctest_field_ty__Person__age ptr;
+    ptr = &b->age;
+    (void)ptr; 
+
     return &b->age;
 }
 
@@ -169,6 +179,11 @@ ctest_field_ptr__Person__age(struct Person *b) {
 typedef void (**ctest_field_ty__Person__job)(uint8_t, const char *);
 CTEST_EXTERN ctest_field_ty__Person__job
 ctest_field_ptr__Person__job(struct Person *b) {
+    
+    ctest_field_ty__Person__job ptr;
+    ptr = &b->job;
+    (void)ptr; 
+
     return &b->job;
 }
 
@@ -176,6 +191,11 @@ ctest_field_ptr__Person__job(struct Person *b) {
 typedef enum Color *ctest_field_ty__Person__favorite_color;
 CTEST_EXTERN ctest_field_ty__Person__favorite_color
 ctest_field_ptr__Person__favorite_color(struct Person *b) {
+    
+    ctest_field_ty__Person__favorite_color ptr;
+    ptr = &b->favorite_color;
+    (void)ptr; 
+
     return &b->favorite_color;
 }
 
@@ -183,6 +203,11 @@ ctest_field_ptr__Person__favorite_color(struct Person *b) {
 typedef uint16_t *ctest_field_ty__Word__word;
 CTEST_EXTERN ctest_field_ty__Word__word
 ctest_field_ptr__Word__word(union Word *b) {
+    
+    ctest_field_ty__Word__word ptr;
+    ptr = &b->word;
+    (void)ptr; 
+
     return &b->word;
 }
 
@@ -190,6 +215,11 @@ ctest_field_ptr__Word__word(union Word *b) {
 typedef Byte (*ctest_field_ty__Word__byte)[2];
 CTEST_EXTERN ctest_field_ty__Word__byte
 ctest_field_ptr__Word__byte(union Word *b) {
+    
+    ctest_field_ty__Word__byte ptr;
+    ptr = &b->byte;
+    (void)ptr; 
+
     return &b->byte;
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
Attempts to fix rust-lang/libc#5196 by adding a check for improper field types into the C side of the field_type test. It then adds this test for union and struct fields.

Also adds a new error type corresponding to `cc::Error` so that in the future it is easier to create tests that expect failure as the success condition.
<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
