### PR TITLE
gnu: remove public configuration for file offset bits

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -166,7 +166,6 @@ fn main() {
         let defaultbits = "32";
 
         let mut tb_env = env::var("CARGO_CFG_LIBC_UNSTABLE_GNU_TIME_BITS");
-        let mut fb_env = env::var("CARGO_CFG_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS");
 
         // FIXME: remove these fallbacks in a few releases
         if let Ok(old_tb_env) = env::var("RUST_LIBC_UNSTABLE_GNU_TIME_BITS") {
@@ -176,47 +175,28 @@ fn main() {
             );
             tb_env = tb_env.or(Ok(old_tb_env));
         }
-        if let Ok(old_fb_env) = env::var("RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS") {
+        if env::var("RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS").is_ok()
+            || env::var("CARGO_CFG_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS").is_ok()
+        {
             println!(
-                "cargo:warning=RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS will be removed; \
-                set `--cfg=libc_unstable_gnu_file_offset_bits=\"...\"` via RUSTFLAGS instead"
+                "cargo:warning=glibc file offset can no longer be set independently of \
+                `gnu_time_bits`"
             );
-            fb_env = fb_env.or(Ok(old_fb_env));
         }
 
-        let (timebits, filebits) = match (tb_env.as_deref(), fb_env.as_deref()) {
-            (Ok(_), Ok(_)) => panic!(
-                "Do not set both libc_unstable_gnu_time_bits and \
-                 libc_unstable_gnu_file_offset_bits"
-            ),
-            (Err(_), Err(_)) => (defaultbits, defaultbits),
-            (Ok(tb), Err(_)) if tb == "64" => (tb, tb),
-            (Ok(tb), Err(_)) if tb == "32" => (tb, defaultbits),
-            (Ok(_), Err(_)) => {
-                panic!("Invalid value for libc_unstable_gnu_time_bits, must be 32 or 64")
-            }
-            (Err(_), Ok(fb)) if fb == "32" || fb == "64" => (defaultbits, fb),
-            (Err(_), Ok(_)) => {
-                panic!("Invalid value for libc_unstable_gnu_file_offset_bits, must be 32 or 64")
+        let timebits = match tb_env.as_deref() {
+            Err(_) => defaultbits,
+            Ok(tb) if tb == "64" => tb,
+            Ok(tb) if tb == "32" => tb,
+            Ok(_) => {
+                panic!("Invalid value for libc_unstable_gnu_time_bits. Must be 32, 64, or unset.")
             }
         };
-        let valid_bits = ["32", "64"];
-        assert!(
-            valid_bits.contains(&filebits) && valid_bits.contains(&timebits),
-            "Invalid value for libc_unstable_gnu_time_bits or \
-            libc_unstable_gnu_file_offset_bits. Must be 32, 64 or unset"
-        );
-        assert!(
-            !(filebits == "32" && timebits == "64"),
-            "libc_unstable_gnu_file_offset_bits must be 64 or unset if \
-            libc_unstable_gnu_time_bits is 64"
-        );
+
         if timebits == "64" {
             set_cfg("linux_time_bits64");
-            set_cfg("gnu_time_bits64");
-        }
-        if filebits == "64" {
             set_cfg("gnu_file_offset_bits64");
+            set_cfg("gnu_time_bits64");
         }
     }
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -52,7 +52,5 @@ $cmd --features extra_traits -- $test_flags
 
 if [ "$env" = "gnu" ] && [ "$bits" = "32" ]; then
     # shellcheck disable=SC2086
-    RUSTFLAGS="$RUSTFLAGS --cfg=libc_unstable_gnu_file_offset_bits=\"64\"" $cmd -- $test_flags
-    # shellcheck disable=SC2086
     RUSTFLAGS="$RUSTFLAGS --cfg=libc_unstable_gnu_time_bits=\"64\"" $cmd -- $test_flags
 fi

--- a/ci/verify-build.py
+++ b/ci/verify-build.py
@@ -302,10 +302,8 @@ def do_semver_checks(cfg: Cfg, target: Target) -> bool:
         # running on the host.
 
     if cfg.baseline_crate_dir is None:
-        eprint(
-            "Non-host target: --baseline-crate-dir must be specified to \
-            run semver-checks"
-        )
+        eprint("Non-host target: --baseline-crate-dir must be specified to \
+            run semver-checks")
         sys.exit(1)
 
     # Since semver-checks doesn't work with `--target`, we build the json ourself and
@@ -406,8 +404,6 @@ def test_target(cfg: Cfg, target: Target) -> TargetResult:
     run([*cmd, "--features=extra_traits"], rustflags=rustflags)
 
     if "gnu" in target_env and target_bits == "32":
-        # Equivalent of _FILE_OFFSET_BITS=64
-        run(cmd, rustflags=f'{rustflags} --cfg=libc_unstable_gnu_file_offset_bits="64"')
         # Equivalent of _TIME_BITS=64
         run(cmd, rustflags=f'{rustflags} --cfg=libc_unstable_gnu_time_bits="64"')
 
@@ -430,7 +426,9 @@ def test_target(cfg: Cfg, target: Target) -> TargetResult:
     # if on nightly or stable
     if "freebsd" in tname and cfg.toolchain >= Toolchain.STABLE:
         for version in FREEBSD_VERSIONS:
-            free_rustflags = f'{rustflags} --cfg=libc_unstable_freebsd_version="{version}"'
+            free_rustflags = (
+                f'{rustflags} --cfg=libc_unstable_freebsd_version="{version}"'
+            )
             run(cmd, rustflags=free_rustflags)
             run([*cmd, "--no-default-features"], rustflags=free_rustflags)
 

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3883,7 +3883,6 @@ fn config_gnu_bits(target: &str, cfg: &mut ctest::TestGenerator) {
     {
         let defaultbits = "32";
         let mut tb_env = env::var("CARGO_CFG_LIBC_UNSTABLE_GNU_TIME_BITS");
-        let mut fb_env = env::var("CARGO_CFG_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS");
 
         // FIXME: remove these fallbacks in a few releases
         if let Ok(old_tb_env) = env::var("RUST_LIBC_UNSTABLE_GNU_TIME_BITS") {
@@ -3893,48 +3892,30 @@ fn config_gnu_bits(target: &str, cfg: &mut ctest::TestGenerator) {
             );
             tb_env = tb_env.or(Ok(old_tb_env));
         }
-        if let Ok(old_fb_env) = env::var("RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS") {
+
+        if env::var("RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS").is_ok()
+            || env::var("CARGO_CFG_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS").is_ok()
+        {
             println!(
-                "cargo:warning=RUST_LIBC_UNSTABLE_GNU_FILE_OFFSET_BITS will be removed; \
-                set `--cfg=libc_unstable_gnu_file_offset_bits=\"...\"` via RUSTFLAGS instead"
+                "cargo:warning=glibc file offset can no longer be set independently of \
+                `gnu_time_bits`"
             );
-            fb_env = fb_env.or(Ok(old_fb_env));
         }
 
-        let (timebits, filebits) = match (tb_env.as_deref(), fb_env.as_deref()) {
-            (Ok(_), Ok(_)) => panic!(
-                "Do not set both libc_unstable_gnu_time_bits and \
-                libc_unstable_gnu_file_offset_bits"
-            ),
-            (Err(_), Err(_)) => (defaultbits, defaultbits),
-            (Ok(tb), Err(_)) if tb == "64" => (tb, tb),
-            (Ok(tb), Err(_)) if tb == "32" => (tb, defaultbits),
-            (Ok(_), Err(_)) => {
-                panic!("Invalid value for libc_unstable_gnu_time_bits, must be 32 or 64")
-            }
-            (Err(_), Ok(fb)) if fb == "32" || fb == "64" => (defaultbits, fb),
-            (Err(_), Ok(_)) => {
-                panic!("Invalid value for libc_unstable_gnu_file_offset_bits, must be 32 or 64")
+        let timebits = match tb_env.as_deref() {
+            Err(_) => defaultbits,
+            Ok(tb) if tb == "64" => tb,
+            Ok(tb) if tb == "32" => tb,
+            Ok(_) => {
+                panic!("Invalid value for libc_unstable_gnu_time_bits. Must be 32, 64, or unset.")
             }
         };
-        let valid_bits = ["32", "64"];
-        assert!(
-            valid_bits.contains(&filebits) && valid_bits.contains(&timebits),
-            "Invalid value for libc_unstable_gnu_time_bits or \
-            libc_unstable_gnu_file_offset_bits. Must be 32, 64 or unset"
-        );
-        assert!(
-            !(filebits == "32" && timebits == "64"),
-            "libc_unstable_gnu_file_offset_bits must be 64 or unset if \
-            libc_unstable_gnu_time_bits is 64"
-        );
+
         if timebits == "64" {
             cfg.define("_TIME_BITS", Some("64"));
+            cfg.define("_FILE_OFFSET_BITS", Some("64"));
             cfg.cfg("linux_time_bits64", None);
             cfg.cfg("gnu_time_bits64", None);
-        }
-        if filebits == "64" {
-            cfg.define("_FILE_OFFSET_BITS", Some("64"));
             cfg.cfg("gnu_file_offset_bits64", None);
         }
     }


### PR DESCRIPTION
It makes sense for us to keep the internal config around for ease of
matching source, but 64-bit off_t with 32-bit time_t is not a
combination we need to support. This is the only option enabled by
toggling _TIME_BITS and _FILE_OFFSET_BITS separately in glibc.

Thus, remove `libc_unstable_gnu_file_offset_bits` but keep the internal
`gnu_file_offset_bits64`.

Closes: https://github.com/rust-lang/libc/issues/5199