### PR TITLE
add environ to unix

### DIFF
--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -597,6 +597,7 @@ dlmopen
 dlvsym
 eaccess
 endutxent
+environ
 epoll_pwait2
 ethhdr
 euidaccess

--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -1304,6 +1304,9 @@ extern "C" {
     pub fn mempcpy(dest: *mut c_void, src: *const c_void, n: size_t) -> *mut c_void;
 
     pub fn tgkill(tgid: crate::pid_t, tid: crate::pid_t, sig: c_int) -> c_int;
+
+    // glibc provides this in <unistd.h> with _GNU_SOURCE
+    pub static mut environ: *mut *mut c_char;
 }
 
 cfg_if! {


### PR DESCRIPTION
see commit messages.

- [x] `libc-test/semver/unix.txt` updated
- [x] commit messages link to POSIX exec spec
- [x] not applicable (no placeholder values)
- [x] `cargo test -p libc-test` — 15 passed

Closes rust-lang/libc#2520

@rustbot label +stable-nominated