### PR TITLE
hurd: clean up module

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -177,7 +177,7 @@ fn main() {
     }
 
     if target_env == "gnu"
-        && matches!(target_os.as_str(), "linux" | "windows")
+        && matches!(target_os.as_str(), "linux" | "windows" | "hurd")
         && target_ptr_width == "32"
         && target_arch != "riscv32"
         && target_arch != "x86_64"

--- a/src/unix/hurd/b32.rs
+++ b/src/unix/hurd/b32.rs
@@ -15,14 +15,14 @@ pub type __u_quad_t = c_ulonglong;
 pub type __intmax_t = c_longlong;
 pub type __uintmax_t = c_ulonglong;
 
-pub type __squad_type = crate::__int64_t;
-pub type __uquad_type = crate::__uint64_t;
+pub type __squad_type = __int64_t;
+pub type __uquad_type = __uint64_t;
 pub type __sword_type = c_int;
 pub type __uword_type = c_uint;
 pub type __slong32_type = c_long;
 pub type __ulong32_type = c_ulong;
-pub type __s64_type = crate::__int64_t;
-pub type __u64_type = crate::__uint64_t;
+pub type __s64_type = __int64_t;
+pub type __u64_type = __uint64_t;
 
 pub type __ipc_pid_t = c_ushort;
 

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -86,6 +86,7 @@ cfg_if! {
     }
 }
 
+// FIXME(1.0,deprecate,64): lfs binding to be removed
 pub type off64_t = __off64_t;
 pub type useconds_t = __useconds_t;
 pub type pid_t = __pid_t;
@@ -118,6 +119,7 @@ cfg_if! {
     }
 }
 
+// FIXME(1.0,deprecate,64): lfs binding to be removed
 pub type ino64_t = __ino64_t;
 pub type dev_t = __dev_t;
 pub type mode_t = __mode_t;
@@ -158,8 +160,11 @@ cfg_if! {
     }
 }
 
+// FIXME(1.0,deprecate,64): lfs binding to be removed
 pub type blkcnt64_t = __blkcnt64_t;
+// FIXME(1.0,deprecate,64): lfs binding to be removed
 pub type fsblkcnt64_t = __fsblkcnt64_t;
+// FIXME(1.0,deprecate,64): lfs binding to be removed
 pub type fsfilcnt64_t = __fsfilcnt64_t;
 
 pub type __pthread_spinlock_t = c_int;
@@ -199,6 +204,7 @@ cfg_if! {
     }
 }
 
+// FIXME(1.0,deprecate,64): lfs binding to be removed
 pub type rlim64_t = __rlim64_t;
 
 pub type __rusage_who = c_int;
@@ -260,6 +266,7 @@ pub type nl_item = c_int;
 pub type iconv_t = *mut c_void;
 
 extern_ty! {
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub type fpos64_t; // FIXME(hurd): fill this out with a struct
     pub type timezone;
 }
