### PR TITLE
freebsd: add `rt_msghdr` and `rt_metrics`

### DIFF
--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -2314,6 +2314,8 @@ regfree
 register_t
 regmatch_t
 regoff_t
+rt_metrics
+rt_msghdr
 rtprio
 rtprio_thread
 sallocx

--- a/src/new/freebsd/net/mod.rs
+++ b/src/new/freebsd/net/mod.rs
@@ -4,3 +4,4 @@
 
 pub(crate) mod dlt;
 pub(crate) mod if_mib;
+pub(crate) mod route;

--- a/src/new/freebsd/net/route.rs
+++ b/src/new/freebsd/net/route.rs
@@ -1,0 +1,39 @@
+//! Header: `net/route.h`
+//!
+//! <https://github.com/freebsd/freebsd-src/blob/main/sys/net/route.h>
+
+use crate::prelude::*;
+
+s_with_default! {
+    pub struct rt_metrics {
+        pub rmx_locks: c_ulong,
+        pub rmx_mtu: c_ulong,
+        pub rmx_hopcount: c_ulong,
+        pub rmx_expire: c_ulong,
+        pub rmx_recvpipe: c_ulong,
+        pub rmx_sendpipe: c_ulong,
+        pub rmx_ssthresh: c_ulong,
+        pub rmx_rtt: c_ulong,
+        pub rmx_rttvar: c_ulong,
+        pub rmx_pksent: c_ulong,
+        pub rmx_weight: c_ulong,
+        pub rmx_nhidx: c_ulong,
+        rmx_filler: Padding<[c_ulong; 2]>,
+    }
+
+    pub struct rt_msghdr {
+        pub rtm_msglen: c_ushort,
+        pub rtm_version: c_uchar,
+        pub rtm_type: c_uchar,
+        pub rtm_index: c_ushort,
+        _rtm_spare1: Padding<c_ushort>,
+        pub rtm_flags: c_int,
+        pub rtm_addrs: c_int,
+        pub rtm_pid: crate::pid_t,
+        pub rtm_seq: c_int,
+        pub rtm_errno: c_int,
+        pub rtm_fmask: c_int,
+        pub rtm_inits: c_ulong,
+        pub rtm_rmx: rt_metrics,
+    }
+}

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -229,6 +229,7 @@ cfg_if! {
         pub use net::dlt::*;
         // FIXME(1.0,remove): these bindings should be left in a public submodule.
         pub use net::if_mib::*;
+        pub use net::route::*;
         pub use netinet6::in6_var::*;
         pub use sys::file::*;
         pub use sys::ioccom::*;


### PR DESCRIPTION
# Description

Add `rt_msghdr` and `rt_metrics` for the `PF_ROUTE` socket on FreeBSD; libc
has them for Apple only. The `RTM_*`/`RTA_*` constants already exist. Field
set follows FreeBSD 13–15 (`rmx_nhidx` + two filler words); CURRENT renames
one filler slot to `rmx_metric`, same layout.

# Sources

FreeBSD `rt_metrics` / `rt_msghdr` (`net/route.h`, releng/14.4):
- https://github.com/freebsd/freebsd-src/blob/3de2d29b088e70add5936c92f6dba3b29a2a922e/sys/net/route.h#L79-L95
- https://github.com/freebsd/freebsd-src/blob/3de2d29b088e70add5936c92f6dba3b29a2a922e/sys/net/route.h#L249-L265

# Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] No placeholder or unstable values like `*LAST` or `*MAX` are included
- [x] Tested locally (`cd libc-test && cargo test --target mytarget`)

@rustbot label +stable-nominated
