### PR TITLE
build: replace checking for host `cfg` with checking for target `cfg`

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -24,8 +24,11 @@ use std::{
 use regex::Regex;
 
 fn do_cc() {
+    // NOTE: family could be one of: unix, windows, wasm, or multiple values
+    // (e.g. "unix,wasm")
+    let family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
     let target = env::var("TARGET").unwrap();
-    if cfg!(unix) || target.contains("cygwin") {
+    if family.contains("unix") || target.contains("cygwin") {
         let exclude = ["redox", "wasi", "wali", "qurt"];
         if !exclude.iter().any(|x| target.contains(x)) {
             let mut cmsg = cc::Build::new();


### PR DESCRIPTION
# Description

This PR replaces the one place in the `libc-test` build script where the `cfg` we check for is retrieving values from the host and not the target machine.

Follows from [this][conv] conversation on Zulip.

[conv]: https://rust-lang.zulipchat.com/#narrow/channel/421156-gsoc/topic/Project.3A.20libc.3A.20transition.20differing.20bit-width.20time/near/607573656

## Sources

Not applicable.

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`); especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
