### PR TITLE
docs: wrap bare URLs in doc comments so `cargo doc` builds off Linux

### DIFF
--- a/src/new/apple/xnu/mod.rs
+++ b/src/new/apple/xnu/mod.rs
@@ -4,7 +4,7 @@
 
 /// Directory: `arm/`
 ///
-/// https://github.com/apple-oss-distributions/xnu/tree/main/bsd/arm
+/// <https://github.com/apple-oss-distributions/xnu/tree/main/bsd/arm>
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 pub(crate) mod arm {
     pub(crate) mod _mcontext;
@@ -12,7 +12,7 @@ pub(crate) mod arm {
 
 /// Directory: `i386/`
 ///
-/// https://github.com/apple-oss-distributions/xnu/tree/main/bsd/i386
+/// <https://github.com/apple-oss-distributions/xnu/tree/main/bsd/i386>
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub(crate) mod i386 {
     pub(crate) mod _mcontext;
@@ -22,7 +22,7 @@ pub(crate) mod mach;
 
 /// Directory: `machine/`
 ///
-/// https://github.com/apple-oss-distributions/xnu/tree/main/bsd/machine
+/// <https://github.com/apple-oss-distributions/xnu/tree/main/bsd/machine>
 pub(crate) mod machine {
     pub(crate) mod _mcontext;
 }

--- a/src/new/apple/xnu/sys/mod.rs
+++ b/src/new/apple/xnu/sys/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod ttycom;
 
 /// Directory: `sys/_types`
 ///
-/// https://github.com/apple-oss-distributions/xnu/tree/main/bsd/sys/_types
+/// <https://github.com/apple-oss-distributions/xnu/tree/main/bsd/sys/_types>
 pub(crate) mod _types {
     pub(crate) mod _ucontext;
 }

--- a/src/new/freebsd/net/dlt.rs
+++ b/src/new/freebsd/net/dlt.rs
@@ -1,6 +1,6 @@
 //! Header: `net/dlt.h`
 //!
-//! https://github.com/freebsd/freebsd-src/blob/main/sys/net/dlt.h
+//! <https://github.com/freebsd/freebsd-src/blob/main/sys/net/dlt.h>
 
 use crate::prelude::*;
 

--- a/src/new/freebsd/net/if_mib.rs
+++ b/src/new/freebsd/net/if_mib.rs
@@ -1,6 +1,6 @@
 //! Header: `net/if_mib.h`
 //!
-//! https://github.com/freebsd/freebsd-src/blob/86691d52a6d3796ad36ba474cf0a9493f6d99202/sys/net/if_mib.h
+//! <https://github.com/freebsd/freebsd-src/blob/86691d52a6d3796ad36ba474cf0a9493f6d99202/sys/net/if_mib.h>
 
 use crate::prelude::*;
 

--- a/src/new/freebsd/net/mod.rs
+++ b/src/new/freebsd/net/mod.rs
@@ -1,6 +1,6 @@
 //! Directory: `net/`
 //!
-//! https://github.com/freebsd/freebsd-src/tree/main/sys/net
+//! <https://github.com/freebsd/freebsd-src/tree/main/sys/net>
 
 pub(crate) mod dlt;
 pub(crate) mod if_mib;

--- a/src/new/freebsd/netinet6/in6_var.rs
+++ b/src/new/freebsd/netinet6/in6_var.rs
@@ -1,6 +1,6 @@
 //! Header: `netinet6/in6_var.h`
 //!
-//! https://github.com/freebsd/freebsd-src/blob/main/sys/netinet6/in6_var.h
+//! <https://github.com/freebsd/freebsd-src/blob/main/sys/netinet6/in6_var.h>
 
 use crate::prelude::*;
 use crate::sys::ioccom::*;

--- a/src/new/freebsd/netinet6/mod.rs
+++ b/src/new/freebsd/netinet6/mod.rs
@@ -1,5 +1,5 @@
 //! Directory: `netinet6/`
 //!
-//! https://github.com/freebsd/freebsd-src/tree/main/sys/netinet6
+//! <https://github.com/freebsd/freebsd-src/tree/main/sys/netinet6>
 
 pub(crate) mod in6_var;

--- a/src/new/freebsd/sys/file.rs
+++ b/src/new/freebsd/sys/file.rs
@@ -1,6 +1,6 @@
 //! Header: `sys/file.h`
 //!
-//! https://github.com/freebsd/freebsd-src/blob/main/sys/sys/file.h
+//! <https://github.com/freebsd/freebsd-src/blob/main/sys/sys/file.h>
 
 use crate::prelude::*;
 

--- a/src/new/freebsd/sys/ioccom.rs
+++ b/src/new/freebsd/sys/ioccom.rs
@@ -1,6 +1,6 @@
 //! Header: `sys/ioccom.h`
 //!
-//! https://github.com/freebsd/freebsd-src/blob/main/sys/sys/ioccom.h
+//! <https://github.com/freebsd/freebsd-src/blob/main/sys/sys/ioccom.h>
 
 use crate::prelude::*;
 

--- a/src/new/freebsd/sys/mod.rs
+++ b/src/new/freebsd/sys/mod.rs
@@ -1,6 +1,6 @@
 //! Directory: `sys/`
 //!
-//! https://github.com/freebsd/freebsd-src/tree/main/sys/sys'
+//! <https://github.com/freebsd/freebsd-src/tree/main/sys/sys>
 
 pub(crate) mod file;
 pub(crate) mod ioccom;

--- a/src/new/freebsd/sys/socket.rs
+++ b/src/new/freebsd/sys/socket.rs
@@ -1,6 +1,6 @@
 //! Header: `sys/socket.h`
 //!
-//! https://github.com/freebsd/freebsd-src/blob/main/sys/sys/socket.h
+//! <https://github.com/freebsd/freebsd-src/blob/main/sys/sys/socket.h>
 
 use crate::prelude::*;
 

--- a/src/new/netbsd/sys/mod.rs
+++ b/src/new/netbsd/sys/mod.rs
@@ -1,6 +1,6 @@
 //! Directory: `sys/`
 //!
-//! https://github.com/NetBSD/src/tree/trunk/sys/sys
+//! <https://github.com/NetBSD/src/tree/trunk/sys/sys>
 
 pub(crate) mod file;
 pub(crate) mod ipc;

--- a/src/new/openbsd/sys/mod.rs
+++ b/src/new/openbsd/sys/mod.rs
@@ -1,5 +1,5 @@
 //! Directory: `sys/`
 //!
-//! https://github.com/openbsd/src/tree/trunk/sys/sys
+//! <https://github.com/openbsd/src/tree/trunk/sys/sys>
 
 pub(crate) mod ipc;


### PR DESCRIPTION
## Description

`RUSTDOCFLAGS: -Dwarnings` is set for the whole CI workflow, but the `docs` job runs on `ubuntu-26.04`, so it only ever documents the Linux modules. Fifteen doc comments under `src/new` carry bare URLs, which rustdoc reports as `this URL is not a hyperlink` — and every one of them is in an Apple or BSD tree the Linux job never compiles. The result is that `cargo doc --workspace --no-deps` fails outright on those hosts while CI stays green.

This wraps each URL in angle brackets, the form already used elsewhere in the same directories (for example `src/new/apple/xnu/net/mod.rs` and `src/new/freebsd/netinet6/mod.rs`). It also drops a stray trailing apostrophe from the URL in `src/new/freebsd/sys/mod.rs`.

Verified with `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --target ...`, which fails on `main` and passes on this branch:

| target | `main` | this branch |
|---|---|---|
| `aarch64-apple-darwin` | 3 errors | ok |
| `x86_64-apple-darwin` | 3 errors | ok |
| `x86_64-unknown-freebsd` | 9 errors | ok |
| `x86_64-unknown-netbsd` | 1 error | ok |

The two remaining lines are in an OpenBSD module and an `i386`-gated one. Neither target has a std available locally so I could not verify them directly, but the edit is identical in form to the thirteen that are verified.

No API change, so there is nothing to add to `libc-test/semver`.

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated — n/a, no API change
- [x] Commit messages permalink to headers for added or changed API — n/a, no API change
- [x] Placeholder or unstable values like `*LAST` or `*MAX` have the standard doc comment — n/a
- [x] Tested locally (`cargo test -p libc-test --target aarch64-apple-darwin`) — passes, 7080 tests

@rustbot label +stable-nominated
