### PR TITLE
ci: Don't set `needs` when in the merge queue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -189,7 +189,8 @@ jobs:
 
   test_tier2:
     name: Test tier2
-    needs: [test_tier1, style_check]
+    # Start immediately if enqueued, otherwise save CI usage
+    needs: ${{ github.event_name == 'merge_group' && [] || [test_tier1, style_check] }}
     strategy:
       fail-fast: true
       max-parallel: 16
@@ -289,7 +290,8 @@ jobs:
 
   test_tier2_vm:
     name: Test tier2 VM
-    needs: [test_tier1, style_check]
+    # Start immediately if enqueued, otherwise save CI usage
+    needs: ${{ github.event_name == 'merge_group' && [] || [test_tier1, style_check] }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true


### PR DESCRIPTION
That is just a way to save on CI for pull requests. Once something is added to the merge queue we should be reasonably confident it will complete, so we may as well start all jobs at once.