### PR TITLE
aix(powerpc64): clean up module

### DIFF
--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -5,6 +5,8 @@ extern_ty! {
     pub type lock_data_instrumented;
 }
 
+pub type simple_lock_data = c_int;
+
 s! {
     pub struct sigset_t {
         pub ss_set: [c_ulong; 4],
@@ -289,6 +291,15 @@ impl siginfo_t {
 }
 
 s_no_extra_traits! {
+    pub union _simple_lock {
+        _slock: simple_lock_data,
+        _slockp: *mut lock_data_instrumented,
+    }
+
+    #[deprecated(
+        since = "0.2.187",
+        note = "Use `_simple_lock` instead. This type doesn't exist upstream."
+    )]
     pub union _kernel_simple_lock {
         pub _slock: c_long,
         pub _slockp: *mut lock_data_instrumented,
@@ -331,8 +342,8 @@ s_no_extra_traits! {
         pub f_dir_off: crate::off_t,
         // Should be pointer to 'cred'
         pub f_cred: *mut c_void,
-        pub f_lock: _kernel_simple_lock,
-        pub f_offset_lock: _kernel_simple_lock,
+        pub f_lock: _simple_lock,
+        pub f_offset_lock: _simple_lock,
         pub f_vinfo: crate::caddr_t,
         pub f_ops: *mut fileops_t,
         pub f_parentp: crate::caddr_t,

--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -331,6 +331,7 @@ s_no_extra_traits! {
         pub fo_fstat: Option<extern "C" fn(file: *mut file, sstat: *mut crate::stat) -> c_int>,
     }
 
+    #[repr(align(256))]
     pub struct file {
         pub f_flag: c_long,
         pub f_count: c_int,

--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -1,4 +1,3 @@
-use crate::off_t;
 use crate::prelude::*;
 
 // Define lock_data_instrumented as an empty enum
@@ -21,8 +20,8 @@ s! {
         pub l_sysid: c_uint,
         pub l_pid: crate::pid_t,
         pub l_vfs: c_int,
-        pub l_start: off_t,
-        pub l_len: off_t,
+        pub l_start: crate::off_t,
+        pub l_len: crate::off_t,
     }
 
     pub struct statvfs {
@@ -34,7 +33,7 @@ s! {
         pub f_files: crate::fsfilcnt_t,
         pub f_ffree: crate::fsfilcnt_t,
         pub f_favail: crate::fsfilcnt_t,
-        pub f_fsid: c_ulong,
+        pub f_fsid: crate::fsid_t,
         pub f_basetype: [c_char; 16],
         pub f_flag: c_ulong,
         pub f_namemax: c_ulong,
@@ -78,8 +77,8 @@ s! {
         pub st_type: c_uint,
         pub st_gen: c_uint,
         st_reserved: Padding<[c_uint; 9]>,
-        pub st_padto_ll: c_uint,
-        pub st_size: off_t,
+        st_padto_ll: Padding<c_uint>,
+        pub st_size: crate::off_t,
     }
 
     pub struct statfs {
@@ -107,7 +106,7 @@ s! {
         pub aio_lio_opcode: c_int,
         pub aio_fildes: c_int,
         pub aio_word1: c_int,
-        pub aio_offset: off_t,
+        pub aio_offset: crate::off_t,
         pub aio_buf: *mut c_void,
         pub aio_return: ssize_t,
         pub aio_errno: c_int,
@@ -126,11 +125,11 @@ s! {
     }
 
     pub struct __vmx_context_t {
-        pub __vr: [crate::__vmxreg_t; 32],
-        pub __pad1: [c_uint; 3],
+        pub __vr: [__vmxreg_t; 32],
+        __pad1: Padding<[c_uint; 3]>,
         pub __vscr: c_uint,
         pub __vrsave: c_uint,
-        pub __pad2: [c_uint; 3],
+        __pad2: Padding<[c_uint; 3]>,
     }
 
     pub struct __vsx_context_t {
@@ -138,8 +137,8 @@ s! {
     }
 
     pub struct __tm_context_t {
-        pub vmx: crate::__vmx_context_t,
-        pub vsx: crate::__vsx_context_t,
+        pub vmx: __vmx_context_t,
+        pub vsx: __vsx_context_t,
         pub gpr: [c_ulonglong; 32],
         pub lr: c_ulonglong,
         pub ctr: c_ulonglong,
@@ -158,7 +157,7 @@ s! {
         pub tmcontext: c_char,
         pub tmstate: c_char,
         pub prevowner: c_char,
-        pub pad: [c_char; 5],
+        pad: Padding<[c_char; 5]>,
     }
 
     pub struct __context64 {
@@ -176,7 +175,7 @@ s! {
         pub fpeu: c_char,
         pub fpinfo: c_char,
         pub fpscr24_31: c_char,
-        pub pad: [c_char; 1],
+        pad: Padding<[c_char; 1]>,
         pub excp_type: c_int,
     }
 
@@ -187,24 +186,24 @@ s! {
     pub struct __extctx_t {
         pub __flags: c_uint,
         pub __rsvd1: [c_uint; 3],
-        pub __vmx: crate::__vmx_context_t,
+        pub __vmx: __vmx_context_t,
         pub __ukeys: [c_uint; 2],
-        pub __vsx: crate::__vsx_context_t,
-        pub __tm: crate::__tm_context_t,
+        pub __vsx: __vsx_context_t,
+        pub __tm: __tm_context_t,
         __reserved: Padding<[c_char; 1860]>,
         pub __extctx_magic: c_int,
     }
 
     pub struct ucontext_t {
-        pub __sc_onstack: c_int,
-        pub uc_sigmask: crate::sigset_t,
-        pub __sc_uerror: c_int,
-        pub uc_mcontext: crate::mcontext_t,
+        __sc_onstack: c_int,
+        pub uc_sigmask: sigset_t,
+        __sc_uerror: c_int,
+        pub uc_mcontext: mcontext_t,
         pub uc_link: *mut ucontext_t,
         pub uc_stack: crate::stack_t,
-        pub __extctx: *mut crate::__extctx_t,
-        pub __extctx_magic: c_int,
-        pub __pad: [c_int; 1],
+        __extctx: *mut __extctx_t,
+        __extctx_magic: c_int,
+        __pad: Padding<[c_int; 1]>,
     }
 
     pub struct utmpx {
@@ -215,17 +214,17 @@ s! {
         pub ut_type: c_short,
         pub ut_tv: crate::timeval,
         pub ut_host: [c_char; 256],
-        pub __dbl_word_pad: c_int,
-        pub __reservedA: [c_int; 2],
-        pub __reservedV: [c_int; 6],
+        __dbl_word_pad: Padding<c_int>,
+        __reservedA: Padding<[c_int; 2]>,
+        __reservedV: Padding<[c_int; 6]>,
     }
 
     pub struct pthread_spinlock_t {
-        pub __sp_word: [c_long; 3],
+        __sp_word: [c_long; 3],
     }
 
     pub struct pthread_barrier_t {
-        pub __br_word: [c_long; 5],
+        __br_word: [c_long; 5],
     }
 
     pub struct msqid_ds {
@@ -255,15 +254,37 @@ s! {
         pub si_addr: *mut c_void,
         pub si_band: c_long,
         pub si_value: crate::sigval,
-        pub __si_flags: c_int,
-        pub __pad: [c_int; 3],
+        __si_flags: c_int,
+        __pad: Padding<[c_int; 3]>,
     }
 
-    pub struct pollfd_ext {
+    pub struct pollfd_ext_t {
         pub fd: c_int,
         pub events: c_short,
         pub revents: c_short,
-        pub data: __pollfd_ext_u,
+        pub u: __c_anonymous_pollfd_ext_t_u,
+    }
+}
+
+impl siginfo_t {
+    pub unsafe fn si_addr(&self) -> *mut c_void {
+        self.si_addr
+    }
+
+    pub unsafe fn si_value(&self) -> crate::sigval {
+        self.si_value
+    }
+
+    pub unsafe fn si_pid(&self) -> crate::pid_t {
+        self.si_pid
+    }
+
+    pub unsafe fn si_uid(&self) -> crate::uid_t {
+        self.si_uid
+    }
+
+    pub unsafe fn si_status(&self) -> c_int {
+        self.si_status
     }
 }
 
@@ -306,8 +327,8 @@ s_no_extra_traits! {
         pub f_type: c_short,
         // Should be pointer to 'vnode'
         pub f_data: *mut c_void,
-        pub f_offset: c_longlong,
-        pub f_dir_off: c_long,
+        pub f_offset: crate::offset_t,
+        pub f_dir_off: crate::off_t,
         // Should be pointer to 'cred'
         pub f_cred: *mut c_void,
         pub f_lock: _kernel_simple_lock,
@@ -319,16 +340,10 @@ s_no_extra_traits! {
         pub f_fdata: [c_char; 160],
     }
 
-    pub union __ld_info_file {
-        pub _ldinfo_fd: c_int,
-        pub _ldinfo_fp: *mut file,
-        pub _core_offset: c_long,
-    }
-
     pub struct ld_info {
         pub ldinfo_next: c_uint,
         pub ldinfo_flags: c_uint,
-        pub _file: __ld_info_file,
+        pub _file: __c_anonymous_ld_info__file,
         pub ldinfo_textorg: *mut c_void,
         pub ldinfo_textsize: c_ulong,
         pub ldinfo_dataorg: *mut c_void,
@@ -336,7 +351,13 @@ s_no_extra_traits! {
         pub ldinfo_filename: [c_char; 2],
     }
 
-    pub union __pollfd_ext_u {
+    pub union __c_anonymous_ld_info__file {
+        pub _ldinfo_fd: c_int,
+        pub _ldinfo_fp: *mut file,
+        pub _core_offset: c_long,
+    }
+
+    pub union __c_anonymous_pollfd_ext_t_u {
         pub addr: *mut c_void,
         pub data32: u32,
         pub data: u64,
@@ -347,32 +368,10 @@ s_no_extra_traits! {
     }
 }
 
-impl siginfo_t {
-    pub unsafe fn si_addr(&self) -> *mut c_void {
-        self.si_addr
-    }
-
-    pub unsafe fn si_value(&self) -> crate::sigval {
-        self.si_value
-    }
-
-    pub unsafe fn si_pid(&self) -> crate::pid_t {
-        self.si_pid
-    }
-
-    pub unsafe fn si_uid(&self) -> crate::uid_t {
-        self.si_uid
-    }
-
-    pub unsafe fn si_status(&self) -> c_int {
-        self.si_status
-    }
-}
-
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
-        impl PartialEq for __pollfd_ext_u {
-            fn eq(&self, other: &__pollfd_ext_u) -> bool {
+        impl PartialEq for __c_anonymous_pollfd_ext_t_u {
+            fn eq(&self, other: &__c_anonymous_pollfd_ext_t_u) -> bool {
                 unsafe {
                     self.addr == other.addr
                         && self.data32 == other.data32
@@ -380,8 +379,8 @@ cfg_if! {
                 }
             }
         }
-        impl Eq for __pollfd_ext_u {}
-        impl hash::Hash for __pollfd_ext_u {
+        impl Eq for __c_anonymous_pollfd_ext_t_u {}
+        impl hash::Hash for __c_anonymous_pollfd_ext_t_u {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self.addr.hash(state);

--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -417,6 +417,7 @@ cfg_if! {
     }
 }
 
+// pthread.h
 pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
     __mt_word: [0, 2, 0, 0, 0, 0, 0, 0],
 };
@@ -426,11 +427,11 @@ pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = pthread_cond_t {
 pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
     __rw_word: [2, 0, 0, 0, 0, 0, 0, 0, 0, 0],
 };
-
 pub const PTHREAD_ONCE_INIT: pthread_once_t = pthread_once_t {
     __on_word: [0, 0, 0, 0, 0, 2, 0, 0, 0],
 };
 
+// sys/resource.h
 pub const RLIM_INFINITY: c_ulong = 0x7fffffffffffffff;
 
 extern "C" {

--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -325,7 +325,13 @@ s_no_extra_traits! {
             ) -> c_int,
         >,
         pub fo_select: Option<
-            extern "C" fn(file: *mut file, a: c_int, b: *mut c_ushort, c: extern "C" fn()) -> c_int,
+            extern "C" fn(
+                file: *mut file,
+                a: c_int,
+                b: c_ushort,
+                c: *mut c_ushort,
+                c: extern "C" fn(),
+            ) -> c_int,
         >,
         pub fo_close: Option<extern "C" fn(file: *mut file) -> c_int>,
         pub fo_fstat: Option<extern "C" fn(file: *mut file, sstat: *mut crate::stat) -> c_int>,

--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -307,30 +307,24 @@ s_no_extra_traits! {
 
     pub struct fileops_t {
         pub fo_rw: Option<
-            extern "C" fn(
-                file: *mut file,
-                rw: crate::uio_rw,
-                io: *mut c_void,
-                ext: c_long,
-                secattr: *mut c_void,
+            unsafe extern "C" fn(
+                *mut file,
+                crate::uio_rw,
+                *mut c_void,
+                c_long,
+                *mut c_void,
             ) -> c_int,
         >,
         pub fo_ioctl: Option<
-            extern "C" fn(
-                file: *mut file,
-                a: c_long,
-                b: crate::caddr_t,
-                c: c_long,
-                d: c_long,
-            ) -> c_int,
+            unsafe extern "C" fn(*mut file, c_long, crate::caddr_t, c_long, c_long) -> c_int,
         >,
         pub fo_select: Option<
-            extern "C" fn(
-                file: *mut file,
-                a: c_int,
-                b: c_ushort,
-                c: *mut c_ushort,
-                c: extern "C" fn(),
+            unsafe extern "C" fn(
+                *mut file,
+                c_int,
+                c_ushort,
+                *mut c_ushort,
+                Option<unsafe extern "C" fn()>,
             ) -> c_int,
         >,
         pub fo_close: Option<extern "C" fn(file: *mut file) -> c_int>,

--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -1,4 +1,3 @@
-use crate::off_t;
 use crate::prelude::*;
 
 // Define lock_data_instrumented as an empty enum
@@ -21,8 +20,8 @@ s! {
         pub l_sysid: c_uint,
         pub l_pid: crate::pid_t,
         pub l_vfs: c_int,
-        pub l_start: off_t,
-        pub l_len: off_t,
+        pub l_start: crate::off_t,
+        pub l_len: crate::off_t,
     }
 
     pub struct statvfs {
@@ -34,7 +33,7 @@ s! {
         pub f_files: crate::fsfilcnt_t,
         pub f_ffree: crate::fsfilcnt_t,
         pub f_favail: crate::fsfilcnt_t,
-        pub f_fsid: c_ulong,
+        pub f_fsid: crate::fsid_t,
         pub f_basetype: [c_char; 16],
         pub f_flag: c_ulong,
         pub f_namemax: c_ulong,
@@ -78,8 +77,8 @@ s! {
         pub st_type: c_uint,
         pub st_gen: c_uint,
         st_reserved: Padding<[c_uint; 9]>,
-        pub st_padto_ll: c_uint,
-        pub st_size: off_t,
+        st_padto_ll: Padding<c_uint>,
+        pub st_size: crate::off_t,
     }
 
     pub struct statfs {
@@ -107,7 +106,7 @@ s! {
         pub aio_lio_opcode: c_int,
         pub aio_fildes: c_int,
         pub aio_word1: c_int,
-        pub aio_offset: off_t,
+        pub aio_offset: crate::off_t,
         pub aio_buf: *mut c_void,
         pub aio_return: ssize_t,
         pub aio_errno: c_int,
@@ -126,11 +125,11 @@ s! {
     }
 
     pub struct __vmx_context_t {
-        pub __vr: [crate::__vmxreg_t; 32],
-        pub __pad1: [c_uint; 3],
+        pub __vr: [__vmxreg_t; 32],
+        __pad1: Padding<[c_uint; 3]>,
         pub __vscr: c_uint,
         pub __vrsave: c_uint,
-        pub __pad2: [c_uint; 3],
+        __pad2: Padding<[c_uint; 3]>,
     }
 
     pub struct __vsx_context_t {
@@ -138,8 +137,8 @@ s! {
     }
 
     pub struct __tm_context_t {
-        pub vmx: crate::__vmx_context_t,
-        pub vsx: crate::__vsx_context_t,
+        pub vmx: __vmx_context_t,
+        pub vsx: __vsx_context_t,
         pub gpr: [c_ulonglong; 32],
         pub lr: c_ulonglong,
         pub ctr: c_ulonglong,
@@ -158,7 +157,7 @@ s! {
         pub tmcontext: c_char,
         pub tmstate: c_char,
         pub prevowner: c_char,
-        pub pad: [c_char; 5],
+        pad: Padding<[c_char; 5]>,
     }
 
     pub struct __context64 {
@@ -176,7 +175,7 @@ s! {
         pub fpeu: c_char,
         pub fpinfo: c_char,
         pub fpscr24_31: c_char,
-        pub pad: [c_char; 1],
+        pad: Padding<[c_char; 1]>,
         pub excp_type: c_int,
     }
 
@@ -187,24 +186,24 @@ s! {
     pub struct __extctx_t {
         pub __flags: c_uint,
         pub __rsvd1: [c_uint; 3],
-        pub __vmx: crate::__vmx_context_t,
+        pub __vmx: __vmx_context_t,
         pub __ukeys: [c_uint; 2],
-        pub __vsx: crate::__vsx_context_t,
-        pub __tm: crate::__tm_context_t,
+        pub __vsx: __vsx_context_t,
+        pub __tm: __tm_context_t,
         __reserved: Padding<[c_char; 1860]>,
         pub __extctx_magic: c_int,
     }
 
     pub struct ucontext_t {
-        pub __sc_onstack: c_int,
-        pub uc_sigmask: crate::sigset_t,
-        pub __sc_uerror: c_int,
-        pub uc_mcontext: crate::mcontext_t,
+        __sc_onstack: c_int,
+        pub uc_sigmask: sigset_t,
+        __sc_uerror: c_int,
+        pub uc_mcontext: mcontext_t,
         pub uc_link: *mut ucontext_t,
         pub uc_stack: crate::stack_t,
-        pub __extctx: *mut crate::__extctx_t,
-        pub __extctx_magic: c_int,
-        pub __pad: [c_int; 1],
+        __extctx: *mut __extctx_t,
+        __extctx_magic: c_int,
+        __pad: Padding<[c_int; 1]>,
     }
 
     pub struct utmpx {
@@ -215,17 +214,17 @@ s! {
         pub ut_type: c_short,
         pub ut_tv: crate::timeval,
         pub ut_host: [c_char; 256],
-        pub __dbl_word_pad: c_int,
-        pub __reservedA: [c_int; 2],
-        pub __reservedV: [c_int; 6],
+        __dbl_word_pad: Padding<c_int>,
+        __reservedA: Padding<[c_int; 2]>,
+        __reservedV: Padding<[c_int; 6]>,
     }
 
     pub struct pthread_spinlock_t {
-        pub __sp_word: [c_long; 3],
+        __sp_word: [c_long; 3],
     }
 
     pub struct pthread_barrier_t {
-        pub __br_word: [c_long; 5],
+        __br_word: [c_long; 5],
     }
 
     pub struct msqid_ds {
@@ -255,15 +254,37 @@ s! {
         pub si_addr: *mut c_void,
         pub si_band: c_long,
         pub si_value: crate::sigval,
-        pub __si_flags: c_int,
-        pub __pad: [c_int; 3],
+        __si_flags: c_int,
+        __pad: Padding<[c_int; 3]>,
     }
 
-    pub struct pollfd_ext {
+    pub struct pollfd_ext_t {
         pub fd: c_int,
         pub events: c_short,
         pub revents: c_short,
-        pub data: __pollfd_ext_u,
+        pub u: __c_anonymous_pollfd_ext_t_u,
+    }
+}
+
+impl siginfo_t {
+    pub unsafe fn si_addr(&self) -> *mut c_void {
+        self.si_addr
+    }
+
+    pub unsafe fn si_value(&self) -> crate::sigval {
+        self.si_value
+    }
+
+    pub unsafe fn si_pid(&self) -> crate::pid_t {
+        self.si_pid
+    }
+
+    pub unsafe fn si_uid(&self) -> crate::uid_t {
+        self.si_uid
+    }
+
+    pub unsafe fn si_status(&self) -> c_int {
+        self.si_status
     }
 }
 
@@ -306,8 +327,8 @@ s_no_extra_traits! {
         pub f_type: c_short,
         // Should be pointer to 'vnode'
         pub f_data: *mut c_void,
-        pub f_offset: c_longlong,
-        pub f_dir_off: c_long,
+        pub f_offset: crate::offset_t,
+        pub f_dir_off: crate::off_t,
         // Should be pointer to 'cred'
         pub f_cred: *mut c_void,
         pub f_lock: _kernel_simple_lock,
@@ -319,16 +340,10 @@ s_no_extra_traits! {
         pub f_fdata: [c_char; 160],
     }
 
-    pub union __ld_info_file {
-        pub _ldinfo_fd: c_int,
-        pub _ldinfo_fp: *mut file,
-        pub _core_offset: c_long,
-    }
-
     pub struct ld_info {
         pub ldinfo_next: c_uint,
         pub ldinfo_flags: c_uint,
-        pub _file: __ld_info_file,
+        pub _file: __c_anonymous_ld_info__file,
         pub ldinfo_textorg: *mut c_void,
         pub ldinfo_textsize: c_ulong,
         pub ldinfo_dataorg: *mut c_void,
@@ -336,7 +351,13 @@ s_no_extra_traits! {
         pub ldinfo_filename: [c_char; 2],
     }
 
-    pub union __pollfd_ext_u {
+    pub union __c_anonymous_ld_info__file {
+        pub _ldinfo_fd: c_int,
+        pub _ldinfo_fp: *mut _file,
+        pub _core_offset: c_long,
+    }
+
+    pub union __c_anonymous_pollfd_ext_t_u {
         pub addr: *mut c_void,
         pub data32: u32,
         pub data: u64,
@@ -347,32 +368,10 @@ s_no_extra_traits! {
     }
 }
 
-impl siginfo_t {
-    pub unsafe fn si_addr(&self) -> *mut c_void {
-        self.si_addr
-    }
-
-    pub unsafe fn si_value(&self) -> crate::sigval {
-        self.si_value
-    }
-
-    pub unsafe fn si_pid(&self) -> crate::pid_t {
-        self.si_pid
-    }
-
-    pub unsafe fn si_uid(&self) -> crate::uid_t {
-        self.si_uid
-    }
-
-    pub unsafe fn si_status(&self) -> c_int {
-        self.si_status
-    }
-}
-
 cfg_if! {
     if #[cfg(feature = "extra_traits")] {
-        impl PartialEq for __pollfd_ext_u {
-            fn eq(&self, other: &__pollfd_ext_u) -> bool {
+        impl PartialEq for __c_anonymous_pollfd_ext_t_u {
+            fn eq(&self, other: &__c_anonymous_pollfd_ext_t_u) -> bool {
                 unsafe {
                     self.addr == other.addr
                         && self.data32 == other.data32
@@ -380,8 +379,8 @@ cfg_if! {
                 }
             }
         }
-        impl Eq for __pollfd_ext_u {}
-        impl hash::Hash for __pollfd_ext_u {
+        impl Eq for __c_anonymous_pollfd_ext_t_u {}
+        impl hash::Hash for __c_anonymous_pollfd_ext_t_u {
             fn hash<H: hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     self.addr.hash(state);

--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -441,6 +441,7 @@ cfg_if! {
     }
 }
 
+// pthread.h
 pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
     __mt_word: [0, 2, 0, 0, 0, 0, 0, 0],
 };
@@ -450,11 +451,11 @@ pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = pthread_cond_t {
 pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
     __rw_word: [2, 0, 0, 0, 0, 0, 0, 0, 0, 0],
 };
-
 pub const PTHREAD_ONCE_INIT: pthread_once_t = pthread_once_t {
     __on_word: [0, 0, 0, 0, 0, 2, 0, 0, 0],
 };
 
+// sys/resource.h
 pub const RLIM_INFINITY: c_ulong = 0x7fffffffffffffff;
 
 extern "C" {

--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -305,6 +305,11 @@ s_no_extra_traits! {
         pub _slockp: *mut lock_data_instrumented,
     }
 
+    #[deprecated(
+        since = "0.2.187",
+        note = "This type is only available when programming against the kernel."
+    )]
+    #[allow(deprecated)]
     pub struct fileops_t {
         pub fo_rw: Option<
             extern "C" fn(
@@ -325,7 +330,13 @@ s_no_extra_traits! {
             ) -> c_int,
         >,
         pub fo_select: Option<
-            extern "C" fn(file: *mut file, a: c_int, b: *mut c_ushort, c: extern "C" fn()) -> c_int,
+            extern "C" fn(
+                file: *mut file,
+                a: c_int,
+                b: c_ushort,
+                c: *mut c_ushort,
+                c: extern "C" fn(),
+            ) -> c_int,
         >,
         pub fo_close: Option<extern "C" fn(file: *mut file) -> c_int>,
         pub fo_fstat: Option<extern "C" fn(file: *mut file, sstat: *mut crate::stat) -> c_int>,

--- a/src/unix/aix/powerpc64.rs
+++ b/src/unix/aix/powerpc64.rs
@@ -7,6 +7,13 @@ extern_ty! {
 
 pub type simple_lock_data = c_int;
 
+extern_ty! {
+    /// This is meant to be the `file` type upstream under `sys/ldr.h`. We
+    /// currently expose the kernel definition but that is slated for removal.
+    /// This opaque type will then be renamed to `file`.
+    pub type _file;
+}
+
 s! {
     pub struct sigset_t {
         pub ss_set: [c_ulong; 4],
@@ -342,6 +349,13 @@ s_no_extra_traits! {
         pub fo_fstat: Option<extern "C" fn(file: *mut file, sstat: *mut crate::stat) -> c_int>,
     }
 
+    #[deprecated(
+        since = "0.2.187",
+        note = "Use `_file` instead. This type is only available when programming against the \
+                kernel, and is otherwise an opaque type."
+    )]
+    #[allow(deprecated)]
+    #[repr(align(256))]
     pub struct file {
         pub f_flag: c_long,
         pub f_count: c_int,


### PR DESCRIPTION
## Description

Stems from rust-lang/libc#5259. Is concerned only with the `aix/powerpc64` module. For details
on the changes, see the relevant patch messages.

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] Commit messages permalink to headers for added or changed API
- [x] Placeholder or unstable values like `*LAST` or `*MAX` have the standard
  doc comment
- [ ] Tested locally (`cargo test -p libc-test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
