### PR TITLE
fuchsia: propose `sigaction` definition

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -267,15 +267,6 @@ s! {
         __dummy4: [c_char; 16],
     }
 
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
-        pub sa_mask: crate::sigset_t,
-        pub sa_flags: c_int,
-        pub sa_restorer: Option<extern "C" fn()>,
-    }
-
     pub struct termios {
         pub c_iflag: crate::tcflag_t,
         pub c_oflag: crate::tcflag_t,
@@ -1036,6 +1027,18 @@ s_no_extra_traits! {
     pub union __c_anonymous_ifaddrs_ifa_ifu {
         ifu_broadaddr: *mut sockaddr,
         ifu_dstaddr: *mut sockaddr,
+    }
+
+    pub union __c_anonymous_sigaction___sa_handler {
+        sa_handler: Option<extern "C" fn(c_int)>,
+        sa_sigaction: Option<extern "C" fn(c_int, *mut siginfo_t, *mut c_void)>,
+    }
+
+    pub struct sigaction {
+        pub __sa_handler: crate::__c_anonymous_sigaction___sa_handler,
+        pub sa_mask: crate::sigset_t,
+        pub sa_flags: c_int,
+        pub sa_restorer: Option<extern "C" fn()>,
     }
 }
 


### PR DESCRIPTION
# Description

Proposes a solution to fix `sigaction`. This contributes to the open question on how to manage this type. Stems from [[1]].

[1]: https://github.com/rust-lang/libc/pull/5127#discussion_r3465915440

# Sources

* `sigaction` in the Zircon kernel.

  > https://cs.opensource.google/fuchsia/fuchsia/+/main:zircon/third_party/ulib/musl/include/signal.h;l=197-205

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
