### PR TITLE
emscripten: add pthread_sigmask, sigwait, faccessat, pthread_kill, se…

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -3227,7 +3227,6 @@ fn test_freebsd(target: &str) {
 
 fn test_emscripten(target: &str) {
     assert!(target.contains("emscripten"));
-    #[expect(unused_variables)] // remove once we need a version check
     let emscripten = VERSIONS.emscripten.unwrap();
 
     let mut cfg = ctest_cfg();
@@ -3394,6 +3393,9 @@ fn test_emscripten(target: &str) {
             // Emscripten does not support fork/exec/wait or any kind of multi-process support
             // https://github.com/emscripten-core/emscripten/blob/3.1.68/tools/system_libs.py#L1100
             "execv" | "execve" | "execvp" | "execvpe" | "fexecve" | "wait4" => true,
+
+            // Emscripten's `pthread_kill` used to only be linkable when building with `-pthread`
+            "pthread_kill" if emscripten < (6, 0) => true,
 
             _ => false,
         }

--- a/src/new/common/posix/pthread.rs
+++ b/src/new/common/posix/pthread.rs
@@ -187,7 +187,12 @@ extern "C" {
 
     // FIXME(reorg): In recent POSIX versions, this is a signal.h function and not required
     // in pthread.
-    #[cfg(any(target_os = "android", target_os = "l4re", target_os = "linux"))]
+    #[cfg(any(
+        target_os = "android",
+        target_os = "emscripten",
+        target_os = "l4re",
+        target_os = "linux"
+    ))]
     pub fn pthread_kill(thread: crate::pthread_t, sig: c_int) -> c_int;
 
     #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
@@ -298,7 +303,12 @@ extern "C" {
 
     // FIXME(reorg): In recent POSIX versions, this is a signal.h function and not required
     // in pthread.
-    #[cfg(any(target_os = "android", target_os = "l4re", target_os = "linux"))]
+    #[cfg(any(
+        target_os = "android",
+        target_os = "emscripten",
+        target_os = "l4re",
+        target_os = "linux"
+    ))]
     pub fn pthread_sigmask(
         how: c_int,
         set: *const crate::sigset_t,

--- a/src/new/emscripten/pthread.rs
+++ b/src/new/emscripten/pthread.rs
@@ -8,7 +8,9 @@ pub use crate::new::common::posix::pthread::{
     pthread_condattr_setclock,
     pthread_condattr_setpshared,
     pthread_create,
+    pthread_kill,
     pthread_mutexattr_setpshared,
     pthread_rwlockattr_getpshared,
     pthread_rwlockattr_setpshared,
+    pthread_sigmask,
 };

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1458,6 +1458,14 @@ extern "C" {
         buflen: size_t,
         result: *mut *mut crate::group,
     ) -> c_int;
+    pub fn sigwait(set: *const crate::sigset_t, sig: *mut c_int) -> c_int;
+    pub fn sigwaitinfo(set: *const crate::sigset_t, info: *mut crate::siginfo_t) -> c_int;
+    pub fn sigtimedwait(
+        set: *const crate::sigset_t,
+        info: *mut crate::siginfo_t,
+        timeout: *const crate::timespec,
+    ) -> c_int;
+    pub fn faccessat(dirfd: c_int, pathname: *const c_char, mode: c_int, flags: c_int) -> c_int;
 }
 
 // Alias <foo> to <foo>64 to mimic glibc's LFS64 support


### PR DESCRIPTION
Adds remaining gated `wasm32-unknown-emscripten` APIs which are implemented by Emscripten - `pthread_sigmask`, `sigwait`, `sigwaitinfo`, `faccessat`, `pthread_kill`.

Link: https://github.com/emscripten-core/emscripten/blob/6a93f7db16cd8e5214b4c3c08a361ccab9ffc67e/system/lib/libc/musl/include/signal.h#L225-L227
Link: https://github.com/emscripten-core/emscripten/blob/6a93f7db16cd8e5214b4c3c08a361ccab9ffc67e/system/lib/libc/musl/include/signal.h#L230-L231
Link: https://github.com/emscripten-core/emscripten/blob/6a93f7db16cd8e5214b4c3c08a361ccab9ffc67e/system/lib/libc/musl/include/unistd.h#L88