### PR TITLE
ci: Bump musl 1.2.5->1.2.6 and Alpine headers 3.20->3.24  (kernel 6.6->7.0)

### DIFF
--- a/ci/docker/aarch64-linux-android/Dockerfile
+++ b/ci/docker/aarch64-linux-android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN dpkg --add-architecture i386
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/ci/docker/aarch64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/ci/docker/aarch64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-musl/Dockerfile
@@ -9,13 +9,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libc6-dev \
     make \
     patch \
-    qemu-user \
     rsync \
+    qemu-user \
     xz-utils
 
 ARG MUSL_VERSION
-COPY install-musl.sh /
-RUN /install-musl.sh aarch64 "$MUSL_VERSION"
+COPY . /ci
+RUN ci/install-musl.sh aarch64 "$MUSL_VERSION"
 
 # FIXME: shouldn't need the `-lgcc` here, shouldn't that be in std?
 ENV PATH=$PATH:/musl-aarch64/bin:/rust/bin \

--- a/ci/docker/arm-linux-androideabi/Dockerfile
+++ b/ci/docker/arm-linux-androideabi/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN dpkg --add-architecture i386
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/ci/docker/arm-unknown-linux-musleabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-musleabihf/Dockerfile
@@ -12,13 +12,13 @@ RUN sed -i -E 's/(archive|security)\.ubuntu\.com/old-releases.ubuntu.com/g' \
         libc6-dev \
         make \
         patch \
-        qemu-user \
         rsync \
+        qemu-user \
         xz-utils
 
 ARG MUSL_VERSION
-COPY install-musl.sh /
-RUN /install-musl.sh arm "$MUSL_VERSION"
+COPY . /ci
+RUN ci/install-musl.sh arm "$MUSL_VERSION"
 
 ENV PATH=$PATH:/musl-arm/bin:/rust/bin \
     CC_arm_unknown_linux_musleabihf=musl-gcc \

--- a/ci/docker/asmjs-unknown-emscripten/Dockerfile
+++ b/ci/docker/asmjs-unknown-emscripten/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 # This is a workaround to avoid the interaction with tzdata.
 ENV DEBIAN_FRONTEND=noninteractive

--- a/ci/docker/i686-linux-android/Dockerfile
+++ b/ci/docker/i686-linux-android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN dpkg --add-architecture i386
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/ci/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/i686-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/ci/docker/i686-unknown-linux-musl/Dockerfile
+++ b/ci/docker/i686-unknown-linux-musl/Dockerfile
@@ -7,15 +7,14 @@ RUN dpkg --add-architecture i386 && \
         gcc-multilib \
         git \
         libc6-dev \
-        libc6-i386 \
         make \
         patch \
         rsync \
         xz-utils
 
 ARG MUSL_VERSION
-COPY install-musl.sh /
-RUN /install-musl.sh i686 "$MUSL_VERSION"
+COPY . /ci
+RUN ci/install-musl.sh i686 "$MUSL_VERSION"
 
 ENV PATH=$PATH:/musl-i686/bin:/rust/bin \
     CC_i686_unknown_linux_musl=musl-gcc \

--- a/ci/docker/i686-unknown-linux-musl/Dockerfile
+++ b/ci/docker/i686-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN dpkg --add-architecture i386 && \
     apt-get update && apt-get install -y --no-install-recommends \

--- a/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/ci/docker/loongarch64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/loongarch64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/ci/docker/loongarch64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/loongarch64-unknown-linux-musl/Dockerfile
@@ -9,13 +9,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libc6-dev \
     make \
     patch \
-    qemu-user \
     rsync \
+    qemu-user \
     xz-utils
 
 ARG MUSL_VERSION
-COPY install-musl.sh /
-RUN /install-musl.sh loongarch64 "$MUSL_VERSION"
+COPY . /ci
+RUN ci/install-musl.sh loongarch64 "$MUSL_VERSION"
 
 ENV CC_loongarch64_unknown_linux_musl=musl-gcc \
     CFLAGS_loongarch64_unknown_linux_musl="-mabi=lp64d -fPIC" \

