### PR TITLE
linux(uclibc): add `cfg` for LFS bindings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -39,6 +39,8 @@ const ALLOWED_CFGS: &[&str] = &[
     "musl_redir_time64",
     "vxworks_lt_25_09",
     "libc_pauthtest",
+    // Corresponds with `__USE_FILE_OFFSET64` in uClibc.
+    "uclibc_file_offset_bits64",
 ];
 
 // Extra values to allow for check-cfg.
@@ -217,6 +219,13 @@ fn main() {
             set_cfg("gnu_file_offset_bits64");
             set_cfg("gnu_time_bits64");
         }
+    }
+
+    match env::var("CARGO_CFG_LIBC_UNSTABLE_UCLIBC_FILE_OFFSET_BITS") {
+        Ok(val) if val == "64" && target_env == "uclibc" && target_ptr_width == "32" => {
+            set_cfg("uclibc_file_offset_bits64")
+        }
+        _ => (),
     }
 
     // On CI: deny all warnings

--- a/build.rs
+++ b/build.rs
@@ -54,6 +54,8 @@ enum Cfg {
     /// transition to 64-bit `time_t` and thus need `__*_time64` redirects. Implies `musl_v1_2`
     /// and 32-bit arch.
     MuslRedirTime64,
+    /// Corresonds to `__USE_FILE_OFFSET64` in uClibc-ng.
+    UclibcFileOffsetBits64,
 }
 
 const ALLOWED_CFGS: &[Cfg] = &[
@@ -76,6 +78,7 @@ const ALLOWED_CFGS: &[Cfg] = &[
     Cfg::MuslV1_2,
     Cfg::Musl32Time64,
     Cfg::MuslRedirTime64,
+    Cfg::UclibcFileOffsetBits64,
 ];
 
 impl fmt::Display for Cfg {
@@ -100,6 +103,7 @@ impl fmt::Display for Cfg {
             Cfg::MuslV1_2 => "musl_v1_2",
             Cfg::Musl32Time64 => "musl32_time64",
             Cfg::MuslRedirTime64 => "musl_redir_time64",
+            Cfg::UclibcFileOffsetBits64 => "uclibc_file_offset_bits64",
         })
     }
 }
@@ -263,9 +267,16 @@ fn main() {
     }
 
     let uclibc_time64_env = env_flag("CARGO_CFG_LIBC_UNSTABLE_UCLIBC_TIME64");
+    let uclibc_off64_env = env_flag("CARGO_CFG_LIBC_UNSTABLE_UCLIBC_OFF64");
+
     let uclibc_time64 = target_env == "uclibc" && uclibc_time64_env;
+    let uclibc_off64 = target_env == "uclibc" && target_ptr_width == "32" && uclibc_off64_env;
+
     if uclibc_time64 {
         cfgs.push(Cfg::LinuxTimeBits64);
+    }
+    if uclibc_off64 {
+        cfgs.push(Cfg::UclibcFileOffsetBits64);
     }
 
     let mut gnu_tb_env = env::var("CARGO_CFG_LIBC_UNSTABLE_GNU_TIME_BITS");
@@ -491,6 +502,10 @@ fn validate_cfg(list: &[Cfg], target_env: &str, target_os: &str, target_ptr_widt
                     list.contains(&Cfg::MuslV1_2),
                     "{cfg:?} set on non-musl1.2 platform"
                 )
