### PR TITLE
meta: Explicitly include items in packaged crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,15 @@ name = "libc"
 version = "1.0.0-alpha.4"
 keywords = ["libc", "ffi", "bindings", "operating", "system"]
 categories = ["external-ffi-bindings", "no-std", "os"]
-exclude = ["/ci/*", "/.github/*", "/triagebot.toml"]
+include = [
+    "/src",
+    "/tests",
+    "/examples",
+    "/build.rs",
+    "/CHANGELOG*",
+    "/LICENSE*",
+    "/README*",
+]
 description = "Raw FFI bindings to platform libraries like libc."
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md> -->

## Description

Exclude `/etc` folder from `cargo package` by explicitly listing items to include. Currently published version of `libc` includes [`/etc/libc-util.py`](https://crates.io/crates/libc/0.2.187/code/etc/libc-util.py) which `cargo-deny` picks up as an executable. Added in https://github.com/rust-lang/libc/commit/27a38e3bda16c72f1bff3af9432e2282427843df 

## Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. See the pull request guidelines
for help
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md#submitting-a-pull-request>.
-->

- [X] ~~Relevant tests in `libc-test/semver` have been updated~~ N/A
- [X] ~~Commit messages permalink to headers for added or changed API~~ N/A
- [X] ~~Placeholder or unstable values like `*LAST` or `*MAX` have the standard doc comment~~ N/A
- [X] Tested locally (`cargo test -p libc-test --target mytarget`);
  - Tested using `cargo package` and inspecting that the Python script is excluded.

<!-- labels: is this PR a breaking change? If it is, delete the following
line: -->
@rustbot label +stable-nominated
