### PR TITLE
Clean up the `libc-test` build script

### DIFF
--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/libc"
+build = "build/main.rs"
 
 [dependencies]
 cfg-if = "1.0.4"

--- a/libc-test/build/main.rs
+++ b/libc-test/build/main.rs
@@ -195,7 +195,7 @@ fn process_semver_file<W: Write, P: AsRef<Path>>(output: &mut W, path: &mut Path
 
 fn main() {
     // Avoid unnecessary re-building.
-    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=.");
     // Ensure version checking works, even if we don't use it.
     LazyLock::force(&VERSIONS);
 

--- a/libc-test/build/main.rs
+++ b/libc-test/build/main.rs
@@ -1,26 +1,15 @@
 #![allow(clippy::match_like_matches_macro)]
 
+mod semver;
+
+use std::env;
 use std::env::VarError;
-use std::fs::File;
-use std::io::{
-    BufRead,
-    BufReader,
-    BufWriter,
-    Write,
-};
-use std::path::{
-    Path,
-    PathBuf,
-};
+use std::io::Write;
 use std::process::{
     Command,
     Stdio,
 };
 use std::sync::LazyLock;
-use std::{
-    env,
-    io,
-};
 
 use regex::Regex;
 
@@ -118,81 +107,6 @@ fn ctest_cfg() -> ctest::TestGenerator {
     cfg
 }
 
-fn do_semver() {
-    let mut out = PathBuf::from(env::var("OUT_DIR").unwrap());
-    out.push("semver.rs");
-    let mut output = BufWriter::new(File::create(&out).unwrap());
-
-    let family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
-    let vendor = env::var("CARGO_CFG_TARGET_VENDOR").unwrap();
-    let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
-
-    // `libc-test/semver` dir.
-    let mut semver_root = PathBuf::from("semver");
-
-    // NOTE: Windows has the same `family` as `os`, no point in including it
-    // twice.
-    // NOTE: Android doesn't include the unix file (or the Linux file) because
-    // there are some many definitions missing it's actually easier just to
-    // maintain a file for Android.
-    // NOTE: AIX and L4Re do not include the unix file because there are
-    // definitions missing on these systems. It is easier to maintain separate
-    // files for them.
-    if family != os && !matches!(os.as_str(), "android" | "aix" | "l4re") && os != "vxworks" {
-        process_semver_file(&mut output, &mut semver_root, &family);
-    }
-    // We don't do semver for unknown targets.
-    if vendor != "unknown" {
-        process_semver_file(&mut output, &mut semver_root, &vendor);
-    }
-    process_semver_file(&mut output, &mut semver_root, &os);
-    let os_arch = format!("{os}-{arch}");
-    process_semver_file(&mut output, &mut semver_root, &os_arch);
-    if !target_env.is_empty() {
-        let os_env = format!("{os}-{target_env}");
-        process_semver_file(&mut output, &mut semver_root, &os_env);
-
-        let os_env_arch = format!("{os}-{target_env}-{arch}");
-        process_semver_file(&mut output, &mut semver_root, &os_env_arch);
-    }
-}
-
-fn process_semver_file<W: Write, P: AsRef<Path>>(output: &mut W, path: &mut PathBuf, file: P) {
-    // NOTE: `path` is reused between calls, so always remove the file again.
-    path.push(file);
-    path.set_extension("txt");
-
-    println!("cargo:rerun-if-changed={}", path.display());
-    let input_file = match File::open(&*path) {
-        Ok(file) => file,
-        Err(ref err) if err.kind() == io::ErrorKind::NotFound => {
-            path.pop();
-            return;
-        }
-        Err(err) => panic!("unexpected error opening file: {err}"),
-    };
-    let input = BufReader::new(input_file);
-
-    writeln!(output, "// Source: {}.", path.display()).unwrap();
-    output.write_all(b"use libc::{\n").unwrap();
-    for line in input.lines() {
-        let line = line.unwrap().into_bytes();
-        match line.first() {
-            // Ignore comments and empty lines.
-            Some(b'#') | None => continue,
-            _ => {
-                output.write_all(b"    ").unwrap();
-                output.write_all(&line).unwrap();
-                output.write_all(b",\n").unwrap();
-            }
-        }
-    }
-    output.write_all(b"};\n\n").unwrap();
-    path.pop();
-}
-
 fn main() {
     // Avoid unnecessary re-building.
     println!("cargo:rerun-if-changed=.");
@@ -201,7 +115,7 @@ fn main() {
 
     do_cc();
     do_ctest();
-    do_semver();
+    semver::do_semver();
 }
 
 macro_rules! headers {

--- a/libc-test/build/semver.rs
+++ b/libc-test/build/semver.rs
@@ -1,0 +1,90 @@
+use std::fs::File;
+use std::io::{
+    BufRead,
+    BufReader,
+    BufWriter,
+    Write,
+};
+use std::path::{
+    Path,
+    PathBuf,
+};
+use std::{
+    env,
+    io,
+};
+
+pub(crate) fn do_semver() {
+    let mut out = PathBuf::from(env::var("OUT_DIR").unwrap());
+    out.push("semver.rs");
+    let mut output = BufWriter::new(File::create(&out).unwrap());
+
+    let family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+    let vendor = env::var("CARGO_CFG_TARGET_VENDOR").unwrap();
+    let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+
+    // `libc-test/semver` dir.
+    let mut semver_root = PathBuf::from("semver");
+
+    // NOTE: Windows has the same `family` as `os`, no point in including it
+    // twice.
+    // NOTE: Android doesn't include the unix file (or the Linux file) because
+    // there are some many definitions missing it's actually easier just to
+    // maintain a file for Android.
+    // NOTE: AIX and L4Re do not include the unix file because there are
+    // definitions missing on these systems. It is easier to maintain separate
+    // files for them.
+    if family != os && !matches!(os.as_str(), "android" | "aix" | "l4re") && os != "vxworks" {
+        process_semver_file(&mut output, &mut semver_root, &family);
+    }
+    // We don't do semver for unknown targets.
+    if vendor != "unknown" {
+        process_semver_file(&mut output, &mut semver_root, &vendor);
+    }
+    process_semver_file(&mut output, &mut semver_root, &os);
+    let os_arch = format!("{os}-{arch}");
+    process_semver_file(&mut output, &mut semver_root, &os_arch);
+    if !target_env.is_empty() {
+        let os_env = format!("{os}-{target_env}");
+        process_semver_file(&mut output, &mut semver_root, &os_env);
+
+        let os_env_arch = format!("{os}-{target_env}-{arch}");
+        process_semver_file(&mut output, &mut semver_root, &os_env_arch);
+    }
+}
+
+fn process_semver_file<W: Write, P: AsRef<Path>>(output: &mut W, path: &mut PathBuf, file: P) {
+    // NOTE: `path` is reused between calls, so always remove the file again.
+    path.push(file);
+    path.set_extension("txt");
+
+    println!("cargo:rerun-if-changed={}", path.display());
+    let input_file = match File::open(&*path) {
+        Ok(file) => file,
+        Err(ref err) if err.kind() == io::ErrorKind::NotFound => {
+            path.pop();
+            return;
+        }
+        Err(err) => panic!("unexpected error opening file: {err}"),
+    };
+    let input = BufReader::new(input_file);
+
+    writeln!(output, "// Source: {}.", path.display()).unwrap();
+    output.write_all(b"use libc::{\n").unwrap();
+    for line in input.lines() {
+        let line = line.unwrap().into_bytes();
+        match line.first() {
+            // Ignore comments and empty lines.
+            Some(b'#') | None => continue,
+            _ => {
+                output.write_all(b"    ").unwrap();
+                output.write_all(&line).unwrap();
+                output.write_all(b",\n").unwrap();
+            }
+        }
+    }
+    output.write_all(b"};\n\n").unwrap();
+    path.pop();
+}


### PR DESCRIPTION
This file is quite large and doesn't have a lot of room for organization. Move to a directory where at least we can split up modules not related to `ctest` config.