### PR TITLE
ci: Select cuttlefish by target instead of a matrix env

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -236,7 +236,6 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-26-intel
           - target: x86_64-linux-android
-            env: { TEST_CUTTLEFISH: 1 }
             # Keep in sync with the Android build pinned in ci/cuttlefish-setup.sh
             artifact-tag: android17
           # FIXME: Exec format error (os error 8)

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -59,13 +59,11 @@ run() {
     mkdir -p target
 
     extra_args=()
-    if [ -n "${TEST_CUTTLEFISH:-}" ]; then
-        # Cuttlefish-based Android targets boot their virtual device inside
-        # the container (see cuttlefish-entrypoint.sh in the target's docker
-        # dir): pass the virtualization device nodes and let the entrypoint
-        # create its tap networking. It starts as root and drops to an
-        # unprivileged user matching HOST_UID for the device and the tests.
-        # Same flags as upstream's containerized Cuttlefish CI.
+    # x86_64-linux-android boots a Cuttlefish virtual device inside the
+    # container. Give it the virtualization device nodes and NET_ADMIN it needs.
+    # These are the same flags Google's android-cuttlefish project uses for its
+    # own containerized CI.
+    if [ "$run_target" = "x86_64-linux-android" ]; then
         extra_args+=(
             --device /dev/kvm
             --device /dev/net/tun


### PR DESCRIPTION
# Description:

This is a tiny follow-up to rust-lang/libc#5269 at @tgross35's request: drop the `TEST_CUTTLEFISH=1` matrix env and select Cuttlefish by matching `x86_64-linux-android` in `run-docker.sh`, like the existing musl/aarch64 target checks.

A libc-0.2 backport might be desired to get the new Android CI infra there as well, but I'll leave it up to the maintainers / reviewers to decide. 
<!-- @rustbot label +stable-nominated -->

# Sources

No library/API changes; this is test-harness and CI-only.

# Checklist

CI-only change: no `src/` or `libc-test/semver` modifications.

- [ ] ~Relevant tests in `libc-test/semver` have been updated~ (N/A)
- [ ] ~No placeholder or unstable values~ (N/A)
- [x] Tested: validated in my fork on GitHub-hosted runners. This PR's own CI run exercises it directly.

# AI disclosure

This PR was written with the help of Claude Code, but was **not** vibe-coded. I'm not a fan of vibe-coding.

I used AI to better understand the codebase myself (asked it a lot of questions), review both my code and any code generated by AI, used it especially to detect bugs and corner-cases and suggest fixes, however I very carefully reviewed & edited each code/comment lines, the commit messages and so on, until I was satisfied with the result.

Even this PR description was written entirely by myself and only reviewed by AI for errors.