@@ -391,6 +398,7 @@ s! {
         pub d_name: [c_char; 1usize],
     }
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub struct dirent64 {
         pub d_ino: __ino64_t,
         pub d_reclen: c_ushort,
@@ -515,6 +523,7 @@ s! {
         >,
     }
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub struct stat64 {
         pub st_fstype: c_int,
         pub st_dev: __fsid_t, /* Actually st_fsid */
@@ -588,6 +597,7 @@ s! {
         f_spare: Padding<[c_uint; 3usize]>,
     }
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub struct statfs64 {
         pub f_type: c_uint,
         pub f_bsize: c_ulong,
@@ -620,6 +630,7 @@ s! {
         f_spare: Padding<[c_uint; 3usize]>,
     }
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub struct statvfs64 {
         pub __f_type: c_uint,
         pub f_bsize: c_ulong,
@@ -921,6 +932,7 @@ s! {
         pub domainname: [c_char; _UTSNAME_LENGTH],
     }
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub struct rlimit64 {
         pub rlim_cur: rlim64_t,
         pub rlim_max: rlim64_t,
@@ -959,6 +971,7 @@ s! {
         pub l_pid: __pid_t,
     }
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub struct flock64 {
         #[cfg(target_pointer_width = "32")]
         pub l_type: c_int,
@@ -1274,6 +1287,7 @@ cfg_if! {
     }
 }
 
+// FIXME(1.0,deprecate,64): lfs binding to be removed
 pub const RLIM64_INFINITY: rlim64_t = 0x7fffffffffffffff;
 pub const RLIM_SAVED_MAX: rlim_t = RLIM_INFINITY;
 pub const RLIM_SAVED_CUR: rlim_t = RLIM_INFINITY;
@@ -3630,7 +3644,9 @@ extern "C" {
 
     pub fn dup3(oldfd: c_int, newfd: c_int, flags: c_int) -> c_int;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn pread64(fd: c_int, buf: *mut c_void, count: size_t, offset: off64_t) -> ssize_t;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn pwrite64(fd: c_int, buf: *const c_void, count: size_t, offset: off64_t) -> ssize_t;
 
     pub fn readv(__fd: c_int, __iovec: *const crate::iovec, __count: c_int) -> ssize_t;
@@ -3651,8 +3667,10 @@ extern "C" {
         __offset: off_t,
     ) -> ssize_t;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn preadv64(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: off64_t)
         -> ssize_t;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn pwritev64(
         fd: c_int,
         iov: *const crate::iovec,
@@ -3721,11 +3739,18 @@ extern "C" {
         oldattr: *mut crate::mq_attr,
     ) -> c_int;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn lseek64(__fd: c_int, __offset: off64_t, __whence: c_int) -> off64_t;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
+    #[allow(clashing_extern_declarations)]
     pub fn fgetpos64(stream: *mut crate::FILE, ptr: *mut fpos64_t) -> c_int;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn fseeko64(stream: *mut crate::FILE, offset: off64_t, whence: c_int) -> c_int;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
+    #[allow(clashing_extern_declarations)]
     pub fn fsetpos64(stream: *mut crate::FILE, ptr: *const fpos64_t) -> c_int;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn ftello64(stream: *mut crate::FILE) -> off64_t;
 
     pub fn bind(__fd: c_int, __addr: *const sockaddr, __len: crate::socklen_t) -> c_int;
@@ -3759,6 +3784,7 @@ extern "C" {
 
     #[cfg_attr(gnu_file_offset_bits64, link_name = "sendfile64")]
     pub fn sendfile(out_fd: c_int, in_fd: c_int, offset: *mut off_t, count: size_t) -> ssize_t;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn sendfile64(out_fd: c_int, in_fd: c_int, offset: *mut off64_t, count: size_t) -> ssize_t;
 
     pub fn shutdown(__fd: c_int, __how: c_int) -> c_int;
@@ -4099,8 +4125,10 @@ extern "C" {
         old_value: *mut crate::itimerspec,
     ) -> c_int;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn fstat64(__fd: c_int, __buf: *mut stat64) -> c_int;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn fstatat64(
         __fd: c_int,
         __file: *const c_char,
@@ -4116,37 +4144,50 @@ extern "C" {
         statxbuf: *mut statx,
     ) -> c_int;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn ftruncate64(__fd: c_int, __length: off64_t) -> c_int;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn truncate64(__file: *const c_char, __length: off64_t) -> c_int;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn lstat64(__file: *const c_char, __buf: *mut stat64) -> c_int;
 
     #[cfg_attr(gnu_file_offset_bits64, link_name = "statfs64")]
     pub fn statfs(path: *const c_char, buf: *mut statfs) -> c_int;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn statfs64(__file: *const c_char, __buf: *mut statfs64) -> c_int;
     #[cfg_attr(gnu_file_offset_bits64, link_name = "fstatfs64")]
     pub fn fstatfs(fd: c_int, buf: *mut statfs) -> c_int;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn fstatfs64(__fildes: c_int, __buf: *mut statfs64) -> c_int;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn statvfs64(__file: *const c_char, __buf: *mut statvfs64) -> c_int;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn fstatvfs64(__fildes: c_int, __buf: *mut statvfs64) -> c_int;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn open64(__file: *const c_char, __oflag: c_int, ...) -> c_int;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn openat64(__fd: c_int, __file: *const c_char, __oflag: c_int, ...) -> c_int;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn fopen64(filename: *const c_char, mode: *const c_char) -> *mut crate::FILE;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn freopen64(
         filename: *const c_char,
         mode: *const c_char,
         file: *mut crate::FILE,
     ) -> *mut crate::FILE;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn creat64(path: *const c_char, mode: mode_t) -> c_int;
 
     pub fn mkostemp(template: *mut c_char, flags: c_int) -> c_int;
     pub fn mkostemps(template: *mut c_char, suffixlen: c_int, flags: c_int) -> c_int;
     pub fn mkstemps(template: *mut c_char, suffixlen: c_int) -> c_int;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn tmpfile64() -> *mut crate::FILE;
 
     pub fn popen(command: *const c_char, mode: *const c_char) -> *mut crate::FILE;
@@ -4299,9 +4340,12 @@ extern "C" {
 
     pub fn faccessat(dirfd: c_int, pathname: *const c_char, mode: c_int, flags: c_int) -> c_int;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn stat64(__file: *const c_char, __buf: *mut stat64) -> c_int;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn readdir64(dirp: *mut crate::DIR) -> *mut dirent64;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn readdir64_r(
         dirp: *mut crate::DIR,
         entry: *mut dirent64,
@@ -4317,6 +4361,7 @@ extern "C" {
 
     pub fn __errno_location() -> *mut c_int;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn mmap64(
         __addr: *mut c_void,
         __len: size_t,
@@ -4345,11 +4390,13 @@ extern "C" {
     pub fn fallocate64(fd: c_int, mode: c_int, offset: off64_t, len: off64_t) -> c_int;
     #[cfg_attr(gnu_file_offset_bits64, link_name = "posix_fallocate64")]
     pub fn posix_fallocate(fd: c_int, offset: off_t, len: off_t) -> c_int;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn posix_fallocate64(fd: c_int, offset: off64_t, len: off64_t) -> c_int;
 
     #[cfg_attr(gnu_file_offset_bits64, link_name = "posix_fadvise64")]
     pub fn posix_fadvise(fd: c_int, offset: off_t, len: off_t, advise: c_int) -> c_int;
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn posix_fadvise64(fd: c_int, offset: off64_t, len: off64_t, advise: c_int) -> c_int;
 
     pub fn madvise(__addr: *mut c_void, __len: size_t, __advice: c_int) -> c_int;
@@ -4358,9 +4405,11 @@ extern "C" {
 
     #[cfg_attr(gnu_file_offset_bits64, link_name = "getrlimit64")]
     pub fn getrlimit(resource: __rlimit_resource_t, rlim: *mut crate::rlimit) -> c_int;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn getrlimit64(resource: __rlimit_resource_t, rlim: *mut rlimit64) -> c_int;
     #[cfg_attr(gnu_file_offset_bits64, link_name = "setrlimit64")]
     pub fn setrlimit(resource: __rlimit_resource_t, rlim: *const crate::rlimit) -> c_int;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn setrlimit64(resource: __rlimit_resource_t, rlim: *const rlimit64) -> c_int;
 
     pub fn getpriority(which: crate::__priority_which, who: crate::id_t) -> c_int;

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -1068,6 +1068,23 @@ impl siginfo_t {
     }
 }
 
+s_no_extra_traits! {
+    pub struct fpos_t {
+        __pos: off_t,
+        __state: __mbstate_t,
+    }
+
+    struct __mbstate_t {
+        __count: c_int,
+        __value: __c_anonymous___mbstate_t___value,
+    }
+
+    union __c_anonymous___mbstate_t___value {
+        __wch: c_int,
+        __wchb: [c_char; 4],
+    }
+}
+
 // const
 
 // aio.h

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -4341,6 +4341,7 @@ extern "C" {
     pub fn syncfs(fd: c_int) -> c_int;
     pub fn fdatasync(fd: c_int) -> c_int;
 
+    #[deprecated(since = "0.2.187", note = "This routine doesn't exist upstream.")]
     pub fn fallocate64(fd: c_int, mode: c_int, offset: off64_t, len: off64_t) -> c_int;
     #[cfg_attr(gnu_file_offset_bits64, link_name = "posix_fallocate64")]
     pub fn posix_fallocate(fd: c_int, offset: off_t, len: off_t) -> c_int;

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -3717,9 +3717,7 @@ extern "C" {
         oldattr: *mut crate::mq_attr,
     ) -> c_int;
 
-    pub fn lseek64(__fd: c_int, __offset: __off64_t, __whence: c_int) -> __off64_t;
-
-    pub fn lseek(__fd: c_int, __offset: __off_t, __whence: c_int) -> __off_t;
+    pub fn lseek64(__fd: c_int, __offset: off64_t, __whence: c_int) -> off64_t;
 
     pub fn fgetpos64(stream: *mut crate::FILE, ptr: *mut fpos64_t) -> c_int;
     pub fn fseeko64(stream: *mut crate::FILE, offset: off64_t, whence: c_int) -> c_int;
@@ -4097,10 +4095,8 @@ extern "C" {
         old_value: *mut crate::itimerspec,
     ) -> c_int;
 
-    pub fn fstat(__fd: c_int, __buf: *mut stat) -> c_int;
     pub fn fstat64(__fd: c_int, __buf: *mut stat64) -> c_int;
 
-    pub fn fstatat(__fd: c_int, __file: *const c_char, __buf: *mut stat, __flag: c_int) -> c_int;
     pub fn fstatat64(
         __fd: c_int,
         __file: *const c_char,
@@ -4116,11 +4112,9 @@ extern "C" {
         statxbuf: *mut statx,
     ) -> c_int;
 
-    pub fn ftruncate(__fd: c_int, __length: __off_t) -> c_int;
-    pub fn ftruncate64(__fd: c_int, __length: __off64_t) -> c_int;
-    pub fn truncate64(__file: *const c_char, __length: __off64_t) -> c_int;
+    pub fn ftruncate64(__fd: c_int, __length: off64_t) -> c_int;
+    pub fn truncate64(__file: *const c_char, __length: off64_t) -> c_int;
 
-    pub fn lstat(__file: *const c_char, __buf: *mut stat) -> c_int;
     pub fn lstat64(__file: *const c_char, __buf: *mut stat64) -> c_int;
 
     #[cfg_attr(gnu_file_offset_bits64, link_name = "statfs64")]
@@ -4130,15 +4124,11 @@ extern "C" {
     pub fn fstatfs(fd: c_int, buf: *mut statfs) -> c_int;
     pub fn fstatfs64(__fildes: c_int, __buf: *mut statfs64) -> c_int;
 
-    pub fn statvfs(__file: *const c_char, __buf: *mut statvfs) -> c_int;
     pub fn statvfs64(__file: *const c_char, __buf: *mut statvfs64) -> c_int;
-    pub fn fstatvfs(__fildes: c_int, __buf: *mut statvfs) -> c_int;
     pub fn fstatvfs64(__fildes: c_int, __buf: *mut statvfs64) -> c_int;
 
-    pub fn open(__file: *const c_char, __oflag: c_int, ...) -> c_int;
     pub fn open64(__file: *const c_char, __oflag: c_int, ...) -> c_int;
 
-    pub fn openat(__fd: c_int, __file: *const c_char, __oflag: c_int, ...) -> c_int;
     pub fn openat64(__fd: c_int, __file: *const c_char, __oflag: c_int, ...) -> c_int;
 
     pub fn fopen64(filename: *const c_char, mode: *const c_char) -> *mut crate::FILE;
@@ -4305,16 +4295,9 @@ extern "C" {
 
     pub fn faccessat(dirfd: c_int, pathname: *const c_char, mode: c_int, flags: c_int) -> c_int;
 
-    pub fn stat(__file: *const c_char, __buf: *mut stat) -> c_int;
     pub fn stat64(__file: *const c_char, __buf: *mut stat64) -> c_int;
 
-    pub fn readdir(dirp: *mut crate::DIR) -> *mut crate::dirent;
-    pub fn readdir64(dirp: *mut crate::DIR) -> *mut crate::dirent64;
-    pub fn readdir_r(
-        dirp: *mut crate::DIR,
-        entry: *mut crate::dirent,
-        result: *mut *mut crate::dirent,
-    ) -> c_int;
+    pub fn readdir64(dirp: *mut crate::DIR) -> *mut dirent64;
     pub fn readdir64_r(
         dirp: *mut crate::DIR,
         entry: *mut dirent64,

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -77,7 +77,15 @@ pub type wchar_t = c_int;
 pub type wint_t = c_uint;
 pub type gid_t = __gid_t;
 pub type uid_t = __uid_t;
-pub type off_t = __off_t;
+
+cfg_if! {
+    if #[cfg(any(target_pointer_width = "64", gnu_file_offset_bits64))] {
+        pub type off_t = __off64_t;
+    } else {
+        pub type off_t = __off_t;
+    }
+}
+
 pub type off64_t = __off64_t;
 pub type useconds_t = __useconds_t;
 pub type pid_t = __pid_t;
@@ -101,7 +109,15 @@ pub type quad_t = __quad_t;
 pub type u_quad_t = __u_quad_t;
 pub type fsid_t = __fsid_t;
 pub type loff_t = __loff_t;
-pub type ino_t = __ino_t;
+
+cfg_if! {
+    if #[cfg(any(target_pointer_width = "64", gnu_file_offset_bits64))] {
+        pub type ino_t = __ino64_t;
+    } else {
+        pub type ino_t = __ino_t;
+    }
+}
+
 pub type ino64_t = __ino64_t;
 pub type dev_t = __dev_t;
 pub type mode_t = __mode_t;
@@ -129,9 +145,19 @@ pub type sigset_t = __sigset_t;
 pub type __fd_mask = c_long;
 pub type fd_mask = __fd_mask;
 pub type blksize_t = __blksize_t;
-pub type blkcnt_t = __blkcnt_t;
-pub type fsblkcnt_t = __fsblkcnt_t;
-pub type fsfilcnt_t = __fsfilcnt_t;
+
+cfg_if! {
+    if #[cfg(any(target_pointer_width = "64", gnu_file_offset_bits64))] {
+        pub type blkcnt_t = __blkcnt64_t;
+        pub type fsblkcnt_t = __fsblkcnt64_t;
+        pub type fsfilcnt_t = __fsfilcnt64_t;
+    } else {
+        pub type blkcnt_t = __blkcnt_t;
+        pub type fsblkcnt_t = __fsblkcnt_t;
+        pub type fsfilcnt_t = __fsfilcnt_t;
+    }
+}
+
 pub type blkcnt64_t = __blkcnt64_t;
 pub type fsblkcnt64_t = __fsblkcnt64_t;
 pub type fsfilcnt64_t = __fsfilcnt64_t;
@@ -164,7 +190,15 @@ pub type pthread_once_t = __pthread_once;
 
 pub type __rlimit_resource = c_uint;
 pub type __rlimit_resource_t = __rlimit_resource;
-pub type rlim_t = __rlim_t;
+
+cfg_if! {
+    if #[cfg(any(target_pointer_width = "64", gnu_file_offset_bits64))] {
+        pub type rlim_t = __rlim64_t;
+    } else {
+        pub type rlim_t = __rlim_t;
+    }
+}
+
 pub type rlim64_t = __rlim64_t;
 
 pub type __rusage_who = c_int;
@@ -350,7 +384,7 @@ s! {
     }
 
     pub struct dirent {
-        pub d_ino: __ino_t,
+        pub d_ino: ino_t,
         pub d_reclen: c_ushort,
         pub d_type: c_uchar,
         pub d_namlen: c_uchar,
@@ -449,22 +483,36 @@ s! {
     pub struct stat {
         pub st_fstype: c_int,
         pub st_dev: __fsid_t, /* Actually st_fsid */
-        pub st_ino: __ino_t,
+        pub st_ino: ino_t,
         pub st_gen: c_uint,
         pub st_rdev: __dev_t,
         pub st_mode: __mode_t,
         pub st_nlink: __nlink_t,
         pub st_uid: __uid_t,
         pub st_gid: __gid_t,
-        pub st_size: __off_t,
-        pub st_atim: crate::timespec,
-        pub st_mtim: crate::timespec,
-        pub st_ctim: crate::timespec,
+        pub st_size: off_t,
+        pub st_atim: timespec,
+        pub st_mtim: timespec,
+        pub st_ctim: timespec,
         pub st_blksize: __blksize_t,
-        pub st_blocks: __blkcnt_t,
+        pub st_blocks: blkcnt_t,
         pub st_author: __uid_t,
         pub st_flags: c_uint,
-        pub st_spare: [c_int; 11usize],
+        st_spare: Padding<
+            [c_int; if cfg!(not(gnu_file_offset_bits64)) {
+                if size_of::<__fsid_t>() == size_of::<c_int>() {
+                    12
+                } else {
+                    11
+                }
+            } else {
+                if size_of::<__fsid_t>() == size_of::<c_int>() {
+                    9
+                } else {
+                    8
+                }
+            }],
+        >,
     }
 
     pub struct stat64 {
@@ -478,14 +526,20 @@ s! {
         pub st_uid: __uid_t,
         pub st_gid: __gid_t,
         pub st_size: __off64_t,
-        pub st_atim: crate::timespec,
-        pub st_mtim: crate::timespec,
-        pub st_ctim: crate::timespec,
+        pub st_atim: timespec,
+        pub st_mtim: timespec,
+        pub st_ctim: timespec,
         pub st_blksize: __blksize_t,
         pub st_blocks: __blkcnt64_t,
         pub st_author: __uid_t,
         pub st_flags: c_uint,
-        pub st_spare: [c_int; 8usize],
+        st_spare: Padding<
+            [c_int; if size_of::<__fsid_t>() == size_of::<c_int>() {
+                9
+            } else {
+                8
+            }],
+        >,
     }
 
     pub struct statx {
@@ -521,17 +575,17 @@ s! {
     pub struct statfs {
         pub f_type: c_uint,
         pub f_bsize: c_ulong,
-        pub f_blocks: __fsblkcnt_t,
-        pub f_bfree: __fsblkcnt_t,
-        pub f_bavail: __fsblkcnt_t,
-        pub f_files: __fsblkcnt_t,
-        pub f_ffree: __fsblkcnt_t,
+        pub f_blocks: fsblkcnt_t,
+        pub f_bfree: fsblkcnt_t,
+        pub f_bavail: fsblkcnt_t,
+        pub f_files: fsblkcnt_t,
+        pub f_ffree: fsblkcnt_t,
         pub f_fsid: __fsid_t,
         pub f_namelen: c_ulong,
-        pub f_favail: __fsfilcnt_t,
+        pub f_favail: fsfilcnt_t,
         pub f_frsize: c_ulong,
         pub f_flag: c_ulong,
-        pub f_spare: [c_uint; 3usize],
+        f_spare: Padding<[c_uint; 3usize]>,
     }
 
     pub struct statfs64 {
@@ -547,23 +601,23 @@ s! {
         pub f_favail: __fsfilcnt64_t,
         pub f_frsize: c_ulong,
         pub f_flag: c_ulong,
-        pub f_spare: [c_uint; 3usize],
+        f_spare: Padding<[c_uint; 3usize]>,
     }
 
     pub struct statvfs {
         pub __f_type: c_uint,
         pub f_bsize: c_ulong,
-        pub f_blocks: __fsblkcnt_t,
-        pub f_bfree: __fsblkcnt_t,
-        pub f_bavail: __fsblkcnt_t,
-        pub f_files: __fsfilcnt_t,
-        pub f_ffree: __fsfilcnt_t,
+        pub f_blocks: fsblkcnt_t,
+        pub f_bfree: fsblkcnt_t,
+        pub f_bavail: fsblkcnt_t,
+        pub f_files: fsfilcnt_t,
+        pub f_ffree: fsfilcnt_t,
         pub f_fsid: __fsid_t,
         pub f_namemax: c_ulong,
-        pub f_favail: __fsfilcnt_t,
+        pub f_favail: fsfilcnt_t,
         pub f_frsize: c_ulong,
         pub f_flag: c_ulong,
-        pub f_spare: [c_uint; 3usize],
+        f_spare: Padding<[c_uint; 3usize]>,
     }
 
     pub struct statvfs64 {
@@ -579,7 +633,7 @@ s! {
         pub f_favail: __fsfilcnt64_t,
         pub f_frsize: c_ulong,
         pub f_flag: c_ulong,
-        pub f_spare: [c_uint; 3usize],
+        f_spare: Padding<[c_uint; 3usize]>,
     }
 
     pub struct aiocb {
@@ -628,6 +682,7 @@ s! {
         pub __pshared: __pthread_process_shared,
         pub __mutex_type: __pthread_mutex_type,
     }
+
     pub struct __pthread_mutex {
         pub __lock: c_uint,
         pub __owner_id: c_uint,
@@ -893,12 +948,14 @@ s! {
         pub l_type: c_int,
         #[cfg(target_pointer_width = "32")]
         pub l_whence: c_int,
+
         #[cfg(target_pointer_width = "64")]
         pub l_type: c_short,
         #[cfg(target_pointer_width = "64")]
         pub l_whence: c_short,
-        pub l_start: __off_t,
-        pub l_len: __off_t,
+
+        pub l_start: off_t,
+        pub l_len: off_t,
         pub l_pid: __pid_t,
     }
 
@@ -907,11 +964,13 @@ s! {
         pub l_type: c_int,
         #[cfg(target_pointer_width = "32")]
         pub l_whence: c_int,
+
         #[cfg(target_pointer_width = "64")]
         pub l_type: c_short,
         #[cfg(target_pointer_width = "64")]
         pub l_whence: c_short,
-        pub l_start: __off_t,
+
+        pub l_start: __off64_t,
         pub l_len: __off64_t,
         pub l_pid: __pid_t,
     }
@@ -1206,10 +1265,17 @@ pub const __PTHREAD_SPIN_LOCK_INITIALIZER: c_int = 0;
 pub const PTHREAD_MUTEX_NORMAL: c_int = 0;
 
 // sys/resource.h
-pub const RLIM_INFINITY: crate::rlim_t = 2147483647;
-pub const RLIM64_INFINITY: crate::rlim64_t = 9223372036854775807;
-pub const RLIM_SAVED_MAX: crate::rlim_t = RLIM_INFINITY;
-pub const RLIM_SAVED_CUR: crate::rlim_t = RLIM_INFINITY;
+cfg_if! {
+    if #[cfg(gnu_file_offset_bits64)] {
+        pub const RLIM_INFINITY: rlim64_t = 0x7fffffffffffffff;
+    } else {
+        pub const RLIM_INFINITY: rlim_t = -1_isize as rlim_t;
+    }
+}
+
+pub const RLIM64_INFINITY: rlim64_t = 0x7fffffffffffffff;
+pub const RLIM_SAVED_MAX: rlim_t = RLIM_INFINITY;
+pub const RLIM_SAVED_CUR: rlim_t = RLIM_INFINITY;
 pub const PRIO_MIN: c_int = -20;
 pub const PRIO_MAX: c_int = 20;
 
@@ -3568,17 +3634,19 @@ extern "C" {
     pub fn readv(__fd: c_int, __iovec: *const crate::iovec, __count: c_int) -> ssize_t;
     pub fn writev(__fd: c_int, __iovec: *const crate::iovec, __count: c_int) -> ssize_t;
 
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "preadv64")]
     pub fn preadv(
         __fd: c_int,
         __iovec: *const crate::iovec,
         __count: c_int,
-        __offset: __off_t,
+        __offset: off_t,
     ) -> ssize_t;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "pwritev64")]
     pub fn pwritev(
         __fd: c_int,
         __iovec: *const crate::iovec,
         __count: c_int,
-        __offset: __off_t,
+        __offset: off_t,
     ) -> ssize_t;
 
     pub fn preadv64(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: off64_t)
@@ -3689,6 +3757,7 @@ extern "C" {
         addrlen: *mut crate::socklen_t,
     ) -> ssize_t;
 
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "sendfile64")]
     pub fn sendfile(out_fd: c_int, in_fd: c_int, offset: *mut off_t, count: size_t) -> ssize_t;
     pub fn sendfile64(out_fd: c_int, in_fd: c_int, offset: *mut off64_t, count: size_t) -> ssize_t;
 
@@ -4056,8 +4125,10 @@ extern "C" {
     pub fn lstat(__file: *const c_char, __buf: *mut stat) -> c_int;
     pub fn lstat64(__file: *const c_char, __buf: *mut stat64) -> c_int;
 
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "statfs64")]
     pub fn statfs(path: *const c_char, buf: *mut statfs) -> c_int;
     pub fn statfs64(__file: *const c_char, __buf: *mut statfs64) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "fstatfs64")]
     pub fn fstatfs(fd: c_int, buf: *mut statfs) -> c_int;
     pub fn fstatfs64(__fildes: c_int, __buf: *mut statfs64) -> c_int;
 
@@ -4248,8 +4319,8 @@ extern "C" {
     ) -> c_int;
     pub fn readdir64_r(
         dirp: *mut crate::DIR,
-        entry: *mut crate::dirent64,
-        result: *mut *mut crate::dirent64,
+        entry: *mut dirent64,
+        result: *mut *mut dirent64,
     ) -> c_int;
     pub fn seekdir(dirp: *mut crate::DIR, loc: c_long);
     pub fn telldir(dirp: *mut crate::DIR) -> c_long;
@@ -4267,7 +4338,7 @@ extern "C" {
         __prot: c_int,
         __flags: c_int,
         __fd: c_int,
-        __offset: __off64_t,
+        __offset: off64_t,
     ) -> *mut c_void;
 
     pub fn mremap(
@@ -4286,9 +4357,11 @@ extern "C" {
     pub fn fdatasync(fd: c_int) -> c_int;
 
     pub fn fallocate64(fd: c_int, mode: c_int, offset: off64_t, len: off64_t) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "posix_fallocate64")]
     pub fn posix_fallocate(fd: c_int, offset: off_t, len: off_t) -> c_int;
     pub fn posix_fallocate64(fd: c_int, offset: off64_t, len: off64_t) -> c_int;
 
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "posix_fadvise64")]
     pub fn posix_fadvise(fd: c_int, offset: off_t, len: off_t, advise: c_int) -> c_int;
 
     pub fn posix_fadvise64(fd: c_int, offset: off64_t, len: off64_t, advise: c_int) -> c_int;
@@ -4297,11 +4370,12 @@ extern "C" {
 
     pub fn posix_madvise(addr: *mut c_void, len: size_t, advice: c_int) -> c_int;
 
-    pub fn getrlimit(resource: crate::__rlimit_resource_t, rlim: *mut crate::rlimit) -> c_int;
-    pub fn getrlimit64(resource: crate::__rlimit_resource_t, rlim: *mut crate::rlimit64) -> c_int;
-    pub fn setrlimit(resource: crate::__rlimit_resource_t, rlim: *const crate::rlimit) -> c_int;
-    pub fn setrlimit64(resource: crate::__rlimit_resource_t, rlim: *const crate::rlimit64)
-        -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "getrlimit64")]
+    pub fn getrlimit(resource: __rlimit_resource_t, rlim: *mut crate::rlimit) -> c_int;
+    pub fn getrlimit64(resource: __rlimit_resource_t, rlim: *mut rlimit64) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "setrlimit64")]
+    pub fn setrlimit(resource: __rlimit_resource_t, rlim: *const crate::rlimit) -> c_int;
+    pub fn setrlimit64(resource: __rlimit_resource_t, rlim: *const rlimit64) -> c_int;
 
     pub fn getpriority(which: crate::__priority_which, who: crate::id_t) -> c_int;
     pub fn setpriority(which: crate::__priority_which, who: crate::id_t, prio: c_int) -> c_int;
@@ -4394,20 +4468,38 @@ extern "C" {
 
     pub fn regfree(preg: *mut crate::regex_t);
 
+    #[cfg_attr(
+        all(gnu_file_offset_bits64, gnu_time_bits64),
+        link_name = "__glob64_time64"
+    )]
+    #[cfg_attr(
+        all(gnu_file_offset_bits64, not(gnu_time_bits64)),
+        link_name = "glob64"
+    )]
     pub fn glob(
         pattern: *const c_char,
         flags: c_int,
         errfunc: Option<extern "C" fn(epath: *const c_char, errno: c_int) -> c_int>,
-        pglob: *mut crate::glob_t,
+        pglob: *mut glob_t,
     ) -> c_int;
-    pub fn globfree(pglob: *mut crate::glob_t);
+    #[cfg_attr(
+        all(gnu_file_offset_bits64, gnu_time_bits64),
+        link_name = "__globfree64_time64"
+    )]
+    #[cfg_attr(
+        all(gnu_file_offset_bits64, not(gnu_time_bits64)),
+        link_name = "globfree64"
+    )]
+    pub fn globfree(pglob: *mut glob_t);
 
+    #[cfg_attr(gnu_time_bits64, link_name = "__glob64_time64")]
     pub fn glob64(
         pattern: *const c_char,
         flags: c_int,
         errfunc: Option<extern "C" fn(epath: *const c_char, errno: c_int) -> c_int>,
         pglob: *mut glob64_t,
     ) -> c_int;
+    #[cfg_attr(gnu_time_bits64, link_name = "__globfree64_time64")]
     pub fn globfree64(pglob: *mut glob64_t);
 
     pub fn getxattr(

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -988,6 +988,10 @@ s! {
         __unused5: Padding<*mut c_void>,
     }
 
+    #[deprecated(
+        since = "0.2.187",
+        note = "Use `glob_t` instead. The definitions are equivalent."
+    )]
     pub struct glob64_t {
         pub gl_pathc: size_t,
         pub gl_pathv: *mut *mut c_char,
@@ -4474,6 +4478,11 @@ extern "C" {
     pub fn globfree(pglob: *mut glob_t);
 
     #[cfg_attr(gnu_time_bits64, link_name = "__glob64_time64")]
+    #[deprecated(
+        since = "0.2.187",
+        note = "Use `glob` instead. Their definitions are equivalent."
+    )]
+    #[allow(deprecated)]
     pub fn glob64(
         pattern: *const c_char,
         flags: c_int,
@@ -4481,6 +4490,11 @@ extern "C" {
         pglob: *mut glob64_t,
     ) -> c_int;
     #[cfg_attr(gnu_time_bits64, link_name = "__globfree64_time64")]
+    #[deprecated(
+        since = "0.2.187",
+        note = "Use `globfree` instead. Their definitions are equivalent."
+    )]
+    #[allow(deprecated)]
     pub fn globfree64(pglob: *mut glob64_t);
 
     pub fn getxattr(

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -1013,10 +1013,7 @@ s! {
     }
 
     pub struct cpu_set_t {
-        #[cfg(all(target_pointer_width = "32", not(target_arch = "x86_64")))]
-        bits: [u32; 32],
-        #[cfg(not(all(target_pointer_width = "32", not(target_arch = "x86_64"))))]
-        bits: [u64; 16],
+        __bits: [__cpu_mask; __CPU_SETSIZE / __NCPUBITS],
     }
 
     pub struct if_nameindex {
@@ -2564,6 +2561,7 @@ pub const SCHED_FIFO: c_int = 1;
 pub const SCHED_RR: c_int = 2;
 pub const _BITS_TYPES_STRUCT_SCHED_PARAM: usize = 1;
 pub const __CPU_SETSIZE: usize = 1024;
+pub const __NCPUBITS: usize = 8 * size_of::<__cpu_mask>();
 pub const CPU_SETSIZE: usize = 1024;
 
 // pthread.h
@@ -3499,36 +3497,36 @@ f! {
 
     pub unsafe fn CPU_ALLOC_SIZE(count: c_int) -> size_t {
         let _dummy: cpu_set_t = mem::zeroed();
-        let size_in_bits = 8 * size_of_val(&_dummy.bits[0]);
+        let size_in_bits = 8 * size_of_val(&_dummy.__bits[0]);
         ((count as size_t + size_in_bits - 1) / 8) as size_t
     }
 
     pub unsafe fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {
-        cpuset.bits.fill(0);
+        cpuset.__bits.fill(0);
     }
 
     pub unsafe fn CPU_SET(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * size_of_val(&cpuset.__bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
-        cpuset.bits[idx] |= 1 << offset;
+        cpuset.__bits[idx] |= 1 << offset;
     }
 
     pub unsafe fn CPU_CLR(cpu: usize, cpuset: &mut cpu_set_t) -> () {
-        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]); // 32, 64 etc
+        let size_in_bits = 8 * size_of_val(&cpuset.__bits[0]); // 32, 64 etc
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
-        cpuset.bits[idx] &= !(1 << offset);
+        cpuset.__bits[idx] &= !(1 << offset);
     }
 
     pub unsafe fn CPU_ISSET(cpu: usize, cpuset: &cpu_set_t) -> bool {
-        let size_in_bits = 8 * size_of_val(&cpuset.bits[0]);
+        let size_in_bits = 8 * size_of_val(&cpuset.__bits[0]);
         let (idx, offset) = (cpu / size_in_bits, cpu % size_in_bits);
-        0 != (cpuset.bits[idx] & (1 << offset))
+        0 != (cpuset.__bits[idx] & (1 << offset))
     }
 
     pub unsafe fn CPU_COUNT_S(size: usize, cpuset: &cpu_set_t) -> c_int {
         let mut s: u32 = 0;
-        let size_of_mask = size_of_val(&cpuset.bits[0]);
-        for i in cpuset.bits[..(size / size_of_mask)].iter() {
+        let size_of_mask = size_of_val(&cpuset.__bits[0]);
+        for i in cpuset.__bits[..(size / size_of_mask)].iter() {
             s += i.count_ones();
         }
         s as c_int
@@ -3539,7 +3537,7 @@ f! {
     }
 
     pub unsafe fn CPU_EQUAL(set1: &cpu_set_t, set2: &cpu_set_t) -> bool {
-        set1.bits == set2.bits
+        set1.__bits == set2.__bits
     }
 
     pub unsafe fn IPTOS_TOS(tos: u8) -> u8 {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -625,7 +625,10 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(not(all(target_os = "linux", target_env = "gnu")))] {
+    if #[cfg(not(any(
+        target_os = "hurd",
+        all(target_os = "linux", target_env = "gnu")
+    )))] {
         extern_ty! {
             pub type fpos_t; // FIXME(unix): fill this out with a struct
         }


### PR DESCRIPTION
# Description

This PR consists of an overall clean up of the GNU Hurd module. It adds proper
handling of types and routines when `_USE_FILE_OFFSET64` is defined by using
the existing `gnu_file_offset_bits64` `cfg`. It also fixes a type definition
and more closely mirrors those of upstream.

It also adds a number of future deprecation annotations. The annotations on
type aliases apply only to 64-bit targets. Other annotations apply to both
64-bit targets and any target with the afore mentioned `cfg` set.

Finally, there were some routines that were duplicated in both the `unix`
module and the `unix/hurd` module. These have been removed from the latter.
This decision was made because the `unix` module's definitions already included
the right link name redirection for bindings where the actual identifier is the
64-bit suffixed one.

## Sources

- glibc.
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=posix/bits/types.h;h=33b582a8eabf09aadc093658db82353c288590d2;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/mach/hurd/bits/typesizes.h;h=514058071bfcea156584fa014e750b402216476b;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=bits/resource.h;h=6b83374331424da439ad0163e1e992d274847fc2;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=libio/bits/types/__fpos_t.h;h=bb04576651b9097b3027e4299cc30c88f334535f;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=libio/bits/types/__fpos64_t.h;h=06a6891154fff74e1ddb6245f4a0467b09c617c5;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/mach/hurd/bits/fcntl.h;h=faa45a1e77e4fdae52cd002fe36bb5e4cd43eb98;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=posix/bits/cpu-set.h;h=ddb79cefc2e5d93003f8da84eca6302f99153a22;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=misc/sys/uio.h;h=77f62ffcc3ac3c6a3d43e494c0062e823e6f624c;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=posix/unistd.h;h=06a6a88b5272f7cc37d1df27f9e6617cdf58d69c;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=libio/stdio.h;h=3bf6a1f63203b111b67b6f101cc188320d3db78c;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=io/sys/sendfile.h;h=e51d19d15c85817970bc40cb51ebf79e0adb67c8;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=io/sys/stat.h;h=3069e187b079461dec1d5c699d49b5aa570a205d;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=io/sys/statfs.h;h=b4c7dc44e7db80dcdf3dca90457903da7ca4c9ba;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=io/sys/statvfs.h;h=6bc86c8335e106e5c993b5e5a2cd3d53eff12891;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=dirent/dirent.h;h=ed2aac64644b0f374aa1f0d1b0806094c6697d2b;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=string/string.h;h=743395b3e3b2dd52194b1a6b8c34df4f8b56d8a1;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=misc/sys/mman.h;h=e84308b1570bf26a071c52660803f1f2fd440944;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=io/fcntl.h;h=d0ad4d665227f30e7f2b2a49e3e823728d190a31;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=resource/sys/resource.h;h=cb76c2d8570b36127eb3a74dda1c6c8d1bb2afec;hb=HEAD>
  - <https://sourceware.org/git/?p=glibc.git;a=blob;f=posix/glob.h;h=4c824eb0d30ec557f9c5d5e1d85d823e1a1900c6;hb=HEAD>

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included
  (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
