### PR TITLE
Add `pthread_gettid_np` for Android and glibc

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -5090,6 +5090,8 @@ fn test_linux(target: &str) {
             "posix_spawn_file_actions_addclosefrom_np" if gnu && sparc64 => true,
             // Needs glibc 2.35 or later.
             "posix_spawn_file_actions_addtcsetpgrp_np" if gnu && sparc64 => true,
+            // Needs glibc 2.42 or later.
+            "pthread_gettid_np" if gnu && versions.glibc.unwrap() < (2, 42) => true,
 
             // FIXME(linux): Deprecated since glibc 2.30. Remove fn once upstream does.
             "sysctl" if gnu => true,

--- a/libc-test/semver/android.txt
+++ b/libc-test/semver/android.txt
@@ -3829,6 +3829,7 @@ pthread_getattr_np
 pthread_getcpuclockid
 pthread_getschedparam
 pthread_getspecific
+pthread_gettid_np
 pthread_join
 pthread_key_create
 pthread_key_delete

--- a/libc-test/semver/linux-gnu.txt
+++ b/libc-test/semver/linux-gnu.txt
@@ -659,6 +659,7 @@ process_vm_readv
 process_vm_writev
 pthread_attr_getaffinity_np
 pthread_attr_setaffinity_np
+pthread_gettid_np
 pthread_rwlockattr_getkind_np
 pthread_rwlockattr_getpshared
 pthread_rwlockattr_setkind_np

--- a/src/new/bionic_libc/pthread.rs
+++ b/src/new/bionic_libc/pthread.rs
@@ -2,6 +2,7 @@
 
 pub use crate::new::common::linux_like::pthread::{
     pthread_getattr_np,
+    pthread_gettid_np,
     pthread_setname_np,
 };
 pub use crate::new::common::posix::pthread::{

--- a/src/new/common/linux_like/pthread.rs
+++ b/src/new/common/linux_like/pthread.rs
@@ -13,6 +13,9 @@ extern "C" {
     #[cfg(target_os = "linux")]
     pub fn pthread_getname_np(thread: crate::pthread_t, name: *mut c_char, len: size_t) -> c_int;
 
+    #[cfg(any(target_os = "android", all(target_os = "linux", target_env = "gnu")))]
+    pub fn pthread_gettid_np(thread: crate::pthread_t) -> crate::pid_t;
+
     #[cfg(any(target_os = "linux", target_os = "l4re"))]
     pub fn pthread_setaffinity_np(
         thread: crate::pthread_t,

--- a/src/new/glibc/sysdeps/nptl/pthread.rs
+++ b/src/new/glibc/sysdeps/nptl/pthread.rs
@@ -28,6 +28,7 @@ pub use crate::new::common::linux_like::pthread::{
     pthread_getaffinity_np,
     pthread_getattr_np,
     pthread_getname_np,
+    pthread_gettid_np,
     pthread_setaffinity_np,
     pthread_setname_np,
 };


### PR DESCRIPTION
Link: https://github.com/bminor/glibc/blob/d2097651cc57834dbfcaa102ddfacae0d86cfb66/sysdeps/nptl/pthread.h#L1320-L1322
Link: https://android.googlesource.com/platform/bionic/+/731631f300090436d7f5df80d50b6275c8c60a93/libc/include/pthread.h#173

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md> -->

## Description

<!-- Add a short description about what this change does, or say "See commit
messages" if details are there. -->

Returns the Linux TID for a given thread, unlike `gettid`, which only returns the id of the calling thread.

This is useful for std in the thread spawn path: the parent can set the TID of the child it just created, whereas today the TID can only be read once the child itself starts running.

This came up while working on rust-lang/rust#160219, which fills the TID when the child starts running and explains what's missing to fill it from the parent right after creation.

libc already carries a by-handle TID query for [Apple](https://github.com/rust-lang/libc/blob/4ef1831337bab5d3663fdb328b03c6b247e897ec/src/unix/bsd/apple/mod.rs#L4348)

pthread_gettid_np was added in glibc [2.42+](https://sourceware.org/bugzilla/show_bug.cgi?id=27880); on Android it has been available since API level 21.

## Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. See the pull request guidelines
for help
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md#submitting-a-pull-request>.
-->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] Commit messages permalink to headers for added or changed API
- [x] Placeholder or unstable values like `*LAST` or `*MAX` have the standard
  doc comment - not applicable
- [x] Tested locally (`cargo test -p libc-test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If it is, delete the following
line: -->
@rustbot label +stable-nominated
