### PR TITLE
docs: update source links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ Please include permalinks to headers in commit messages for all API changes.
 Common sources include:
 
 * Linux uapi: https://github.com/torvalds/linux/tree/master/include/uapi
-* Glibc: https://sourceware.org/git/?p=glibc.git;a=tree
+* Glibc: https://github.com/sailfishos-mirror/glibc (original is https://sourceware.org/git/?p=glibc.git;a=tree)
 * Musl: https://github.com/kraj/musl (original is https://git.musl-libc.org/cgit/musl/tree/)
 * Apple XNU: https://github.com/apple-oss-distributions/xnu, libc https://github.com/apple-oss-distributions/Libc/tree/main/include
 * Android: https://cs.android.com/android/platform/superproject/main

--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -4923,7 +4923,7 @@ fn test_linux(target: &str) {
             "PR_SME_VL_LEN_MAX" | "PR_SME_SET_VL_INHERIT" | "PR_SME_SET_VL_ONE_EXEC" if gnu => true,
 
             // FIXME(linux): The below is no longer const in glibc 2.34:
-            // https://github.com/bminor/glibc/commit/5d98a7dae955bafa6740c26eaba9c86060ae0344
+            // https://github.com/sailfishos-mirror/glibc/commit/5d98a7dae955bafa6740c26eaba9c86060ae0344
             "PTHREAD_STACK_MIN" | "SIGSTKSZ" | "MINSIGSTKSZ" if gnu => true,
 
             // value changed

--- a/src/new/glibc/mod.rs
+++ b/src/new/glibc/mod.rs
@@ -1,21 +1,21 @@
 //! GNU libc.
 //!
 //! * Headers: <https://sourceware.org/git/?p=glibc.git> (official)
-//! * Headers: <https://github.com/bminor/glibc> (mirror)
+//! * Headers: <https://github.com/sailfishos-mirror/glibc> (mirror)
 //!
 //! This module structure is modeled after glibc's source tree. Its build system selects headers
 //! from different locations based on the platform, which we mimic here with reexports.
 
 /// Source directory: `posix/`
 ///
-/// <https://github.com/bminor/glibc/tree/master/posix>
+/// <https://github.com/sailfishos-mirror/glibc/tree/master/posix>
 mod posix {
     pub(crate) mod unistd;
 }
 
 /// Source directory: `sysdeps/`
 ///
-/// <https://github.com/bminor/glibc/tree/master/sysdeps>
+/// <https://github.com/sailfishos-mirror/glibc/tree/master/sysdeps>
 mod sysdeps {
     // FIXME(pthread): eventually all platforms should use this module
     #[cfg(target_os = "linux")]

--- a/src/new/glibc/posix/unistd.rs
+++ b/src/new/glibc/posix/unistd.rs
@@ -1,6 +1,6 @@
 //! Header: `unistd.h`
 //!
-//! <https://github.com/bminor/glibc/blob/master/posix/unistd.h>
+//! <https://github.com/sailfishos-mirror/glibc/blob/master/posix/unistd.h>
 
 pub use crate::new::common::posix::unistd::{
     STDERR_FILENO,

--- a/src/new/glibc/sysdeps/nptl/mod.rs
+++ b/src/new/glibc/sysdeps/nptl/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Native POSIX threading library.
 //!
-//! <https://github.com/bminor/glibc/tree/master/sysdeps/nptl>
+//! <https://github.com/sailfishos-mirror/glibc/tree/master/sysdeps/nptl>
 
 pub(crate) mod bits {
     #[cfg_attr(

--- a/src/new/glibc/sysdeps/nptl/pthread.rs
+++ b/src/new/glibc/sysdeps/nptl/pthread.rs
@@ -1,6 +1,6 @@
 //! Source header: `sysdeps/nptl/pthread.h`
 //!
-//! <https://github.com/bminor/glibc/blob/master/sysdeps/nptl/pthread.h>
+//! <https://github.com/sailfishos-mirror/glibc/blob/master/sysdeps/nptl/pthread.h>
 
 use super::bits::struct_mutex::*;
 use crate::prelude::*;

--- a/src/new/glibc/sysdeps/unix/linux/mod.rs
+++ b/src/new/glibc/sysdeps/unix/linux/mod.rs
@@ -1,6 +1,6 @@
 //! Source directory: `sysdeps/unix/sysv/linux` (the `sysv` is flattened).
 //!
-//! <https://github.com/bminor/glibc/tree/master/sysdeps/unix/sysv/linux>
+//! <https://github.com/sailfishos-mirror/glibc/tree/master/sysdeps/unix/sysv/linux>
 
 /// Directory: `net/`
 ///

--- a/src/new/glibc/sysdeps/unix/linux/net/route.rs
+++ b/src/new/glibc/sysdeps/unix/linux/net/route.rs
@@ -1,7 +1,7 @@
 //! Header: `net/route.h`
 //!
 //! Source header: `sysdeps/unix/sysv/linux/net/route.h`
-//! <https://github.com/bminor/glibc/blob/master/sysdeps/unix/sysv/linux/net/route.h>
+//! <https://github.com/sailfishos-mirror/glibc/blob/master/sysdeps/unix/sysv/linux/net/route.h>
 
 use crate::prelude::*;
 

--- a/src/new/glibc/sysdeps/unix/mod.rs
+++ b/src/new/glibc/sysdeps/unix/mod.rs
@@ -1,6 +1,6 @@
 //! Source directory: `sysdeps/unix/`
 //!
-//! <https://github.com/bminor/glibc/tree/master/sysdeps/unix>
+//! <https://github.com/sailfishos-mirror/glibc/tree/master/sysdeps/unix>
 
 #[cfg(target_os = "linux")]
 pub(crate) mod linux;

--- a/src/new/musl/arch/generic/mod.rs
+++ b/src/new/musl/arch/generic/mod.rs
@@ -1,6 +1,7 @@
 //! Source directory: `arch/generic/`
 //!
-//! <https://github.com/kraj/musl/tree/master/arch/generic>
+//! * Headers: <https://git.musl-libc.org/cgit/musl/tree/arch/generic> (official)
+//! * Headers: <https://github.com/kraj/musl/tree/master/arch/generic> (mirror)
 
 pub(crate) mod bits {
     // Currently unused

--- a/src/new/musl/arch/mips/mod.rs
+++ b/src/new/musl/arch/mips/mod.rs
@@ -1,6 +1,7 @@
 //! Source directory: `arch/mips/`
 //!
-//! <https://github.com/kraj/musl/tree/master/arch/mips>
+//! * Headers: <https://git.musl-libc.org/cgit/musl/tree/arch/mips> (official)
+//! * Headers: <https://github.com/kraj/musl/tree/master/arch/mips> (mirror)
 
 pub(crate) mod bits {
     pub(crate) mod socket;

--- a/src/new/musl/arch/mips64/mod.rs
+++ b/src/new/musl/arch/mips64/mod.rs
@@ -1,6 +1,7 @@
 //! Source directory: `arch/mips64/`
 //!
-//! <https://github.com/kraj/musl/tree/master/arch/mips64>
+//! * Headers: <https://git.musl-libc.org/cgit/musl/tree/arch/mips64> (official)
+//! * Headers: <https://github.com/kraj/musl/tree/master/arch/mips64> (mirror)
 
 pub(crate) mod bits {
     pub(crate) mod socket;

--- a/src/new/musl/arch/mod.rs
+++ b/src/new/musl/arch/mod.rs
@@ -1,6 +1,7 @@
 //! Source directory: `arch/`
 //!
-//! <https://github.com/kraj/musl/tree/master/arch>
+//! * Headers: <https://git.musl-libc.org/cgit/musl/tree/arch> (official)
+//! * Headers: <https://github.com/kraj/musl/tree/master/arch> (mirror)
 
 pub(crate) mod generic;
 

--- a/src/new/musl/mod.rs
+++ b/src/new/musl/mod.rs
@@ -24,7 +24,8 @@ pub(crate) mod pthread;
 
 /// Directory: `sys/`
 ///
-/// <https://github.com/kraj/musl/tree/kraj/master/include/sys>
+/// * Headers: <https://git.musl-libc.org/cgit/musl/tree/include/sys> (official)
+/// * Headers: <https://github.com/kraj/musl/tree/master/include/sys> (mirror)
 pub(crate) mod sys {
     pub(crate) mod socket;
 }

--- a/src/new/musl/pthread.rs
+++ b/src/new/musl/pthread.rs
@@ -1,6 +1,7 @@
 //! Header: `pthread.h`
 //!
-//! <https://github.com/kraj/musl/blob/kraj/master/include/pthread.h>
+//! * Headers: <https://git.musl-libc.org/cgit/musl/blob/include/pthread.h> (official)
+//! * Headers: <https://github.com/kraj/musl/blob/master/include/pthread.h> (mirror)
 
 pub use crate::new::common::linux_like::pthread::{
     pthread_getaffinity_np,

--- a/src/new/musl/sys/socket.rs
+++ b/src/new/musl/sys/socket.rs
@@ -1,6 +1,7 @@
 //! Header: `sys/socket.h`
 //!
-//! <https://github.com/kraj/musl/blob/kraj/master/include/sys/socket.h>
+//! * Headers: <https://git.musl-libc.org/cgit/musl/blob/arch/include/sys/socket.h> (official)
+//! * Headers: <https://github.com/kraj/musl/blob/kraj/master/include/sys/socket.h> (mirror)
 
 use crate::prelude::*;
 

--- a/src/new/redox/mod.rs
+++ b/src/new/redox/mod.rs
@@ -1,3 +1,4 @@
 //! Redox libc.
 //!
-//! * Headers: <https://gitlab.redox-os.org/redox-os/relibc>
+//! * Headers: <https://gitlab.redox-os.org/redox-os/relibc> (official)
+//! * Headers: <https://github.com/redox-os/relibc> (mirror)

--- a/src/new/relibc/mod.rs
+++ b/src/new/relibc/mod.rs
@@ -1,5 +1,6 @@
 //! Redox OS libc.
 //!
-//! * Headers: <https://gitlab.redox-os.org/redox-os/relibc>
+//! * Headers: <https://gitlab.redox-os.org/redox-os/relibc> (official)
+//! * Headers: <https://github.com/redox-os/relibc> (mirror)
 
 pub(crate) mod unistd;


### PR DESCRIPTION
The https://github.com/bminor/glibc mirror was archived on February 15, 2026. This updates the affected links to point to the active https://github.com/sailfishos-mirror/glibc mirror instead.

@rustbot label +stable-nominated
