### PR TITLE
crate: clean up leftovers from pre-rustc 1.19 without `union`s

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -5781,7 +5781,6 @@ fn test_haiku(target: &str) {
             ("stat", "st_crtime_nsec") => true,
 
             // these are actually unions, but we cannot represent it well
-            ("sem_t", "named_sem_id") => true,
             ("sigaction", "sa_sigaction") => true,
             ("fpu_state", "_fpreg") => true,
             // these fields have a simplified data definition in libc

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -6178,8 +6178,6 @@ fn test_qurt(target: &str) {
             // These are compatibility stubs in libc, not from QuRT headers
             "stat" | "tm" | "timespec" | "timeval" | "itimerspec" | "dirent" | "DIR"
             | "termios" | "rlimit" | "rusage" | "flock" | "div_t" | "ldiv_t" | "lldiv_t" => true,
-            // sem_t is typedef of anonymous struct in C (no struct tag)
-            "sem_t" => true,
             _ => false,
         }
     });

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -6178,8 +6178,6 @@ fn test_qurt(target: &str) {
             // These are compatibility stubs in libc, not from QuRT headers
             "stat" | "tm" | "timespec" | "timeval" | "itimerspec" | "dirent" | "DIR"
             | "termios" | "rlimit" | "rusage" | "flock" | "div_t" | "ldiv_t" | "lldiv_t" => true,
-            // sigaction: sa_handler/sa_sigaction are a union in C but separate fields in Rust
-            "sigaction" => true,
             // sem_t is typedef of anonymous struct in C (no struct tag)
             "sem_t" => true,
             _ => false,

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4322,10 +4322,6 @@ fn test_linux(target: &str) {
                 Some(f.replace("e_nsec", ".tv_nsec"))
             }
 
-            // FIXME(linux): epoll_event.data is actually a union in C, but in Rust
-            // it is only a u64 because we only expose one field
-            // http://man7.org/linux/man-pages/man2/epoll_wait.2.html
-            ("epoll_event", "u64") => Some("data.u64".to_string()),
             // The following structs have a field called `type` in C,
             // but `type` is a Rust keyword, so these fields are translated
             // to `type_` in Rust.

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -5698,9 +5698,6 @@ fn test_haiku(target: &str) {
 
             "Elf64_Phdr" => true,
 
-            // is an union
-            "cpuid_info" => true,
-
             _ => false,
         }
     });
@@ -5787,7 +5784,6 @@ fn test_haiku(target: &str) {
             ("sem_t", "named_sem_id") => true,
             ("sigaction", "sa_sigaction") => true,
             ("fpu_state", "_fpreg") => true,
-            ("cpu_topology_node_info", "data") => true,
             // these fields have a simplified data definition in libc
             ("fpu_state", "_xmm") => true,
             ("savefpu", "_fp_ymm") => true,

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -5170,8 +5170,6 @@ fn test_linux(target: &str) {
             ("sigaction", "sa_sigaction") => true,
             // __timeval type is a patch which doesn't exist in glibc
             ("utmpx", "ut_tv") => true,
-            // sigval is actually a union, but we pretend it's a struct
-            ("sigevent", "sigev_value") => true,
             // this one is an anonymous union
             ("ff_effect", "u") => true,
             // `__exit_status` type is a patch which is absent in musl

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -1120,8 +1120,6 @@ fn test_solarish(target: &str) {
                 // expose stat.Xtim.tv_nsec fields
                 Some(field.ident().trim_end_matches("e_nsec").to_string() + ".tv_nsec")
             }
-            // epoll_event.data is a union in C; our `u64` field lives at `data.u64`
-            "epoll_event" if field.ident() == "u64" => Some("data.u64".to_string()),
             _ => None,
         }
     });

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -368,12 +368,6 @@ s! {
         sa_userdata: *mut c_void,
     }
 
-    pub struct sem_t {
-        pub type_: i32,
-        pub named_sem_id: i32, // actually a union with unnamed_sem (i32)
-        padding: Padding<[i32; 2]>,
-    }
-
     pub struct ucred {
         pub pid: crate::pid_t,
         pub uid: crate::uid_t,
@@ -496,6 +490,19 @@ s! {
         pub ut_line: [c_char; 16],
         pub ut_host: [c_char; 128],
         __ut_reserved: Padding<[c_char; 64]>,
+    }
+}
+
+s_no_extra_traits! {
+    pub struct sem_t {
+        pub type_: i32,
+        pub named_sem_id: __c_anonymous_sem_t_u,
+        padding: Padding<[i32; 2]>,
+    }
+
+    pub union __c_anonymous_sem_t_u {
+        pub named_sem_id: i32,
+        pub unnamed_sem: i32,
     }
 }
 

--- a/src/unix/solarish/illumos.rs
+++ b/src/unix/solarish/illumos.rs
@@ -48,12 +48,6 @@ s! {
         pub fi_name: [c_char; crate::FILNAME_MAX as usize],
     }
 
-    #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), repr(packed(4)))]
-    pub struct epoll_event {
-        pub events: u32,
-        pub u64: u64,
-    }
-
     pub struct utmpx {
         pub ut_user: [c_char; _UTX_USERSIZE],
         pub ut_id: [c_char; _UTX_IDSIZE],
@@ -66,6 +60,21 @@ s! {
         pub ut_pad: [c_int; _UTX_PADSIZE],
         pub ut_syslen: c_short,
         pub ut_host: [c_char; _UTX_HOSTSIZE],
+    }
+}
+
+s_no_extra_traits! {
+    #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), repr(packed(4)))]
+    pub struct epoll_event {
+        pub events: u32,
+        pub data: epoll_data,
+    }
+
+    pub union epoll_data {
+        pub ptr: *mut c_void,
+        pub fd: c_int,
+        pub u32: u32,
+        pub u64: u64,
     }
 }
 


### PR DESCRIPTION
## Description

This PR tries to address issue rust-lang/libc#1020. It cleans up a bunch of old ctest skips
over fields and types that were previously (more than six years ago) not proper
`union`s.

Note as well that `_channel_connect_attr` in QNX I couldn't check even though it
seems like it may be some left over `struct`-as-`union` type. I just coulnd't
get access to the SDK in the QNX site.

Then there's an unnamed field that is itself a `union` in Haiku targets under
`sigaction`. I've not changed that one because I don't know of a way of handling
a combination of both unnamed `union` and unnamed field.

The same applies to `cpu_topology_node_info` in Haiku targets.

For details on the rest of the changes, see the patch messages.

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] Commit messages permalink to headers for added or changed API
- [x] Placeholder or unstable values like `*LAST` or `*MAX` have the standard
  doc comment
- [ ] Tested locally (`cargo test -p libc-test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated