### PR TITLE
linux: select powerpc64 speed symbols by ELF ABI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ targets = [
     "powerpc64-ibm-aix",
     "powerpc64-unknown-freebsd",
     "powerpc64-unknown-linux-gnu",
+    "powerpc64-unknown-linux-gnuelfv2",
     "powerpc64-wrs-vxworks",
     "riscv32-wrs-vxworks",
     "riscv32gc-unknown-linux-musl",

--- a/build.rs
+++ b/build.rs
@@ -30,6 +30,7 @@ const ALLOWED_CFGS: &[&str] = &[
     // GNU to expose a 64-bit `time_t`.
     "gnu_time_bits64",
     "libc_deny_warnings",
+    "libc_elfv2",
     // Corresponds to `__USE_TIME_BITS64` in UAPI
     "linux_time_bits64",
     "musl_v1_2_3",
@@ -92,9 +93,12 @@ fn main() {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
     let target_abi = env::var("CARGO_CFG_TARGET_ABI").unwrap_or_default();
 
-    // FIXME(msrv): Once the MSRV is 1.78, use `cfg(target_abi = "pauthtest")`
-    // directly instead of translating it to `libc_pauthtest`. `target_abi`
-    // cannot be used directly in cfg expressions on the current MSRV.
+    // FIXME(msrv): Once the MSRV is 1.78, use `cfg(target_abi)` directly instead
+    // of translating its values. `target_abi` cannot be used directly in cfg
+    // expressions on the current MSRV.
+    if target_abi == "elfv2" {
+        set_cfg("libc_elfv2");
+    }
     if target_abi == "pauthtest" {
         set_cfg("libc_pauthtest");
     }

--- a/ci/verify-build.py
+++ b/ci/verify-build.py
@@ -189,6 +189,7 @@ TARGETS = [
     Target("powerpc-wrs-vxworks-spe", dist=False),
     Target("powerpc64-ibm-aix", dist=False),
     Target("powerpc64-unknown-freebsd", dist=False),
+    Target("powerpc64-unknown-linux-gnuelfv2", dist=False),
     Target("powerpc64-wrs-vxworks", dist=False),
     Target("riscv32-wrs-vxworks", dist=False),
     Target("riscv32gc-unknown-linux-gnu", dist=False),

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1711,7 +1711,8 @@ extern "C" {
             target_os = "linux",
             target_env = "gnu",
             target_arch = "powerpc64",
-            target_endian = "big"
+            target_endian = "big",
+            not(libc_elfv2)
         ),
         link_name = "cfgetispeed@GLIBC_2.3"
     )]
@@ -1720,7 +1721,7 @@ extern "C" {
             target_os = "linux",
             target_env = "gnu",
             target_arch = "powerpc64",
-            target_endian = "little"
+            any(target_endian = "little", libc_elfv2)
         ),
         link_name = "cfgetispeed@GLIBC_2.17"
     )]
@@ -1812,7 +1813,8 @@ extern "C" {
             target_os = "linux",
             target_env = "gnu",
             target_arch = "powerpc64",
-            target_endian = "big"
+            target_endian = "big",
+            not(libc_elfv2)
         ),
         link_name = "cfgetospeed@GLIBC_2.3"
     )]
@@ -1821,7 +1823,7 @@ extern "C" {
             target_os = "linux",
             target_env = "gnu",
             target_arch = "powerpc64",
-            target_endian = "little"
+            any(target_endian = "little", libc_elfv2)
         ),
         link_name = "cfgetospeed@GLIBC_2.17"
     )]
@@ -1913,7 +1915,8 @@ extern "C" {
             target_os = "linux",
             target_env = "gnu",
             target_arch = "powerpc64",
-            target_endian = "big"
+            target_endian = "big",
+            not(libc_elfv2)
         ),
         link_name = "cfsetispeed@GLIBC_2.3"
     )]
@@ -1922,7 +1925,7 @@ extern "C" {
             target_os = "linux",
             target_env = "gnu",
             target_arch = "powerpc64",
-            target_endian = "little"
+            any(target_endian = "little", libc_elfv2)
         ),
         link_name = "cfsetispeed@GLIBC_2.17"
     )]
@@ -2014,7 +2017,8 @@ extern "C" {
             target_os = "linux",
             target_env = "gnu",
             target_arch = "powerpc64",
-            target_endian = "big"
+            target_endian = "big",
+            not(libc_elfv2)
         ),
         link_name = "cfsetospeed@GLIBC_2.3"
     )]
@@ -2023,7 +2027,7 @@ extern "C" {
             target_os = "linux",
             target_env = "gnu",
             target_arch = "powerpc64",
-            target_endian = "little"
+            any(target_endian = "little", libc_elfv2)
         ),
         link_name = "cfsetospeed@GLIBC_2.17"
     )]
@@ -2422,7 +2426,8 @@ cfg_if! {
                     target_os = "linux",
                     target_env = "gnu",
                     target_arch = "powerpc64",
-                    target_endian = "big"
+                    target_endian = "big",
+                    not(libc_elfv2)
                 ),
                 link_name = "cfsetspeed@GLIBC_2.3"
             )]
@@ -2431,7 +2436,7 @@ cfg_if! {
                     target_os = "linux",
                     target_env = "gnu",
                     target_arch = "powerpc64",
-                    target_endian = "little"
+                    any(target_endian = "little", libc_elfv2)
                 ),
                 link_name = "cfsetspeed@GLIBC_2.17"
             )]


### PR DESCRIPTION
## Description

Starting with Rust 1.98, `powerpc64-unknown-linux-gnuelfv2` will be a
supported triple. During my attempts to try to build a bunch of projects
for this new target, though, libc failed to compile. This is because the
`cf*speed` link names assumed all big-endian powerpc64 targets use ELFv1,
which was reasonable in the past, but not anymore. Now, this uses the
target ABI to select the correct symbol versions instead.

## Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. See the pull request guidelines
for help
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md#submitting-a-pull-request>.
-->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] Commit messages permalink to headers for added or changed API
- [ ] Placeholder or unstable values like `*LAST` or `*MAX` have the standard
  doc comment
- [x] Tested locally (`cargo test -p libc-test --target mytarget`);
  especially relevant for platforms that may not be checked in CI


@rustbot label +stable-nominated
