### PR TITLE
fuchsia, emscripten: struct ipc_perm: rename __ipc_perm_key to __key

### DIFF
--- a/src/fuchsia/aarch64.rs
+++ b/src/fuchsia/aarch64.rs
@@ -64,7 +64,7 @@ s! {
                 removed."
     )]
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/fuchsia/riscv64.rs
+++ b/src/fuchsia/riscv64.rs
@@ -43,7 +43,7 @@ s! {
                 removed."
     )]
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/fuchsia/x86_64.rs
+++ b/src/fuchsia/x86_64.rs
@@ -105,7 +105,7 @@ s! {
                 removed."
     )]
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,

--- a/src/unix/linux_like/emscripten/mod.rs
+++ b/src/unix/linux_like/emscripten/mod.rs
@@ -157,7 +157,7 @@ s! {
     }
 
     pub struct ipc_perm {
-        pub __ipc_perm_key: crate::key_t,
+        pub __key: crate::key_t,
         pub uid: crate::uid_t,
         pub gid: crate::gid_t,
         pub cuid: crate::uid_t,


### PR DESCRIPTION
 ## Description

  Rename the remaining Fuchsia and Emscripten `ipc_perm::__ipc_perm_key` fields to `__key`, matching musl and the Linux-musl definitions updated previously.

  This is a source-level field rename. Field types and layouts are unchanged.

  Upstream header: https://github.com/kraj/musl/blob/a42e9dee266f398026a33d0793c66225c7997755/include/sys/ipc.h#L16-L17

  Fixes rust-lang/libc#4442.

  ## Validation

  - `cargo test --workspace`
  - `cargo check -p libc`
  - Fuchsia aarch64 and x86_64 target checks
  - Emscripten wasm32 target check
  - `git diff --check`

  ## Checklist

  - [x] No semver list change is needed because no symbol was added or removed
  - [x] The commit message includes a permanent link to the relevant header
  - [x] The available host and cross-target checks pass