### PR TITLE
Fix path reolution in sandboxed build environments

### DIFF
--- a/src/new/glibc/sysdeps/nptl/mod.rs
+++ b/src/new/glibc/sysdeps/nptl/mod.rs
@@ -4,24 +4,32 @@
 //!
 //! <https://github.com/bminor/glibc/tree/master/sysdeps/nptl>
 
+#[path = "."]
 pub(crate) mod bits {
     #[cfg_attr(
-        any(
-            target_arch = "mips",
-            target_arch = "mips32r6",
-            target_arch = "mips",
-            target_arch = "mips32r6",
-        ),
-        path = "../../mips/nptl/bits/struct_mutex.rs"
+        any(target_arch = "mips", target_arch = "mips32r6",),
+        path = "../mips/nptl/bits/struct_mutex.rs"
     )]
     #[cfg_attr(
         any(target_arch = "powerpc", target_arch = "powerpc64"),
-        path = "../../powerpc/nptl/bits/struct_mutex.rs"
+        path = "../powerpc/nptl/bits/struct_mutex.rs"
     )]
-    #[cfg_attr(target_arch = "s390x", path = "../../s390/nptl/bits/struct_mutex.rs")]
+    #[cfg_attr(target_arch = "s390x", path = "../s390/nptl/bits/struct_mutex.rs")]
     #[cfg_attr(
         any(target_arch = "x86", target_arch = "x86_64"),
-        path = "../../x86/nptl/bits/struct_mutex.rs"
+        path = "../x86/nptl/bits/struct_mutex.rs"
+    )]
+    #[cfg_attr(
+        not(any(
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "powerpc",
+            target_arch = "powerpc64",
+            target_arch = "s390x",
+            target_arch = "x86",
+            target_arch = "x86_64",
+        )),
+        path = "bits/struct_mutex.rs"
     )]
     pub(crate) mod struct_mutex;
 }


### PR DESCRIPTION
## Description

This fixes an invalid relative module path resolution in src/new/glibc/sysdeps/nptl/mod.rs that causes build failures in sandboxed/hermetic build environments (e.g. Bazel, Nix, and isolated containers).
When rustc runs inside these sandboxes, calling `open()` on `sysdeps/nptl/bits/../../x86/nptl/bits/struct_mutex.rs` may fail with `ENOENT` because the bits directory may not exist.

## Checklist

- [N/A] Relevant tests in `libc-test/semver` have been updated
- [N/A] Commit messages permalink to headers for added or changed API
- [N/A] Placeholder or unstable values like `*LAST` or `*MAX` have the standard
  doc comment
- [YES] Tested locally (`cargo test -p libc-test --target mytarget`); also tested on Fuchsia CI builders
@rustbot label +stable-nominated
