### PR TITLE
Re-add `stat` definition for Vita and 3DS (to fix compilation on main)

### DIFF
--- a/etc/libc-util.py
+++ b/etc/libc-util.py
@@ -344,8 +344,6 @@ class CheckAllTargets:
         # libc problems
         ("aarch64-unknown-nto-qnx800", "libc error, unsupported arch"),
         ("aarch64.*-gnu_ilp32.*time_bits=64", "libc error, time64 mismatches"),
-        ("armv6k-nintendo-3ds", "libc error, stat missing"),
-        ("armv7-sony-vita-newlibeabihf", "libc error, stat missing"),
         ("csky.*gnu.*time_bits=64", "libc error, time64 mismatches"),
         ("i686-pc-nto-qnx700", "libc error, unsupported arch"),
         ("managarm-mlibc", "libc error, unresolved import"),

--- a/src/unix/newlib/generic.rs
+++ b/src/unix/newlib/generic.rs
@@ -1,5 +1,4 @@
 //! Common types used by most newlib platforms
-use crate::off_t;
 #[allow(unused_imports)] // needed for platforms that don't use the prelude here
 use crate::prelude::*;
 
@@ -9,6 +8,7 @@ s! {
         __val: u32,
     }
 
+    #[cfg(not(target_os = "vita"))]
     pub struct stat {
         pub st_dev: crate::dev_t,
         pub st_ino: crate::ino_t,
@@ -17,7 +17,7 @@ s! {
         pub st_uid: crate::uid_t,
         pub st_gid: crate::gid_t,
         pub st_rdev: crate::dev_t,
-        pub st_size: off_t,
+        pub st_size: crate::off_t,
         pub st_atim: crate::timespec,
         pub st_mtim: crate::timespec,
         pub st_ctim: crate::timespec,

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -265,4 +265,7 @@ extern "C" {
     pub fn gethostid() -> c_long;
 }
 
-pub use crate::unix::newlib::generic::dirent;
+pub use crate::unix::newlib::generic::{
+    dirent,
+    stat,
+};

--- a/src/unix/newlib/vita/mod.rs
+++ b/src/unix/newlib/vita/mod.rs
@@ -60,6 +60,23 @@ s! {
         pub sched_priority: c_int,
     }
 
+    pub struct stat {
+        pub st_dev: crate::dev_t,
+        pub st_ino: crate::ino_t,
+        pub st_mode: crate::mode_t,
+        pub st_nlink: crate::nlink_t,
+        pub st_uid: crate::uid_t,
+        pub st_gid: crate::gid_t,
+        pub st_rdev: crate::dev_t,
+        pub st_size: crate::off_t,
+        pub st_atime: crate::time_t,
+        pub st_mtime: crate::time_t,
+        pub st_ctime: crate::time_t,
+        pub st_blksize: crate::blksize_t,
+        pub st_blocks: crate::blkcnt_t,
+        pub st_spare4: [c_long; 2usize],
+    }
+
     #[repr(align(8))]
     pub struct dirent {
         __offset: [u8; 88],


### PR DESCRIPTION


## Description

Re-add `stat` definition for Vita and 3DS to fix compilation on main

[This comment](https://github.com/rust-lang/libc/pull/5132#discussion_r3631645349) made me realize that these targets are failing on main (and I'm one of the target maintainers for `armv7-sony-vita-newlibeabihf`).

It seems that both were broken by rust-lang/libc#5061 becasuse of a missing re-export, but at the same time it made me realize that the new definition seems incorrect for the Vita.

VitaSDK uses its own newlib fork, with its `stat` defined in https://github.com/vitasdk/newlib/blob/fbb8375870d799758e0b4358d2f1708781aa26a6/newlib/libc/sys/vita/sys/stat.h#L27-L55

For horizon, that definition is the same as the old one (and libc-0.2 one), and the discussion in rust-lang/libc#2795 implies it's correct, but I'm not sure where can we find the canonical headers for it.

## Checklist

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] Commit messages permalink to headers for added or changed API
- [X] Placeholder or unstable values like `*LAST` or `*MAX` have the standard
  doc comment
- [ ] Tested locally (`cargo test -p libc-test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

Checked locally using both `./etc/libc-util.py check-all-targets --only {target} libc` and `cargo +nightly check --target {target} -Z build-std=core` for:

- `armv7-sony-vita-newlibeabihf`
- `armv6k-nintendo-3ds`

And TYSM for maintaining `libc`!