--- a/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/ci/docker/powerpc64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/powerpc64-unknown-linux-musl/Dockerfile
@@ -18,8 +18,8 @@ RUN curl -O https://static.rust-lang.org/dist/2026-06-26/rust-std-nightly-powerp
     find rust-std-nightly-powerpc64-unknown-linux-musl/ -name libcompiler_builtins*.rlib -exec sh -c "cp {} /compiler_builtins.rlib" \;
 
 ARG MUSL_VERSION
-COPY install-musl.sh /
-RUN /install-musl.sh powerpc64 "$MUSL_VERSION"
+COPY . /ci
+RUN ci/install-musl.sh powerpc64 "$MUSL_VERSION"
 
 # Rust's unwind unconditionally links to libgcc_s.so.1
 # We instead get the unwinding symbols from the self-contained libunwind.a

--- a/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/ci/docker/powerpc64le-unknown-linux-musl/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/ci/docker/powerpc64le-unknown-linux-musl/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-musl/Dockerfile
@@ -9,13 +9,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libc6-dev \
     make \
     patch \
-    qemu-user \
     rsync \
+    qemu-user \
     xz-utils
 
 ARG MUSL_VERSION
-COPY install-musl.sh /
-RUN /install-musl.sh powerpc64le "$MUSL_VERSION"
+COPY . /ci
+RUN ci/install-musl.sh powerpc64le "$MUSL_VERSION"
 
 # FIXME: shouldn't need the `-lgcc` here, shouldn't that be in std?
 ENV PATH=$PATH:/musl-powerpc64/bin:/rust/bin \

--- a/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc-riscv64-linux-gnu \
     libc6-dev \
     libc6-dev-riscv64-cross \
-    qemu-system-riscv64 \
+    qemu-system-riscv \
     qemu-user
 
 ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc \

--- a/ci/docker/s390x-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/s390x-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/ci/docker/s390x-unknown-linux-musl/Dockerfile
+++ b/ci/docker/s390x-unknown-linux-musl/Dockerfile
@@ -1,18 +1,21 @@
 FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
     ca-certificates \
+    curl \
     gcc \
     gcc-s390x-linux-gnu \
-    qemu-user \
-    xz-utils \
+    git \
+    libc6-dev \
+    make \
     patch \
-    rsync
+    rsync \
+    qemu-user \
+    xz-utils
 
 ARG MUSL_VERSION
-COPY install-musl.sh /
-RUN /install-musl.sh s390x "$MUSL_VERSION"
+COPY . /ci
+RUN ci/install-musl.sh s390x "$MUSL_VERSION"
 
 # FIXME: shouldn't need the `-lgcc` here, shouldn't that be in std?
 ENV CC_s390x_unknown_linux_gnu=musl-gcc \

--- a/ci/docker/s390x-unknown-linux-musl/Dockerfile
+++ b/ci/docker/s390x-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \

--- a/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/sparc64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc-sparc64-linux-gnu \
     libc6-dev \
     libc6-dev-sparc64-cross \
-    qemu-system-sparc64 \
+    qemu-system-sparc \
     qemu-user
 
 ENV CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_LINKER=sparc64-linux-gnu-gcc \

--- a/ci/docker/wasm32-unknown-emscripten/Dockerfile
+++ b/ci/docker/wasm32-unknown-emscripten/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 # This is a workaround to avoid the interaction with tzdata.
 ENV DEBIAN_FRONTEND=noninteractive
@@ -15,7 +15,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gdb \
     git \
     libc6-dev \
-    libxml2 \
     make \
     python3 \
     tzdata \

--- a/ci/docker/wasm32-wasip1/Dockerfile
+++ b/ci/docker/wasm32-wasip1/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 COPY wasi.sh /
 RUN /wasi.sh

--- a/ci/docker/wasm32-wasip2/Dockerfile
+++ b/ci/docker/wasm32-wasip2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 COPY wasi.sh /
 RUN /wasi.sh

