### PR TITLE
Support new qnx targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ targets = [
     "aarch64-unknown-hermit",
     "aarch64-unknown-illumos",
     "aarch64-unknown-netbsd",
-    "aarch64-unknown-nto-qnx800",
+    "aarch64-unknown-qnx",
     "aarch64-unknown-openbsd",
     "aarch64-unknown-redox",
     "aarch64-wrs-vxworks",

--- a/build.rs
+++ b/build.rs
@@ -48,7 +48,7 @@ const CHECK_CFG_EXTRA: &[(&str, &[&str])] = &[
     ),
     (
         "target_env",
-        &["illumos", "wasi", "aix", "ohos", "nto71_iosock", "nto80"],
+        &["illumos", "wasi", "aix", "ohos", "nto71_iosock"],
     ),
     (
         "target_arch",

--- a/build.rs
+++ b/build.rs
@@ -43,7 +43,7 @@ const CHECK_CFG_EXTRA: &[(&str, &[&str])] = &[
     (
         "target_os",
         &[
-            "switch", "aix", "ohos", "hurd", "rtems", "visionos", "nuttx", "cygwin", "qurt",
+            "switch", "aix", "ohos", "hurd", "rtems", "visionos", "nuttx", "cygwin", "qurt", "qnx",
         ],
     ),
     (

--- a/libc-test/tests/makedev.rs
+++ b/libc-test/tests/makedev.rs
@@ -29,6 +29,7 @@ cfg_if::cfg_if! {
         target_os = "emscripten",
         target_os = "fuchsia",
         target_os = "nto",
+        target_os = "qnx",
         target_os = "hurd",
         target_os = "openbsd",
         target_os = "cygwin",

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -93,7 +93,7 @@ cfg_if! {
     } else if #[cfg(target_os = "netbsd")] {
         mod netbsd;
         pub(crate) use netbsd::*;
-    } else if #[cfg(target_os = "nto")] {
+    } else if #[cfg(any(target_os = "nto", target_os = "qnx"))] {
         mod nto;
         pub(crate) use nto::*;
     } else if #[cfg(target_os = "nuttx")] {
@@ -217,7 +217,7 @@ cfg_if! {
         pub use utmpx_::*;
     } else if #[cfg(target_os = "openbsd")] {
         pub use sys::ipc::*;
-    } else if #[cfg(target_os = "nto")] {
+    } else if #[cfg(any(target_os = "nto", target_os = "qnx"))] {
         pub use net::bpf::*;
         pub use net::if_::*;
     } else if #[cfg(target_os = "freebsd")] {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -28,7 +28,7 @@ cfg_if! {
     ))] {
         pub type uid_t = c_ushort;
         pub type gid_t = c_ushort;
-    } else if #[cfg(target_os = "nto")] {
+    } else if #[cfg(any(target_os = "nto", target_os = "qnx"))] {
         pub type uid_t = i32;
         pub type gid_t = i32;
     } else {
@@ -253,7 +253,7 @@ pub const SIG_ERR: sighandler_t = !0 as sighandler_t;
 
 cfg_if! {
     if #[cfg(all(
-        not(target_os = "nto"),
+        not(any(target_os = "nto", target_os = "qnx")),
         not(target_os = "aix"),
         not(target_os = "espidf")
     ))] {
@@ -274,7 +274,11 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(not(any(target_os = "nto", target_os = "l4re")))] {
+    if #[cfg(not(any(
+        target_os = "nto",
+        target_os = "qnx",
+        target_os = "l4re"
+    )))] {
         pub const USRQUOTA: c_int = 0;
         pub const GRPQUOTA: c_int = 1;
     }
@@ -337,7 +341,7 @@ pub const LOG_PRIMASK: c_int = 7;
 pub const LOG_FACMASK: c_int = 0x3f8;
 
 cfg_if! {
-    if #[cfg(not(target_os = "nto"))] {
+    if #[cfg(not(any(target_os = "nto", target_os = "qnx")))] {
         pub const PRIO_MIN: c_int = -20;
         pub const PRIO_MAX: c_int = 20;
     }
@@ -371,7 +375,7 @@ pub const ATF_PUBL: c_int = 0x08;
 pub const ATF_USETRAILERS: c_int = 0x10;
 
 cfg_if! {
-    if #[cfg(any(target_os = "nto", target_os = "aix"))] {
+    if #[cfg(any(target_os = "nto", target_os = "qnx", target_os = "aix"))] {
         pub const FNM_PERIOD: c_int = 1 << 1;
     } else {
         pub const FNM_PERIOD: c_int = 1 << 2;
@@ -418,7 +422,7 @@ cfg_if! {
         target_os = "cygwin",
     ))] {
         pub const FNM_NOESCAPE: c_int = 1 << 0;
-    } else if #[cfg(target_os = "nto")] {
+    } else if #[cfg(any(target_os = "nto", target_os = "qnx"))] {
         pub const FNM_NOESCAPE: c_int = 1 << 2;
     } else if #[cfg(target_os = "aix")] {
         pub const FNM_NOESCAPE: c_int = 1 << 3;
