### PR TITLE
newlib: give RTEMS its own socket address types

### DIFF
--- a/src/unix/newlib/arm/mod.rs
+++ b/src/unix/newlib/arm/mod.rs
@@ -40,23 +40,39 @@ s! {
 #[cfg(not(target_os = "rtems"))]
 pub const AF_INET6: c_int = 23;
 
+// RTEMS gets these from the `rtems` module; libbsd's values are FreeBSD's.
+#[cfg(not(target_os = "rtems"))]
 pub const FIONBIO: c_ulong = 1;
 
+#[cfg(not(target_os = "rtems"))]
 pub const POLLIN: c_short = 0x1;
+#[cfg(not(target_os = "rtems"))]
 pub const POLLPRI: c_short = 0x2;
+#[cfg(not(target_os = "rtems"))]
 pub const POLLHUP: c_short = 0x4;
+#[cfg(not(target_os = "rtems"))]
 pub const POLLERR: c_short = 0x8;
+#[cfg(not(target_os = "rtems"))]
 pub const POLLOUT: c_short = 0x10;
+#[cfg(not(target_os = "rtems"))]
 pub const POLLNVAL: c_short = 0x20;
 
+#[cfg(not(target_os = "rtems"))]
 pub const SOL_SOCKET: c_int = 65535;
 
+#[cfg(not(target_os = "rtems"))]
 pub const MSG_OOB: c_int = 1;
+#[cfg(not(target_os = "rtems"))]
 pub const MSG_PEEK: c_int = 2;
+#[cfg(not(target_os = "rtems"))]
 pub const MSG_DONTWAIT: c_int = 4;
+#[cfg(not(target_os = "rtems"))]
 pub const MSG_DONTROUTE: c_int = 0;
+#[cfg(not(target_os = "rtems"))]
 pub const MSG_WAITALL: c_int = 0;
+#[cfg(not(target_os = "rtems"))]
 pub const MSG_MORE: c_int = 0;
+#[cfg(not(target_os = "rtems"))]
 pub const MSG_NOSIGNAL: c_int = 0;
 
 pub use crate::unix::newlib::generic::{

--- a/src/unix/newlib/arm/mod.rs
+++ b/src/unix/newlib/arm/mod.rs
@@ -3,12 +3,17 @@ use crate::prelude::*;
 pub type clock_t = c_long;
 pub type wchar_t = u32;
 
+// RTEMS gets its socket address types from the `rtems` module: its stack is
+// libbsd, so every one of these starts with the BSD length byte and
+// `sockaddr_storage` is 128 bytes. See `super::rtems`.
 s! {
+    #[cfg(not(target_os = "rtems"))]
     pub struct sockaddr {
         pub sa_family: crate::sa_family_t,
         pub sa_data: [c_char; 14],
     }
 
+    #[cfg(not(target_os = "rtems"))]
     pub struct sockaddr_in6 {
         pub sin6_family: crate::sa_family_t,
         pub sin6_port: crate::in_port_t,
@@ -17,6 +22,7 @@ s! {
         pub sin6_scope_id: u32,
     }
 
+    #[cfg(not(target_os = "rtems"))]
     pub struct sockaddr_in {
         pub sin_family: crate::sa_family_t,
         pub sin_port: crate::in_port_t,
@@ -24,12 +30,14 @@ s! {
         pub sin_zero: [u8; 8],
     }
 
+    #[cfg(not(target_os = "rtems"))]
     pub struct sockaddr_storage {
         pub ss_family: crate::sa_family_t,
         __ss_padding: Padding<[u8; 26]>,
     }
 }
 
+#[cfg(not(target_os = "rtems"))]
 pub const AF_INET6: c_int = 23;
 
 pub const FIONBIO: c_ulong = 1;

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -577,6 +577,8 @@ pub const PF_INET: c_int = 2;
 cfg_if! {
     if #[cfg(target_os = "espidf")] {
         pub const PF_INET6: c_int = 10;
+    } else if #[cfg(target_os = "rtems")] {
+        pub const PF_INET6: c_int = 28;
     } else {
         pub const PF_INET6: c_int = 23;
     }

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -340,6 +340,8 @@ pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
 cfg_if! {
     if #[cfg(target_os = "espidf")] {
         pub const NCCS: usize = 11;
+    } else if #[cfg(target_os = "rtems")] {
+        pub const NCCS: usize = 20;
     } else {
         pub const NCCS: usize = 32;
     }
@@ -399,7 +401,7 @@ pub const PTHREAD_MUTEX_ERRORCHECK: c_int = 2;
 cfg_if! {
     if #[cfg(any(target_os = "horizon", target_os = "espidf"))] {
         pub const FD_SETSIZE: c_int = 64;
-    } else if #[cfg(target_os = "vita")] {
+    } else if #[cfg(any(target_os = "vita", target_os = "rtems"))] {
         pub const FD_SETSIZE: c_int = 256;
     } else {
         pub const FD_SETSIZE: c_int = 1024;
@@ -531,7 +533,7 @@ pub const O_NONBLOCK: c_int = 16384;
 
 pub const O_ACCMODE: c_int = 3;
 cfg_if! {
-    if #[cfg(target_os = "espidf")] {
+    if #[cfg(any(target_os = "espidf", target_os = "rtems"))] {
         pub const O_CLOEXEC: c_int = 0x40000;
     } else {
         pub const O_CLOEXEC: c_int = 0x80000;
@@ -640,7 +642,13 @@ cfg_if! {
 }
 pub const SO_TYPE: c_int = 0x1008;
 
-pub const SOCK_CLOEXEC: c_int = O_CLOEXEC;
+cfg_if! {
+    if #[cfg(target_os = "rtems")] {
+        pub const SOCK_CLOEXEC: c_int = 0x10000000;
+    } else {
+        pub const SOCK_CLOEXEC: c_int = O_CLOEXEC;
+    }
+}
 
 pub const INET_ADDRSTRLEN: c_int = 16;
 
@@ -664,7 +672,7 @@ pub const IFF_ALTPHYS: c_int = IFF_LINK2; // use alternate physical connection
 pub const IFF_MULTICAST: c_int = 0x8000; // supports multicast
 
 cfg_if! {
-    if #[cfg(target_os = "vita")] {
+    if #[cfg(any(target_os = "vita", target_os = "rtems"))] {
         pub const TCP_NODELAY: c_int = 1;
         pub const TCP_MAXSEG: c_int = 2;
     } else if #[cfg(target_os = "espidf")] {
@@ -700,7 +708,7 @@ cfg_if! {
     }
 }
 cfg_if! {
-    if #[cfg(target_os = "vita")] {
+    if #[cfg(any(target_os = "vita", target_os = "rtems"))] {
         pub const IP_TTL: c_int = 4;
     } else if #[cfg(target_os = "espidf")] {
         pub const IP_TTL: c_int = 2;
