### PR TITLE
Add tier 2 illumos CI 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -302,6 +302,7 @@ jobs:
             target: x86_64-unknown-freebsd
           - target: x86_64-pc-solaris
           - target: x86_64-unknown-netbsd
+          - target: x86_64-unknown-illumos
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -360,6 +361,27 @@ jobs:
             /usr/sbin/pkg_add curl
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
               --profile minimal --default-toolchain nightly -y
+          run: |
+            set -ex
+            . "$HOME/.cargo/env"
+            which rustc
+            rustc -Vv
+            ./ci/run.sh ${{ matrix.target }}
+
+      - name: test on illumos
+        uses: vmactions/omnios-vm@7f2be0b927aad1a78498c8aeeac4c4ce1fabd322 # v1.3.3
+        if: contains(matrix.target, 'illumos')
+        with:
+          # Use the latest LTS
+          release: "r151054-build"
+          usesh: true
+          mem: 4096
+          copyback: false
+          prepare: |
+            set -ex
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
+              --profile minimal --default-toolchain nightly -y
+            uname -a
           run: |
             set -ex
             . "$HOME/.cargo/env"

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1052,7 +1052,7 @@ fn test_solarish(target: &str) {
     );
 
     if is_illumos {
-        headers!(cfg, "sys/epoll.h", "sys/eventfd.h",);
+        headers!(cfg, "sys/epoll.h", "sys/eventfd.h", "sys/timerfd.h",);
     }
 
     if is_solaris {
@@ -1084,6 +1084,8 @@ fn test_solarish(target: &str) {
                 // expose stat.Xtim.tv_nsec fields
                 Some(field.ident().trim_end_matches("e_nsec").to_string() + ".tv_nsec")
             }
+            // epoll_event.data is a union in C; our `u64` field lives at `data.u64`
+            "epoll_event" if field.ident() == "u64" => Some("data.u64".to_string()),
             _ => None,
         }
     });
@@ -1110,6 +1112,15 @@ fn test_solarish(target: &str) {
         // defined on older systems.  It is, however, safe to use on systems which do not
         // explicitly support it. (A no-op is an acceptable implementation of EPOLLEXCLUSIVE.)
         "EPOLLEXCLUSIVE" if is_illumos => true,
+
+        // FIXME(illumos)
+        // illumos has changed this constant, see https://www.illumos.org/issues/16200 for details.
+        // We would like to keep this header value in sync with what is present in the illumos
+        // sysroot that rustc is cross compiled with. There is an in progress bump in
+        // https://github.com/illumos/sysroot/pull/5, however this will still predate the new value.
+        // When this does eventually make it to the sysroot we should update it in this crate and
+        // remove this test skip.
+        "PTHREAD_MUTEX_DEFAULT" if is_illumos => true,
 
         _ => false,
     });


### PR DESCRIPTION
Fixes: rust-lang/libc#1405

As discussed in rust-lang/libc#1405 we want CI support for illumos. It looks like solaris has already added CI support in a previous
commit so we can safely mark the issue as closed.

This adds illumos ci via the `vmactions/omnios-vm` github action and relies on the latest omnios LTS release (r151054) which is supported until 2028-05-01.

Additionally this PR fixes an epoll test issue that was looking for timerfd that I discovered while working on this.