### PR TITLE
Bump libc-test to edition 2024

### DIFF
--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -3,7 +3,7 @@ name = "libc-test"
 version = "0.1.0"
 description = "A test crate for the libc crate."
 publish = false
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/libc"
 

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3547,8 +3547,8 @@ fn test_neutrino(target: &str) {
 }
 
 fn which_vxworks() -> Option<(u32, u32)> {
-    let version = env::var("WIND_RELEASE_ID").ok()?; // When in VxWorks setup, WIND_RELEASE_ID is
-                                                     // always set as the version of the release.
+    // When in VxWorks setup, WIND_RELEASE_ID is always set as the version of the release.
+    let version = env::var("WIND_RELEASE_ID").ok()?;
 
     let mut pieces = version.trim().split(['.']);
 

--- a/libc-test/tests/style_lib/mod.rs
+++ b/libc-test/tests/style_lib/mod.rs
@@ -39,6 +39,7 @@ use annotate_snippets::{
     Snippet,
 };
 use proc_macro2::Span;
+use syn::Token;
 use syn::parse::{
     Parse,
     ParseStream,
@@ -48,7 +49,6 @@ use syn::visit::{
     self,
     Visit,
 };
-use syn::Token;
 
 const ALLOWED_REPEATED_MACROS: &[&str] = &["s", "s_no_extra_traits", "s_paren"];
 const ALLOWED_POSITIVE_S_CFGS: &[&str] = &[


### PR DESCRIPTION
These only needs to build with recent Rust, so we may as well allow newer syntax.