@@ -722,7 +730,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(target_os = "vita")] {
+    if #[cfg(any(target_os = "vita", target_os = "rtems"))] {
         pub const IP_ADD_MEMBERSHIP: c_int = 12;
         pub const IP_DROP_MEMBERSHIP: c_int = 13;
     } else if #[cfg(target_os = "espidf")] {
@@ -757,6 +765,11 @@ cfg_if! {
         pub const NO_DATA: c_int = 211;
         pub const NO_RECOVERY: c_int = 212;
         pub const TRY_AGAIN: c_int = 213;
+    } else if #[cfg(target_os = "rtems")] {
+        pub const HOST_NOT_FOUND: c_int = 1;
+        pub const TRY_AGAIN: c_int = 2;
+        pub const NO_RECOVERY: c_int = 3;
+        pub const NO_DATA: c_int = 4;
     } else {
         pub const HOST_NOT_FOUND: c_int = 1;
         pub const NO_DATA: c_int = 2;
@@ -764,7 +777,13 @@ cfg_if! {
         pub const TRY_AGAIN: c_int = 4;
     }
 }
-pub const NO_ADDRESS: c_int = 2;
+cfg_if! {
+    if #[cfg(target_os = "rtems")] {
+        pub const NO_ADDRESS: c_int = NO_DATA;
+    } else {
+        pub const NO_ADDRESS: c_int = 2;
+    }
+}
 
 pub const AI_PASSIVE: c_int = 1;
 pub const AI_CANONNAME: c_int = 2;
