### PR TITLE
ci: Add a retry to BSD dependency installs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -315,20 +315,14 @@ jobs:
           release: ${{ matrix.release }}
           usesh: true
           copyback: false
-          prepare: |
-            set -ex
-            pkg install -y libnghttp2 curl
-            curl https://sh.rustup.rs -sSf --output rustup.sh
-            sh rustup.sh -y --default-toolchain nightly --profile=minimal
-            . "$HOME/.cargo/env"
-            rustup target add ${{ matrix.target }}
+          prepare: ./ci/bsd-prepare.sh ${{ matrix.target }}
           run: |
             set -ex
             . "$HOME/.cargo/env"
             LIBC_CI=1 ./ci/run.sh ${{ matrix.target }}
             ./ci/run.sh ${{ matrix.target }}
 
-      - name: test on Solaris
+      - name: Test on Solaris
         uses: vmactions/solaris-vm@d30dd6c228c8661ade859e36ead7660b9a62efcc # v1.3.7
         if: contains(matrix.target, 'solaris')
         with:
@@ -336,17 +330,8 @@ jobs:
           usesh: true
           mem: 4096
           copyback: false
-          prepare: |
-            set -ex
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
-              --profile minimal --default-toolchain nightly -y
-            uname -a
-          run: |
-            set -ex
-            . "$HOME/.cargo/env"
-            which rustc
-            rustc -Vv
-            ./ci/run.sh ${{ matrix.target }}
+          prepare: ./ci/bsd-prepare.sh ${{ matrix.target }}
+          run: ./ci/bsd-run.sh ${{ matrix.target }}
 
       - name: Test on NetBSD
         uses: vmactions/netbsd-vm@99816dccf75edf233ed6cd00a159e3a5b85ea373 # v1.4.0
@@ -356,19 +341,10 @@ jobs:
           usesh: true
           mem: 4096
           copyback: false
-          prepare: |
-            set -ex
-            /usr/sbin/pkg_add curl
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
-              --profile minimal --default-toolchain nightly -y
-          run: |
-            set -ex
-            . "$HOME/.cargo/env"
-            which rustc
-            rustc -Vv
-            ./ci/run.sh ${{ matrix.target }}
+          prepare: ./ci/bsd-prepare.sh ${{ matrix.target }}
+          run: ./ci/bsd-run.sh ${{ matrix.target }}
 
-      - name: test on illumos
+      - name: Test on illumos
         uses: vmactions/omnios-vm@7f2be0b927aad1a78498c8aeeac4c4ce1fabd322 # v1.3.3
         if: contains(matrix.target, 'illumos')
         with:
@@ -377,17 +353,8 @@ jobs:
           usesh: true
           mem: 4096
           copyback: false
-          prepare: |
-            set -ex
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
-              --profile minimal --default-toolchain nightly -y
-            uname -a
-          run: |
-            set -ex
-            . "$HOME/.cargo/env"
-            which rustc
-            rustc -Vv
-            ./ci/run.sh ${{ matrix.target }}
+          prepare: ./ci/bsd-prepare.sh ${{ matrix.target }}
+          run: ./ci/bsd-run.sh ${{ matrix.target }}
 
   ctest_msrv:
     name: Check ctest MSRV

--- a/ci/bsd-prepare.sh
+++ b/ci/bsd-prepare.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Prepare BSD environments in vmactions containers, which don't have many tools
+# installed by default.
+
+set -eux
+
+target="$1"
+
+uname -a
+case "$(uname -s)" in
+    FreeBSD) deps="pkg install -y libnghttp2 curl" ;;
+    NetBSD) deps="/usr/sbin/pkg_add curl" ;;
+    # Solaris and Illumos already have curl installed
+    *) deps="true" ;;
+esac
+
+# Installs have been flaky so give them a retry
+count=0
+success=false
+while [ $count -lt 3 ]; do
+    $deps && success=true || true
+    [ $success = true ] && break
+    sleep 3s
+    count=$(( count + 1))
+done
+
+if [ "$success" != true ]; then
+    echo "failed to install dependencies"
+    exit 1
+fi
+
+curl --proto '=https' --tlsv1.2 -sSf --retry 5 https://sh.rustup.rs | sh -s -- \
+    --profile minimal \
+    --default-toolchain nightly \
+    --target "$target" \
+    -y

--- a/ci/bsd-run.sh
+++ b/ci/bsd-run.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -eux
+
+target="$1"
+
+# shellcheck source=/dev/null
+. "$HOME/.cargo/env"
+
+# System info
+uname -a
+which rustc
+rustc -Vv
+
+./ci/run.sh "$target"


### PR DESCRIPTION
We occasionally get something like:

    pkg_add: Can't process http://cdn.NetBSD.org:80/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All//curl*: 
    pkg_add: no pkg found for 'curl', sorry.
    pkg_add: 1 package addition failed

In case this is the fallout of a network issue, add a retry to both the dependency and download steps. This is all moved to a script so the VMs can share.