### PR TITLE
ctest: improve documentation for TestGenerator fields.

### DIFF
--- a/ctest/src/generator.rs
+++ b/ctest/src/generator.rs
@@ -57,25 +57,46 @@ type CEnum = Box<dyn Fn(&str) -> bool>;
 #[derive(Default)]
 #[expect(missing_debug_implementations)]
 pub struct TestGenerator {
+    /// A vector of tuples, the left side being the header itself, and the right
+    /// being a list of defines that the header is associated with. Note that
+    /// these defines are only valid for the header, they are immediately undefined
+    /// afterwards.
     pub(crate) headers: Vec<(BoxStr, Vec<BoxStr>)>,
+    /// The target that the tests run on. Defaults to the native target.
     pub(crate) target: Option<String>,
+    /// A list of paths to include directories to find headers in.
     pub(crate) includes: Vec<PathBuf>,
+    /// The directory to output the generated test files.
     out_dir: Option<PathBuf>,
+    /// A list of flags to pass to the compiler with checking if they are supported.
     pub(crate) flags: Vec<String>,
+    /// A list of flags that are passed to the compiler if supported.
     pub(crate) flags_if_supported: Vec<String>,
+    /// A list of defines and their values.
     pub(crate) global_defines: Vec<(String, Option<String>)>,
+    /// A list of cfgs and their values to expand the crate with.
     cfg: Vec<(String, Option<String>)>,
+    /// A list of functions that remaps names used in the tests.
     mapped_names: Vec<MappedName>,
     /// The programming language to generate tests in.
     pub(crate) language: Language,
+    /// A list of functions that determine what items to skip all tests for.
     pub(crate) skips: Vec<Skip>,
+    /// Whether to output which items were skipped completely.
     pub(crate) verbose_skip: bool,
+    /// A list of functions that determine if an item is volatile.
     pub(crate) volatile_items: Vec<VolatileItem>,
+    /// A list of functions that determine if an item is a C style enum.
     pub(crate) c_enums: Vec<CEnum>,
+    /// A list of functions that determine if a type is actually an array argument.
     pub(crate) array_arg: Option<ArrayArg>,
+    /// Whether to skip testing private items.
     pub(crate) skip_private: bool,
+    /// Determines for which items the roundtrip test should be skipped.
     pub(crate) skip_roundtrip: Option<SkipTest>,
+    /// Determines for which items the signededness test should be skipped.
     pub(crate) skip_signededness: Option<SkipTest>,
+    /// Determines for which items the fn_ptrcheck test should be skipped.
     pub(crate) skip_fn_ptrcheck: Option<SkipTest>,
     /// The Rust edition to generate code against.
     pub(crate) edition: Option<u32>,

--- a/ctest/tests/basic.rs
+++ b/ctest/tests/basic.rs
@@ -175,6 +175,7 @@ fn test_entrypoint_invalid_syntax() {
     assert!(fails)
 }
 
+/// Test if a field with a raw identifier successfully has tests generated.
 #[test]
 fn test_raw_identifier_field() {
     let include_path = PathBuf::from("tests/input");


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
Added documentation to fields of `TestGenerator` since it is not always obvious what the field is used for at a glance (for example the `headers` field).
<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [X] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
