### PR TITLE
freebsd: move `net/if_mib.h` to `src/new` module

### DIFF
--- a/src/new/freebsd/net/if_mib.rs
+++ b/src/new/freebsd/net/if_mib.rs
@@ -1,0 +1,48 @@
+//! Header: `net/if_mib.h`
+//!
+//! https://github.com/freebsd/freebsd-src/blob/86691d52a6d3796ad36ba474cf0a9493f6d99202/sys/net/if_mib.h
+
+use crate::prelude::*;
+
+/// non-interface-specific
+pub const IFMIB_SYSTEM: c_int = 1;
+/// per-interface data table
+pub const IFMIB_IFDATA: c_int = 2;
+
+/// generic stats for all kinds of ifaces
+pub const IFDATA_GENERAL: c_int = 1;
+/// specific to the type of interface
+pub const IFDATA_LINKSPECIFIC: c_int = 2;
+/// driver name and unit
+pub const IFDATA_DRIVERNAME: c_int = 3;
+
+/// number of interfaces configured
+pub const IFMIB_IFCOUNT: c_int = 1;
+
+/// functions not specific to a type of iface
+pub const NETLINK_GENERIC: c_int = 0;
+
+pub const DOT3COMPLIANCE_STATS: c_int = 1;
+pub const DOT3COMPLIANCE_COLLS: c_int = 2;
+
+pub const dot3ChipSetAMD7990: c_int = 1;
+pub const dot3ChipSetAMD79900: c_int = 2;
+pub const dot3ChipSetAMD79C940: c_int = 3;
+
+pub const dot3ChipSetIntel82586: c_int = 1;
+pub const dot3ChipSetIntel82596: c_int = 2;
+pub const dot3ChipSetIntel82557: c_int = 3;
+
+pub const dot3ChipSetNational8390: c_int = 1;
+pub const dot3ChipSetNationalSonic: c_int = 2;
+
+pub const dot3ChipSetFujitsu86950: c_int = 1;
+
+pub const dot3ChipSetDigitalDC21040: c_int = 1;
+pub const dot3ChipSetDigitalDC21140: c_int = 2;
+pub const dot3ChipSetDigitalDC21041: c_int = 3;
+pub const dot3ChipSetDigitalDC21140A: c_int = 4;
+pub const dot3ChipSetDigitalDC21142: c_int = 5;
+
+pub const dot3ChipSetWesternDigital83C690: c_int = 1;
+pub const dot3ChipSetWesternDigital83C790: c_int = 2;

--- a/src/new/freebsd/net/mod.rs
+++ b/src/new/freebsd/net/mod.rs
@@ -3,3 +3,4 @@
 //! https://github.com/freebsd/freebsd-src/tree/main/sys/net
 
 pub(crate) mod dlt;
+pub(crate) mod if_mib;

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -227,6 +227,8 @@ cfg_if! {
         pub use net::if_::*;
     } else if #[cfg(target_os = "freebsd")] {
         pub use net::dlt::*;
+        // FIXME(1.0,remove): these bindings should be left in a public submodule.
+        pub use net::if_mib::*;
         pub use netinet6::in6_var::*;
         pub use sys::file::*;
         pub use sys::ioccom::*;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -2830,51 +2830,6 @@ pub const IFDR_MSG_SIZE: c_int = 64;
 pub const IFDR_REASON_MSG: c_int = 1;
 pub const IFDR_REASON_VENDOR: c_int = 2;
 
-// sys/net/if_mib.h
-
-/// non-interface-specific
-pub const IFMIB_SYSTEM: c_int = 1;
-/// per-interface data table
-pub const IFMIB_IFDATA: c_int = 2;
-
-/// generic stats for all kinds of ifaces
-pub const IFDATA_GENERAL: c_int = 1;
-/// specific to the type of interface
-pub const IFDATA_LINKSPECIFIC: c_int = 2;
-/// driver name and unit
-pub const IFDATA_DRIVERNAME: c_int = 3;
-
-/// number of interfaces configured
-pub const IFMIB_IFCOUNT: c_int = 1;
-
-/// functions not specific to a type of iface
-pub const NETLINK_GENERIC: c_int = 0;
-
-pub const DOT3COMPLIANCE_STATS: c_int = 1;
-pub const DOT3COMPLIANCE_COLLS: c_int = 2;
-
-pub const dot3ChipSetAMD7990: c_int = 1;
-pub const dot3ChipSetAMD79900: c_int = 2;
-pub const dot3ChipSetAMD79C940: c_int = 3;
-
-pub const dot3ChipSetIntel82586: c_int = 1;
-pub const dot3ChipSetIntel82596: c_int = 2;
-pub const dot3ChipSetIntel82557: c_int = 3;
-
-pub const dot3ChipSetNational8390: c_int = 1;
-pub const dot3ChipSetNationalSonic: c_int = 2;
-
-pub const dot3ChipSetFujitsu86950: c_int = 1;
-
-pub const dot3ChipSetDigitalDC21040: c_int = 1;
-pub const dot3ChipSetDigitalDC21140: c_int = 2;
-pub const dot3ChipSetDigitalDC21041: c_int = 3;
-pub const dot3ChipSetDigitalDC21140A: c_int = 4;
-pub const dot3ChipSetDigitalDC21142: c_int = 5;
-
-pub const dot3ChipSetWesternDigital83C690: c_int = 1;
-pub const dot3ChipSetWesternDigital83C790: c_int = 2;
-
 // sys/netinet/in.h
 // Protocols (RFC 1700)
 // NOTE: These are in addition to the constants defined in src/unix/mod.rs


### PR DESCRIPTION
## Description

This PR updates rust-lang/libc#3367 by rebasing onto latest `main` and adjusting the solution
to fit the plan outlined at [^1].

[^1]: https://github.com/rust-lang/libc/pull/3201#issuecomment-4736374182

The patch itself moves the `net/if_mib.h` definitions that overlap with those of
`netlink/netlink.h` into a module of their own under the `new` module. This is
to avoid blocking future additions of `netlink.h` API, which seems more
prevalent according to the author of rust-lang/libc#3367.

This should unblock rust-lang/libc#3201.

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] Commit messages permalink to headers for added or changed API
- [x] Placeholder or unstable values like `*LAST` or `*MAX` have the standard
  doc comment
- [ ] Tested locally (`cargo test -p libc-test --target mytarget`); especially
  relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
