### PR TITLE
emscripten: Add in6_pktinfo struct

### DIFF
--- a/libc-test/semver/emscripten.txt
+++ b/libc-test/semver/emscripten.txt
@@ -6,4 +6,5 @@ getgrnam
 getgrnam_r
 getpwnam_r
 getpwuid_r
+in6_pktinfo
 posix_fallocate64

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -212,6 +212,11 @@ s! {
         pub cmsg_type: c_int,
     }
 
+    pub struct in6_pktinfo {
+        pub ipi6_addr: crate::in6_addr,
+        pub ipi6_ifindex: c_uint,
+    }
+
     pub struct sem_t {
         __val: [c_int; 4],
     }


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description

The latest Emscripten now supports proper TCP & UDP sockets in Node.js. This adds the missing struct definition that otherwise results in a build failure when using UDP sockets, due to this struct not being included in the shared headers.

# Sources

- musl netinet/in.h: https://git.musl-libc.org/cgit/musl/tree/include/netinet/in.h?id=v1.2.5#n307

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