@@ -773,6 +792,9 @@ cfg_if! {
     if #[cfg(target_os = "espidf")] {
         pub const AI_NUMERICSERV: c_int = 8;
         pub const AI_ADDRCONFIG: c_int = 64;
+    } else if #[cfg(target_os = "rtems")] {
+        pub const AI_NUMERICSERV: c_int = 0x00000008;
+        pub const AI_ADDRCONFIG: c_int = 0x00000400;
     } else {
         pub const AI_NUMERICSERV: c_int = 0;
         pub const AI_ADDRCONFIG: c_int = 0;
@@ -785,7 +807,7 @@ pub const NI_NOFQDN: c_int = 1;
 pub const NI_NUMERICHOST: c_int = 2;
 pub const NI_NAMEREQD: c_int = 4;
 cfg_if! {
-    if #[cfg(target_os = "espidf")] {
+    if #[cfg(any(target_os = "espidf", target_os = "rtems"))] {
         pub const NI_NUMERICSERV: c_int = 8;
         pub const NI_DGRAM: c_int = 16;
     } else {
@@ -800,6 +822,11 @@ cfg_if! {
         pub const EAI_FAMILY: c_int = 204;
         pub const EAI_MEMORY: c_int = 203;
         pub const EAI_NONAME: c_int = 200;
+        pub const EAI_SOCKTYPE: c_int = 10;
+    } else if #[cfg(target_os = "rtems")] {
+        pub const EAI_FAMILY: c_int = 5;
+        pub const EAI_MEMORY: c_int = 6;
+        pub const EAI_NONAME: c_int = 8;
         pub const EAI_SOCKTYPE: c_int = 10;
     } else if #[cfg(not(target_os = "vita"))] {
         pub const EAI_FAMILY: c_int = -303;

--- a/src/unix/newlib/rtems/mod.rs
+++ b/src/unix/newlib/rtems/mod.rs
@@ -50,6 +50,27 @@ s! {
 pub const AF_UNIX: c_int = 1;
 pub const AF_INET6: c_int = 28;
 
+// `_IOW('f', 126, int)`, i.e. FreeBSD's value, not newlib's 1.
+pub const FIONBIO: c_ulong = 0x8004667e;
+
+pub const POLLIN: c_short = 0x0001;
+pub const POLLPRI: c_short = 0x0002;
+pub const POLLOUT: c_short = 0x0004;
+pub const POLLERR: c_short = 0x0008;
+pub const POLLHUP: c_short = 0x0010;
+pub const POLLNVAL: c_short = 0x0020;
+
+pub const SOL_SOCKET: c_int = 0xffff;
+
+pub const MSG_OOB: c_int = 0x1;
+pub const MSG_PEEK: c_int = 0x2;
+pub const MSG_DONTROUTE: c_int = 0x4;
+pub const MSG_WAITALL: c_int = 0x40;
+pub const MSG_DONTWAIT: c_int = 0x80;
+pub const MSG_NOSIGNAL: c_int = 0x20000;
+// Not provided by RTEMS; kept at 0 so portable code compiles, as elsewhere.
+pub const MSG_MORE: c_int = 0;
+
 pub const RTLD_DEFAULT: *mut c_void = -2isize as *mut c_void;
 
 pub const UTIME_OMIT: c_long = -1;

--- a/src/unix/newlib/rtems/mod.rs
+++ b/src/unix/newlib/rtems/mod.rs
@@ -2,14 +2,53 @@
 
 use crate::prelude::*;
 
+// RTEMS's networking is rtems-libbsd, a port of the FreeBSD stack, and its
+// headers are FreeBSD's: every socket address begins with a one-byte length
+// followed by a one-byte family. Definitions below follow
+// `newlib/libc/sys/rtems/include/{sys/socket.h,sys/_sockaddr_storage.h,
+// netinet/in.h,netinet6/in6.h}` and libbsd's `sys/un.h`.
 s! {
+    pub struct sockaddr {
+        pub sa_len: u8,
+        pub sa_family: crate::sa_family_t,
+        pub sa_data: [c_char; 14],
+    }
+
+    pub struct sockaddr_in {
+        pub sin_len: u8,
+        pub sin_family: crate::sa_family_t,
+        pub sin_port: crate::in_port_t,
+        pub sin_addr: crate::in_addr,
+        pub sin_zero: [c_char; 8],
+    }
+
+    pub struct sockaddr_in6 {
+        pub sin6_len: u8,
+        pub sin6_family: crate::sa_family_t,
+        pub sin6_port: crate::in_port_t,
+        pub sin6_flowinfo: u32,
+        pub sin6_addr: crate::in6_addr,
+        pub sin6_scope_id: u32,
+    }
+
     pub struct sockaddr_un {
+        pub sun_len: u8,
         pub sun_family: crate::sa_family_t,
-        pub sun_path: [c_char; 108usize],
+        pub sun_path: [c_char; 104usize],
+    }
+
+    // _SS_MAXSIZE 128, _SS_ALIGNSIZE 8, so _SS_PAD1SIZE 6 and _SS_PAD2SIZE 112.
+    pub struct sockaddr_storage {
+        pub ss_len: u8,
+        pub ss_family: crate::sa_family_t,
+        __ss_pad1: Padding<[u8; 6]>,
+        __ss_align: i64,
+        __ss_pad2: Padding<[u8; 112]>,
     }
 }
 
 pub const AF_UNIX: c_int = 1;
+pub const AF_INET6: c_int = 28;
 
 pub const RTLD_DEFAULT: *mut c_void = -2isize as *mut c_void;
 


### PR DESCRIPTION

On `armv7-rtems-eabihf` every `libc` socket address struct is missing the BSD
length byte, and 27 socket/file constants have the wrong value. The result:
**`TcpListener::bind` succeeds but `local_addr()` fails with `InvalidInput`**,
and every `accept`/`peer_addr`/`recv_from` fails the same way — `std` cannot
parse an address RTEMS returns. Networking is unusable on the target.

Two commits: the address structs (`sockaddr`, `sockaddr_in`, `sockaddr_in6`,
`sockaddr_un`, `sockaddr_storage`), then the constants (`AF_INET6`, `PF_INET6`,
`SOL_SOCKET`, `FIONBIO`, `POLL*`, `MSG_*`, `O_CLOEXEC`, `SOCK_CLOEXEC`, `NCCS`,
`FD_SETSIZE`, `TCP_NODELAY`, `TCP_MAXSEG`, `IP_TTL`, `IP_{ADD,DROP}_MEMBERSHIP`,
`h_errno`, `AI_*`, `NI_*`, `EAI_*`).

## Why `newlib/rtems/`, not `newlib/arm/`

RTEMS's network stack is `rtems-libbsd`, imported from FreeBSD, so its socket
addresses carry a leading one-byte length. **The length byte comes from the OS,
not the architecture** — plain newlib on arm has no such stack and no length
byte. `src/unix/newlib/mod.rs` already selects by `target_os` first (espidf,
horizon, vita) before falling through to `target_arch`, and already glob-imports
`mod rtems` for `target_os = "rtems"`, so this follows the layout that is there.
`newlib/arm`'s copies become `#[cfg(not(target_os = "rtems"))]`, so **no
non-RTEMS target changes**.

`newlib/aarch64/mod.rs:22` already has `sin_len` — correct *shape*, wrong
*place*: it silently changes plain `aarch64-none-newlib` too. This PR does not
repeat that. `sa_family_t = u8` is **correct** for RTEMS and is left alone; one
length byte plus one family byte is exactly the BSD layout.

## Evidence

From the toolchain headers a shim compile actually resolves (`arm-rtems6-gcc -M`):

```c
struct sockaddr    { unsigned char sa_len;  sa_family_t sa_family; char sa_data[14]; };
struct sockaddr_in { uint8_t sin_len; sa_family_t sin_family; in_port_t sin_port;
                     struct in_addr sin_addr; char sin_zero[8]; };
struct sockaddr_storage { unsigned char ss_len; sa_family_t ss_family; /* ... */ };
```

`sys/socket.h:246` has `AF_INET6 28`; `libc` says 23. `_SS_MAXSIZE` is 128,
where `newlib/arm/mod.rs:27` declared `sockaddr_storage` as **28 bytes**.

In the guest, `getsockname` on `0.0.0.0:5064` returns `10 02 00 00 …` —
`ss_len = 16`, `ss_family = 2`. `std`'s `socket_addr_from_c` reads offset 0,
gets **16**, matches neither `AF_INET` nor `AF_INET6`, and returns
`InvalidInput` with `raw_os_error() == None` — no syscall failed.

Same binary and image, `libc` the only variable:

```
before:  cannot bind CA TCP port 5064: invalid argument
after:   serving 3 records on CA port 5064 (TCP + UDP search)
         tcp local_addr = Ok(0.0.0.0:5064)
         TCP accept peer=Ok(192.168.2.127:48684) local=Ok(10.0.2.15:5064)
```

Scope measured by compiling, for `armv7-rtems-eabihf`, a generated file of
`const _: () = assert!(libc::NAME == <value from arm-rtems6-gcc>);`, so `cfg`
resolution is the compiler's and not a script's:

| | before | after |
|---|---|---|
| constants wrong (of 305 measurable) | 27 | 0 |
| `sockaddr*` layout facts wrong | 10 of 10 | 0 |

`arm` is the only reachable RTEMS outlier: `aarch64` has the right shape but no
`sockaddr_storage`; `powerpc` (devkitPPC) documents having no sockaddr;
`espidf`/`vita` already carry length bytes; `horizon` is not BSD-derived.

## Verification

- Builds for `armv7-rtems-eabihf`; `cargo +nightly fmt --all -- --check` clean.
- `riscv32imc-esp-espidf` builds, unchanged. `armv7-sony-vita-newlibeabihf` and
  `armv6k-nintendo-3ds` fail *identically* before and after (pre-existing
  `E0573` at `src/unix/mod.rs:936`).
- RTEMS 6.0.0 `2faafecb`, gcc 13.3.0, newlib `1b3dcfd`, BSP
  `xilinx_zynq_a9_qemu` under `qemu-system-arm`.

Must reach 0.2 to unblock anyone: `library/std/Cargo.toml` depends on
`libc 0.2.x`, so a `main`-only fix never reaches the `std` that `-Zbuild-std`
compiles.

@rustbot label stable-nominated

## Not in this PR

- **Scalar type widths** — `time_t`, `dev_t`, `ino_t`, `rlim_t`, `clock_t` are 8
  bytes on RTEMS and declared 4; `clockid_t` is signed and declared unsigned.
  Separate PR (rust-lang/libc#5308), because it overlaps the open rust-lang/libc#5132. Both PRs
  add to `src/unix/newlib/rtems/mod.rs`; whichever lands second needs a one-hunk
  context rebase there.
- `fcntl(F_DUPFD)` fails on an `rtems-libbsd` socket, so `TcpStream::try_clone`
  cannot work there. **Not a `libc` defect** — `rtems-libbsd` installs
  `rtems_bsd_sysgen_open_error` as `.open_h` on every socket, which
  `duplicate_iop` (`cpukit/libcsupport/src/fcntl.c`) calls. Reported separately.

