### PR TITLE
Add __errno for newlib targets

### DIFF
--- a/libc-test/semver/espidf.txt
+++ b/libc-test/semver/espidf.txt
@@ -32,6 +32,7 @@ SIGSEGV
 SIGTERM
 SOL_SOCKET
 SOMAXCONN
+__errno
 cmsghdr
 dirent
 eventfd

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -841,6 +841,7 @@ f! {
 }
 
 extern "C" {
+    pub fn __errno() -> *mut c_int;
     pub fn getrlimit(resource: c_int, rlim: *mut crate::rlimit) -> c_int;
     pub fn setrlimit(resource: c_int, rlim: *const crate::rlimit) -> c_int;
 


### PR DESCRIPTION
newlib errno is (*__errno()) so rust needs this to read errno on newlib targets. std already links the symbol

source newlib sys/errno.h
https://github.com/eblot/newlib/blob/master/newlib/libc/include/sys/errno.h

Closes rust-lang/libc#1995
