### PR TITLE
nuttx: clean up module

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -14,6 +14,7 @@ pub type intptr_t = isize;
 pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
+#[cfg(not(target_os = "nuttx"))]
 pub type pid_t = i32;
 pub type in_addr_t = u32;
 pub type in_port_t = u16;

--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -30,7 +30,14 @@ pub type suseconds_t = i32;
 pub type tcflag_t = u32;
 pub type clockid_t = i32;
 pub type time_t = i64;
-pub type wchar_t = i32;
+
+cfg_if! {
+    if #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))] {
+        pub type wchar_t = c_int;
+    } else if #[cfg(any(target_arch = "arm", target_arch = "aarch64"))] {
+        pub type wchar_t = c_uint;
+    }
+}
 
 s! {
     pub struct stat {

--- a/src/unix/nuttx/mod.rs
+++ b/src/unix/nuttx/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     DIR,
 };
 
+pub type pid_t = c_int;
 pub type nlink_t = u16;
 pub type ino_t = u16;
 pub type blkcnt_t = u64;
@@ -24,11 +25,11 @@ pub type pthread_rwlockattr_t = i32;
 pub type pthread_t = i32;
 pub type rlim_t = i64;
 pub type sa_family_t = u16;
-pub type socklen_t = u32;
+pub type socklen_t = c_uint;
 pub type speed_t = usize;
 pub type suseconds_t = i32;
 pub type tcflag_t = u32;
-pub type clockid_t = i32;
+pub type clockid_t = c_int;
 pub type time_t = i64;
 
 cfg_if! {


### PR DESCRIPTION
# Description

This PR consists of an overall clean up of the NuttX module. It adds missing types, fixes one type definition, replaces equivalent with mirrored definitions (fixed-width types with "variable" C types,) and provides correct support for some build-time configuration options.

The build-time configuration options correspond with `CONFIG_SMALL_MEMORY` and `CONFIG_FS_LARGEFILE`. The former enables types with pointer bit width (`size_t` and `ssize_t`) to be narrower than required in the target. It is enabled by default in 16-bit machine word targets but can also be enabled in other targets. The latter option enables support for LFS bindings. The default under all targets is to expose 32-bit types and **no** suffixed 64-bit types. It is only if the above option is set that (1) suffixed types are exposed and (2) unsuffixed types are made 64-bits wide. I have decided against exposing the suffixed types because it's redundant.

## Sources

- NuttX source repository.
  - <https://github.com/search?q=repo%3Aapache%2Fnuttx+path%3Aarch%2F**%2F*+%2F%5Cb_ssize_t%5Cb%2F&type=code>
  - <https://github.com/apache/nuttx/blob/master/include/sys/types.h>

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
