### PR TITLE
chore: remove some clippy lint `allow`s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,10 +193,7 @@ ptr_as_ptr = "warn"
 unnecessary_semicolon = "warn"
 
 # FIXME(clippy): these should be fixed if possible
-expl_impl_clone_on_copy = "allow"
-uninlined_format_args = "allow"
 unnecessary_cast = "allow"  # some casts like `as usize` are only needed for some targets
-used_underscore_binding = "allow"
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Description

The FIXME says these lints should be fixed, but it looks like they already are, as no warnings appeared when I removed the `allow`s. So I removed them for good.

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

This change doesn't cause any warnings on the `libc-0.2` branch either, so:
@rustbot label +stable-nominated