### PR TITLE
[0.2] linux: Replace `c_enum!` with `e!` for `tpacket_versions`

### DIFF
--- a/src/new/linux_uapi/linux/if_packet.rs
+++ b/src/new/linux_uapi/linux/if_packet.rs
@@ -200,11 +200,12 @@ pub const TPACKET3_HDRLEN: usize = ((size_of::<tpacket3_hdr>() + TPACKET_ALIGNME
     & !(TPACKET_ALIGNMENT - 1))
     + size_of::<crate::sockaddr_ll>();
 
-c_enum! {
+e! {
+    #[repr(u32)]
     pub enum tpacket_versions {
-        pub TPACKET_V1,
-        pub TPACKET_V2,
-        pub TPACKET_V3,
+        TPACKET_V1,
+        TPACKET_V2,
+        TPACKET_V3,
     }
 }
 


### PR DESCRIPTION
This was changed to `c_enum!` in 1.0 but should remain `e!` in 0.2 to avoid the breaking change. In a backport, it was unintentionally changed to `c_enum!`. Change back to `e!` here.

Fixes: ed270220197c ("linux: Move `if_packet.h` API to `src/new`")