### PR TITLE
Fix c_void_returns lint warning

### DIFF
--- a/src/teeos/mod.rs
+++ b/src/teeos/mod.rs
@@ -49,7 +49,7 @@ pub type clockid_t = c_int;
 
 pub type suseconds_t = c_long;
 
-pub type once_fn = extern "C" fn() -> c_void;
+pub type once_fn = extern "C" fn();
 
 pub type pthread_once_t = c_int;
 

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -2693,12 +2693,12 @@ extern "C" {
 
     pub fn pthread_cancel(thread: crate::pthread_t) -> c_int;
 
-    pub fn pthread_cleanup_pop(execute: c_int) -> c_void;
+    pub fn pthread_cleanup_pop(execute: c_int);
 
     pub fn pthread_cleanup_push(
         routine: Option<unsafe extern "C" fn(*mut c_void)>,
         arg: *mut c_void,
-    ) -> c_void;
+    );
 
     pub fn pthread_condattr_getclock(
         attr: *const pthread_condattr_t,
@@ -2839,7 +2839,7 @@ extern "C" {
     pub fn pthread_spin_trylock(lock: *mut pthread_spinlock_t) -> c_int;
     pub fn pthread_spin_unlock(lock: *mut pthread_spinlock_t) -> c_int;
 
-    pub fn pthread_testcancel() -> c_void;
+    pub fn pthread_testcancel();
 }
 
 #[link(name = "iconv")]


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

Nightly added a lint warning on `c_void` returns this patch removes the return type to implicitly return `()`.

See a sample failing job here: https://github.com/rust-lang/libc/actions/runs/28580626120/job/84739740809?pr=5065#step:9:2195
<!-- Add a short description about what this change does -->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