--- a/ci/docker/x86_64-linux-android/Dockerfile
+++ b/ci/docker/x86_64-linux-android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/ci/docker/x86_64-unknown-linux-gnux32/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnux32/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/ci/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/ci/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xz-utils
 
 ARG MUSL_VERSION
-COPY install-musl.sh /
-RUN /install-musl.sh x86_64 "$MUSL_VERSION"
+COPY . /ci
+RUN ci/install-musl.sh x86_64 "$MUSL_VERSION"
 
 ENV PATH=$PATH:/musl-x86_64/bin:/rust/bin \
     EXTRA_RUSTFLAGS="-L /musl-x86_64/lib"

--- a/ci/install-musl.sh
+++ b/ci/install-musl.sh
@@ -8,7 +8,7 @@ set -eux
 arch="$1"
 version="$2"
 old_musl=1.1.24
-new_musl=1.2.5
+new_musl=1.2.6
 
 case "$arch" in
     loongarch64) musl_version="$new_musl" ;;
@@ -119,18 +119,20 @@ rm -rf "$musl"
 
 # Download, configure, build, and install musl-sanitized kernel headers.
 
-# Alpine follows stable kernel releases, 3.20 uses Linux 6.6 headers.
-alpine_version=3.20
+# Alpine follows stable kernel releases, 3.24 uses Linux 7.0 headers.
+alpine_version=3.24
 alpine_git=https://git.alpinelinux.org/aports
 
