### PR TITLE
macros: Merge `f!` and `safe_f!`

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -3103,9 +3103,7 @@ f! {
     pub const unsafe fn CMSG_LEN(len: c_uint) -> c_uint {
         (CMSG_ALIGN(size_of::<cmsghdr>()) + len as size_t) as c_uint
     }
-}
 
-safe_f! {
     pub const safe fn WIFSTOPPED(status: c_int) -> bool {
         (status & 0xff) == 0x7f
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -575,6 +575,31 @@ mod tests {
         assert_eq!(PRIV_ON_1, 42u16);
     }
 
+    #[test]
+    #[deny(unused_unsafe)]
+    fn f_safety() {
+        // Enusure the created functions are safe / unsafe / const as expected
+        f! {
+            pub unsafe fn unsafe_foo() -> u32 { 100 }
+            pub const unsafe fn const_unsafe_foo() -> u32 { 101 }
+        }
+        safe_f! {
+            pub safe fn safe_foo() -> u32 { 200 }
+            pub const safe fn const_safe_foo() -> u32 { 201 }
+        }
+
+        assert_eq!(unsafe { unsafe_foo() }, 100u32);
+        assert_eq!(const { unsafe { const_unsafe_foo() } }, 101u32);
+        assert_eq!(safe_foo(), 200u32);
+        assert_eq!(const { const_safe_foo() }, 201u32);
+
+        // Check the ABI
+        let _: unsafe extern "C" fn() -> u32 = unsafe_foo;
+        let _: unsafe extern "C" fn() -> u32 = const_unsafe_foo;
+        let _: extern "C" fn() -> u32 = safe_foo;
+        let _: extern "C" fn() -> u32 = const_safe_foo;
+    }
+
     fn type_id_of_val<T: 'static>(_: &T) -> TypeId {
         TypeId::of::<T>()
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -380,36 +380,59 @@ macro_rules! c_enum {
     (@ty) => { $crate::prelude::CEnumRepr };
 }
 
-/// Define a `unsafe` function.
+/// Define a function that can be either `safe` or `unsafe` and optionally `const`. This always
+/// marks the function inline and adds `extern "C"`.
 macro_rules! f {
     ($(
+        $(#[$attr:meta])*
+        pub $(const $($const_dummy:literal)?)?
+        $(unsafe $($unsafe_dummy:literal)?)? $(safe $($safe_dummy:literal)?)?
+        fn $i:ident ($($arg:ident: $argty:ty),* $(,)?) -> $ret:ty
+            $body:block
+    )+) => {$(
+        f! {
+            @single
+            $(#[$attr])*
+            pub $(const $($const_dummy)?)?
+            $(unsafe $($unsafe_dummy)?)? $(safe $($safe_dummy)?)?
+            fn $i ($($arg: $argty),*) -> $ret
+                $body
+        }
+    )+};
+
+    (@single
         $(#[$attr:meta])*
         pub $(const $($const_dummy:literal)?)? unsafe
         fn $i:ident ($($arg:ident: $argty:ty),* $(,)?) -> $ret:ty
             $body:block
-    )+) => {$(
+    ) => {
         #[inline]
         $(#[$attr])*
         pub $(const $($const_dummy)?)? unsafe extern "C"
         fn $i ($($arg: $argty),*) -> $ret
             $body
-    )+};
-}
+    };
 
-/// Define a safe function.
-macro_rules! safe_f {
-    ($(
+    (@single
         $(#[$attr:meta])*
         pub $(const $($const_dummy:literal)?)? safe
         fn $i:ident ($($arg:ident: $argty:ty),* $(,)?) -> $ret:ty
             $body:block
-    )+) => {$(
+    ) => {
         #[inline]
         $(#[$attr])*
         pub $(const $($const_dummy)?)? extern "C"
         fn $i ($($arg: $argty),*) -> $ret
             $body
-    )+};
+    };
+
+    (@single
+        pub $(const $($const_dummy:literal)?)?
+        fn $i:ident ($($arg:ident: $argty:ty),* $(,)?) -> $ret:ty
+            $body:block
+    ) => {
+        compile_error!("either `safe` or `unsafe` must be specified");
+    };
 }
 
 /// Polyfill for std's `offset_of`.
@@ -582,8 +605,6 @@ mod tests {
         f! {
             pub unsafe fn unsafe_foo() -> u32 { 100 }
             pub const unsafe fn const_unsafe_foo() -> u32 { 101 }
-        }
-        safe_f! {
             pub safe fn safe_foo() -> u32 { 200 }
             pub const safe fn const_safe_foo() -> u32 { 201 }
         }

--- a/src/new/linux_uapi/linux/sctp.rs
+++ b/src/new/linux_uapi/linux/sctp.rs
@@ -74,9 +74,7 @@ f! {
         *flags &= !SCTP_PR_SCTP_MASK;
         *flags |= policy;
     }
-}
 
-safe_f! {
     pub const safe fn SCTP_PR_TTL_ENABLED(policy: c_int) -> bool {
         policy == SCTP_PR_SCTP_TTL
     }

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -2516,9 +2516,7 @@ f! {
         let fd = fd as usize;
         return ((*set).fds_bits[fd / bits] & (1 << (fd % bits))) != 0;
     }
-}
 
-safe_f! {
     pub const safe fn WIFSTOPPED(status: c_int) -> bool {
         (status & _W_STOPPED) != 0
     }

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -4171,9 +4171,7 @@ f! {
     pub const unsafe fn VM_MAKE_TAG(id: u8) -> u32 {
         (id as u32) << 24u32
     }
-}
 
-safe_f! {
     pub const safe fn WSTOPSIG(status: c_int) -> c_int {
         status >> 8
     }

--- a/src/unix/bsd/freebsdlike/dragonfly/mod.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly/mod.rs
@@ -1279,9 +1279,7 @@ f! {
         let (idx, offset) = ((cpu >> 6) & 3, cpu & 63);
         0 != cpuset.ary[idx] & (1 << offset)
     }
-}
 
-safe_f! {
     pub const safe fn WIFSIGNALED(status: c_int) -> bool {
         (status & 0o177) != 0o177 && (status & 0o177) != 0
     }

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs
@@ -271,7 +271,7 @@ pub const MINCORE_SUPER: c_int = 0x20;
 /// max length of devicename
 pub const SPECNAMELEN: c_int = 63;
 
-safe_f! {
+f! {
     pub const safe fn makedev(major: c_uint, minor: c_uint) -> crate::dev_t {
         let major = major as crate::dev_t;
         let minor = minor as crate::dev_t;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs
@@ -317,7 +317,7 @@ pub const KI_NSPARE_PTR: usize = 6;
 
 pub const MINCORE_SUPER: c_int = 0x20;
 
-safe_f! {
+f! {
     pub const safe fn makedev(major: c_uint, minor: c_uint) -> crate::dev_t {
         let major = major as crate::dev_t;
         let minor = minor as crate::dev_t;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs
@@ -339,7 +339,7 @@ pub const DOMAINSET_POLICY_INTERLEAVE: c_int = 4;
 
 pub const MINCORE_SUPER: c_int = 0x20;
 
-safe_f! {
+f! {
     pub const safe fn makedev(major: c_uint, minor: c_uint) -> crate::dev_t {
         let major = major as crate::dev_t;
         let minor = minor as crate::dev_t;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs
@@ -341,7 +341,7 @@ pub const DOMAINSET_POLICY_INTERLEAVE: c_int = 4;
 
 pub const MINCORE_SUPER: c_int = 0x60;
 
-safe_f! {
+f! {
     pub const safe fn makedev(major: c_uint, minor: c_uint) -> crate::dev_t {
         let major = major as crate::dev_t;
         let minor = minor as crate::dev_t;

--- a/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs
@@ -343,7 +343,7 @@ pub const DOMAINSET_POLICY_INTERLEAVE: c_int = 4;
 
 pub const MINCORE_SUPER: c_int = 0x60;
 
-safe_f! {
+f! {
     pub const safe fn makedev(major: c_uint, minor: c_uint) -> crate::dev_t {
         let major = major as crate::dev_t;
         let minor = minor as crate::dev_t;

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -4416,9 +4416,7 @@ f! {
     pub unsafe fn PROT_MAX_EXTRACT(x: c_int) -> c_int {
         (x >> 16) & (crate::PROT_READ | crate::PROT_WRITE | crate::PROT_EXEC)
     }
-}
 
-safe_f! {
     pub const safe fn WIFSIGNALED(status: c_int) -> bool {
         (status & 0o177) != 0o177 && (status & 0o177) != 0 && status != 0x13
     }

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -1436,7 +1436,7 @@ pub const POSIX_SPAWN_SETSCHEDULER: c_short = 0x08;
 pub const POSIX_SPAWN_SETSIGDEF: c_short = 0x10;
 pub const POSIX_SPAWN_SETSIGMASK: c_short = 0x20;
 
-safe_f! {
+f! {
     pub const safe fn WIFCONTINUED(status: c_int) -> bool {
         status == 0x13
     }

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -500,9 +500,7 @@ f! {
     pub unsafe fn FD_ZERO(set: *mut fd_set) -> () {
         (*set).fds_bits.fill(0);
     }
-}
 
-safe_f! {
     pub const safe fn WTERMSIG(status: c_int) -> c_int {
         status & 0o177
     }

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1858,9 +1858,7 @@ f! {
     pub unsafe fn PROT_MPROTECT_EXTRACT(x: c_int) -> c_int {
         (x >> 3) & 0x7
     }
-}
 
-safe_f! {
     pub const safe fn WSTOPSIG(status: c_int) -> c_int {
         status >> 8
     }

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1856,9 +1856,7 @@ f! {
     pub const unsafe fn CMSG_SPACE(length: c_uint) -> c_uint {
         (_ALIGN(size_of::<cmsghdr>()) + _ALIGN(length as usize)) as c_uint
     }
-}
 
-safe_f! {
     pub const safe fn WSTOPSIG(status: c_int) -> c_int {
         status >> 8
     }

--- a/src/unix/cygwin/mod.rs
+++ b/src/unix/cygwin/mod.rs
@@ -1783,9 +1783,7 @@ f! {
     pub unsafe fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
         cmsg.offset(1).cast_mut().cast()
     }
-}
 
-safe_f! {
     pub const safe fn makedev(ma: c_uint, mi: c_uint) -> dev_t {
         let ma = ma as dev_t;
         let mi = mi as dev_t;

--- a/src/unix/haiku/mod.rs
+++ b/src/unix/haiku/mod.rs
@@ -1442,9 +1442,7 @@ f! {
     pub unsafe fn FD_ZERO(set: *mut fd_set) -> () {
         (*set).fds_bits.fill(0);
     }
-}
 
-safe_f! {
     pub const safe fn WIFEXITED(status: c_int) -> bool {
         (status & !0xff) == 0
     }

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -3589,6 +3589,91 @@ f! {
     pub unsafe fn FD_ZERO(set: *mut fd_set) -> () {
         (*set).fds_bits.fill(0);
     }
+
+    pub const safe fn makedev(major: c_uint, minor: c_uint) -> crate::dev_t {
+        let major = major as crate::dev_t;
+        let minor = minor as crate::dev_t;
+        let mut dev = 0;
+        dev |= major << 8;
+        dev |= minor;
+        dev
+    }
+
+    pub const safe fn major(dev: crate::dev_t) -> c_uint {
+        ((dev >> 8) & 0xff) as c_uint
+    }
+
+    pub const safe fn minor(dev: crate::dev_t) -> c_uint {
+        (dev & 0xffff00ff) as c_uint
+    }
+
+    pub safe fn SIGRTMAX() -> c_int {
+        unsafe { __libc_current_sigrtmax() }
+    }
+
+    pub safe fn SIGRTMIN() -> c_int {
+        unsafe { __libc_current_sigrtmin() }
+    }
+
+    pub const safe fn WIFSTOPPED(status: c_int) -> bool {
+        (status & 0xff) == 0x7f
+    }
+
+    pub const safe fn WSTOPSIG(status: c_int) -> c_int {
+        (status >> 8) & 0xff
+    }
+
+    pub const safe fn WIFCONTINUED(status: c_int) -> bool {
+        status == 0xffff
+    }
+
+    pub const safe fn WIFSIGNALED(status: c_int) -> bool {
+        ((status & 0x7f) + 1) as i8 >= 2
+    }
+
+    pub const safe fn WTERMSIG(status: c_int) -> c_int {
+        status & 0x7f
+    }
+
+    pub const safe fn WIFEXITED(status: c_int) -> bool {
+        (status & 0x7f) == 0
+    }
+
+    pub const safe fn WEXITSTATUS(status: c_int) -> c_int {
+        (status >> 8) & 0xff
+    }
+
+    pub const safe fn WCOREDUMP(status: c_int) -> bool {
+        (status & 0x80) != 0
+    }
+
+    pub const safe fn W_EXITCODE(ret: c_int, sig: c_int) -> c_int {
+        (ret << 8) | sig
+    }
+
+    pub const safe fn W_STOPCODE(sig: c_int) -> c_int {
+        (sig << 8) | 0x7f
+    }
+
+    pub const safe fn QCMD(cmd: c_int, type_: c_int) -> c_int {
+        (cmd << 8) | (type_ & 0x00ff)
+    }
+
+    pub const safe fn IPOPT_COPIED(o: u8) -> u8 {
+        o & IPOPT_COPY
+    }
+
+    pub const safe fn IPOPT_CLASS(o: u8) -> u8 {
+        o & IPOPT_CLASS_MASK
+    }
+
+    pub const safe fn IPOPT_NUMBER(o: u8) -> u8 {
+        o & IPOPT_NUMBER_MASK
+    }
+
+    pub const safe fn IPTOS_ECN(x: u8) -> u8 {
+        x & crate::IPTOS_ECN_MASK
+    }
 }
 
 extern "C" {
@@ -4630,93 +4715,6 @@ extern "C" {
 
     pub fn gnu_get_libc_release() -> *const c_char;
     pub fn gnu_get_libc_version() -> *const c_char;
-}
-
-safe_f! {
-    pub const safe fn makedev(major: c_uint, minor: c_uint) -> crate::dev_t {
-        let major = major as crate::dev_t;
-        let minor = minor as crate::dev_t;
-        let mut dev = 0;
-        dev |= major << 8;
-        dev |= minor;
-        dev
-    }
-
-    pub const safe fn major(dev: crate::dev_t) -> c_uint {
-        ((dev >> 8) & 0xff) as c_uint
-    }
-
-    pub const safe fn minor(dev: crate::dev_t) -> c_uint {
-        (dev & 0xffff00ff) as c_uint
-    }
-
-    pub safe fn SIGRTMAX() -> c_int {
-        unsafe { __libc_current_sigrtmax() }
-    }
-
-    pub safe fn SIGRTMIN() -> c_int {
-        unsafe { __libc_current_sigrtmin() }
-    }
-
-    pub const safe fn WIFSTOPPED(status: c_int) -> bool {
-        (status & 0xff) == 0x7f
-    }
-
-    pub const safe fn WSTOPSIG(status: c_int) -> c_int {
-        (status >> 8) & 0xff
-    }
-
-    pub const safe fn WIFCONTINUED(status: c_int) -> bool {
-        status == 0xffff
-    }
-
-    pub const safe fn WIFSIGNALED(status: c_int) -> bool {
-        ((status & 0x7f) + 1) as i8 >= 2
-    }
-
-    pub const safe fn WTERMSIG(status: c_int) -> c_int {
-        status & 0x7f
-    }
-
-    pub const safe fn WIFEXITED(status: c_int) -> bool {
-        (status & 0x7f) == 0
-    }
-
-    pub const safe fn WEXITSTATUS(status: c_int) -> c_int {
-        (status >> 8) & 0xff
-    }
-
-    pub const safe fn WCOREDUMP(status: c_int) -> bool {
-        (status & 0x80) != 0
-    }
-
-    pub const safe fn W_EXITCODE(ret: c_int, sig: c_int) -> c_int {
-        (ret << 8) | sig
-    }
-
-    pub const safe fn W_STOPCODE(sig: c_int) -> c_int {
-        (sig << 8) | 0x7f
-    }
-
-    pub const safe fn QCMD(cmd: c_int, type_: c_int) -> c_int {
-        (cmd << 8) | (type_ & 0x00ff)
-    }
-
-    pub const safe fn IPOPT_COPIED(o: u8) -> u8 {
-        o & IPOPT_COPY
-    }
-
-    pub const safe fn IPOPT_CLASS(o: u8) -> u8 {
-        o & IPOPT_CLASS_MASK
-    }
-
-    pub const safe fn IPOPT_NUMBER(o: u8) -> u8 {
-        o & IPOPT_NUMBER_MASK
-    }
-
-    pub const safe fn IPTOS_ECN(x: u8) -> u8 {
-        x & crate::IPTOS_ECN_MASK
-    }
 }
 
 cfg_if! {

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -3488,9 +3488,7 @@ f! {
     pub unsafe fn SO_EE_OFFENDER(ee: *const crate::sock_extended_err) -> *mut crate::sockaddr {
         ee.offset(1) as *mut crate::sockaddr
     }
-}
 
-safe_f! {
     pub const safe fn makedev(ma: c_uint, mi: c_uint) -> crate::dev_t {
         let ma = ma as crate::dev_t;
         let mi = mi as crate::dev_t;

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -1301,9 +1301,7 @@ f! {
     pub unsafe fn CPU_EQUAL(set1: &cpu_set_t, set2: &cpu_set_t) -> bool {
         set1.bits == set2.bits
     }
-}
 
-safe_f! {
     pub const safe fn makedev(major: c_uint, minor: c_uint) -> crate::dev_t {
         let major = major as crate::dev_t;
         let minor = minor as crate::dev_t;

--- a/src/unix/linux_like/linux_l4re_shared.rs
+++ b/src/unix/linux_like/linux_l4re_shared.rs
@@ -1562,9 +1562,7 @@ f! {
     pub unsafe fn ELF64_R_INFO(sym: Elf64_Xword, t: Elf64_Xword) -> Elf64_Xword {
         sym << (32 + t)
     }
-}
 
-safe_f! {
     pub const safe fn makedev(major: c_uint, minor: c_uint) -> crate::dev_t {
         let major = major as crate::dev_t;
         let minor = minor as crate::dev_t;

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -1855,9 +1855,7 @@ f! {
     pub unsafe fn FD_ZERO(set: *mut fd_set) -> () {
         (*set).fds_bits.fill(0);
     }
-}
 
-safe_f! {
     pub safe fn SIGRTMAX() -> c_int {
         unsafe { __libc_current_sigrtmax() }
     }

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -432,6 +432,23 @@ cfg_if! {
     }
 }
 
+f! {
+    // It seems htonl, etc are macros on macOS. So we have to reimplement them. So let's
+    // reimplement them for all UNIX platforms
+    pub const safe fn htonl(hostlong: u32) -> u32 {
+        u32::to_be(hostlong)
+    }
+    pub const safe fn htons(hostshort: u16) -> u16 {
+        u16::to_be(hostshort)
+    }
+    pub const safe fn ntohl(netlong: u32) -> u32 {
+        u32::from_be(netlong)
+    }
+    pub const safe fn ntohs(netshort: u16) -> u16 {
+        u16::from_be(netshort)
+    }
+}
+
 extern "C" {
     pub static in6addr_loopback: in6_addr;
     pub static in6addr_any: in6_addr;
@@ -2136,23 +2153,6 @@ extern "C" {
     #[cfg_attr(gnu_file_offset_bits64, link_name = "lockf64")]
     pub fn lockf(fd: c_int, cmd: c_int, len: off_t) -> c_int;
 
-}
-
-safe_f! {
-    // It seems htonl, etc are macros on macOS. So we have to reimplement them. So let's
-    // reimplement them for all UNIX platforms
-    pub const safe fn htonl(hostlong: u32) -> u32 {
-        u32::to_be(hostlong)
-    }
-    pub const safe fn htons(hostshort: u16) -> u16 {
-        u16::to_be(hostshort)
-    }
-    pub const safe fn ntohl(netlong: u32) -> u32 {
-        u32::from_be(netlong)
-    }
-    pub const safe fn ntohs(netshort: u16) -> u16 {
-        u16::from_be(netshort)
-    }
 }
 
 cfg_if! {

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -174,7 +174,7 @@ pub const GRND_NONBLOCK: c_uint = 0x1;
 pub const GRND_RANDOM: c_uint = 0x2;
 
 // Horizon OS works doesn't or can't hold any of this information
-safe_f! {
+f! {
     pub const safe fn WIFSTOPPED(_status: c_int) -> bool {
         false
     }

--- a/src/unix/newlib/rtems/mod.rs
+++ b/src/unix/newlib/rtems/mod.rs
@@ -86,7 +86,7 @@ pub const WUNTRACED: c_int = 2;
 // sys/socket.h
 pub const SOMAXCONN: c_int = 128;
 
-safe_f! {
+f! {
     pub const safe fn WIFSTOPPED(status: c_int) -> bool {
         (status & 0xff) == 0x7f
     }

--- a/src/unix/nto/mod.rs
+++ b/src/unix/nto/mod.rs
@@ -2342,9 +2342,7 @@ f! {
         let ngrps = if ngrps > 0 { ngrps - 1 } else { 0 };
         size_of::<sockcred>() + size_of::<crate::gid_t>() * ngrps
     }
-}
 
-safe_f! {
     pub const safe fn WIFSTOPPED(status: c_int) -> bool {
         (status & 0xff) == 0x7f
     }

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -1149,9 +1149,7 @@ f! {
     pub unsafe fn FD_ZERO(set: *mut fd_set) -> () {
         (*set).fds_bits.fill(0);
     }
-}
 
-safe_f! {
     pub const safe fn WIFSTOPPED(status: c_int) -> bool {
         (status & 0xff) == 0x7f
     }

--- a/src/unix/solarish/mod.rs
+++ b/src/unix/solarish/mod.rs
@@ -2275,9 +2275,7 @@ f! {
     pub unsafe fn FD_ZERO(set: *mut fd_set) -> () {
         (*set).fds_bits.fill(0);
     }
-}
 
-safe_f! {
     pub safe fn SIGRTMAX() -> c_int {
         unsafe { crate::sysconf(_SC_SIGRT_MAX) as c_int }
     }

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -1492,6 +1492,30 @@ f! {
     pub const unsafe fn CMSG_LEN(length: c_uint) -> c_uint {
         CMSG_ALIGN(size_of::<cmsghdr>()) as c_uint + length
     }
+
+    // Dummy functions, these don't really exist in VxWorks.
+    // wait.h macros
+    pub const safe fn WIFEXITED(status: c_int) -> bool {
+        (status & 0xFF00) == 0
+    }
+    pub const safe fn WIFSIGNALED(status: c_int) -> bool {
+        (status & 0xFF00) != 0
+    }
+    pub const safe fn WIFSTOPPED(status: c_int) -> bool {
+        (status & 0xFF0000) != 0
+    }
+    pub const safe fn WEXITSTATUS(status: c_int) -> c_int {
+        status & 0xFF
+    }
+    pub const safe fn WIFCONTINUED(status: c_int) -> c_int {
+        (status >> 24) & 0xFF
+    }
+    pub const safe fn WTERMSIG(status: c_int) -> c_int {
+        (status >> 8) & 0xFF
+    }
+    pub const safe fn WSTOPSIG(status: c_int) -> c_int {
+        (status >> 16) & 0xFF
+    }
 }
 
 extern "C" {
@@ -2404,33 +2428,6 @@ extern "C" {
     // vxCpuLib.h
     pub fn vxCpuEnabledGet() -> crate::cpuset_t; // Get set of running CPU's in the system
     pub fn vxCpuConfiguredGet() -> crate::cpuset_t; // Get set of Configured CPU's in the system
-}
-
-//Dummy functions, these don't really exist in VxWorks.
-
-// wait.h macros
-safe_f! {
-    pub const safe fn WIFEXITED(status: c_int) -> bool {
-        (status & 0xFF00) == 0
-    }
-    pub const safe fn WIFSIGNALED(status: c_int) -> bool {
-        (status & 0xFF00) != 0
-    }
-    pub const safe fn WIFSTOPPED(status: c_int) -> bool {
-        (status & 0xFF0000) != 0
-    }
-    pub const safe fn WEXITSTATUS(status: c_int) -> c_int {
-        status & 0xFF
-    }
-    pub const safe fn WIFCONTINUED(status: c_int) -> c_int {
-        (status >> 24) & 0xFF
-    }
-    pub const safe fn WTERMSIG(status: c_int) -> c_int {
-        (status >> 8) & 0xFF
-    }
-    pub const safe fn WSTOPSIG(status: c_int) -> c_int {
-        (status >> 16) & 0xFF
-    }
 }
 
 pub unsafe fn posix_memalign(memptr: *mut *mut c_void, align: size_t, size: size_t) -> c_int {


### PR DESCRIPTION

Now that we have separate `safe` and `unsafe` syntax, there isn't much
reason to keep the macros split.