### PR TITLE
musl: Rename `musl_v1_2_3` to `musl_v1_2`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,34 +198,34 @@ jobs:
           - target: aarch64-linux-android
           - target: aarch64-unknown-linux-musl
           - target: aarch64-unknown-linux-musl
-            env: { TEST_MUSL_V1_2_3: 1 }
+            env: { TEST_MUSL_V1_2: 1 }
             artifact-tag: new-musl
           - target: arm-linux-androideabi
           - target: arm-unknown-linux-gnueabihf
           - target: arm-unknown-linux-musleabihf
           - target: arm-unknown-linux-musleabihf
-            env: { TEST_MUSL_V1_2_3: 1 }
+            env: { TEST_MUSL_V1_2: 1 }
             artifact-tag: new-musl
           # FIXME(#4297): Disabled due to spurious failue
           # - target: i686-linux-android
           - target: i686-unknown-linux-musl
           - target: i686-unknown-linux-musl
-            env: { TEST_MUSL_V1_2_3: 1 }
+            env: { TEST_MUSL_V1_2: 1 }
             artifact-tag: new-musl
           - target: loongarch64-unknown-linux-gnu
           - target: loongarch64-unknown-linux-musl
           - target: loongarch64-unknown-linux-musl
-            env: { TEST_MUSL_V1_2_3: 1 }
+            env: { TEST_MUSL_V1_2: 1 }
             artifact-tag: new-musl
           - target: powerpc64-unknown-linux-gnu
           - target: powerpc64-unknown-linux-musl
           - target: powerpc64-unknown-linux-musl
-            env: { RUST_LIBC_UNSTABLE_MUSL_V1_2_3: 1 }
+            env: { RUST_LIBC_UNSTABLE_MUSL_V1_2: 1 }
             artifact-tag: new-musl
           - target: powerpc64le-unknown-linux-gnu
           - target: powerpc64le-unknown-linux-musl
           - target: powerpc64le-unknown-linux-musl
-            env: { TEST_MUSL_V1_2_3: 1 }
+            env: { TEST_MUSL_V1_2: 1 }
             artifact-tag: new-musl
           - target: riscv64gc-unknown-linux-gnu
           - target: s390x-unknown-linux-gnu
@@ -242,7 +242,7 @@ jobs:
           # - target: x86_64-unknown-linux-gnux32
           - target: x86_64-unknown-linux-musl
           - target: x86_64-unknown-linux-musl
-            env: { TEST_MUSL_V1_2_3: 1 }
+            env: { TEST_MUSL_V1_2: 1 }
             artifact-tag: new-musl
           # FIXME: It seems some items in `src/unix/mod.rs` aren't defined on redox actually.
           # - target: x86_64-unknown-redox

