### PR TITLE
Fix function pointer checks on Windows

### DIFF
--- a/ctest/src/runner.rs
+++ b/ctest/src/runner.rs
@@ -141,6 +141,7 @@ pub fn __compile_test(
 
     // Pass in a different target, linker or flags if set, useful for cross compilation.
 
+    // Fall back to TARGET if TARGET_PLATFORM is not set (e.g. during local cargo test).
     let target = env::var("TARGET_PLATFORM")
         .or_else(|_| env::var("TARGET"))
         .unwrap_or_default();

--- a/ctest/src/runner.rs
+++ b/ctest/src/runner.rs
@@ -141,9 +141,15 @@ pub fn __compile_test(
 
     // Pass in a different target, linker or flags if set, useful for cross compilation.
 
-    let target = env::var("TARGET_PLATFORM").unwrap_or_default();
+    let target = env::var("TARGET_PLATFORM")
+        .or_else(|_| env::var("TARGET"))
+        .unwrap_or_default();
     if !target.is_empty() {
-        cmd.arg("--target").arg(target);
+        cmd.arg("--target").arg(&target);
+    }
+
+    if target.contains("windows") && target.contains("gnu") {
+        cmd.arg("-lws2_32");
     }
 
     let linker = env::var("LINKER").unwrap_or_default();

--- a/ctest/templates/test.c
+++ b/ctest/templates/test.c
@@ -8,6 +8,14 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#ifdef _MSC_VER
+    /* Disable MSVC warning C4197: 'top-level volatile in cast is ignored'.
+     * This occurs when casting to a volatile-qualified type (e.g. `(volatile char) -1`)
+     * to check its signedness, since volatile is ignored on rvalue expressions.
+     */
+    #pragma warning(disable:4197)
+#endif
+
 {%- for (header, defines) in self.headers +%}
 {%- for define in defines +%}
 
@@ -89,6 +97,9 @@ CTEST_EXTERN uint64_t ctest_offset_of__{{ item.id }}__{{ item.field.ident() }}(v
 }
 
 CTEST_EXTERN uint64_t ctest_size_of__{{ item.id }}__{{ item.field.ident() }}(void) {
+    /* MSVC C compiler does not support empty compound literals like `(Type){}`.
+     * Using the standard pointer-to-null dereference is portable across all compilers.
+     */
     return sizeof((({{ item.c_ty }} *)0)->{{ item.c_field }});
 }
 {%- endfor +%}

--- a/ctest/templates/test.c
+++ b/ctest/templates/test.c
@@ -89,7 +89,7 @@ CTEST_EXTERN uint64_t ctest_offset_of__{{ item.id }}__{{ item.field.ident() }}(v
 }
 
 CTEST_EXTERN uint64_t ctest_size_of__{{ item.id }}__{{ item.field.ident() }}(void) {
-    return sizeof((({{ item.c_ty }}){}).{{ item.c_field }});
+    return sizeof((({{ item.c_ty }} *)0)->{{ item.c_field }});
 }
 {%- endfor +%}
 

--- a/ctest/templates/test.rs
+++ b/ctest/templates/test.rs
@@ -46,22 +46,29 @@ mod generated_tests {
         }
 
         #[cfg(target_os = "windows")]
-        let (rust, c) = unsafe {
+        let (rust, c) = {
             let resolve = |addr: u64| -> u64 {
                 if addr == 0 {
                     return 0;
                 }
                 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-                {
+                unsafe {
                     let bytes = addr as *const u8;
+                    // Check for a jump instruction (0xff 0x25), which is used for import thunks.
                     if *bytes == 0xff && *bytes.add(1) == 0x25 {
                         if cfg!(target_arch = "x86_64") {
+                            // On x86_64, the jump is RIP-relative: jmp [RIP + displacement]
+                            // bytes[2..6] holds the 32-bit signed displacement.
+                            // bytes.add(6) is the instruction pointer (RIP) after the instruction.
                             let displacement = (bytes.add(2) as *const i32).read_unaligned();
-                            let address_of_pointer = bytes.add(6).offset(displacement as isize) as *const *const ();
-                            return *address_of_pointer as u64;
+                            let slot_addr = bytes.add(6).offset(displacement as isize) as *const *const ();
+                            return *slot_addr as u64;
                         } else if cfg!(target_arch = "x86") {
-                            let address_of_pointer = (bytes.add(2) as *const *const *const ()).read_unaligned();
-                            return *address_of_pointer as u64;
+                            // On x86, the jump contains the absolute address of the import table slot: jmp [absolute_address]
+                            // bytes[2..6] holds the 32-bit absolute address.
+                            let slot_addr_val = (bytes.add(2) as *const usize).read_unaligned();
+                            let slot_addr = slot_addr_val as *const *const ();
+                            return *slot_addr as u64;
                         }
                     }
                 }

--- a/ctest/templates/test.rs
+++ b/ctest/templates/test.rs
@@ -39,6 +39,46 @@ mod generated_tests {
         }
     }
 
+    fn check_same_fn_ptr(rust: u64, c: u64, attr: &str) {
+        if rust == c {
+            NTESTS.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+
+        #[cfg(target_os = "windows")]
+        let (rust, c) = unsafe {
+            let resolve = |addr: u64| -> u64 {
+                if addr == 0 {
+                    return 0;
+                }
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                {
+                    let bytes = addr as *const u8;
+                    if *bytes == 0xff && *bytes.add(1) == 0x25 {
+                        if cfg!(target_arch = "x86_64") {
+                            let displacement = (bytes.add(2) as *const i32).read_unaligned();
+                            let address_of_pointer = bytes.add(6).offset(displacement as isize) as *const *const ();
+                            return *address_of_pointer as u64;
+                        } else if cfg!(target_arch = "x86") {
+                            let address_of_pointer = (bytes.add(2) as *const *const *const ()).read_unaligned();
+                            return *address_of_pointer as u64;
+                        }
+                    }
+                }
+                addr
+            };
+
+            (resolve(rust), resolve(c))
+        };
+
+        if rust != c {
+            eprintln!("bad {attr}: rust: {rust:?} != c {c:?}");
+            FAILED.store(true, Ordering::Relaxed);
+        } else {
+            NTESTS.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
     fn check_same_bytes(rust: &[u8], c: &[u8], attr: &str) {
         if rust == c {
             NTESTS.fetch_add(1, Ordering::Relaxed);
@@ -360,7 +400,7 @@ mod generated_tests {
         }
         let actual = unsafe { ctest_foreign_fn__{{ item.id }}() } as u64;
         let expected = {{ item.id }} as *const () as u64;
-        check_same(actual, expected, "`{{ item.id }}` function pointer");
+        check_same_fn_ptr(actual, expected, "`{{ item.id }}` function pointer");
     }
 {%- endfor +%}
 

--- a/ctest/tests/input/hierarchy.out.c
+++ b/ctest/tests/input/hierarchy.out.c
@@ -4,6 +4,14 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+
+#ifdef _MSC_VER
+    /* Disable MSVC warning C4197: 'top-level volatile in cast is ignored'.
+     * This occurs when casting to a volatile-qualified type (e.g. `(volatile char) -1`)
+     * to check its signedness, since volatile is ignored on rvalue expressions.
+     */
+    #pragma warning(disable:4197)
+#endif
 #include <hierarchy.h>
 
 #if defined(__cplusplus)

--- a/ctest/tests/input/hierarchy.out.rs
+++ b/ctest/tests/input/hierarchy.out.rs
@@ -35,6 +35,53 @@ mod generated_tests {
         }
     }
 
+    fn check_same_fn_ptr(rust: u64, c: u64, attr: &str) {
+        if rust == c {
+            NTESTS.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+
+        #[cfg(target_os = "windows")]
+        let (rust, c) = {
+            let resolve = |addr: u64| -> u64 {
+                if addr == 0 {
+                    return 0;
+                }
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                unsafe {
+                    let bytes = addr as *const u8;
+                    // Check for a jump instruction (0xff 0x25), which is used for import thunks.
+                    if *bytes == 0xff && *bytes.add(1) == 0x25 {
+                        if cfg!(target_arch = "x86_64") {
+                            // On x86_64, the jump is RIP-relative: jmp [RIP + displacement]
+                            // bytes[2..6] holds the 32-bit signed displacement.
+                            // bytes.add(6) is the instruction pointer (RIP) after the instruction.
+                            let displacement = (bytes.add(2) as *const i32).read_unaligned();
+                            let slot_addr = bytes.add(6).offset(displacement as isize) as *const *const ();
+                            return *slot_addr as u64;
+                        } else if cfg!(target_arch = "x86") {
+                            // On x86, the jump contains the absolute address of the import table slot: jmp [absolute_address]
+                            // bytes[2..6] holds the 32-bit absolute address.
+                            let slot_addr_val = (bytes.add(2) as *const usize).read_unaligned();
+                            let slot_addr = slot_addr_val as *const *const ();
+                            return *slot_addr as u64;
+                        }
+                    }
+                }
+                addr
+            };
+
+            (resolve(rust), resolve(c))
+        };
+
+        if rust != c {
+            eprintln!("bad {attr}: rust: {rust:?} != c {c:?}");
+            FAILED.store(true, Ordering::Relaxed);
+        } else {
+            NTESTS.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
     fn check_same_bytes(rust: &[u8], c: &[u8], attr: &str) {
         if rust == c {
             NTESTS.fetch_add(1, Ordering::Relaxed);
@@ -255,7 +302,7 @@ mod generated_tests {
         }
         let actual = unsafe { ctest_foreign_fn__malloc() } as u64;
         let expected = malloc as *const () as u64;
-        check_same(actual, expected, "`malloc` function pointer");
+        check_same_fn_ptr(actual, expected, "`malloc` function pointer");
     }
 
 /* Tests if the pointer to the static variable matches in both Rust and C. */

--- a/ctest/tests/input/macro.out.c
+++ b/ctest/tests/input/macro.out.c
@@ -5,6 +5,14 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#ifdef _MSC_VER
+    /* Disable MSVC warning C4197: 'top-level volatile in cast is ignored'.
+     * This occurs when casting to a volatile-qualified type (e.g. `(volatile char) -1`)
+     * to check its signedness, since volatile is ignored on rvalue expressions.
+     */
+    #pragma warning(disable:4197)
+#endif
+
 #define SUPPRESS_ERROR
 #include <macro.h>
 #undef SUPPRESS_ERROR
@@ -56,7 +64,10 @@ CTEST_EXTERN uint64_t ctest_offset_of__VecU8__x(void) {
 }
 
 CTEST_EXTERN uint64_t ctest_size_of__VecU8__x(void) {
-    return sizeof(((struct VecU8){}).x);
+    /* MSVC C compiler does not support empty compound literals like `(Type){}`.
+     * Using the standard pointer-to-null dereference is portable across all compilers.
+     */
+    return sizeof(((struct VecU8 *)0)->x);
 }
 
 CTEST_EXTERN uint64_t ctest_offset_of__VecU8__y(void) {
@@ -64,7 +75,10 @@ CTEST_EXTERN uint64_t ctest_offset_of__VecU8__y(void) {
 }
 
 CTEST_EXTERN uint64_t ctest_size_of__VecU8__y(void) {
-    return sizeof(((struct VecU8){}).y);
+    /* MSVC C compiler does not support empty compound literals like `(Type){}`.
+     * Using the standard pointer-to-null dereference is portable across all compilers.
+     */
+    return sizeof(((struct VecU8 *)0)->y);
 }
 
 CTEST_EXTERN uint64_t ctest_offset_of__VecU16__x(void) {
@@ -72,7 +86,10 @@ CTEST_EXTERN uint64_t ctest_offset_of__VecU16__x(void) {
 }
 
 CTEST_EXTERN uint64_t ctest_size_of__VecU16__x(void) {
-    return sizeof(((struct VecU16){}).x);
+    /* MSVC C compiler does not support empty compound literals like `(Type){}`.
+     * Using the standard pointer-to-null dereference is portable across all compilers.
+     */
+    return sizeof(((struct VecU16 *)0)->x);
 }
 
 CTEST_EXTERN uint64_t ctest_offset_of__VecU16__y(void) {
@@ -80,7 +97,10 @@ CTEST_EXTERN uint64_t ctest_offset_of__VecU16__y(void) {
 }
 
 CTEST_EXTERN uint64_t ctest_size_of__VecU16__y(void) {
-    return sizeof(((struct VecU16){}).y);
+    /* MSVC C compiler does not support empty compound literals like `(Type){}`.
+     * Using the standard pointer-to-null dereference is portable across all compilers.
+     */
+    return sizeof(((struct VecU16 *)0)->y);
 }
 
 

--- a/ctest/tests/input/macro.out.edition-2024.c
+++ b/ctest/tests/input/macro.out.edition-2024.c
@@ -5,6 +5,14 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#ifdef _MSC_VER
+    /* Disable MSVC warning C4197: 'top-level volatile in cast is ignored'.
+     * This occurs when casting to a volatile-qualified type (e.g. `(volatile char) -1`)
+     * to check its signedness, since volatile is ignored on rvalue expressions.
+     */
+    #pragma warning(disable:4197)
+#endif
+
 #define SUPPRESS_ERROR
 #include <macro.h>
 #undef SUPPRESS_ERROR
@@ -56,7 +64,10 @@ CTEST_EXTERN uint64_t ctest_offset_of__VecU8__x(void) {
 }
 
 CTEST_EXTERN uint64_t ctest_size_of__VecU8__x(void) {
-    return sizeof(((struct VecU8){}).x);
+    /* MSVC C compiler does not support empty compound literals like `(Type){}`.
+     * Using the standard pointer-to-null dereference is portable across all compilers.
+     */
+    return sizeof(((struct VecU8 *)0)->x);
 }
 
 CTEST_EXTERN uint64_t ctest_offset_of__VecU8__y(void) {
@@ -64,7 +75,10 @@ CTEST_EXTERN uint64_t ctest_offset_of__VecU8__y(void) {
 }
 
 CTEST_EXTERN uint64_t ctest_size_of__VecU8__y(void) {
-    return sizeof(((struct VecU8){}).y);
+    /* MSVC C compiler does not support empty compound literals like `(Type){}`.
+     * Using the standard pointer-to-null dereference is portable across all compilers.
+     */
+    return sizeof(((struct VecU8 *)0)->y);
 }
 
 CTEST_EXTERN uint64_t ctest_offset_of__VecU16__x(void) {
@@ -72,7 +86,10 @@ CTEST_EXTERN uint64_t ctest_offset_of__VecU16__x(void) {
 }
 
 CTEST_EXTERN uint64_t ctest_size_of__VecU16__x(void) {
-    return sizeof(((struct VecU16){}).x);
+    /* MSVC C compiler does not support empty compound literals like `(Type){}`.
+     * Using the standard pointer-to-null dereference is portable across all compilers.
+     */
+    return sizeof(((struct VecU16 *)0)->x);
 }
 
 CTEST_EXTERN uint64_t ctest_offset_of__VecU16__y(void) {
@@ -80,7 +97,10 @@ CTEST_EXTERN uint64_t ctest_offset_of__VecU16__y(void) {
 }
 
 CTEST_EXTERN uint64_t ctest_size_of__VecU16__y(void) {
-    return sizeof(((struct VecU16){}).y);
+    /* MSVC C compiler does not support empty compound literals like `(Type){}`.
+     * Using the standard pointer-to-null dereference is portable across all compilers.
+     */
+    return sizeof(((struct VecU16 *)0)->y);
 }
 
 

--- a/ctest/tests/input/macro.out.edition-2024.rs
+++ b/ctest/tests/input/macro.out.edition-2024.rs
@@ -35,6 +35,53 @@ mod generated_tests {
         }
     }
 
+    fn check_same_fn_ptr(rust: u64, c: u64, attr: &str) {
+        if rust == c {
+            NTESTS.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+
+        #[cfg(target_os = "windows")]
+        let (rust, c) = {
+            let resolve = |addr: u64| -> u64 {
+                if addr == 0 {
+                    return 0;
+                }
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                unsafe {
+                    let bytes = addr as *const u8;
+                    // Check for a jump instruction (0xff 0x25), which is used for import thunks.
+                    if *bytes == 0xff && *bytes.add(1) == 0x25 {
+                        if cfg!(target_arch = "x86_64") {
+                            // On x86_64, the jump is RIP-relative: jmp [RIP + displacement]
+                            // bytes[2..6] holds the 32-bit signed displacement.
+                            // bytes.add(6) is the instruction pointer (RIP) after the instruction.
+                            let displacement = (bytes.add(2) as *const i32).read_unaligned();
+                            let slot_addr = bytes.add(6).offset(displacement as isize) as *const *const ();
+                            return *slot_addr as u64;
+                        } else if cfg!(target_arch = "x86") {
+                            // On x86, the jump contains the absolute address of the import table slot: jmp [absolute_address]
+                            // bytes[2..6] holds the 32-bit absolute address.
+                            let slot_addr_val = (bytes.add(2) as *const usize).read_unaligned();
+                            let slot_addr = slot_addr_val as *const *const ();
+                            return *slot_addr as u64;
+                        }
+                    }
+                }
+                addr
+            };
+
+            (resolve(rust), resolve(c))
+        };
+
+        if rust != c {
+            eprintln!("bad {attr}: rust: {rust:?} != c {c:?}");
+            FAILED.store(true, Ordering::Relaxed);
+        } else {
+            NTESTS.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
     fn check_same_bytes(rust: &[u8], c: &[u8], attr: &str) {
         if rust == c {
             NTESTS.fetch_add(1, Ordering::Relaxed);

--- a/ctest/tests/input/macro.out.rs
+++ b/ctest/tests/input/macro.out.rs
@@ -35,6 +35,53 @@ mod generated_tests {
         }
     }
 
+    fn check_same_fn_ptr(rust: u64, c: u64, attr: &str) {
+        if rust == c {
+            NTESTS.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+
+        #[cfg(target_os = "windows")]
+        let (rust, c) = {
+            let resolve = |addr: u64| -> u64 {
+                if addr == 0 {
+                    return 0;
+                }
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                unsafe {
+                    let bytes = addr as *const u8;
+                    // Check for a jump instruction (0xff 0x25), which is used for import thunks.
+                    if *bytes == 0xff && *bytes.add(1) == 0x25 {
+                        if cfg!(target_arch = "x86_64") {
+                            // On x86_64, the jump is RIP-relative: jmp [RIP + displacement]
+                            // bytes[2..6] holds the 32-bit signed displacement.
+                            // bytes.add(6) is the instruction pointer (RIP) after the instruction.
+                            let displacement = (bytes.add(2) as *const i32).read_unaligned();
+                            let slot_addr = bytes.add(6).offset(displacement as isize) as *const *const ();
+                            return *slot_addr as u64;
+                        } else if cfg!(target_arch = "x86") {
+                            // On x86, the jump contains the absolute address of the import table slot: jmp [absolute_address]
+                            // bytes[2..6] holds the 32-bit absolute address.
+                            let slot_addr_val = (bytes.add(2) as *const usize).read_unaligned();
+                            let slot_addr = slot_addr_val as *const *const ();
+                            return *slot_addr as u64;
+                        }
+                    }
+                }
+                addr
+            };
+
+            (resolve(rust), resolve(c))
+        };
+
+        if rust != c {
+            eprintln!("bad {attr}: rust: {rust:?} != c {c:?}");
+            FAILED.store(true, Ordering::Relaxed);
+        } else {
+            NTESTS.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
     fn check_same_bytes(rust: &[u8], c: &[u8], attr: &str) {
         if rust == c {
             NTESTS.fetch_add(1, Ordering::Relaxed);

--- a/ctest/tests/input/simple.out.with-renames.c
+++ b/ctest/tests/input/simple.out.with-renames.c
@@ -4,6 +4,14 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+
+#ifdef _MSC_VER
+    /* Disable MSVC warning C4197: 'top-level volatile in cast is ignored'.
+     * This occurs when casting to a volatile-qualified type (e.g. `(volatile char) -1`)
+     * to check its signedness, since volatile is ignored on rvalue expressions.
+     */
+    #pragma warning(disable:4197)
+#endif
 #include <simple.h>
 
 #if defined(__cplusplus)
@@ -105,7 +113,10 @@ CTEST_EXTERN uint64_t ctest_offset_of__Person__name(void) {
 }
 
 CTEST_EXTERN uint64_t ctest_size_of__Person__name(void) {
-    return sizeof(((struct Person){}).name);
+    /* MSVC C compiler does not support empty compound literals like `(Type){}`.
+     * Using the standard pointer-to-null dereference is portable across all compilers.
+     */
+    return sizeof(((struct Person *)0)->name);
 }
 
 CTEST_EXTERN uint64_t ctest_offset_of__Person__age(void) {
@@ -113,7 +124,10 @@ CTEST_EXTERN uint64_t ctest_offset_of__Person__age(void) {
 }
 
 CTEST_EXTERN uint64_t ctest_size_of__Person__age(void) {
-    return sizeof(((struct Person){}).age);
+    /* MSVC C compiler does not support empty compound literals like `(Type){}`.
+     * Using the standard pointer-to-null dereference is portable across all compilers.
+     */
+    return sizeof(((struct Person *)0)->age);
 }
 
 CTEST_EXTERN uint64_t ctest_offset_of__Person__job(void) {
@@ -121,7 +135,10 @@ CTEST_EXTERN uint64_t ctest_offset_of__Person__job(void) {
 }
 
 CTEST_EXTERN uint64_t ctest_size_of__Person__job(void) {
-    return sizeof(((struct Person){}).job);
+    /* MSVC C compiler does not support empty compound literals like `(Type){}`.
+     * Using the standard pointer-to-null dereference is portable across all compilers.
+     */
+    return sizeof(((struct Person *)0)->job);
 }
 
 CTEST_EXTERN uint64_t ctest_offset_of__Person__favorite_color(void) {
@@ -129,7 +146,10 @@ CTEST_EXTERN uint64_t ctest_offset_of__Person__favorite_color(void) {
 }
 
 CTEST_EXTERN uint64_t ctest_size_of__Person__favorite_color(void) {
-    return sizeof(((struct Person){}).favorite_color);
+    /* MSVC C compiler does not support empty compound literals like `(Type){}`.
+     * Using the standard pointer-to-null dereference is portable across all compilers.
+     */
+    return sizeof(((struct Person *)0)->favorite_color);
 }
 
 CTEST_EXTERN uint64_t ctest_offset_of__Word__word(void) {
@@ -137,7 +157,10 @@ CTEST_EXTERN uint64_t ctest_offset_of__Word__word(void) {
 }
 
 CTEST_EXTERN uint64_t ctest_size_of__Word__word(void) {
-    return sizeof(((union Word){}).word);
+    /* MSVC C compiler does not support empty compound literals like `(Type){}`.
+     * Using the standard pointer-to-null dereference is portable across all compilers.
+     */
+    return sizeof(((union Word *)0)->word);
 }
 
 CTEST_EXTERN uint64_t ctest_offset_of__Word__byte(void) {
@@ -145,7 +168,10 @@ CTEST_EXTERN uint64_t ctest_offset_of__Word__byte(void) {
 }
 
 CTEST_EXTERN uint64_t ctest_size_of__Word__byte(void) {
-    return sizeof(((union Word){}).byte);
+    /* MSVC C compiler does not support empty compound literals like `(Type){}`.
+     * Using the standard pointer-to-null dereference is portable across all compilers.
+     */
+    return sizeof(((union Word *)0)->byte);
 }
 
 

--- a/ctest/tests/input/simple.out.with-renames.rs
+++ b/ctest/tests/input/simple.out.with-renames.rs
@@ -35,6 +35,53 @@ mod generated_tests {
         }
     }
 
+    fn check_same_fn_ptr(rust: u64, c: u64, attr: &str) {
+        if rust == c {
+            NTESTS.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+
+        #[cfg(target_os = "windows")]
+        let (rust, c) = {
+            let resolve = |addr: u64| -> u64 {
+                if addr == 0 {
+                    return 0;
+                }
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                unsafe {
+                    let bytes = addr as *const u8;
+                    // Check for a jump instruction (0xff 0x25), which is used for import thunks.
+                    if *bytes == 0xff && *bytes.add(1) == 0x25 {
+                        if cfg!(target_arch = "x86_64") {
+                            // On x86_64, the jump is RIP-relative: jmp [RIP + displacement]
+                            // bytes[2..6] holds the 32-bit signed displacement.
+                            // bytes.add(6) is the instruction pointer (RIP) after the instruction.
+                            let displacement = (bytes.add(2) as *const i32).read_unaligned();
+                            let slot_addr = bytes.add(6).offset(displacement as isize) as *const *const ();
+                            return *slot_addr as u64;
+                        } else if cfg!(target_arch = "x86") {
+                            // On x86, the jump contains the absolute address of the import table slot: jmp [absolute_address]
+                            // bytes[2..6] holds the 32-bit absolute address.
+                            let slot_addr_val = (bytes.add(2) as *const usize).read_unaligned();
+                            let slot_addr = slot_addr_val as *const *const ();
+                            return *slot_addr as u64;
+                        }
+                    }
+                }
+                addr
+            };
+
+            (resolve(rust), resolve(c))
+        };
+
+        if rust != c {
+            eprintln!("bad {attr}: rust: {rust:?} != c {c:?}");
+            FAILED.store(true, Ordering::Relaxed);
+        } else {
+            NTESTS.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
     fn check_same_bytes(rust: &[u8], c: &[u8], attr: &str) {
         if rust == c {
             NTESTS.fetch_add(1, Ordering::Relaxed);
@@ -1086,7 +1133,7 @@ mod generated_tests {
         }
         let actual = unsafe { ctest_foreign_fn__calloc() } as u64;
         let expected = calloc as *const () as u64;
-        check_same(actual, expected, "`calloc` function pointer");
+        check_same_fn_ptr(actual, expected, "`calloc` function pointer");
     }
 
 /* Tests if the pointer to the static variable matches in both Rust and C. */

--- a/ctest/tests/input/simple.out.with-skips.c
+++ b/ctest/tests/input/simple.out.with-skips.c
@@ -4,6 +4,14 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+
+#ifdef _MSC_VER
+    /* Disable MSVC warning C4197: 'top-level volatile in cast is ignored'.
+     * This occurs when casting to a volatile-qualified type (e.g. `(volatile char) -1`)
+     * to check its signedness, since volatile is ignored on rvalue expressions.
+     */
+    #pragma warning(disable:4197)
+#endif
 #include <simple.h>
 
 #if defined(__cplusplus)

--- a/ctest/tests/input/simple.out.with-skips.rs
+++ b/ctest/tests/input/simple.out.with-skips.rs
@@ -35,6 +35,53 @@ mod generated_tests {
         }
     }
 
+    fn check_same_fn_ptr(rust: u64, c: u64, attr: &str) {
+        if rust == c {
+            NTESTS.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+
+        #[cfg(target_os = "windows")]
+        let (rust, c) = {
+            let resolve = |addr: u64| -> u64 {
+                if addr == 0 {
+                    return 0;
+                }
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                unsafe {
+                    let bytes = addr as *const u8;
+                    // Check for a jump instruction (0xff 0x25), which is used for import thunks.
+                    if *bytes == 0xff && *bytes.add(1) == 0x25 {
+                        if cfg!(target_arch = "x86_64") {
+                            // On x86_64, the jump is RIP-relative: jmp [RIP + displacement]
+                            // bytes[2..6] holds the 32-bit signed displacement.
+                            // bytes.add(6) is the instruction pointer (RIP) after the instruction.
+                            let displacement = (bytes.add(2) as *const i32).read_unaligned();
+                            let slot_addr = bytes.add(6).offset(displacement as isize) as *const *const ();
+                            return *slot_addr as u64;
+                        } else if cfg!(target_arch = "x86") {
+                            // On x86, the jump contains the absolute address of the import table slot: jmp [absolute_address]
+                            // bytes[2..6] holds the 32-bit absolute address.
+                            let slot_addr_val = (bytes.add(2) as *const usize).read_unaligned();
+                            let slot_addr = slot_addr_val as *const *const ();
+                            return *slot_addr as u64;
+                        }
+                    }
+                }
+                addr
+            };
+
+            (resolve(rust), resolve(c))
+        };
+
+        if rust != c {
+            eprintln!("bad {attr}: rust: {rust:?} != c {c:?}");
+            FAILED.store(true, Ordering::Relaxed);
+        } else {
+            NTESTS.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
     fn check_same_bytes(rust: &[u8], c: &[u8], attr: &str) {
         if rust == c {
             NTESTS.fetch_add(1, Ordering::Relaxed);

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -847,8 +847,12 @@ fn test_windows(target: &str) {
     });
 
     cfg.skip_struct_field(move |s, field| s.ident() == "CONTEXT" && field.ident() == "Fp");
-    // FIXME(windows): All functions point to the wrong addresses?
-    cfg.skip_fn_ptrcheck(|_| true);
+    // FIXME(windows): ctime and difftime are inline functions on the C side,
+    // so their addresses resolve to local wrappers rather than the DLL exports.
+    cfg.skip_fn_ptrcheck(|name| match name {
+        "ctime" | "difftime" => true,
+        _ => false,
+    });
 
     cfg.skip_signededness(move |c| {
         match c {

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -847,10 +847,10 @@ fn test_windows(target: &str) {
     });
 
     cfg.skip_struct_field(move |s, field| s.ident() == "CONTEXT" && field.ident() == "Fp");
-    // FIXME(windows): ctime and difftime are inline functions on the C side,
-    // so their addresses resolve to local wrappers rather than the DLL exports.
+    // FIXME(windows): ctime, difftime, gmtime_s, localtime_s, and getpid either resolve to different
+    // addresses or are inline/wrapper functions on the C side.
     cfg.skip_fn_ptrcheck(|name| match name {
-        "ctime" | "difftime" => true,
+        "ctime" | "difftime" | "gmtime_s" | "localtime_s" | "getpid" => true,
         _ => false,
     });
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
