### PR TITLE
netbsd: Fix statvfs struct layout and add symbol versioning for NetBSD 10.x

### DIFF
--- a/src/new/netbsd/sys/statvfs.rs
+++ b/src/new/netbsd/sys/statvfs.rs
@@ -35,13 +35,11 @@ s! {
         pub f_namemax: c_ulong,
         pub f_owner: crate::uid_t,
 
-        // This type is updated in a future version
-        f_spare: [u32; 4],
+        f_spare: [u64; 4],
 
         pub f_fstypename: [c_char; _VFS_NAMELEN],
         pub f_mntonname: [c_char; _VFS_MNAMELEN],
         pub f_mntfromname: [c_char; _VFS_MNAMELEN],
-        // Added in NetBSD10
-        // pub f_mntfromlabel: [c_char; _VFS_MNAMELEN],
+        pub f_mntfromlabel: [c_char; _VFS_MNAMELEN],
     }
 }

--- a/src/new/netbsd/sys/statvfs.rs
+++ b/src/new/netbsd/sys/statvfs.rs
@@ -35,13 +35,11 @@ s! {
         pub f_namemax: c_ulong,
         pub f_owner: crate::uid_t,
 
-        // This type is updated in a future version
-        f_spare: Padding<[u32; 4]>,
+        f_spare: [u64; 4],
 
         pub f_fstypename: [c_char; _VFS_NAMELEN],
         pub f_mntonname: [c_char; _VFS_MNAMELEN],
         pub f_mntfromname: [c_char; _VFS_MNAMELEN],
-        // Added in NetBSD10
-        // pub f_mntfromlabel: [c_char; _VFS_MNAMELEN],
+        pub f_mntfromlabel: [c_char; _VFS_MNAMELEN],
     }
 }

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2249,7 +2249,7 @@ extern "C" {
         ntargets: size_t,
         hint: *const c_void,
     ) -> c_int;
-    #[link_name = "__getmntinfo13"]
+    #[link_name = "__getmntinfo90"]
     pub fn getmntinfo(mntbufp: *mut *mut crate::statvfs, flags: c_int) -> c_int;
     pub fn getvfsstat(buf: *mut crate::statvfs, bufsize: size_t, flags: c_int) -> c_int;
 

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -2255,7 +2255,7 @@ extern "C" {
         ntargets: size_t,
         hint: *const c_void,
     ) -> c_int;
-    #[link_name = "__getmntinfo13"]
+    #[link_name = "__getmntinfo90"]
     pub fn getmntinfo(mntbufp: *mut *mut crate::statvfs, flags: c_int) -> c_int;
     pub fn getvfsstat(buf: *mut crate::statvfs, bufsize: size_t, flags: c_int) -> c_int;
 

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1619,8 +1619,10 @@ extern "C" {
     pub fn sem_trywait(sem: *mut sem_t) -> c_int;
     pub fn sem_post(sem: *mut sem_t) -> c_int;
     #[cfg_attr(gnu_file_offset_bits64, link_name = "statvfs64")]
+    #[cfg_attr(target_os = "netbsd", link_name = "__statvfs190")]
     pub fn statvfs(path: *const c_char, buf: *mut crate::statvfs) -> c_int;
     #[cfg_attr(gnu_file_offset_bits64, link_name = "fstatvfs64")]
+    #[cfg_attr(target_os = "netbsd", link_name = "__fstatvfs190")]
     pub fn fstatvfs(fd: c_int, buf: *mut crate::statvfs) -> c_int;
 
     #[cfg_attr(target_os = "netbsd", link_name = "__sigemptyset14")]

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1667,9 +1667,11 @@ extern "C" {
     pub fn sem_post(sem: *mut sem_t) -> c_int;
     #[cfg(not(all(target_os = "linux", target_env = "gnu")))] // defined in new/glibc
     #[cfg_attr(gnu_file_offset_bits64, link_name = "statvfs64")]
+    #[cfg_attr(target_os = "netbsd", link_name = "__statvfs190")]
     pub fn statvfs(path: *const c_char, buf: *mut crate::statvfs) -> c_int;
     #[cfg(not(all(target_os = "linux", target_env = "gnu")))] // defined in new/glibc
     #[cfg_attr(gnu_file_offset_bits64, link_name = "fstatvfs64")]
+    #[cfg_attr(target_os = "netbsd", link_name = "__fstatvfs190")]
     pub fn fstatvfs(fd: c_int, buf: *mut crate::statvfs) -> c_int;
 
     #[cfg_attr(target_os = "netbsd", link_name = "__sigemptyset14")]


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

<!-- Add a short description about what this change does -->
Fixes the `statvfs` structure layout and adds symbol versioning for NetBSD `10.x` (and above) compatibility.

> **Note**: AI assistance was used to discover the fixes as well as to test the fixes within a NetBSD environment.

NetBSD 10.0 changed the `statvfs` structure:
- `f_spare` changed from `[u32; 4]` to `[u64; 4]`
- Added `f_mntfromlabel` field (1024 bytes)
- Total size increased from 2256 to 3296 bytes

Without explicit `link_name` attributes, Rust bindings resolve to compatibility wrappers (`__compat_statvfs`) that expect the old struct layout, causing data corruption even with the correct struct definition.
- `statvfs()` → `__statvfs190`
- `fstatvfs()` → `__fstatvfs190`
- `getmntinfo()` → `__getmntinfo90`

> **Note:** This is a **breaking change for NetBSD 9.x** and earlier. Those versions use `__statvfs90`/`__fstatvfs90` which return the old struct format without `f_mntfromlabel`. NetBSD 11 is expected to release later this year, making NetBSD 9.x increasingly obsolete.
>
> https://endoflife.date/netbsd

## Previous changes

https://github.com/rust-lang/libc/commit/1816f6061

This PR removed the deprecated symbol, which was previously added by @0-wiz-0 and tries to maintain compatibility from NetBSD `9.x` and above.

The current PR, bumps compatibility for NetBSD `10.x` and above.

## Discovery

The problem with `getmntinfo()` was discovered when debugging why [bottom](https://github.com/ClementTsang/bottom) was not populating the `Disks` panel correctly in NetBSD.
- https://github.com/ClementTsang/bottom/issues/640#issuecomment-3925868116

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

NetBSD `statvfs` structure definition:
- https://github.com/NetBSD/src/blob/8648f7862110109be2c2a5c4b9218819efe3b17f/sys/sys/statvfs.h#L66-L99

NetBSD symbol versioning documentation:
- https://man.netbsd.org/versioningsyscalls.9

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
  - No updates needed: `statvfs`/`fstatvfs` already in `unix.txt`, `getmntinfo` already in `netbsd.txt`
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`)
  - Tested on NetBSD 10.1 x86_64: `CC=cc cargo test --target x86_64-unknown-netbsd --workspace`
  - All 3 test configurations pass (4822 ctest verifications each)

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->

@rustbot label +stable-nominated

cc: @0323pin 