@@ -572,6 +576,7 @@ cfg_if! {
         target_os = "android",
         target_os = "openbsd",
         target_os = "nto",
+        target_os = "qnx",
     ))] {
         #[link(name = "c")]
         #[link(name = "m")]
@@ -2152,6 +2157,7 @@ cfg_if! {
         target_os = "android",
         target_os = "haiku",
         target_os = "nto",
+        target_os = "qnx",
         target_os = "solaris",
         target_os = "cygwin",
         target_os = "aix",
@@ -2273,7 +2279,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(target_os = "nto")] {
+    if #[cfg(any(target_os = "nto", target_os = "qnx"))] {
         extern "C" {
             pub fn readlinkat(
                 dirfd: c_int,
@@ -2347,10 +2353,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(any(
-        target_os = "aix",
-        all(target_os = "nto", target_env = "nto80")
-    ))] {
+    if #[cfg(any(target_os = "aix", target_os = "qnx",))] {
         extern "C" {
             pub fn cfsetspeed(termios: *mut crate::termios, speed: crate::speed_t) -> c_int;
         }
@@ -2507,7 +2510,7 @@ cfg_if! {
     } else if #[cfg(target_os = "cygwin")] {
         mod cygwin;
         pub use self::cygwin::*;
-    } else if #[cfg(target_os = "nto")] {
+    } else if #[cfg(any(target_os = "nto", target_os = "qnx"))] {
         mod nto;
         pub use self::nto::*;
     } else if #[cfg(target_os = "aix")] {

--- a/src/unix/nto/arch/aarch64.rs
+++ b/src/unix/nto/arch/aarch64.rs
@@ -5,7 +5,7 @@
 //! * `aarch64-unknown-nto-qnx700`
 //! * `aarch64-unknown-nto-qnx710`
 //! * `aarch64-unknown-nto-qnx710_iosock`
-//! * `aarch64-unknown-nto-qnx800`
+//! * `aarch64-unknown-qnx`
 
 use crate::prelude::*;
 

--- a/src/unix/nto/arch/x86_64.rs
+++ b/src/unix/nto/arch/x86_64.rs
@@ -4,7 +4,7 @@
 //!
 //! * `x86_64-pc-nto-qnx710`
 //! * `x86_64-pc-nto-qnx710_iosock`
-//! * `x86_64-pc-nto-qnx800`
+//! * `x86_64-pc-qnx`
 
 use crate::prelude::*;
 

--- a/src/unix/nto/io_sock/mod.rs
+++ b/src/unix/nto/io_sock/mod.rs
@@ -4,8 +4,8 @@
 //!
 //! * `aarch64-unknown-nto-qnx710`
 //! * `x86_64-pc-nto-qnx710`
-//! * `aarch64-unknown-nto-qnx800`
-//! * `x86_64-pc-nto-qnx800`
+//! * `aarch64-unknown-qnx`
+//! * `x86_64-pc-qnx`
 
 use crate::prelude::*;
 

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -2219,9 +2219,20 @@ pub const PTHREAD_PROCESS_SHARED: c_int = 0x01;
 
 pub const PTHREAD_KEYS_MAX: usize = 128;
 
+#[cfg(not(any(target_env = "nto71", target_env = "nto71_iosock", target_os = "qnx")))]
 pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
     __u: 0x80000000,
     __owner: 0xffffffff,
+};
+#[cfg(any(target_env = "nto71", target_env = "nto71_iosock"))]
+pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
+    __u: 0x82000000,
+    __owner: 0,
+};
+#[cfg(target_os = "qnx")]
+pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
+    __u: 0x80000000,
+    __owner: 0,
 };
 pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = pthread_cond_t {
     __u: CLOCK_REALTIME as u32,

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -5,11 +5,11 @@
 //! * `aarch64-unknown-nto-qnx700`
 //! * `aarch64-unknown-nto-qnx710`
 //! * `aarch64-unknown-nto-qnx710_iosock`
-//! * `aarch64-unknown-nto-qnx800`
+//! * `aarch64-unknown-qnx`
 //! * `i686-pc-nto-qnx700`
 //! * `x86_64-pc-nto-qnx710`
 //! * `x86_64-pc-nto-qnx710_iosock`
-//! * `x86_64-pc-nto-qnx800`
+//! * `x86_64-pc-qnx`
 //!
 //! There are sub-modules for the target architecture, and sub-modules for the
 //! kind of networking library used. QNX SDP 7.0 uses `io-pkt`, QNX SDP 8.0
@@ -725,10 +725,10 @@ s_no_extra_traits! {
     // get native f128 support.
     //
     // The definition was taken from the definition of the _Maxalignt struct in the QNX SDK.
-    // However, on QNX7, there is a different definition of std::max_align_t (the C++ version of
+    // However, on QNX SDP 7, there is a different definition of std::max_align_t (the C++ version of
     // this type). In practice, this doesn't make a difference for the _alignment_ properties of the
     // type - however, it changes the size, so using in in any other form than the zero-sized array
-    // form would be bogus and it would potentially change the size of the data type. On QNX8, this
+    // form would be bogus and it would potentially change the size of the data type. On QNX SDP 8, this
     // got fixed and both C and C++ are using the same definition.
     pub struct max_align_t {
         _ll: crate::c_longlong,
@@ -2998,7 +2998,7 @@ cfg_if! {
     if #[cfg(any(target_env = "nto70", target_env = "nto71"))] {
         mod io_pkt;
         pub use self::io_pkt::*;
-    } else if #[cfg(any(target_env = "nto71_iosock", target_env = "nto80"))] {
+    } else if #[cfg(any(target_env = "nto71_iosock", target_os = "qnx"))] {
         mod io_sock;
         pub use self::io_sock::*;
     } else {


### PR DESCRIPTION
# Description

Updates libc to support the newly renamed targets for QNX SDP 8

This PR largely involves adding `target_os = "qnx"` everywhere that said `target_os = "nto"`, and replacing `target_env = "nto800"` with `target_os = "qnx"`.

Plus there are some pthread mutex fixes, which we took from the our header files.

# Sources

For QNX SDP 8.0:

```console
$ grep "#define PTHREAD_MUTEX_INITIALIZER" /home/ubuntu/qnx800/target/qnx/usr/include/pthread.h -A1
#define PTHREAD_MUTEX_INITIALIZER                   \
	{ .__u = { .__count = _NTO_SYNC_NONRECURSIVE }, .__owner = _NTO_SYNC_MUTEX_FREE }
$ rg "#define _NTO_SYNC_NONRECURSIVE" /home/ubuntu/qnx800
/home/ubuntu/qnx800/target/qnx/usr/include/sys/target_nto.h
540:#define _NTO_SYNC_NONRECURSIVE	0x80000000U	/* mutexes */
$ rg "#define _NTO_SYNC_MUTEX_FREE" /home/ubuntu/qnx800
/home/ubuntu/qnx800/target/qnx/usr/include/sys/target_nto.h
550:#define _NTO_SYNC_MUTEX_FREE	0x00000000U	/*    0  newly-initialized mutex */
```

For QNX SDP 7.1:

```console
$ grep "#define PTHREAD_MUTEX_INITIALIZER" /home/ubuntu/qnx710/target/qnx7/usr/include/pthread.h -A1
#define PTHREAD_MUTEX_INITIALIZER	\
	{ .__u = { .__count = (_NTO_SYNC_NONRECURSIVE | _NTO_SYNC_NODESTROY) }, .__owner = _NTO_SYNC_MUTEX_FREE }
$ rg "#define _NTO_SYNC_NONRECURSIVE" /home/ubuntu/qnx710
/home/ubuntu/qnx710/target/qnx7/usr/include/sys/target_nto.h
470:#define _NTO_SYNC_NONRECURSIVE	0x80000000U	/* mutexes */
$ rg "#define _NTO_SYNC_NODESTROY" /home/ubuntu/qnx710
/home/ubuntu/qnx710/target/qnx7/usr/include/sys/target_nto.h
476:#define _NTO_SYNC_NODESTROY		0x02000000U /* mutexes */
$ rg "#define _NTO_SYNC_MUTEX_FREE" /home/ubuntu/qnx710
/home/ubuntu/qnx710/target/qnx7/usr/include/sys/target_nto.h
479:#define _NTO_SYNC_MUTEX_FREE	0x00000000U	/*    0  mutexes, and old cond, sem, spin */
```

I don't have QNX SDP 7.0 available, so the old code path was left as-is.

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated (there are none)
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI
  - These tests do not pass but they didn't pass before this PR either

@rustbot label +stable-nominated
