### PR TITLE
redox: clock_settime, pause

### DIFF
--- a/libc-test/semver/redox.txt
+++ b/libc-test/semver/redox.txt
@@ -301,6 +301,7 @@ chroot
 clearerr
 clock_getres
 clock_gettime
+clock_settime
 difftime
 dirfd
 endgrent
@@ -353,6 +354,7 @@ open_memstream
 open_wmemstream
 openat
 openpty
+pause
 pipe2
 pthread_condattr_setclock
 qsort

--- a/libc-test/semver/redox.txt
+++ b/libc-test/semver/redox.txt
@@ -301,6 +301,7 @@ chroot
 clearerr
 clock_getres
 clock_gettime
+clock_settime
 difftime
 dirfd
 endgrent
@@ -346,6 +347,7 @@ open_memstream
 open_wmemstream
 openat
 openpty
+pause
 pipe2
 pthread_condattr_setclock
 qsort

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1180,6 +1180,11 @@ extern "C" {
     #[cfg_attr(gnu_file_offset_bits64, link_name = "lseek64")]
     pub fn lseek(fd: c_int, offset: off_t, whence: c_int) -> off_t;
     pub fn pathconf(path: *const c_char, name: c_int) -> c_long;
+    #[cfg_attr(
+        all(target_os = "macos", target_arch = "x86"),
+        link_name = "pause$UNIX2003"
+    )]
+    pub fn pause() -> c_int;
     pub fn pipe(fds: *mut c_int) -> c_int;
     pub fn posix_memalign(memptr: *mut *mut c_void, align: size_t, size: size_t) -> c_int;
     pub fn aligned_alloc(alignment: size_t, size: size_t) -> *mut c_void;
@@ -2256,11 +2261,6 @@ cfg_if! {
     if #[cfg(not(target_os = "redox"))] {
         extern "C" {
             pub fn getsid(pid: pid_t) -> pid_t;
-            #[cfg_attr(
-                all(target_os = "macos", target_arch = "x86"),
-                link_name = "pause$UNIX2003"
-            )]
-            pub fn pause() -> c_int;
             #[cfg_attr(
                 all(target_os = "macos", any(target_arch = "x86", target_arch = "x86_64")),
                 link_name = "readdir_r$INODE64"

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1157,6 +1157,11 @@ extern "C" {
     #[cfg_attr(gnu_file_offset_bits64, link_name = "lseek64")]
     pub fn lseek(fd: c_int, offset: off_t, whence: c_int) -> off_t;
     pub fn pathconf(path: *const c_char, name: c_int) -> c_long;
+    #[cfg_attr(
+        all(target_os = "macos", target_arch = "x86"),
+        link_name = "pause$UNIX2003"
+    )]
+    pub fn pause() -> c_int;
     pub fn pipe(fds: *mut c_int) -> c_int;
     pub fn posix_memalign(memptr: *mut *mut c_void, align: size_t, size: size_t) -> c_int;
     pub fn aligned_alloc(alignment: size_t, size: size_t) -> *mut c_void;
@@ -2247,11 +2252,6 @@ cfg_if! {
     if #[cfg(not(target_os = "redox"))] {
         extern "C" {
             pub fn getsid(pid: pid_t) -> pid_t;
-            #[cfg_attr(
-                all(target_os = "macos", target_arch = "x86"),
-                link_name = "pause$UNIX2003"
-            )]
-            pub fn pause() -> c_int;
             #[cfg_attr(
                 all(target_os = "macos", not(target_arch = "aarch64")),
                 link_name = "readdir_r$INODE64"

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -1443,6 +1443,7 @@ extern "C" {
     pub fn gettimeofday(tp: *mut crate::timeval, tz: *mut crate::timezone) -> c_int;
     pub fn clock_getres(clk_id: crate::clockid_t, tp: *mut crate::timespec) -> c_int;
     pub fn clock_gettime(clk_id: crate::clockid_t, tp: *mut crate::timespec) -> c_int;
+    pub fn clock_settime(clk_id: crate::clockid_t, tp: *mut crate::timespec) -> c_int;
     pub fn strftime(
         s: *mut c_char,
         max: size_t,

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -1443,6 +1443,7 @@ extern "C" {
     pub fn gettimeofday(tp: *mut crate::timeval, tz: *mut crate::timezone) -> c_int;
     pub fn clock_getres(clk_id: crate::clockid_t, tp: *mut crate::timespec) -> c_int;
     pub fn clock_gettime(clk_id: crate::clockid_t, tp: *mut crate::timespec) -> c_int;
+    pub fn clock_settime(clk_id: crate::clockid_t, tp: *const crate::timespec) -> c_int;
     pub fn strftime(
         s: *mut c_char,
         max: size_t,


### PR DESCRIPTION
Related: bytecodealliance/rustix#1638

Sources:
* [clock_settime](https://gitlab.redox-os.org/redox-os/relibc/-/blob/3628bf4677029f0a3186f7d859789a573c47a334/src/header/time/mod.rs#L301)
* [pause](https://gitlab.redox-os.org/redox-os/relibc/-/blob/b3d55c929ed11f276310b32659d0171e063b8448/src/header/unistd/mod.rs#L851)

<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md> -->

## Description

I unmasked `clock_settime` and `pause` on Redox as both have been supported for a while.

<!-- Add a short description about what this change does, or say "See commit
messages" if details are there. -->

## Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. See the pull request guidelines
for help
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md#submitting-a-pull-request>.
-->

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] Commit messages permalink to headers for added or changed API
- [x] Placeholder or unstable values like `*LAST` or `*MAX` have the standard
  doc comment
- [x] Tested locally (`cargo test -p libc-test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If it is, delete the following
line: -->
@rustbot label +stable-nominated

