### PR TITLE
[0.2] Restore Send and Sync for `DIR`, release 0.2.188

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.2.188](https://github.com/rust-lang/libc/compare/0.2.187...0.2.188) - 2026-07-21
+
+### Changed
+
+- Restore `Send` and `Sync` for `DIR` ([35b062263401](https://github.com/rust-lang/libc/commit/35b062263401733cd89065c6a553640f2ba51ff1))
+
+These were removed in 0.2.187 because `libc` does not actually make `Send` and `Sync`
+guarantees about `DIR` (or other extern types), but this caused some crates to break.
+The traits are added back for now to allow time to migrate, but will be removed again
+in the future; please make sure your crates are not relying on `libc::DIR: Send` or
+`libc::DIR: Sync`.
+
+
 ## [0.2.187](https://github.com/rust-lang/libc/compare/0.2.186...0.2.187) - 2026-07-20
 
 This release contains a number of improvements related to 64-bit `time_t` configuration.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
-version = "0.2.187"
+version = "0.2.188"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc"
-version = "0.2.187"
+version = "0.2.188"
 keywords = ["libc", "ffi", "bindings", "operating", "system"]
 categories = ["external-ffi-bindings", "no-std", "os"]
 exclude = ["/ci/*", "/.github/*", "/triagebot.toml", "cherry-pick-stable.sh"]

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/rust-lang/libc"
 
 [dependencies]
 cfg-if = "1.0.4"
-libc = { path = "..", version = "0.2.187", default-features = false }
+libc = { path = "..", version = "0.2.188", default-features = false }
 
 [dev-dependencies]
 syn = { version = "2.0.108", features = ["full", "visit"] }

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -84,6 +84,10 @@ extern_ty! {
     pub type fpos64_t; // FIXME(fuchsia): fill this out with a struct
 }
 
+// Deprecated impls: see #5296
+unsafe impl Send for DIR {}
+unsafe impl Sync for DIR {}
+
 // PUB_STRUCT
 
 s! {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -41,6 +41,10 @@ extern_ty! {
     pub type DIR;
 }
 
+// Deprecated impls: see #5296
+unsafe impl Send for DIR {}
+unsafe impl Sync for DIR {}
+
 #[cfg(not(target_os = "nuttx"))]
 pub type locale_t = *mut c_void;
 

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -6,6 +6,10 @@ extern_ty! {
     pub type DIR;
 }
 
+// Deprecated impls: see #5296
+unsafe impl Send for DIR {}
+unsafe impl Sync for DIR {}
+
 pub type intmax_t = i64;
 pub type uintmax_t = u64;
 

--- a/src/wasi/mod.rs
+++ b/src/wasi/mod.rs
@@ -51,6 +51,10 @@ extern_ty! {
     pub type __locale_struct;
 }
 
+// Deprecated impls: see #5296
+unsafe impl Send for DIR {}
+unsafe impl Sync for DIR {}
+
 s_paren! {
     // in wasi-libc clockid_t is const struct __clockid* (where __clockid is an opaque struct),
     // but that's an implementation detail that we don't want to have to deal with


### PR DESCRIPTION
In https://github.com/rust-lang/libc/commit/1cf49df2cce5297d8fd2980667dce80609c544ed ("Fix the soundness bug in the representation of extern
types") we changed our extern type representation from a 0-variant enum
to a `struct T((), PhantomData<(*mut u8, PhantomPinned)>)`. This had the
effect of removing the `Send` and `Sync` impls which was expected to be
a no-op, but due to ecosystem use and an interesting quirk in the trait
solver this wound up being user-visible.

Add back `Send` and `Sync` for now, only on the 0.2 branch. If the
ecosystem crate in question (discussed at the "Closes" issue) updates,
we can try this again.

There are other types that may have lost similar trait implementations.
These are left as-is for now, to be revisited if we get breakage
reports.

Closes: https://github.com/rust-lang/libc/issues/5296