### PR TITLE
meta: Add rust-bors.toml

### DIFF
--- a/rust-bors.toml
+++ b/rust-bors.toml
@@ -1,0 +1,1 @@
+# This repo uses merge queues, bors is only enabled for squashing.


### PR DESCRIPTION
We don't need bors to handle merging but it would be nice to use for squashing, since we can't do that with the merge queues.

Discussion: https://rust-lang.zulipchat.com/#narrow/channel/496228-t-infra.2Fbors/topic/Squash-and-merge.3F/with/607990937