### PR TITLE
style: run rustfmt with nightly toolchain in ci/style.py

### DIFF
--- a/ci/style.py
+++ b/ci/style.py
@@ -19,7 +19,7 @@ IGNORE_FILES = [
 def main():
     # if `CI` is set, do a check rather than overwriting
     check_only = os.getenv("CI") is not None
-    run(["rustfmt", "-V"])
+    run(["rustfmt", "+nightly", "-V"])
 
     fmt_files = []
     for dir in FMT_DIRS:
@@ -33,9 +33,9 @@ def main():
     # Run once from workspace root to get everything that wasn't handled as an
     # individual file.
     if check_only:
-        run(["cargo", "fmt", "--check"])
+        run(["cargo", "+nightly", "fmt", "--check"])
     else:
-        run(["cargo", "fmt"])
+        run(["cargo", "+nightly", "fmt"])
 
     for file in iglob("libc-test/semver/*.txt"):
         check_semver_file(Path(file))
@@ -112,7 +112,7 @@ def fmt_one(fpath: Path, check_only: bool):
 
     # Invoke rustfmt passing via stdin/stdout so we don't need to write the file. Exits
     # on failure.
-    cmd = ["rustfmt", "--config-path=.rustfmt.toml"]
+    cmd = ["rustfmt", "+nightly", "--config-path=.rustfmt.toml"]
     if check_only:
         res = check_output(cmd + ["--check"], input=text)
 


### PR DESCRIPTION
Updates the ci/style.py script to automatically invoke `rustfmt` and
`cargo fmt` with a nightly toolchain via `rustup`, so contributors don't need to
figure this out manually.

Closes rust-lang/libc#5324 