-# This routine piggybacks on: https://git.alpinelinux.org/aports/tree/main/linux-headers?h=3.20-stable
+# This routine piggybacks on: https://git.alpinelinux.org/aports/tree/main/linux-headers?h=3.24-stable
 git clone -n --depth=1 --filter=tree:0 -b "${alpine_version}-stable" "$alpine_git"
 (
     cd aports
     git sparse-checkout set --no-cone main/linux-headers
     git checkout
-
     cd main/linux-headers
+
+    # Create a version of APKBUILD that dumps the variables we're interested
+    # in. This file doesn't retrieve or build anything on its own.
     cp APKBUILD APKBUILD.vars
     cat <<- EOF >> APKBUILD.vars
         echo "\$source" > alpine-source

--- a/ci/install-musl.sh
+++ b/ci/install-musl.sh
@@ -30,8 +30,17 @@ musl="musl-${musl_version}"
 # first. See https://github.com/rust-lang/ci-mirrors/blob/main/files/libc.toml.
 curl --retry 5 "https://ci-mirrors.rust-lang.org/libc/${musl}.tar.gz" | tar xzf -
 
-# Configure, build, and install musl:
 cd "$musl"
+
+# Apply patches
+if [ "$musl_version" = "$old_musl" ]; then
+    patch_dir="$(realpath ../ci/musl-patches-1.1.x)"
+    for patchfile in "$patch_dir"/*; do
+        cat "$patchfile" | patch -p1
+    done
+fi
+
+# Configure, build, and install musl:
 case ${1} in
     aarch64)
         musl_arch=aarch64

--- a/ci/musl-patches-1.1.x/0001-remove-non-prototype-basename.patch
+++ b/ci/musl-patches-1.1.x/0001-remove-non-prototype-basename.patch
@@ -1,0 +1,59 @@
+From 725e17ed6dff4d0cd22487bb64470881e86a92e7 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Mon, 6 Nov 2023 08:26:19 -0500
+Subject: [PATCH] remove non-prototype declaration of basename from string.h
+
+commit 37bb3cce4598c19288628e675eaf1cda6e96958f suppressed the
+declaration for C++, where it is wrongly interpreted as declaring the
+function as taking no arguments. with C23 removing non-prototype
+declarations, that problem is now also relevant to C.
+
+the non-prototype declaration for basename originates with commit
+06aec8d7152dfb8360cb7ed9b3d7215ca0b0b500, where it was designed to
+avoid conflicts with programs which declare basename with the GNU
+signature taking const char *. that change was probably misguided, as
+it represents not only misaligned expectations with the caller, but
+also undefined behavior (calling a function that's been declared with
+the wrong type).
+
+we could opt to fix the declaration, but since glibc, with the
+gratuitously incompatible GNU-basename function, seems to be the only
+implementation that declares it in string.h, it seems better to just
+remove the declaration. this provides some warning if applications are
+being built expecting the GNU behavior but not getting it. if we
+declared it here, it would only produce a warning if the caller also
+declares it themselves (rare) or if the caller attempts to pass a
+const-qualified pointer.
+---
+
+rust-libc note: this patch is applied to musl 1.1.x builds because
+without it, recent compilers emit errors like:
+
+    In file included from /checkout/target/aarch64-unknown-linux-musl/debug/build/libc-test-1eed7f417ef9e9ac/out/ctest_output.c:51:
+    /musl-aarch64/include/string.h:97:7: error: conflicting types for 'basename'; have 'char *(void)'
+       97 | char *basename();
+          |       ^~~~~~~~
+    In file included from /checkout/target/aarch64-unknown-linux-musl/debug/build/libc-test-1eed7f417ef9e9ac/out/ctest_output.c:19:
+    /musl-aarch64/include/libgen.h:9:7: note: previous declaration of 'basename' with type 'char *(char *)'
+        9 | char *basename(char *);
+          |       ^~~~~~~~
+    cc1: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics
+
+
+ include/string.h | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/include/string.h b/include/string.h
+index db73d2a92..83e2b9464 100644
+--- a/include/string.h
++++ b/include/string.h
+@@ -95,9 +95,6 @@ char *strchrnul(const char *, int);
+ char *strcasestr(const char *, const char *);
+ void *memrchr(const void *, int, size_t);
+ void *mempcpy(void *, const void *, size_t);
+-#ifndef __cplusplus
+-char *basename();
+-#endif
+ #endif
+
+ #ifdef __cplusplus

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4804,6 +4804,9 @@ fn test_linux(target: &str) {
             "AT_HWCAP3" | "AT_HWCAP4" => kernel < (6, 9),
             "PTRACE_SET_SYSCALL_INFO" => kernel < (6, 16),
 
+            // Changed value recently
+            "SW_MAX" | "SW_CNT" => kernel < (6, 16),
+
             // Added in kernel versions 6.12..6.14 but we can't include `linux/fcntl.h`
             // (conflicts), so these need to wait on glibc's redefinition in 2.44-2.43.
             "AT_HANDLE_CONNECTABLE" | "AT_HANDLE_MNT_ID_UNIQUE" | "AT_EXECVE_CHECK" => {

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4308,6 +4308,9 @@ fn test_linux(target: &str) {
             // Extern types
             "DIR" | "FILE" | "fpos_t" | "timezone" => true,
 
+            // Many more fields added in the glibc update to go with 6.17
+            "tcp_info" if gnu && versions.glibc.unwrap() < (2, 43) => true,
+
             _ => false,
         }
     });

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4274,6 +4274,7 @@ fn test_linux(target: &str) {
 
             // Recent additions
             "ptp_sys_offset_extended" if kernel < (6, 12) => true,
+            "epoll_params" if old_musl => true,
             "epoll_params" => kernel < (6, 9),
             "mnt_ns_info" => kernel < (6, 12),
 
@@ -4789,6 +4790,7 @@ fn test_linux(target: &str) {
             | "PF_RANDOMIZE" | "PF_NO_SETAFFINITY" | "PF_MCE_EARLY" | "PF_MEMALLOC_PIN"
             | "PF_BLOCK_TS" | "PF_SUSPEND_TASK" => true,
 
+            "EPIOCSPARAMS" | "EPIOCGPARAMS" if old_musl => true,
             "EPIOCSPARAMS" | "EPIOCGPARAMS" => kernel < (6, 9),
             "MAP_DROPPABLE" => kernel < (6, 11),
             "SOF_TIMESTAMPING_OPT_RX_FILTER" => kernel < (6, 12),
@@ -4806,6 +4808,7 @@ fn test_linux(target: &str) {
             "SECURE_ALL_BITS" | "SECURE_ALL_LOCKS" => kernel < (6, 14),
 
             // Recent additions
+            "AT_HWCAP3" | "AT_HWCAP4" if old_musl => true,
             "AT_HWCAP3" | "AT_HWCAP4" => kernel < (6, 9),
             "PTRACE_SET_SYSCALL_INFO" => kernel < (6, 16),
 

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3805,6 +3805,8 @@ fn test_linux(target: &str) {
     let i686 = target.contains("i686");
     let ppc = target.contains("powerpc");
     let ppc64 = target.contains("powerpc64");
+    let ppc64le = target.contains("powerpc64le");
+    let _ppc64be = target.contains("powerpc64-");
     let ppc32 = ppc && !ppc64;
     let s390x = target.contains("s390x");
     let sparc = target.contains("sparc");
@@ -4949,6 +4951,10 @@ fn test_linux(target: &str) {
 
             // FIXME(linux): function pointers changed since Ubuntu 23.10
             "strtol" | "strtoll" | "strtoul" | "strtoull" | "fscanf" | "scanf" | "sscanf" => true,
+
+            // FIXME(ppc): function pointers changed in Ubuntu 26.04 to support IEEE binary128
+            // `long double`. We should update at some point but there is no hurry.
+            "printf" | "fprintf" | "sprintf" | "snprintf" | "syslog" if gnu && ppc64le => true,
 
             _ => false,
         }

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -233,19 +233,23 @@ s! {
         /// This contains the bitfields `tcpi_snd_wscale` and `tcpi_rcv_wscale`.
         /// Each is 4 bits.
         pub tcpi_snd_rcv_wscale: u8,
+
         pub tcpi_rto: u32,
         pub tcpi_ato: u32,
         pub tcpi_snd_mss: u32,
         pub tcpi_rcv_mss: u32,
+
         pub tcpi_unacked: u32,
         pub tcpi_sacked: u32,
         pub tcpi_lost: u32,
         pub tcpi_retrans: u32,
         pub tcpi_fackets: u32,
+
         pub tcpi_last_data_sent: u32,
         pub tcpi_last_ack_sent: u32,
         pub tcpi_last_data_recv: u32,
         pub tcpi_last_ack_recv: u32,
+
         pub tcpi_pmtu: u32,
         pub tcpi_rcv_ssthresh: u32,
         pub tcpi_rtt: u32,
@@ -254,9 +258,55 @@ s! {
         pub tcpi_snd_cwnd: u32,
         pub tcpi_advmss: u32,
         pub tcpi_reordering: u32,
+
         pub tcpi_rcv_rtt: u32,
         pub tcpi_rcv_space: u32,
+
         pub tcpi_total_retrans: u32,
+
+        pub tcpi_pacing_rate: u64,
+        pub tcpi_max_pacing_rate: u64,
+        pub tcpi_bytes_acked: u64,
+        pub tcpi_bytes_received: u64,
+        pub tcpi_segs_out: u32,
+        pub tcpi_segs_in: u32,
+
+        pub tcpi_notsent_bytes: u32,
+        pub tcpi_min_rtt: u32,
+        pub tcpi_data_segs_in: u32,
+        pub tcpi_data_segs_out: u32,
+
+        pub tcpi_delivery_rate: u64,
+
+        pub tcpi_busy_time: u64,
+        pub tcpi_rwnd_limited: u64,
+        pub tcpi_sndbuf_limited: u64,
+
+        pub tcpi_delivered: u32,
+        pub tcpi_delivered_ce: u32,
+
+        pub tcpi_bytes_sent: u64,
+        pub tcpi_bytes_retrans: u64,
+        pub tcpi_dsack_dups: u32,
+        pub tcpi_reord_seen: u32,
+
+        pub tcpi_rcv_ooopack: u32,
+        pub tcpi_snd_wnd: u32,
+        pub tcpi_rcv_wnd: u32,
+
+        pub tcpi_rehash: u32,
+        pub tcpi_total_rto: u16,
+        pub tcpi_total_rto_recoveries: u16,
+        pub tcpi_total_rto_time: u32,
+        pub tcpi_received_ce: u32,
+        pub tcpi_delivered_e1_bytes: u32,
+        pub tcpi_delivered_e0_bytes: u32,
+        pub tcpi_delivered_ce_bytes: u32,
+        pub tcpi_received_e1_bytes: u32,
+        pub tcpi_received_e0_bytes: u32,
+        pub tcpi_received_ce_bytes: u32,
+        pub tcpi_accecn_fail_mode: u16,
+        pub tcpi_accecn_opt_seen: u16,
     }
 
     pub struct fanotify_event_info_pidfd {

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -3067,7 +3067,6 @@ pub const NFT_NG_RANDOM: c_int = 1;
 /// This symbol is prone to change across releases upstream.
 /// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const FF_MAX: __u16 = 0x7f;
-
 pub const FF_CNT: usize = FF_MAX as usize + 1;
 
 // linux/input-event-codes.h
@@ -3088,61 +3087,51 @@ pub const INPUT_PROP_CNT: usize = INPUT_PROP_MAX as usize + 1;
 /// This symbol is prone to change across releases upstream.
 /// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const EV_MAX: __u16 = 0x1f;
-
 pub const EV_CNT: usize = EV_MAX as usize + 1;
 
 /// This symbol is prone to change across releases upstream.
 /// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SYN_MAX: __u16 = 0xf;
-
 pub const SYN_CNT: usize = SYN_MAX as usize + 1;
 
 /// This symbol is prone to change across releases upstream.
 /// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const KEY_MAX: __u16 = 0x2ff;
-
 pub const KEY_CNT: usize = KEY_MAX as usize + 1;
 
 /// This symbol is prone to change across releases upstream.
 /// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const REL_MAX: __u16 = 0x0f;
-
 pub const REL_CNT: usize = REL_MAX as usize + 1;
 
 /// This symbol is prone to change across releases upstream.
 /// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const ABS_MAX: __u16 = 0x3f;
-
 pub const ABS_CNT: usize = ABS_MAX as usize + 1;
 
 /// This symbol is prone to change across releases upstream.
 /// See the [usage guidelines](crate#usage-guidelines) for details.
-pub const SW_MAX: __u16 = 0x10;
-
+pub const SW_MAX: __u16 = 0x11;
 pub const SW_CNT: usize = SW_MAX as usize + 1;
 
 /// This symbol is prone to change across releases upstream.
 /// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const MSC_MAX: __u16 = 0x07;
-
 pub const MSC_CNT: usize = MSC_MAX as usize + 1;
 
 /// This symbol is prone to change across releases upstream.
 /// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const LED_MAX: __u16 = 0x0f;
-
 pub const LED_CNT: usize = LED_MAX as usize + 1;
 
 /// This symbol is prone to change across releases upstream.
 /// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const REP_MAX: __u16 = 0x01;
-
 pub const REP_CNT: usize = REP_MAX as usize + 1;
 
 /// This symbol is prone to change across releases upstream.
 /// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const SND_MAX: __u16 = 0x07;
-
 pub const SND_CNT: usize = SND_MAX as usize + 1;
 
 // linux/uinput.h

--- a/src/unix/linux_like/linux_l4re_shared.rs
+++ b/src/unix/linux_like/linux_l4re_shared.rs
@@ -1438,8 +1438,8 @@ pub const NT_LWPSTATUS: c_int = 16;
 pub const NT_LWPSINFO: c_int = 17;
 pub const NT_PRFPXREG: c_int = 20;
 
-#[allow(overflowing_literals)] // fixed in a future kernel version
-pub const MS_NOUSER: c_ulong = 0xffffffff80000000;
+// FIXME(1.0): C uses an unsigned int here.
+pub const MS_NOUSER: c_ulong = 1 << 31;
 
 f! {
     pub fn CMSG_NXTHDR(


### PR DESCRIPTION
Based on https://github.com/rust-lang/libc/pull/5175