+            }
+            Cfg::UclibcFileOffsetBits64 => {
+                assert_eq!(target_env, "uclibc", "{cfg:?} set with env {target_env}");
+                assert_eq!(target_ptr_width, "32", "{cfg:?} set on non-32-bit platform");
             }
         }
     }

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4041,6 +4041,13 @@ fn test_linux(target: &str) {
         // glibc versions older than 2.29.
         .define("__GLIBC_USE_DEPRECATED_SCANF", None);
 
+    if uclibc
+        && pointer_width == 32
+        && env::var("CARGO_CFG_LIBC_UNSTABLE_UCLIBC_FILE_OFFSET_BITS").is_ok()
+    {
+        cfg.cfg("uclibc_file_offset_bits64", None);
+    }
+
     config_gnu_bits(target, &mut cfg);
     // The L4Re libc headers contain some L4Re helper functions which are not needed for the libc
     // interface and must not be added to the libc crate

--- a/libc-test/build/main.rs
+++ b/libc-test/build/main.rs
@@ -3995,6 +3995,10 @@ fn test_linux(t: &Target) {
         // glibc versions older than 2.29.
         .define("__GLIBC_USE_DEPRECATED_SCANF", None);
 
+    if uclibc && p32 && env::var("CARGO_CFG_LIBC_UNSTABLE_UCLIBC_OFF64").is_ok() {
+        cfg.cfg("uclibc_file_offset_bits64", None);
+    }
+
     config_gnu_bits(t, &mut cfg);
     // The L4Re libc headers contain some L4Re helper functions which are not needed for the libc
     // interface and must not be added to the libc crate

--- a/src/unix/linux_like/linux/uclibc/arm/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/arm/mod.rs
@@ -1,4 +1,3 @@
-use crate::off64_t;
 use crate::prelude::*;
 
 pub type wchar_t = c_uint;
@@ -31,47 +30,68 @@ s! {
     }
 
     pub struct stat {
-        pub st_dev: c_ulonglong,
+        pub st_dev: crate::dev_t,
+
+        #[cfg(not(uclibc_file_offset_bits64))]
         __pad1: Padding<c_ushort>,
+        #[cfg(not(uclibc_file_offset_bits64))]
         pub st_ino: crate::ino_t,
+
+        #[cfg(uclibc_file_offset_bits64)]
+        __pad1: Padding<c_uint>,
+        #[cfg(uclibc_file_offset_bits64)]
+        pub __st_ino: crate::ino_t,
+
         pub st_mode: crate::mode_t,
         pub st_nlink: crate::nlink_t,
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
-        pub st_rdev: c_ulonglong,
+        pub st_rdev: crate::dev_t,
+
+        #[cfg(not(uclibc_file_offset_bits64))]
         __pad2: Padding<c_ushort>,
-        pub st_size: off_t,
+
+        #[cfg(uclibc_file_offset_bits64)]
+        __pad2: Padding<c_uint>,
+
+        pub st_size: crate::off_t,
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
         pub st_atime: crate::time_t,
-        pub st_atime_nsec: c_long,
+        pub st_atime_nsec: c_ulong,
         pub st_mtime: crate::time_t,
-        pub st_mtime_nsec: c_long,
+        pub st_mtime_nsec: c_ulong,
         pub st_ctime: crate::time_t,
-        pub st_ctime_nsec: c_long,
-        __unused4: Padding<c_ulong>,
-        __unused5: Padding<c_ulong>,
+        pub st_ctime_nsec: c_ulong,
+
+        #[cfg(not(uclibc_file_offset_bits64))]
+        __uclibc_unused4: Padding<c_ulong>,
+        #[cfg(not(uclibc_file_offset_bits64))]
+        __uclibc_unused5: Padding<c_ulong>,
+
+        #[cfg(uclibc_file_offset_bits64)]
+        pub st_ino: crate::ino_t,
     }
 
     pub struct stat64 {
-        pub st_dev: c_ulonglong,
-        pub __pad1: c_uint,
+        pub st_dev: crate::dev_t,
+        __pad1: Padding<c_uint>,
         pub __st_ino: crate::ino_t,
         pub st_mode: crate::mode_t,
         pub st_nlink: crate::nlink_t,
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
-        pub st_rdev: c_ulonglong,
-        pub __pad2: c_uint,
-        pub st_size: off64_t,
+        pub st_rdev: crate::dev_t,
+        __pad2: Padding<c_uint>,
+        pub st_size: crate::off64_t,
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt64_t,
         pub st_atime: crate::time_t,
-        pub st_atime_nsec: c_long,
+        pub st_atime_nsec: c_ulong,
         pub st_mtime: crate::time_t,
-        pub st_mtime_nsec: c_long,
+        pub st_mtime_nsec: c_ulong,
         pub st_ctime: crate::time_t,
-        pub st_ctime_nsec: c_long,
+        pub st_ctime_nsec: c_ulong,
         pub st_ino: crate::ino64_t,
     }
 
@@ -113,7 +133,7 @@ s! {
         pub f_namelen: c_int,
         pub f_frsize: c_int,
         pub f_flags: c_int,
-        pub f_spare: [c_int; 4],
+        f_spare: Padding<[c_int; 4]>,
     }
 
     pub struct statfs64 {
@@ -124,27 +144,12 @@ s! {
         pub f_bavail: crate::fsblkcnt64_t,
         pub f_files: crate::fsfilcnt64_t,
         pub f_ffree: crate::fsfilcnt64_t,
+
         pub f_fsid: crate::fsid_t,
         pub f_namelen: c_int,
         pub f_frsize: c_int,
         pub f_flags: c_int,
-        pub f_spare: [c_int; 4],
-    }
-
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        __f_unused: Padding<c_int>,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
+        f_spare: Padding<[c_int; 4]>,
     }
 
     pub struct sigset_t {

--- a/src/unix/linux_like/linux/uclibc/arm/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/arm/mod.rs
@@ -4,18 +4,10 @@ use crate::prelude::*;
 pub type wchar_t = c_uint;
 
 pub type clock_t = c_long;
-pub type fsblkcnt_t = c_ulong;
-pub type fsfilcnt_t = c_ulong;
-pub type ino_t = c_ulong;
-pub type off_t = c_long;
 pub type pthread_t = c_ulong;
 
 pub type nlink_t = c_uint;
 pub type blksize_t = c_long;
-pub type blkcnt_t = c_long;
-
-pub type fsblkcnt64_t = u64;
-pub type fsfilcnt64_t = u64;
 
 s! {
     pub struct cmsghdr {

--- a/src/unix/linux_like/linux/uclibc/arm/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/arm/mod.rs
@@ -9,6 +9,14 @@ pub type nlink_t = c_uint;
 pub type blksize_t = c_long;
 
 s! {
+    pub struct flock {
+        pub l_type: c_short,
+        pub l_whence: c_short,
+        pub l_start: crate::off_t,
+        pub l_len: crate::off_t,
+        pub l_pid: crate::pid_t,
+    }
+
     pub struct cmsghdr {
         pub cmsg_len: size_t,
         pub cmsg_level: c_int,
@@ -93,14 +101,6 @@ s! {
         pub st_ctime: crate::time_t,
         pub st_ctime_nsec: c_ulong,
         pub st_ino: crate::ino64_t,
-    }
-
-    pub struct flock {
-        pub l_type: c_short,
-        pub l_whence: c_short,
-        pub l_start: off_t,
-        pub l_len: off_t,
-        pub l_pid: crate::pid_t,
     }
 
     pub struct sysinfo {

--- a/src/unix/linux_like/linux/uclibc/arm/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/arm/mod.rs
@@ -1,4 +1,3 @@
-use crate::off64_t;
 use crate::prelude::*;
 
 pub type wchar_t = c_uint;
@@ -31,47 +30,68 @@ s! {
     }
 
     pub struct stat {
-        pub st_dev: c_ulonglong,
+        pub st_dev: crate::dev_t,
+
+        #[cfg(not(uclibc_file_offset_bits64))]
         __pad1: Padding<c_ushort>,
+        #[cfg(not(uclibc_file_offset_bits64))]
         pub st_ino: crate::ino_t,
+
+        #[cfg(uclibc_file_offset_bits64)]
+        __pad1: Padding<c_uint>,
+        #[cfg(uclibc_file_offset_bits64)]
+        pub __st_ino: crate::ino_t,
+
         pub st_mode: crate::mode_t,
         pub st_nlink: crate::nlink_t,
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
-        pub st_rdev: c_ulonglong,
+        pub st_rdev: crate::dev_t,
+
+        #[cfg(not(uclibc_file_offset_bits64))]
         __pad2: Padding<c_ushort>,
-        pub st_size: off_t,
+
+        #[cfg(uclibc_file_offset_bits64)]
+        __pad2: Padding<c_uint>,
+
+        pub st_size: crate::off_t,
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
         pub st_atime: crate::time_t,
-        pub st_atime_nsec: c_long,
+        pub st_atime_nsec: c_ulong,
         pub st_mtime: crate::time_t,
-        pub st_mtime_nsec: c_long,
+        pub st_mtime_nsec: c_ulong,
         pub st_ctime: crate::time_t,
-        pub st_ctime_nsec: c_long,
-        __unused4: Padding<c_ulong>,
-        __unused5: Padding<c_ulong>,
+        pub st_ctime_nsec: c_ulong,
+
+        #[cfg(not(uclibc_file_offset_bits64))]
+        __uclibc_unused4: Padding<c_ulong>,
+        #[cfg(not(uclibc_file_offset_bits64))]
+        __uclibc_unused5: Padding<c_ulong>,
+
+        #[cfg(uclibc_file_offset_bits64)]
+        pub st_ino: crate::ino_t,
     }
 
     pub struct stat64 {
-        pub st_dev: c_ulonglong,
+        pub st_dev: crate::dev_t,
         __pad1: Padding<c_uint>,
         pub __st_ino: crate::ino_t,
         pub st_mode: crate::mode_t,
         pub st_nlink: crate::nlink_t,
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
-        pub st_rdev: c_ulonglong,
+        pub st_rdev: crate::dev_t,
         __pad2: Padding<c_uint>,
-        pub st_size: off64_t,
+        pub st_size: crate::off64_t,
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt64_t,
         pub st_atime: crate::time_t,
-        pub st_atime_nsec: c_long,
+        pub st_atime_nsec: c_ulong,
         pub st_mtime: crate::time_t,
-        pub st_mtime_nsec: c_long,
+        pub st_mtime_nsec: c_ulong,
         pub st_ctime: crate::time_t,
-        pub st_ctime_nsec: c_long,
+        pub st_ctime_nsec: c_ulong,
         pub st_ino: crate::ino64_t,
     }
 
@@ -124,27 +144,12 @@ s! {
         pub f_bavail: crate::fsblkcnt64_t,
         pub f_files: crate::fsfilcnt64_t,
         pub f_ffree: crate::fsfilcnt64_t,
+
         pub f_fsid: crate::fsid_t,
         pub f_namelen: c_int,
         pub f_frsize: c_int,
         pub f_flags: c_int,
         f_spare: Padding<[c_int; 4]>,
-    }
-
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        __f_unused: Padding<c_int>,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: Padding<[c_int; 6]>,
     }
 
     pub struct sigset_t {

--- a/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
@@ -183,16 +183,6 @@ s! {
         pub c_cc: [crate::cc_t; crate::NCCS],
     }
 
-    pub struct flock {
-        pub l_type: c_short,
-        pub l_whence: c_short,
-        pub l_start: crate::off_t,
-        pub l_len: crate::off_t,
-        pub l_sysid: c_long,
-        pub l_pid: crate::pid_t,
-        pad: Padding<[c_long; 4]>,
-    }
-
     pub struct sysinfo {
         pub uptime: c_long,
         pub loads: [c_ulong; 3],

--- a/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
@@ -1,4 +1,3 @@
-use crate::off64_t;
 use crate::prelude::*;
 
 pub type clock_t = i32;
@@ -16,16 +15,29 @@ s! {
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
-        pub st_pad2: [c_long; 1],
+
+        #[cfg(not(uclibc_file_offset_bits64))]
+        st_pad2: Padding<[c_long; 1]>,
+
+        #[cfg(uclibc_file_offset_bits64)]
+        st_pad2: Padding<[c_long; 2]>,
+
         pub st_size: crate::off_t,
+
+        #[cfg(not(uclibc_file_offset_bits64))]
         st_pad3: Padding<c_long>,
+
         pub st_atime: crate::time_t,
-        pub st_atime_nsec: c_long,
+        pub st_atime_nsec: c_ulong,
         pub st_mtime: crate::time_t,
-        pub st_mtime_nsec: c_long,
+        pub st_mtime_nsec: c_ulong,
         pub st_ctime: crate::time_t,
-        pub st_ctime_nsec: c_long,
+        pub st_ctime_nsec: c_ulong,
         pub st_blksize: crate::blksize_t,
+
+        #[cfg(uclibc_file_offset_bits64)]
+        st_pad4: Padding<c_long>,
+
         pub st_blocks: crate::blkcnt_t,
         st_pad5: Padding<[c_long; 14]>,
     }
@@ -40,33 +52,17 @@ s! {
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
         st_pad2: Padding<[c_long; 2]>,
-        pub st_size: off64_t,
+        pub st_size: crate::off64_t,
         pub st_atime: crate::time_t,
-        pub st_atime_nsec: c_long,
+        pub st_atime_nsec: c_ulong,
         pub st_mtime: crate::time_t,
-        pub st_mtime_nsec: c_long,
+        pub st_mtime_nsec: c_ulong,
         pub st_ctime: crate::time_t,
-        pub st_ctime_nsec: c_long,
+        pub st_ctime_nsec: c_ulong,
         pub st_blksize: crate::blksize_t,
         st_pad3: Padding<c_long>,
         pub st_blocks: crate::blkcnt64_t,
-        st_pad5: Padding<[c_long; 14]>,
-    }
-
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsblkcnt64_t,
-        pub f_bfree: crate::fsblkcnt64_t,
-        pub f_bavail: crate::fsblkcnt64_t,
-        pub f_files: crate::fsfilcnt64_t,
-        pub f_ffree: crate::fsfilcnt64_t,
-        pub f_favail: crate::fsfilcnt64_t,
-        pub f_fsid: c_ulong,
-        pub __f_unused: c_int,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        pub __f_spare: [c_int; 6],
+        st_pad4: Padding<[c_long; 14]>,
     }
 
     pub struct pthread_attr_t {
@@ -160,36 +156,6 @@ s! {
         pub msg_lrpid: crate::pid_t,
         __glibc_reserved4: Padding<c_ulong>,
         __glibc_reserved5: Padding<c_ulong>,
-    }
-
-    pub struct statfs {
-        pub f_type: c_long,
-        pub f_bsize: c_long,
-        pub f_frsize: c_long,
-        pub f_blocks: crate::fsblkcnt_t,
-        pub f_bfree: crate::fsblkcnt_t,
-        pub f_files: crate::fsblkcnt_t,
-        pub f_ffree: crate::fsblkcnt_t,
-        pub f_bavail: crate::fsblkcnt_t,
-        pub f_fsid: crate::fsid_t,
-
-        pub f_namelen: c_long,
-        f_spare: [c_long; 6],
-    }
-
-    pub struct statfs64 {
-        pub f_type: c_long,
-        pub f_bsize: c_long,
-        pub f_frsize: c_long,
-        pub f_blocks: crate::fsblkcnt64_t,
-        pub f_bfree: crate::fsblkcnt64_t,
-        pub f_files: crate::fsblkcnt64_t,
-        pub f_ffree: crate::fsblkcnt64_t,
-        pub f_bavail: crate::fsblkcnt64_t,
-        pub f_fsid: crate::fsid_t,
-        pub f_namelen: c_long,
-        pub f_flags: c_long,
-        pub f_spare: [c_long; 5],
     }
 
     pub struct msghdr {

--- a/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
@@ -3,15 +3,8 @@ use crate::prelude::*;
 
 pub type clock_t = i32;
 pub type wchar_t = i32;
-pub type off_t = i32;
-pub type ino_t = u32;
-pub type blkcnt_t = i32;
 pub type blksize_t = i32;
 pub type nlink_t = u32;
-pub type fsblkcnt_t = c_ulong;
-pub type fsfilcnt_t = c_ulong;
-pub type fsblkcnt64_t = u64;
-pub type fsfilcnt64_t = u64;
 
 s! {
     pub struct stat {
@@ -24,7 +17,7 @@ s! {
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
         pub st_pad2: [c_long; 1],
-        pub st_size: off_t,
+        pub st_size: crate::off_t,
         st_pad3: Padding<c_long>,
         pub st_atime: crate::time_t,
         pub st_atime_nsec: c_long,
@@ -227,8 +220,8 @@ s! {
     pub struct flock {
         pub l_type: c_short,
         pub l_whence: c_short,
-        pub l_start: off_t,
-        pub l_len: off_t,
+        pub l_start: crate::off_t,
+        pub l_len: crate::off_t,
         pub l_sysid: c_long,
         pub l_pid: crate::pid_t,
         pad: Padding<[c_long; 4]>,

--- a/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
@@ -1,4 +1,3 @@
-use crate::off64_t;
 use crate::prelude::*;
 
 pub type clock_t = i32;
@@ -16,16 +15,29 @@ s! {
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
+
+        #[cfg(not(uclibc_file_offset_bits64))]
         st_pad2: Padding<[c_long; 1]>,
+
+        #[cfg(uclibc_file_offset_bits64)]
+        st_pad2: Padding<[c_long; 2]>,
+
         pub st_size: crate::off_t,
+
+        #[cfg(not(uclibc_file_offset_bits64))]
         st_pad3: Padding<c_long>,
+
         pub st_atime: crate::time_t,
-        pub st_atime_nsec: c_long,
+        pub st_atime_nsec: c_ulong,
         pub st_mtime: crate::time_t,
-        pub st_mtime_nsec: c_long,
+        pub st_mtime_nsec: c_ulong,
         pub st_ctime: crate::time_t,
-        pub st_ctime_nsec: c_long,
+        pub st_ctime_nsec: c_ulong,
         pub st_blksize: crate::blksize_t,
+
+        #[cfg(uclibc_file_offset_bits64)]
+        st_pad4: Padding<c_long>,
+
         pub st_blocks: crate::blkcnt_t,
         st_pad5: Padding<[c_long; 14]>,
     }
@@ -40,33 +52,17 @@ s! {
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
         st_pad2: Padding<[c_long; 2]>,
-        pub st_size: off64_t,
+        pub st_size: crate::off64_t,
         pub st_atime: crate::time_t,
-        pub st_atime_nsec: c_long,
+        pub st_atime_nsec: c_ulong,
         pub st_mtime: crate::time_t,
-        pub st_mtime_nsec: c_long,
+        pub st_mtime_nsec: c_ulong,
         pub st_ctime: crate::time_t,
-        pub st_ctime_nsec: c_long,
+        pub st_ctime_nsec: c_ulong,
         pub st_blksize: crate::blksize_t,
         st_pad3: Padding<c_long>,
         pub st_blocks: crate::blkcnt64_t,
-        st_pad5: Padding<[c_long; 14]>,
-    }
-
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsblkcnt64_t,
-        pub f_bfree: crate::fsblkcnt64_t,
-        pub f_bavail: crate::fsblkcnt64_t,
-        pub f_files: crate::fsfilcnt64_t,
-        pub f_ffree: crate::fsfilcnt64_t,
-        pub f_favail: crate::fsfilcnt64_t,
-        pub f_fsid: c_ulong,
-        __f_unused: Padding<c_int>,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: Padding<[c_int; 6]>,
+        st_pad4: Padding<[c_long; 14]>,
     }
 
     pub struct pthread_attr_t {
@@ -153,36 +149,6 @@ s! {
         pub msg_lrpid: crate::pid_t,
         __glibc_reserved4: Padding<c_ulong>,
         __glibc_reserved5: Padding<c_ulong>,
-    }
-
-    pub struct statfs {
-        pub f_type: c_long,
-        pub f_bsize: c_long,
-        pub f_frsize: c_long,
-        pub f_blocks: crate::fsblkcnt_t,
-        pub f_bfree: crate::fsblkcnt_t,
-        pub f_files: crate::fsblkcnt_t,
-        pub f_ffree: crate::fsblkcnt_t,
-        pub f_bavail: crate::fsblkcnt_t,
-        pub f_fsid: crate::fsid_t,
-
-        pub f_namelen: c_long,
-        f_spare: Padding<[c_long; 6]>,
-    }
-
-    pub struct statfs64 {
-        pub f_type: c_long,
-        pub f_bsize: c_long,
-        pub f_frsize: c_long,
-        pub f_blocks: crate::fsblkcnt64_t,
-        pub f_bfree: crate::fsblkcnt64_t,
-        pub f_files: crate::fsblkcnt64_t,
-        pub f_ffree: crate::fsblkcnt64_t,
-        pub f_bavail: crate::fsblkcnt64_t,
-        pub f_fsid: crate::fsid_t,
-        pub f_namelen: c_long,
-        pub f_flags: c_long,
-        f_spare: Padding<[c_long; 5]>,
     }
 
     pub struct msghdr {

--- a/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
@@ -176,16 +176,6 @@ s! {
         pub c_cc: [crate::cc_t; crate::NCCS],
     }
 
-    pub struct flock {
-        pub l_type: c_short,
-        pub l_whence: c_short,
-        pub l_start: crate::off_t,
-        pub l_len: crate::off_t,
-        pub l_sysid: c_long,
-        pub l_pid: crate::pid_t,
-        pad: Padding<[c_long; 4]>,
-    }
-
     pub struct sysinfo {
         pub uptime: c_long,
         pub loads: [c_ulong; 3],

--- a/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips32/mod.rs
@@ -3,15 +3,8 @@ use crate::prelude::*;
 
 pub type clock_t = i32;
 pub type wchar_t = i32;
-pub type off_t = i32;
-pub type ino_t = u32;
-pub type blkcnt_t = i32;
 pub type blksize_t = i32;
 pub type nlink_t = u32;
-pub type fsblkcnt_t = c_ulong;
-pub type fsfilcnt_t = c_ulong;
-pub type fsblkcnt64_t = u64;
-pub type fsfilcnt64_t = u64;
 
 s! {
     pub struct stat {
@@ -24,7 +17,7 @@ s! {
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
         st_pad2: Padding<[c_long; 1]>,
-        pub st_size: off_t,
+        pub st_size: crate::off_t,
         st_pad3: Padding<c_long>,
         pub st_atime: crate::time_t,
         pub st_atime_nsec: c_long,
@@ -220,8 +213,8 @@ s! {
     pub struct flock {
         pub l_type: c_short,
         pub l_whence: c_short,
-        pub l_start: off_t,
-        pub l_len: off_t,
+        pub l_start: crate::off_t,
+        pub l_len: crate::off_t,
         pub l_sysid: c_long,
         pub l_pid: crate::pid_t,
         pad: Padding<[c_long; 4]>,

--- a/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
@@ -1,4 +1,3 @@
-use crate::off64_t;
 use crate::prelude::*;
 
 pub type blksize_t = i64;
@@ -6,52 +5,30 @@ pub type nlink_t = u64;
 pub type off_t = i64;
 pub type wchar_t = i32;
 
+pub type stat64 = stat;
+
 s! {
     pub struct stat {
-        pub st_dev: c_ulong,
-        st_pad1: Padding<[c_long; 2]>,
+        pub st_dev: c_uint,
+        st_pad1: Padding<[c_int; 3]>,
         pub st_ino: crate::ino_t,
         pub st_mode: crate::mode_t,
         pub st_nlink: crate::nlink_t,
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
-        pub st_rdev: c_ulong,
-        st_pad2: Padding<[c_ulong; 1]>,
-        pub st_size: off_t,
-        st_pad3: Padding<c_long>,
-        pub st_atime: crate::time_t,
-        pub st_atime_nsec: c_long,
-        pub st_mtime: crate::time_t,
-        pub st_mtime_nsec: c_long,
-        pub st_ctime: crate::time_t,
-        pub st_ctime_nsec: c_long,
-        pub st_blksize: crate::blksize_t,
-        st_pad4: Padding<c_long>,
+        pub st_rdev: c_uint,
+        st_pad2: Padding<[c_uint; 3]>,
+        pub st_size: crate::off_t,
+        pub st_atime: c_int,
+        pub st_atime_nsec: c_int,
+        pub st_mtime: c_int,
+        pub st_mtime_nsec: c_int,
+        pub st_ctime: c_int,
+        pub st_ctime_nsec: c_int,
+        pub st_blksize: c_int,
+        st_pad3: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
-        st_pad5: Padding<[c_long; 7]>,
-    }
-
-    pub struct stat64 {
-        pub st_dev: c_ulong,
-        st_pad1: Padding<[c_long; 2]>,
-        pub st_ino: crate::ino64_t,
-        pub st_mode: crate::mode_t,
-        pub st_nlink: crate::nlink_t,
-        pub st_uid: crate::uid_t,
-        pub st_gid: crate::gid_t,
-        pub st_rdev: c_ulong,
-        st_pad2: Padding<[c_long; 2]>,
-        pub st_size: off64_t,
-        pub st_atime: crate::time_t,
-        pub st_atime_nsec: c_long,
-        pub st_mtime: crate::time_t,
-        pub st_mtime_nsec: c_long,
-        pub st_ctime: crate::time_t,
-        pub st_ctime_nsec: c_long,
-        pub st_blksize: crate::blksize_t,
-        st_pad3: Padding<c_long>,
-        pub st_blocks: crate::blkcnt64_t,
-        st_pad5: Padding<[c_long; 7]>,
+        st_pad4: Padding<[c_int; 14]>,
     }
 
     pub struct pthread_attr_t {
@@ -121,21 +98,6 @@ s! {
         pub msg_lrpid: crate::pid_t,
         __glibc_reserved4: Padding<c_ulong>,
         __glibc_reserved5: Padding<c_ulong>,
-    }
-
-    pub struct statfs {
-        pub f_type: c_long,
-        pub f_bsize: c_long,
-        pub f_frsize: c_long,
-        pub f_blocks: crate::fsblkcnt_t,
-        pub f_bfree: crate::fsblkcnt_t,
-        pub f_files: crate::fsblkcnt_t,
-        pub f_ffree: crate::fsblkcnt_t,
-        pub f_bavail: crate::fsblkcnt_t,
-        pub f_fsid: crate::fsid_t,
-
-        pub f_namelen: c_long,
-        f_spare: [c_long; 6],
     }
 
     pub struct msghdr {

--- a/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
@@ -1,11 +1,7 @@
 use crate::off64_t;
 use crate::prelude::*;
 
-pub type blkcnt_t = i64;
 pub type blksize_t = i64;
-pub type fsblkcnt_t = c_ulong;
-pub type fsfilcnt_t = c_ulong;
-pub type ino_t = u64;
 pub type nlink_t = u64;
 pub type off_t = i64;
 pub type wchar_t = i32;

--- a/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mips64/mod.rs
@@ -1,4 +1,3 @@
-use crate::off64_t;
 use crate::prelude::*;
 
 pub type blksize_t = i64;
@@ -6,52 +5,30 @@ pub type nlink_t = u64;
 pub type off_t = i64;
 pub type wchar_t = i32;
 
+pub type stat64 = stat;
+
 s! {
     pub struct stat {
-        pub st_dev: c_ulong,
-        st_pad1: Padding<[c_long; 2]>,
+        pub st_dev: c_uint,
+        st_pad1: Padding<[c_int; 3]>,
         pub st_ino: crate::ino_t,
         pub st_mode: crate::mode_t,
         pub st_nlink: crate::nlink_t,
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
-        pub st_rdev: c_ulong,
-        st_pad2: Padding<[c_ulong; 1]>,
-        pub st_size: off_t,
-        st_pad3: Padding<c_long>,
-        pub st_atime: crate::time_t,
-        pub st_atime_nsec: c_long,
-        pub st_mtime: crate::time_t,
-        pub st_mtime_nsec: c_long,
-        pub st_ctime: crate::time_t,
-        pub st_ctime_nsec: c_long,
-        pub st_blksize: crate::blksize_t,
-        st_pad4: Padding<c_long>,
+        pub st_rdev: c_uint,
+        st_pad2: Padding<[c_uint; 3]>,
+        pub st_size: crate::off_t,
+        pub st_atime: c_int,
+        pub st_atime_nsec: c_int,
+        pub st_mtime: c_int,
+        pub st_mtime_nsec: c_int,
+        pub st_ctime: c_int,
+        pub st_ctime_nsec: c_int,
+        pub st_blksize: c_int,
+        st_pad3: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
-        st_pad5: Padding<[c_long; 7]>,
-    }
-
-    pub struct stat64 {
-        pub st_dev: c_ulong,
-        st_pad1: Padding<[c_long; 2]>,
-        pub st_ino: crate::ino64_t,
-        pub st_mode: crate::mode_t,
-        pub st_nlink: crate::nlink_t,
-        pub st_uid: crate::uid_t,
-        pub st_gid: crate::gid_t,
-        pub st_rdev: c_ulong,
-        st_pad2: Padding<[c_long; 2]>,
-        pub st_size: off64_t,
-        pub st_atime: crate::time_t,
-        pub st_atime_nsec: c_long,
-        pub st_mtime: crate::time_t,
-        pub st_mtime_nsec: c_long,
-        pub st_ctime: crate::time_t,
-        pub st_ctime_nsec: c_long,
-        pub st_blksize: crate::blksize_t,
-        st_pad3: Padding<c_long>,
-        pub st_blocks: crate::blkcnt64_t,
-        st_pad5: Padding<[c_long; 7]>,
+        st_pad4: Padding<[c_int; 14]>,
     }
 
     pub struct pthread_attr_t {
@@ -113,21 +90,6 @@ s! {
         pub msg_lrpid: crate::pid_t,
         __glibc_reserved4: Padding<c_ulong>,
         __glibc_reserved5: Padding<c_ulong>,
-    }
-
-    pub struct statfs {
-        pub f_type: c_long,
-        pub f_bsize: c_long,
-        pub f_frsize: c_long,
-        pub f_blocks: crate::fsblkcnt_t,
-        pub f_bfree: crate::fsblkcnt_t,
-        pub f_files: crate::fsblkcnt_t,
-        pub f_ffree: crate::fsblkcnt_t,
-        pub f_bavail: crate::fsblkcnt_t,
-        pub f_fsid: crate::fsid_t,
-
-        pub f_namelen: c_long,
-        f_spare: Padding<[c_long; 6]>,
     }
 
     pub struct msghdr {

--- a/src/unix/linux_like/linux/uclibc/mips/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mod.rs
@@ -2,6 +2,40 @@ use crate::prelude::*;
 
 pub type pthread_t = c_ulong;
 
+s! {
+    pub struct statfs {
+        pub f_type: c_long,
+        pub f_bsize: c_long,
+        pub f_frsize: c_long,
+        pub f_blocks: crate::fsblkcnt_t,
+        pub f_bfree: crate::fsblkcnt_t,
+        pub f_files: crate::fsblkcnt_t,
+        pub f_ffree: crate::fsblkcnt_t,
+        pub f_bavail: crate::fsblkcnt_t,
+
+        pub f_fsid: crate::fsid_t,
+        pub f_namelen: c_long,
+        pub f_flags: c_long,
+        f_spare: Padding<[c_long; 5]>,
+    }
+
+    pub struct statfs64 {
+        pub f_type: c_long,
+        pub f_bsize: c_long,
+        pub f_frsize: c_long,
+        pub f_blocks: crate::fsblkcnt64_t,
+        pub f_bfree: crate::fsblkcnt64_t,
+        pub f_files: crate::fsblkcnt64_t,
+        pub f_ffree: crate::fsblkcnt64_t,
+        pub f_bavail: crate::fsblkcnt64_t,
+
+        pub f_fsid: crate::fsid_t,
+        pub f_namelen: c_long,
+        pub f_flags: c_long,
+        f_spare: Padding<[c_long; 5]>,
+    }
+}
+
 pub const SFD_CLOEXEC: c_int = 0x080000;
 
 pub const NCCS: usize = 32;

--- a/src/unix/linux_like/linux/uclibc/mips/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mips/mod.rs
@@ -34,6 +34,18 @@ s! {
         pub f_flags: c_long,
         f_spare: Padding<[c_long; 5]>,
     }
+
+    pub struct flock {
+        pub l_type: c_short,
+        pub l_whence: c_short,
+        pub l_start: crate::off_t,
+        pub l_len: crate::off_t,
+        #[cfg(not(all(uclibc_file_offset_bits64, target_arch = "mips64")))]
+        pub l_sysid: c_long,
+        pub l_pid: crate::pid_t,
+        #[cfg(not(all(uclibc_file_offset_bits64, target_arch = "mips64")))]
+        pad: [c_long; 4],
+    }
 }
 
 pub const SFD_CLOEXEC: c_int = 0x080000;

--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -52,6 +52,14 @@ cfg_if! {
 }
 
 s! {
+    pub struct flock64 {
+        pub l_type: c_short,
+        pub l_whence: c_short,
+        pub l_start: crate::off64_t,
+        pub l_len: crate::off64_t,
+        pub l_pid: crate::pid_t,
+    }
+
     pub struct statvfs {
         // Different than GNU!
         pub f_bsize: c_ulong,

--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -8,7 +8,6 @@ pub type shmatt_t = c_ulong;
 pub type msgqnum_t = c_ulong;
 pub type msglen_t = c_ulong;
 pub type regoff_t = c_int;
-pub type rlim_t = c_ulong;
 pub type __rlimit_resource_t = c_ulong;
 pub type __priority_which_t = c_uint;
 
@@ -22,6 +21,29 @@ cfg_if! {
         pub type suseconds_t = c_long;
     }
 }
+
+cfg_if! {
+    if #[cfg(uclibc_file_offset_bits64)] {
+        pub type ino_t = u64;
+        pub type off_t = i64;
+        pub type rlim_t = u64;
+        pub type blkcnt_t = i64;
+        pub type fsblkcnt_t = u64;
+        pub type fsfilcnt_t = u64;
+    } else {
+        pub type ino_t = c_ulong;
+        pub type off_t = c_long;
+        pub type rlim_t = c_ulong;
+        pub type blkcnt_t = c_long;
+        pub type fsblkcnt_t = c_ulong;
+        pub type fsfilcnt_t = c_ulong;
+    }
+}
+
+// Other LFS types have definitions provided by top-level modules (i.e. `unix`,
+// `linux_like` and `linux`.)
+pub type fsblkcnt64_t = u64;
+pub type fsfilcnt64_t = u64;
 
 cfg_if! {
     if #[cfg(doc)] {

--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -1,7 +1,3 @@
-// FIXME(ulibc): this module has definitions that are redundant with the parent
-#![allow(dead_code)]
-
-use crate::off64_t;
 use crate::prelude::*;
 
 pub type shmatt_t = c_ulong;
@@ -66,15 +62,29 @@ s! {
         pub f_files: crate::fsfilcnt_t,
         pub f_ffree: crate::fsfilcnt_t,
         pub f_favail: crate::fsfilcnt_t,
-        #[cfg(target_endian = "little")]
         pub f_fsid: c_ulong,
         #[cfg(target_pointer_width = "32")]
         __f_unused: Padding<c_int>,
-        #[cfg(target_endian = "big")]
-        pub f_fsid: c_ulong,
         pub f_flag: c_ulong,
         pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
+        __f_spare: Padding<[c_int; 6]>,
+    }
+
+    pub struct statvfs64 {
+        pub f_bsize: c_ulong,
+        pub f_frsize: c_ulong,
+        pub f_blocks: crate::fsblkcnt64_t,
+        pub f_bfree: crate::fsblkcnt64_t,
+        pub f_bavail: crate::fsblkcnt64_t,
+        pub f_files: crate::fsfilcnt64_t,
+        pub f_ffree: crate::fsfilcnt64_t,
+        pub f_favail: crate::fsfilcnt64_t,
+        pub f_fsid: c_ulong,
+        #[cfg(target_pointer_width = "32")]
+        __f_unused: Padding<c_int>,
+        pub f_flag: c_ulong,
+        pub f_namemax: c_ulong,
+        __f_spare: Padding<[c_int; 6]>,
     }
 
     pub struct regex_t {
@@ -411,8 +421,18 @@ extern "C" {
         flags: c_int,
     ) -> c_int;
 
-    pub fn pwritev(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: off64_t) -> ssize_t;
-    pub fn preadv(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: off64_t) -> ssize_t;
+    pub fn pwritev(
+        fd: c_int,
+        iov: *const crate::iovec,
+        iovcnt: c_int,
+        offset: crate::off64_t,
+    ) -> ssize_t;
+    pub fn preadv(
+        fd: c_int,
+        iov: *const crate::iovec,
+        iovcnt: c_int,
+        offset: crate::off64_t,
+    ) -> ssize_t;
 
     pub fn sethostid(hostid: c_long) -> c_int;
     pub fn fanotify_mark(

--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -1,7 +1,3 @@
-// FIXME(ulibc): this module has definitions that are redundant with the parent
-#![allow(dead_code)]
-
-use crate::off64_t;
 use crate::prelude::*;
 
 pub type shmatt_t = c_ulong;
@@ -66,12 +62,26 @@ s! {
         pub f_files: crate::fsfilcnt_t,
         pub f_ffree: crate::fsfilcnt_t,
         pub f_favail: crate::fsfilcnt_t,
-        #[cfg(target_endian = "little")]
         pub f_fsid: c_ulong,
         #[cfg(target_pointer_width = "32")]
         __f_unused: Padding<c_int>,
-        #[cfg(target_endian = "big")]
+        pub f_flag: c_ulong,
+        pub f_namemax: c_ulong,
+        __f_spare: Padding<[c_int; 6]>,
+    }
+
+    pub struct statvfs64 {
+        pub f_bsize: c_ulong,
+        pub f_frsize: c_ulong,
+        pub f_blocks: crate::fsblkcnt64_t,
+        pub f_bfree: crate::fsblkcnt64_t,
+        pub f_bavail: crate::fsblkcnt64_t,
+        pub f_files: crate::fsfilcnt64_t,
+        pub f_ffree: crate::fsfilcnt64_t,
+        pub f_favail: crate::fsfilcnt64_t,
         pub f_fsid: c_ulong,
+        #[cfg(target_pointer_width = "32")]
+        __f_unused: Padding<c_int>,
         pub f_flag: c_ulong,
         pub f_namemax: c_ulong,
         __f_spare: Padding<[c_int; 6]>,
@@ -338,8 +348,18 @@ extern "C" {
         flags: c_int,
     ) -> c_int;
 
-    pub fn pwritev(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: off64_t) -> ssize_t;
-    pub fn preadv(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: off64_t) -> ssize_t;
+    pub fn pwritev(
+        fd: c_int,
+        iov: *const crate::iovec,
+        iovcnt: c_int,
+        offset: crate::off64_t,
+    ) -> ssize_t;
+    pub fn preadv(
+        fd: c_int,
+        iov: *const crate::iovec,
+        iovcnt: c_int,
+        offset: crate::off64_t,
+    ) -> ssize_t;
 
     pub fn sethostid(hostid: c_long) -> c_int;
     pub fn fanotify_mark(

--- a/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
@@ -14,6 +14,14 @@ pub type pthread_t = c_ulong;
 pub type stat64 = stat;
 
 s! {
+    pub struct flock {
+        pub l_type: c_short,
+        pub l_whence: c_short,
+        pub l_start: crate::off_t,
+        pub l_len: crate::off_t,
+        pub l_pid: crate::pid_t,
+    }
+
     pub struct ipc_perm {
         pub __key: crate::key_t,
         pub uid: crate::uid_t,

--- a/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
@@ -1,6 +1,5 @@
 //! Definitions for uclibc on 64bit systems
 
-use crate::off64_t;
 use crate::prelude::*;
 
 pub type blksize_t = i64;
@@ -11,6 +10,8 @@ pub type off_t = c_long;
 pub type stat64 = stat;
 pub type wchar_t = c_int;
 pub type pthread_t = c_ulong;
+
+pub type stat64 = stat;
 
 s! {
     pub struct ipc_perm {
@@ -99,7 +100,7 @@ s! {
     }
 
     pub struct stat {
-        pub st_dev: c_ulong,
+        pub st_dev: crate::dev_t,
         pub st_ino: crate::ino_t,
         // According to uclibc/libc/sysdeps/linux/x86_64/bits/stat.h, order of
         // nlink and mode are swapped on 64 bit systems.
@@ -107,8 +108,9 @@ s! {
         pub st_mode: crate::mode_t,
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
-        pub st_rdev: c_ulong, // dev_t
-        pub st_size: off_t,   // file size
+        __pad0: Padding<c_int>,
+        pub st_rdev: crate::dev_t, // dev_t
+        pub st_size: crate::off_t, // file size
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
         pub st_atime: crate::time_t,
@@ -117,7 +119,7 @@ s! {
         pub st_mtime_nsec: c_ulong,
         pub st_ctime: crate::time_t,
         pub st_ctime_nsec: c_ulong,
-        st_pad4: Padding<[c_long; 3]>,
+        __uclibc_unused: Padding<[c_long; 3]>,
     }
 
     // FIXME(1.0): This should not implement `PartialEq`
@@ -137,49 +139,35 @@ s! {
     }
 
     pub struct statfs {
-        // FIXME(ulibc)
-        pub f_type: fsword_t,
-        pub f_bsize: fsword_t,
+        pub f_type: c_long,
+        pub f_bsize: c_long,
         pub f_blocks: crate::fsblkcnt_t,
         pub f_bfree: crate::fsblkcnt_t,
         pub f_bavail: crate::fsblkcnt_t,
         pub f_files: crate::fsfilcnt_t,
         pub f_ffree: crate::fsfilcnt_t,
+
         pub f_fsid: crate::fsid_t,
-        pub f_namelen: fsword_t,
-        pub f_frsize: fsword_t,
-        f_spare: [fsword_t; 5],
+        pub f_namelen: c_long,
+        pub f_frsize: c_long,
+        pub f_flags: c_long,
+        f_spare: Padding<[c_long; 4]>,
     }
 
     pub struct statfs64 {
-        pub f_type: c_int,
-        pub f_bsize: c_int,
+        pub f_type: c_long,
+        pub f_bsize: c_long,
         pub f_blocks: crate::fsblkcnt64_t,
         pub f_bfree: crate::fsblkcnt64_t,
         pub f_bavail: crate::fsblkcnt64_t,
         pub f_files: crate::fsfilcnt64_t,
         pub f_ffree: crate::fsfilcnt64_t,
-        pub f_fsid: crate::fsid_t,
-        pub f_namelen: c_int,
-        pub f_frsize: c_int,
-        pub f_flags: c_int,
-        pub f_spare: [c_int; 4],
-    }
 
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        __f_unused: Padding<c_int>,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
+        pub f_fsid: crate::fsid_t,
+        pub f_namelen: c_long,
+        pub f_frsize: c_long,
+        pub f_flags: c_long,
+        f_spare: Padding<[c_long; 4]>,
     }
 
     pub struct msghdr {

--- a/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
@@ -3,22 +3,14 @@
 use crate::off64_t;
 use crate::prelude::*;
 
-pub type blkcnt_t = i64;
 pub type blksize_t = i64;
 pub type clock_t = i64;
-pub type fsblkcnt_t = c_ulong;
-pub type fsfilcnt_t = c_ulong;
-pub type fsword_t = c_long;
-pub type ino_t = c_ulong;
 pub type nlink_t = c_uint;
 pub type off_t = c_long;
 // [uClibc docs] Note stat64 has the same shape as stat for x86-64.
 pub type stat64 = stat;
 pub type wchar_t = c_int;
 pub type pthread_t = c_ulong;
-
-pub type fsblkcnt64_t = u64;
-pub type fsfilcnt64_t = u64;
 
 s! {
     pub struct ipc_perm {

--- a/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/x86_64/mod.rs
@@ -1,6 +1,5 @@
 //! Definitions for uclibc on 64bit systems
 
-use crate::off64_t;
 use crate::prelude::*;
 
 pub type blksize_t = i64;
@@ -11,6 +10,8 @@ pub type off_t = c_long;
 pub type stat64 = stat;
 pub type wchar_t = c_int;
 pub type pthread_t = c_ulong;
+
+pub type stat64 = stat;
 
 s! {
     pub struct ipc_perm {
@@ -91,7 +92,7 @@ s! {
     }
 
     pub struct stat {
-        pub st_dev: c_ulong,
+        pub st_dev: crate::dev_t,
         pub st_ino: crate::ino_t,
         // According to uclibc/libc/sysdeps/linux/x86_64/bits/stat.h, order of
         // nlink and mode are swapped on 64 bit systems.
@@ -99,8 +100,9 @@ s! {
         pub st_mode: crate::mode_t,
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
-        pub st_rdev: c_ulong, // dev_t
-        pub st_size: off_t,   // file size
+        __pad0: Padding<c_int>,
+        pub st_rdev: crate::dev_t, // dev_t
+        pub st_size: crate::off_t, // file size
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
         pub st_atime: crate::time_t,
@@ -109,7 +111,7 @@ s! {
         pub st_mtime_nsec: c_ulong,
         pub st_ctime: crate::time_t,
         pub st_ctime_nsec: c_ulong,
-        st_pad4: Padding<[c_long; 3]>,
+        __uclibc_unused: Padding<[c_long; 3]>,
     }
 
     // FIXME(1.0): This should not implement `PartialEq`
@@ -129,49 +131,34 @@ s! {
     }
 
     pub struct statfs {
-        // FIXME(ulibc)
-        pub f_type: fsword_t,
-        pub f_bsize: fsword_t,
+        pub f_type: c_long,
+        pub f_bsize: c_long,
         pub f_blocks: crate::fsblkcnt_t,
         pub f_bfree: crate::fsblkcnt_t,
         pub f_bavail: crate::fsblkcnt_t,
         pub f_files: crate::fsfilcnt_t,
         pub f_ffree: crate::fsfilcnt_t,
+
         pub f_fsid: crate::fsid_t,
-        pub f_namelen: fsword_t,
-        pub f_frsize: fsword_t,
-        f_spare: Padding<[fsword_t; 5]>,
+        pub f_namelen: c_long,
+        pub f_frsize: c_long,
+        pub f_flags: c_long,
+        f_spare: Padding<[c_long; 4]>,
     }
 
     pub struct statfs64 {
-        pub f_type: c_int,
-        pub f_bsize: c_int,
+        pub f_type: c_long,
+        pub f_bsize: c_long,
         pub f_blocks: crate::fsblkcnt64_t,
         pub f_bfree: crate::fsblkcnt64_t,
         pub f_bavail: crate::fsblkcnt64_t,
         pub f_files: crate::fsfilcnt64_t,
         pub f_ffree: crate::fsfilcnt64_t,
         pub f_fsid: crate::fsid_t,
-        pub f_namelen: c_int,
-        pub f_frsize: c_int,
-        pub f_flags: c_int,
-        f_spare: Padding<[c_int; 4]>,
-    }
-
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        __f_unused: Padding<c_int>,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: Padding<[c_int; 6]>,
+        pub f_namelen: c_long,
+        pub f_frsize: c_long,
+        pub f_flags: c_long,
+        f_spare: Padding<[c_long; 4]>,
     }
 
     pub struct msghdr {


### PR DESCRIPTION
# Description

This PR adds a new `cfg` for file offset types in uClibc to ensure target
triples with a 32-bit machine word size can also have 64-bit unsuffixed file
offset types. None of these changes affect 64-bit platforms.

The LFS types continue being exposed by default in all platforms, but when the
`cfg` option is issued, they will have equivalent definitions to the unsuffixed
types.

Would like to ask @operutka, @lancethepants, @skrap and @japaric whether you
think it's worth it to add this `cfg`, you folks being or having been
maintainers for targets using uClibc. It was originally part of rust-lang/libc#5165, but got
split because our need to customize rust-lang/libc to fit upstream build options
wasn't entirely clear.

## Sources

- Upstream uclibc-ng sources showing `ino_t` defined in terms of its 64-bit
  variant, and the definition for the 64-bit variant. There's a "chain" of types
  that leads to the final type with which `ino64_t` is defined. This chain is
  made most obvious by the final type alias, which appends a `_TYPE` and
  prepends two underscores to the type identifier in question. Notice how the
  `__uquad_t` type is always defined as a 64-bit type, even on systems where
  that requires using a record type with a two-element array (32-bit per
  element).

  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/typesizes.h#L33>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/types.h#L55-L70>
- Upstream uclibc-ng sources showing `off_t` defined in terms of its 64-bit
  variant when LFS64 support and `__USE_FILE_OFFSET64` are enabled. Much like
  the above, there's a "chain" of types leading to the type whose bitwidth is
  made clear. The chain is shortened to the last few types.

  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/typesizes.h#L37>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/types.h#L109-L121>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/types.h#L55-L70>
- Upstream uclibc-ng sources showing `rlim_t` defined in terms of its 64-bit
  variant when LFS64 support and `__USE_FILE_OFFSET64` are enabled. This follows
  the same reasoning as the above.

  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/resource.h#L131-L138>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/types.h#L149-L150>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/typesizes.h#L39-L40>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/types.h#L107>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/types.h#L110-L122>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/types.h#L55-L70>
- Upstream uclibc-ng sources showing `blkcnt_t` defined in terms of its 64-bit
  variant. This follows the same reasoning as the above.

  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/include/sys/stat.h#L89-L96>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/types.h#L172-L173>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/typesizes.h#L41-L42>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/types.h#L109-L121>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/types.h#L55-L70>
- Upstream uclibc-ng sources showing `fsblckcnt_t` and `fsfilcnt_t` defined in
  terms of their 64-bit variants. This first of the below sources also includes
  references to the above types.

  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/include/sys/types.h#L233-L265>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/typesizes.h#L43-L44>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/typesizes.h#L45-L46>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/types.h#L110-L122>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/types.h#L55-L70>
- Upstream uclibc-ng sources showing how `flock` and `flock64` are independent,
  but when defined with `__USE_FILE_OFFSET64`, will end up having the same
  record layout. The second source shows how this definition can actually be
  unified across all child modules to the `uclibc` module because the fields
  that are conditionally compiled under MIPS will never be any different if
  `__USE_FILE_OFFSET64` is defined.

  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/x86_64/bits/fcntl.h#L166-L189>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/mips/bits/fcntl.h#L164-L198>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/arm/bits/fcntl.h#L152-L175>
- Upstream uclibc-ng sources showing how `statvfs` and `statvfs64` are
  independent, but like the above, have equivalent definitions when
  `__USE_FILE_OFFSET64` is defined. This also shows how there does not seem to
  be a need for the fields to be reordered depending on the system's endianness.

  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/statvfs.h#L28-L75>
- Upstream uclibc-ng sources showing how `statfs` and `statfs64` are
  independent, but like the above, have equivalent definitions when
  `__USE_FILE_OFFSET64` is defined. A bunch of field types were changed to both
  accurately reflect the upstream types used, and to add missing fields. The
  former has not been documented in full in the below sources because the types
  involved are already part of the sources cited in other list items. Some
  required special-casing in MIPS platforms has been necessary, as there were
  fields that had altogether different types. These were only ever so slightly
  tweaked for the same reasons as above. `statfs` in MIPS got unified as the
  definitions for both the o32 and N64/N32 ABIs are equivalent under
  `__USE_FILE_OFFSET64`.

  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/statfs.h#L24-L64>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/mips/bits/statfs.h#L24-L70>
- Upstream uclibc-ng sources showing the same as the above but for `stat` and
  `stat64`. There was also some special casing required in MIPS platforms,
  though the definitions for both x86_64 and arm converged. These have been kept
  in their corresponding modules because there's need for MIPS to have their own
  and it was decided against a top-level, field-specific `cfg`.

  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/common/bits/stat.h#L35-L130>
  > <https://github.com/wbx-github/uclibc-ng/blob/50c470ef4e688e6eea6fd1eff13083e4fd7b7c95/libc/sysdeps/linux/mips/bits/stat.h#L38-L214>

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] Commit messages permalink to headers for added or changed API
- [x] Placeholder or unstable values like `*LAST` or `*MAX` have the standard
  doc comment
- [ ] Tested locally (`cargo test -p libc-test --target mytarget`); especially
  relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