--- a/build.rs
+++ b/build.rs
@@ -33,8 +33,8 @@ const ALLOWED_CFGS: &[&str] = &[
     "libc_elfv2",
     // Corresponds to `__USE_TIME_BITS64` in UAPI
     "linux_time_bits64",
-    "musl_v1_2_3",
-    // musl v1.2.3+ && 32-bit: time_t is i64, struct layouts change
+    "musl_v1_2",
+    // musl v1.2.0+ && 32-bit: time_t is i64, struct layouts change
     "musl32_time64",
     // Corresponds to `_REDIR_TIME64` in musl: symbol redirects to __*_time64
     "musl_redir_time64",
@@ -150,13 +150,20 @@ fn main() {
         _ => (),
     }
 
-    let mut musl_v1_2_3 = env_flag("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2_3");
+    let mut musl_v1_2 = env_flag("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2");
+    if let Ok(old_musl_v1_2_3) = env::var("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2_3") {
+        println!(
+            "cargo:warning=`--cfg=libc_unstable_musl_v1_2_3` will be removed; \
+            set `--cfg=libc_unstable_musl_v1_2`instead"
+        );
+        musl_v1_2 |= old_musl_v1_2_3 != "0";
+    }
     if let Ok(old_musl_v1_2_3) = env::var("RUST_LIBC_UNSTABLE_MUSL_V1_2_3") {
         println!(
             "cargo:warning=RUST_LIBC_UNSTABLE_MUSL_V1_2_3 will be removed; \
-            set `--cfg=libc_unstable_musl_v1_2_3` via RUSTFLAGS instead"
+            set `--cfg=libc_unstable_musl_v1_2` via RUSTFLAGS instead"
         );
-        musl_v1_2_3 |= old_musl_v1_2_3 != "0";
+        musl_v1_2 |= old_musl_v1_2_3 != "0";
     }
 
     // OpenHarmony uses a fork of the musl libc
@@ -168,11 +175,11 @@ fn main() {
         || target_env == "ohos"
         || target_abi == "pauthtest"
     {
-        musl_v1_2_3 = true;
+        musl_v1_2 = true;
     }
 
-    if musl && musl_v1_2_3 {
-        set_cfg("musl_v1_2_3");
+    if musl && musl_v1_2 {
+        set_cfg("musl_v1_2");
         if target_ptr_width == "32" {
             set_cfg("musl32_time64");
             set_cfg("linux_time_bits64");

--- a/build.rs
+++ b/build.rs
@@ -33,7 +33,7 @@ const ALLOWED_CFGS: &[&str] = &[
     "libc_elfv2",
     // Corresponds to `__USE_TIME_BITS64` in UAPI
     "linux_time_bits64",
-    "musl_v1_2_3",
+    "musl_v1_2",
     // musl v1.2.3+ && 32-bit: time_t is i64, struct layouts change
     "musl32_time64",
     // Corresponds to `_REDIR_TIME64` in musl: symbol redirects to __*_time64
@@ -150,13 +150,20 @@ fn main() {
         _ => (),
     }
 
-    let mut musl_v1_2_3 = env_flag("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2_3");
-    if let Ok(old_musl_v1_2_3) = env::var("RUST_LIBC_UNSTABLE_MUSL_V1_2_3") {
+    let mut musl_v1_2 = env_flag("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2_3");
+    if let Ok(old_musl_v1_2_3) = env::var("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2_3") {
+        println!(
+            "cargo:warning=`--cfg=libc_unstable_musl_v1_2_3` will be removed; \
+            set `--cfg=libc_unstable_musl_v1_2`instead"
+        );
+        musl_v1_2 |= old_musl_v1_2_3 != "0";
+    }
+    if let Ok(old_musl_v1_2) = env::var("RUST_LIBC_UNSTABLE_MUSL_V1_2_3") {
         println!(
             "cargo:warning=RUST_LIBC_UNSTABLE_MUSL_V1_2_3 will be removed; \
-            set `--cfg=libc_unstable_musl_v1_2_3` via RUSTFLAGS instead"
+            set `--cfg=libc_unstable_musl_v1_2` via RUSTFLAGS instead"
         );
-        musl_v1_2_3 |= old_musl_v1_2_3 != "0";
+        musl_v1_2 |= old_musl_v1_2 != "0";
     }
 
     // OpenHarmony uses a fork of the musl libc
@@ -168,11 +175,11 @@ fn main() {
         || target_env == "ohos"
         || target_abi == "pauthtest"
     {
-        musl_v1_2_3 = true;
+        musl_v1_2 = true;
     }
 
-    if musl && musl_v1_2_3 {
-        set_cfg("musl_v1_2_3");
+    if musl && musl_v1_2 {
+        set_cfg("musl_v1_2");
         if target_ptr_width == "32" {
             set_cfg("musl32_time64");
             set_cfg("linux_time_bits64");

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -40,8 +40,8 @@ run() {
     # and test them both in `ci/run.sh` more similar to what we do with glibc,
     # rather than needing two separate jobs.
     if [[ "$run_target" = *"musl"* ]]; then
-        if [ -n "${TEST_MUSL_V1_2_3:-}" ]; then
-            export RUSTFLAGS="$RUSTFLAGS --cfg=libc_unstable_musl_v1_2_3"
+        if [ -n "${TEST_MUSL_V1_2:-}" ]; then
+            export RUSTFLAGS="$RUSTFLAGS --cfg=libc_unstable_musl_v1_2"
             build_args+=("--build-arg=MUSL_VERSION=new")
         else
             build_args+=("--build-arg=MUSL_VERSION=old")

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -41,7 +41,7 @@ run() {
     # rather than needing two separate jobs.
     if [[ "$run_target" = *"musl"* ]]; then
         if [ -n "${TEST_MUSL_V1_2_3:-}" ]; then
-            export RUSTFLAGS="$RUSTFLAGS --cfg=libc_unstable_musl_v1_2_3"
+            export RUSTFLAGS="$RUSTFLAGS --cfg=libc_unstable_musl_v1_2"
             build_args+=("--build-arg=MUSL_VERSION=new")
         else
             build_args+=("--build-arg=MUSL_VERSION=old")

--- a/ci/verify-build.py
+++ b/ci/verify-build.py
@@ -410,7 +410,7 @@ def test_target(cfg: Cfg, target: Target) -> TargetResult:
 
     if "musl" in target_env:
         # Check with breaking changes from musl, including 64-bit time_t on 32-bit
-        run(cmd, rustflags=f"{rustflags} --cfg=libc_unstable_musl_v1_2_3")
+        run(cmd, rustflags=f"{rustflags} --cfg=libc_unstable_musl_v1_2")
 
     # Test again without default features, i.e. without `std`
     run([*cmd, "--no-default-features"], rustflags=rustflags)

--- a/etc/libc-util.py
+++ b/etc/libc-util.py
@@ -427,7 +427,7 @@ class CheckAllTargets:
                 new.attributes = base.attributes | {"time_bits": "64"}
                 new.target_dir = base.target_dir / "time64"
                 new.extra_rustflags = base.extra_rustflags + [
-                    "--cfg=libc_unstable_musl_v1_2_3"
+                    "--cfg=libc_unstable_musl_v1_2"
                 ]
                 new_checks.append(new)
 

--- a/libc-test/build/main.rs
+++ b/libc-test/build/main.rs
@@ -4521,16 +4521,10 @@ fn test_linux(target: &str) {
             }
         }
         if musl {
-            // LFS64 types have been removed in musl 1.2.4+
-            if name.starts_with("RLIM64") {
-                return true;
-            }
-            // CI fails because musl targets use Linux v4 kernel
-            if name.starts_with("NI_IDN") {
-                return true;
-            }
-
             match name {
+                // LFS64 types have been removed in musl 1.2.4+
+                x if x.starts_with("RLIM64") && musl_v1_2 => return true,
+
                 // FIXME: Does not exist on non-x86 architectures, slated for removal
                 // in libc in 1.0
                 "MAP_32BIT" if ppc64 => return true,
@@ -4582,11 +4576,14 @@ fn test_linux(target: &str) {
                 | "PR_SCHED_CORE_SHARE_FROM"
                 | "PR_SCHED_CORE_SHARE_TO" => return true,
 
+                // Not present in musl, deprecated in libc.
+                "NI_IDN" => return true,
+
                 /* Added in versions more recent than what we test */
                 // Since 1.2.0
-                "SO_DETACH_REUSEPORT_BPF" => return true,
+                "SO_DETACH_REUSEPORT_BPF" if old_musl => return true,
                 // Since 1.2.3
-                "SO_BUSY_POLL_BUDGET" | "SO_PREFER_BUSY_POLL" => return true,
+                "SO_BUSY_POLL_BUDGET" | "SO_PREFER_BUSY_POLL" if old_musl => return true,
 
                 // FIXME(musl): value was updated in new musl
                 "RLIM_NLIMITS" => return true,

--- a/libc-test/build/main.rs
+++ b/libc-test/build/main.rs
@@ -3969,22 +3969,22 @@ fn test_linux(target: &str) {
         None => panic!("failed to detect kernel version for Linux target {target}"),
     };
 
-    let mut musl_v1_2_3 = env_flag("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2_3");
-    if musl_v1_2_3 {
+    let mut musl_v1_2 = env_flag("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2_3");
+    if musl_v1_2 {
         assert!(musl);
     }
 
     // Some platforms only exist with recent musl. Keep in sync with libc's build.rs.
     if musl && (loongarch64 || hexagon || pauthtest/* || ohos */) {
-        musl_v1_2_3 = true;
+        musl_v1_2 = true;
     }
 
-    let old_musl = musl && !musl_v1_2_3;
+    let old_musl = musl && !musl_v1_2;
 
     let mut cfg = ctest_cfg();
 
-    if musl_v1_2_3 {
-        cfg.cfg("musl_v1_2_3", None);
+    if musl_v1_2 {
+        cfg.cfg("musl_v1_2", None);
         if b32 {
             cfg.cfg("musl32_time64", None);
             cfg.cfg("linux_time_bits64", None);
@@ -4258,9 +4258,9 @@ fn test_linux(target: &str) {
     cfg.rename_struct_field(move |struct_, field| {
         match (struct_.ident(), field.ident()) {
             // Our stat *_nsec fields normally don't actually exist but are part
-            // of a timeval struct - this is fixed in musl_v1_2_3
+            // of a timeval struct - this is fixed in musl_v1_2
             ("stat" | "statfs" | "statvfs" | "stat64" | "statfs64" | "statvfs64", f)
-                if !musl_v1_2_3 && f.ends_with("_nsec") =>
+                if !musl_v1_2 && f.ends_with("_nsec") =>
             {
                 Some(f.replace("e_nsec", ".tv_nsec"))
             }

--- a/libc-test/build/main.rs
+++ b/libc-test/build/main.rs
@@ -3969,22 +3969,22 @@ fn test_linux(target: &str) {
         None => panic!("failed to detect kernel version for Linux target {target}"),
     };
 
-    let mut musl_v1_2_3 = env_flag("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2_3");
-    if musl_v1_2_3 {
+    let mut musl_v1_2 = env_flag("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2");
+    if musl_v1_2 {
         assert!(musl);
     }
 
     // Some platforms only exist with recent musl. Keep in sync with libc's build.rs.
     if musl && (loongarch64 || hexagon || pauthtest/* || ohos */) {
-        musl_v1_2_3 = true;
+        musl_v1_2 = true;
     }
 
-    let old_musl = musl && !musl_v1_2_3;
+    let old_musl = musl && !musl_v1_2;
 
     let mut cfg = ctest_cfg();
 
-    if musl_v1_2_3 {
-        cfg.cfg("musl_v1_2_3", None);
+    if musl_v1_2 {
+        cfg.cfg("musl_v1_2", None);
         if b32 {
             cfg.cfg("musl32_time64", None);
             cfg.cfg("linux_time_bits64", None);
@@ -4258,9 +4258,9 @@ fn test_linux(target: &str) {
     cfg.rename_struct_field(move |struct_, field| {
         match (struct_.ident(), field.ident()) {
             // Our stat *_nsec fields normally don't actually exist but are part
-            // of a timeval struct - this is fixed in musl_v1_2_3
+            // of a timeval struct - this is fixed in musl_v1_2
             ("stat" | "statfs" | "statvfs" | "stat64" | "statfs64" | "statvfs64", f)
-                if !musl_v1_2_3 && f.ends_with("_nsec") =>
+                if !musl_v1_2 && f.ends_with("_nsec") =>
             {
                 Some(f.replace("e_nsec", ".tv_nsec"))
             }

--- a/libc-test/tests/style_lib/mod.rs
+++ b/libc-test/tests/style_lib/mod.rs
@@ -55,7 +55,7 @@ const ALLOWED_POSITIVE_S_CFGS: &[&str] = &[
     "gnu_file_offset_bits64",
     "gnu_time_bits64",
     "musl32_time64",
-    "musl_v1_2_3",
+    "musl_v1_2",
 ];
 
 pub type Error = Box<dyn std::error::Error>;

--- a/src/new/emscripten/sched.rs
+++ b/src/new/emscripten/sched.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 cfg_if! {
-    if #[cfg(musl_v1_2_3)] {
+    if #[cfg(musl_v1_2)] {
         s! {
             struct __c_anon_sched_param__reserved2 {
                 __reserved1: crate::time_t,

--- a/src/new/musl/sched.rs
+++ b/src/new/musl/sched.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 cfg_if! {
-    if #[cfg(musl_v1_2_3)] {
+    if #[cfg(musl_v1_2)] {
         s! {
             struct __c_anon_sched_param__reserved2 {
                 __reserved1: crate::time_t,

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -25,17 +25,17 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
         pub st_ino: crate::ino_t,
@@ -60,9 +60,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/arm/mod.rs
@@ -27,17 +27,17 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
         pub st_ino: crate::ino_t,
@@ -62,9 +62,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b32/hexagon.rs
+++ b/src/unix/linux_like/linux/musl/b32/hexagon.rs
@@ -17,24 +17,24 @@ s! {
         __st_blksize_padding: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_int; 2]>,
@@ -47,9 +47,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b32/hexagon.rs
+++ b/src/unix/linux_like/linux/musl/b32/hexagon.rs
@@ -18,24 +18,24 @@ s! {
         __st_blksize_padding: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_int; 2]>,
@@ -48,9 +48,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -25,17 +25,17 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
         pub st_blksize: crate::blksize_t,
@@ -67,9 +67,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/mips/mod.rs
@@ -23,17 +23,17 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
         pub st_blksize: crate::blksize_t,
@@ -65,9 +65,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -35,17 +35,17 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
         __unused: Padding<[c_long; 2]>,
@@ -70,9 +70,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/musl/b32/powerpc.rs
@@ -37,17 +37,17 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
         __unused: Padding<[c_long; 2]>,
@@ -72,9 +72,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
@@ -20,24 +20,24 @@ s! {
         pub __pad2: c_int,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_int; 2usize]>,

--- a/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
@@ -22,24 +22,24 @@ s! {
         pub __pad2: c_int,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_int; 2usize]>,

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -27,17 +27,17 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
         pub st_ino: crate::ino_t,
@@ -66,9 +66,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/musl/b32/x86/mod.rs
@@ -25,17 +25,17 @@ s! {
         #[cfg(musl32_time64)]
         __st_ctim32: Padding<__c_anonymous_timespec32>,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
         pub st_ino: crate::ino_t,
@@ -64,9 +64,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -20,24 +20,24 @@ s! {
         __pad1: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_uint; 2]>,
@@ -51,9 +51,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed
@@ -66,9 +66,9 @@ s! {
         pub cgid: crate::gid_t,
         pub mode: crate::mode_t,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __seq: c_int,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "The type of this field has changed from c_ushort to c_int,

--- a/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/aarch64/mod.rs
@@ -22,24 +22,24 @@ s! {
         __pad1: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_uint; 2]>,
@@ -53,9 +53,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed
@@ -68,9 +68,9 @@ s! {
         pub cgid: crate::gid_t,
         pub mode: crate::mode_t,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __seq: c_int,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "The type of this field has changed from c_ushort to c_int,

--- a/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
@@ -23,24 +23,24 @@ s! {
         __pad2: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_int; 2usize]>,

--- a/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs
@@ -25,24 +25,24 @@ s! {
         __pad2: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_int; 2usize]>,

--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -21,24 +21,24 @@ s! {
         pub st_size: off_t,
         __pad3: Padding<c_int>,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         pub st_blksize: crate::blksize_t,
@@ -54,9 +54,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b64/mips64.rs
+++ b/src/unix/linux_like/linux/musl/b64/mips64.rs
@@ -19,24 +19,24 @@ s! {
         pub st_size: off_t,
         __pad3: Padding<c_int>,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         pub st_blksize: crate::blksize_t,
@@ -52,9 +52,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -30,24 +30,24 @@ s! {
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_long; 3]>,
@@ -66,9 +66,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b64/powerpc64.rs
+++ b/src/unix/linux_like/linux/musl/b64/powerpc64.rs
@@ -32,24 +32,24 @@ s! {
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_long; 3]>,
@@ -68,9 +68,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
@@ -23,24 +23,24 @@ s! {
         __pad2: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_int; 2usize]>,

--- a/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
@@ -25,24 +25,24 @@ s! {
         __pad2: Padding<c_int>,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_int; 2usize]>,

--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -11,9 +11,9 @@ pub type statfs64 = statfs;
 
 s! {
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed
@@ -40,24 +40,24 @@ s! {
         pub st_rdev: crate::dev_t,
         pub st_size: off_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         pub st_blksize: crate::blksize_t,

--- a/src/unix/linux_like/linux/musl/b64/s390x.rs
+++ b/src/unix/linux_like/linux/musl/b64/s390x.rs
@@ -10,9 +10,9 @@ pub type stat64 = stat;
 
 s! {
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed
@@ -39,24 +39,24 @@ s! {
         pub st_rdev: crate::dev_t,
         pub st_size: off_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         pub st_blksize: crate::blksize_t,

--- a/src/unix/linux_like/linux/musl/b64/wasm32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/wasm32/mod.rs
@@ -21,33 +21,33 @@ s! {
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_long; 3]>,
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b64/wasm32/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/wasm32/mod.rs
@@ -23,33 +23,33 @@ s! {
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_long; 3]>,
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -20,24 +20,24 @@ s! {
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_long; 3]>,
@@ -104,9 +104,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/musl/b64/x86_64/mod.rs
@@ -22,24 +22,24 @@ s! {
         pub st_blksize: crate::blksize_t,
         pub st_blocks: crate::blkcnt_t,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_atime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_mtime_nsec: c_long,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime: crate::time_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         pub st_ctime_nsec: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_atim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_mtim: crate::timespec,
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub st_ctim: crate::timespec,
 
         __unused: Padding<[c_long; 3]>,
@@ -106,9 +106,9 @@ s! {
     }
 
     pub struct ipc_perm {
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub __key: crate::key_t,
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "This field is incorrectly named and will be changed

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -441,7 +441,7 @@ s! {
         pub ut_host: [c_char; 256],
         pub ut_exit: __exit_status,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "The ABI of this field has changed from c_long to c_int with padding, \
@@ -449,14 +449,14 @@ s! {
         )]
         pub ut_session: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         #[cfg(not(target_endian = "little"))]
         __ut_pad2: Padding<c_int>,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub ut_session: c_int,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         #[cfg(target_endian = "little")]
         __ut_pad2: Padding<c_int>,
 
@@ -596,7 +596,7 @@ pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: usize = 8;
 pub const __SIZEOF_PTHREAD_BARRIERATTR_T: usize = 4;
 
 // Value was changed in 1.2.4
-pub const CPU_SETSIZE: c_int = if cfg!(musl_v1_2_3) { 1024 } else { 128 };
+pub const CPU_SETSIZE: c_int = if cfg!(musl_v1_2) { 1024 } else { 128 };
 
 pub const PTRACE_TRACEME: c_int = 0;
 pub const PTRACE_PEEKTEXT: c_int = 1;

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -449,7 +449,7 @@ s! {
         pub ut_host: [c_char; 256],
         pub ut_exit: __exit_status,
 
-        #[cfg(not(musl_v1_2_3))]
+        #[cfg(not(musl_v1_2))]
         #[deprecated(
             since = "0.2.173",
             note = "The ABI of this field has changed from c_long to c_int with padding, \
@@ -457,14 +457,14 @@ s! {
         )]
         pub ut_session: c_long,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         #[cfg(not(target_endian = "little"))]
         __ut_pad2: Padding<c_int>,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         pub ut_session: c_int,
 
-        #[cfg(musl_v1_2_3)]
+        #[cfg(musl_v1_2)]
         #[cfg(target_endian = "little")]
         __ut_pad2: Padding<c_int>,
 
@@ -604,7 +604,7 @@ pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: usize = 8;
 pub const __SIZEOF_PTHREAD_BARRIERATTR_T: usize = 4;
 
 // Value was changed in 1.2.4
-pub const CPU_SETSIZE: c_int = if cfg!(musl_v1_2_3) { 1024 } else { 128 };
+pub const CPU_SETSIZE: c_int = if cfg!(musl_v1_2) { 1024 } else { 128 };
 
 pub const PTRACE_TRACEME: c_int = 0;
 pub const PTRACE_PEEKTEXT: c_int = 1;

--- a/src/unix/linux_like/linux_l4re_shared.rs
+++ b/src/unix/linux_like/linux_l4re_shared.rs
@@ -1011,6 +1011,10 @@ pub const NI_NOFQDN: c_int = 4;
 pub const NI_NAMEREQD: c_int = 8;
 pub const NI_DGRAM: c_int = 16;
 #[cfg(not(target_env = "uclibc"))]
+#[cfg_attr(
+    target_env = "musl",
+    deprecated(since = "0.2.190", note = "not present in musl")
+)]
 pub const NI_IDN: c_int = 32;
 
 cfg_if! {

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -277,7 +277,7 @@ cfg_if! {
     if #[cfg(any(
         target_env = "gnu",
         target_os = "android",
-        all(target_env = "musl", musl_v1_2_3)
+        all(target_env = "musl", musl_v1_2)
     ))] {
         s! {
             pub struct statx {
@@ -1698,7 +1698,7 @@ cfg_if! {
     if #[cfg(any(
         target_env = "gnu",
         target_os = "android",
-        all(target_env = "musl", musl_v1_2_3),
+        all(target_env = "musl", musl_v1_2),
         target_os = "l4re"
     ))] {
         pub const AT_STATX_SYNC_TYPE: c_int = 0x6000;
@@ -2249,7 +2249,7 @@ cfg_if! {
     if #[cfg(any(
         target_env = "gnu",
         target_os = "android",
-        all(target_env = "musl", musl_v1_2_3)
+        all(target_env = "musl", musl_v1_2)
     ))] {
         extern "C" {
             pub fn statx(

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -277,7 +277,7 @@ cfg_if! {
     if #[cfg(any(
         target_env = "gnu",
         target_os = "android",
-        all(target_env = "musl", musl_v1_2_3)
+        all(target_env = "musl", musl_v1_2)
     ))] {
         s! {
             pub struct statx {
@@ -1699,7 +1699,7 @@ cfg_if! {
     if #[cfg(any(
         target_env = "gnu",
         target_os = "android",
-        all(target_env = "musl", musl_v1_2_3),
+        all(target_env = "musl", musl_v1_2),
         target_os = "l4re"
     ))] {
         pub const AT_STATX_SYNC_TYPE: c_int = 0x6000;
@@ -2250,7 +2250,7 @@ cfg_if! {
     if #[cfg(any(
         target_env = "gnu",
         target_os = "android",
-        all(target_env = "musl", musl_v1_2_3)
+        all(target_env = "musl", musl_v1_2)
     ))] {
         extern "C" {
             pub fn statx(


### PR DESCRIPTION
1.2.0 was the release that introduced 64-bit `time_t` everywhere [1],
which is the main thing we are interested in with this config. There is
nothing special about 1.2.3, and most gated API will work down to 1.2.0.
This has been a source of mild confusion.

To make things more clear, drop the `_3`. We continue to support
`libc_unstable_musl_v1_2_3` for now but emit a warning if set.

Closes: https://github.com/rust-lang/libc/issues/5200

[1]: https://musl.libc.org/releases.html