### PR TITLE
linux: add `ifaddrmsg` and `rtattr`

### DIFF
--- a/libc-test/semver/linux.txt
+++ b/libc-test/semver/linux.txt
@@ -4184,6 +4184,7 @@ id_t
 idtype_t
 if_freenameindex
 if_nameindex
+ifaddrmsg
 ifaddrs
 ifconf
 ifinfomsg
@@ -4435,6 +4436,7 @@ remap_file_pages
 removexattr
 rlim64_t
 rlimit64
+rtattr
 rtentry
 sbrk
 sched_get_priority_max

--- a/src/new/linux_uapi/linux/if_addr.rs
+++ b/src/new/linux_uapi/linux/if_addr.rs
@@ -1,5 +1,7 @@
 //! Header: `uapi/linux/if_addr.h`
 
+use crate::prelude::*;
+
 s! {
     pub struct ifaddrmsg {
         pub ifa_family: u8,
@@ -9,3 +11,27 @@ s! {
         pub ifa_index: u32,
     }
 }
+
+pub const IFA_UNSPEC: c_ushort = 0;
+pub const IFA_ADDRESS: c_ushort = 1;
+pub const IFA_LOCAL: c_ushort = 2;
+pub const IFA_LABEL: c_ushort = 3;
+pub const IFA_BROADCAST: c_ushort = 4;
+pub const IFA_ANYCAST: c_ushort = 5;
+pub const IFA_CACHEINFO: c_ushort = 6;
+pub const IFA_MULTICAST: c_ushort = 7;
+pub const IFA_FLAGS: c_ushort = 8;
+
+pub const IFA_F_SECONDARY: u32 = 0x01;
+pub const IFA_F_TEMPORARY: u32 = 0x01;
+pub const IFA_F_NODAD: u32 = 0x02;
+pub const IFA_F_OPTIMISTIC: u32 = 0x04;
+pub const IFA_F_DADFAILED: u32 = 0x08;
+pub const IFA_F_HOMEADDRESS: u32 = 0x10;
+pub const IFA_F_DEPRECATED: u32 = 0x20;
+pub const IFA_F_TENTATIVE: u32 = 0x40;
+pub const IFA_F_PERMANENT: u32 = 0x80;
+pub const IFA_F_MANAGETEMPADDR: u32 = 0x100;
+pub const IFA_F_NOPREFIXROUTE: u32 = 0x200;
+pub const IFA_F_MCAUTOJOIN: u32 = 0x400;
+pub const IFA_F_STABLE_PRIVACY: u32 = 0x800;

--- a/src/new/linux_uapi/linux/if_addr.rs
+++ b/src/new/linux_uapi/linux/if_addr.rs
@@ -1,0 +1,11 @@
+//! Header: `uapi/linux/if_addr.h`
+
+s! {
+    pub struct ifaddrmsg {
+        pub ifa_family: u8,
+        pub ifa_prefixlen: u8,
+        pub ifa_flags: u8,
+        pub ifa_scope: u8,
+        pub ifa_index: u32,
+    }
+}

--- a/src/new/linux_uapi/linux/mod.rs
+++ b/src/new/linux_uapi/linux/mod.rs
@@ -4,6 +4,7 @@
 
 pub(crate) mod can;
 pub(crate) mod futex;
+pub(crate) mod if_addr;
 pub(crate) mod if_link;
 pub(crate) mod if_packet;
 pub(crate) mod keyctl;

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -183,6 +183,7 @@ cfg_if! {
         pub use linux::can::netlink::*;
         pub use linux::can::raw::*;
         pub use linux::futex::*;
+        pub use linux::if_addr::*;
         pub use linux::if_link::*;
         pub use linux::if_packet::*;
         pub use linux::keyctl::*;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1136,31 +1136,6 @@ pub const AT_HANDLE_FID: c_int = 0x200;
 pub const AT_HANDLE_MNT_ID_UNIQUE: c_int = 0x001;
 pub const AT_HANDLE_CONNECTABLE: c_int = 0x002;
 
-// linux/if_addr.h
-pub const IFA_UNSPEC: c_ushort = 0;
-pub const IFA_ADDRESS: c_ushort = 1;
-pub const IFA_LOCAL: c_ushort = 2;
-pub const IFA_LABEL: c_ushort = 3;
-pub const IFA_BROADCAST: c_ushort = 4;
-pub const IFA_ANYCAST: c_ushort = 5;
-pub const IFA_CACHEINFO: c_ushort = 6;
-pub const IFA_MULTICAST: c_ushort = 7;
-pub const IFA_FLAGS: c_ushort = 8;
-
-pub const IFA_F_SECONDARY: u32 = 0x01;
-pub const IFA_F_TEMPORARY: u32 = 0x01;
-pub const IFA_F_NODAD: u32 = 0x02;
-pub const IFA_F_OPTIMISTIC: u32 = 0x04;
-pub const IFA_F_DADFAILED: u32 = 0x08;
-pub const IFA_F_HOMEADDRESS: u32 = 0x10;
-pub const IFA_F_DEPRECATED: u32 = 0x20;
-pub const IFA_F_TENTATIVE: u32 = 0x40;
-pub const IFA_F_PERMANENT: u32 = 0x80;
-pub const IFA_F_MANAGETEMPADDR: u32 = 0x100;
-pub const IFA_F_NOPREFIXROUTE: u32 = 0x200;
-pub const IFA_F_MCAUTOJOIN: u32 = 0x400;
-pub const IFA_F_STABLE_PRIVACY: u32 = 0x800;
-
 // linux/fs.h
 
 // Flags for preadv2/pwritev2

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -998,6 +998,11 @@ s! {
         pub ifi_change: c_uint,
     }
 
+    pub struct rtattr {
+        pub rta_len: c_ushort,
+        pub rta_type: c_ushort,
+    }
+
     // netdb.h
     pub struct netent {
         pub n_name: *mut c_char,


### PR DESCRIPTION
# Description

Add `ifaddrmsg` and `rtattr`, the rtnetlink message bodies, next to `ifinfomsg`. Used to parse RTM_*ADDR/RTM_*LINK dumps and walk rtattr attributes.

# Sources

- `ifaddrmsg` (`linux/if_addr.h`): https://github.com/torvalds/linux/blob/dc59e4fea9d83f03bad6bddf3fa2e52491777482/include/uapi/linux/if_addr.h#L8
- `rtattr` (`linux/rtnetlink.h`): https://github.com/torvalds/linux/blob/dc59e4fea9d83f03bad6bddf3fa2e52491777482/include/uapi/linux/rtnetlink.h#L219

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`)
