### PR TITLE
[0.2] Deprecate `CLONE_INTO_CGROUP` and `CLONE_CLEAR_SIGHAND`

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -863,8 +863,16 @@ pub const ELFOSABI_ARM_AEABI: u8 = 64;
 pub const CLONE_NEWTIME: c_int = 0x80;
 // DIFF(main): changed to `c_ulonglong` in e9abac9ac2. This is broken so should be fixed.
 #[allow(overflowing_literals)]
+#[deprecated(
+    since = "0.2.188",
+    note = "This constant overflows. In the near future, `libc` will change to a wider type, see #3584."
+)]
 pub const CLONE_CLEAR_SIGHAND: c_int = 0x100000000;
 #[allow(overflowing_literals)]
+#[deprecated(
+    since = "0.2.188",
+    note = "This constant overflows. In the near future, `libc` will change to a wider type, see #3584."
+)]
 pub const CLONE_INTO_CGROUP: c_int = 0x200000000;
 
 pub const M_MXFAST: c_int = 1;


### PR DESCRIPTION
These won't be removed but we need to widen the type.

Link: https://github.com/rust-lang/libc/issues/3584
Link: https://github.com/rust-lang/libc/pull/3585