### PR TITLE
linux: Add SECCOMP_IOCTL_NOTIF_* ioctl numbers

### DIFF
--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1438,6 +1438,11 @@ pub const SECCOMP_USER_NOTIF_FLAG_CONTINUE: c_ulong = 1;
 pub const SECCOMP_ADDFD_FLAG_SETFD: c_ulong = 1;
 pub const SECCOMP_ADDFD_FLAG_SEND: c_ulong = 2;
 
+pub const SECCOMP_IOCTL_NOTIF_RECV: Ioctl = _IOWR::<seccomp_notif>(b'!' as u32, 0);
+pub const SECCOMP_IOCTL_NOTIF_SEND: Ioctl = _IOWR::<seccomp_notif_resp>(b'!' as u32, 1);
+pub const SECCOMP_IOCTL_NOTIF_ID_VALID: Ioctl = _IOW::<__u64>(b'!' as u32, 2);
+pub const SECCOMP_IOCTL_NOTIF_ADDFD: Ioctl = _IOW::<seccomp_notif_addfd>(b'!' as u32, 3);
+
 pub const TFD_CLOEXEC: c_int = O_CLOEXEC;
 pub const TFD_NONBLOCK: c_int = O_NONBLOCK;
 pub const TFD_TIMER_ABSTIME: c_int = 1;


### PR DESCRIPTION
The userspace-notification structs and flags are already bound; only [the ioctl numbers][ref] were missing.

[ref]: https://github.com/torvalds/linux/blob/master/include/uapi/linux/seccomp.h#L147-L152

@rustbot label +stable-nominated

