### PR TITLE
apple: change `BPF_ALIGNMENT` to `usize`

### DIFF
--- a/src/new/apple/xnu/net/bpf.rs
+++ b/src/new/apple/xnu/net/bpf.rs
@@ -47,7 +47,7 @@ pub const DLT_ATM_RFC1483: c_uint = 11; // LLC/SNAP encapsulated atm
 pub const DLT_RAW: c_uint = 12; // raw IP
 pub const DLT_LOOP: c_uint = 108;
 
-pub const BPF_ALIGNMENT: c_int = size_of::<i32>() as c_int;
+pub const BPF_ALIGNMENT: size_t = size_of::<i32>();
 
 pub const BIOCGRSIG: c_ulong = _IOR::<c_uint>('B' as c_ulong, 114);
 pub const BIOCSRSIG: c_ulong = _IOW::<c_uint>('B' as c_ulong, 115);


### PR DESCRIPTION
# Description

The header defines `BPF_ALIGNMENT` as `sizeof(int32_t)`, which is `usize`, not `c_int`.

Breaking change for anyone matching on the current type, so no stable-nomination.

# Sources

Apple `BPF_ALIGNMENT` (`net/bpf.h`):
- https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/net/bpf.h#L126

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated (no new symbols)
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`)
