### PR TITLE
freebsd: fix docs links and wording

### DIFF
--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
@@ -259,11 +259,11 @@ s! {
 }
 
 /// This symbol is prone to change across releases upstream.
-/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const ELAST: c_int = 96;
 
 /// This symbol is prone to change across releases upstream.
-/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const RAND_MAX: c_int = 0x7fff_fffd;
 
 pub const KI_NSPARE_PTR: usize = 6;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -304,11 +304,11 @@ s! {
 }
 
 /// This symbol is prone to change across releases upstream.
-/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const RAND_MAX: c_int = 0x7fff_fffd;
 
 /// This symbol is prone to change across releases upstream.
-/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const ELAST: c_int = 97;
 
 /// max length of devicename

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -317,11 +317,11 @@ s! {
 }
 
 /// This symbol is prone to change across releases upstream.
-/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const RAND_MAX: c_int = 0x7fff_ffff;
 
 /// This symbol is prone to change across releases upstream.
-/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const ELAST: c_int = 97;
 
 pub const KF_TYPE_EVENTFD: c_int = 13;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -319,11 +319,11 @@ s! {
 }
 
 /// This symbol is prone to change across releases upstream.
-/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const RAND_MAX: c_int = 0x7fff_ffff;
 
 /// This symbol is prone to change across releases upstream.
-/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const ELAST: c_int = 97;
 
 pub const KF_TYPE_EVENTFD: c_int = 13;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
@@ -321,11 +321,11 @@ s! {
 }
 
 /// This symbol is prone to change across releases upstream.
-/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const RAND_MAX: c_int = 0x7fff_ffff;
 
 /// This symbol is prone to change across releases upstream.
-/// See the [usage guidelines](crate::#usage-guidelines) for details and use.
+/// See the [usage guidelines](crate#usage-guidelines) for details.
 pub const ELAST: c_int = 97;
 
 pub const KF_TYPE_EVENTFD: c_int = 13;


### PR DESCRIPTION
# Description

Fixes broken rustdoc links.

Makes usage advice less redundant.

Fixes as well rust-lang/libc#5119 and rust-lang/libc#5118.

# Sources

Not applicable.

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
