### PR TITLE
aix: annotate LFS types as slated for deprecation

### DIFF
--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -10,6 +10,7 @@ pub type blkcnt_t = c_long;
 pub type clock_t = c_int;
 pub type daddr_t = c_long;
 pub type dev_t = c_ulong;
+// FIXME(1.0,deprecate): lfs binding to be removed
 pub type fpos64_t = c_longlong;
 pub type fsblkcnt_t = c_ulong;
 pub type fsfilcnt_t = c_ulong;
@@ -21,6 +22,7 @@ pub type rlim_t = c_ulong;
 pub type speed_t = c_uint;
 pub type tcflag_t = c_uint;
 pub type time_t = c_long;
+// FIXME(1.0,deprecate): lfs binding to be removed
 pub type time64_t = i64;
 pub type timer_t = c_long;
 pub type wchar_t = c_uint;
@@ -33,6 +35,7 @@ pub type suseconds_t = c_int;
 pub type useconds_t = c_uint;
 pub type off_t = c_long;
 pub type offset_t = c_longlong;
+// FIXME(1.0,deprecate): lfs binding to be removed
 pub type off64_t = c_longlong;
 pub type idtype_t = c_uint;
 
@@ -48,6 +51,7 @@ pub type nl_item = c_int;
 pub type mqd_t = c_int;
 pub type shmatt_t = c_ulong;
 pub type regoff_t = c_long;
+// FIXME(1.0,deprecate): lfs binding to be removed
 pub type rlim64_t = c_ulonglong;
 
 pub type sem_t = c_int;

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -118,6 +118,7 @@ s! {
         pub c_cc: [crate::cc_t; crate::NCCS],
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct flock64 {
         pub l_type: c_short,
         pub l_whence: c_short,
@@ -443,6 +444,7 @@ s! {
         __unused: Padding<[*mut c_void; 34]>,
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct rlimit64 {
         pub rlim_cur: rlim64_t,
         pub rlim_max: rlim64_t,
@@ -466,6 +468,7 @@ s! {
         shm_reserved1: Padding<crate::int64_t>,
     }
 
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub struct stat64 {
         pub st_dev: dev_t,
         pub st_ino: ino_t,
@@ -2917,25 +2920,33 @@ extern "C" {
     pub fn ffsl(value: c_long) -> c_int;
     pub fn ffsll(value: c_longlong) -> c_int;
     pub fn fgetgrent(file: *mut crate::FILE) -> *mut crate::group;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn fgetpos64(stream: *mut crate::FILE, ptr: *mut fpos64_t) -> c_int;
     pub fn fgetpwent(file: *mut crate::FILE) -> *mut crate::passwd;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn fopen64(filename: *const c_char, mode: *const c_char) -> *mut crate::FILE;
     pub fn freelocale(loc: crate::locale_t);
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn freopen64(
         filename: *const c_char,
         mode: *const c_char,
         file: *mut crate::FILE,
     ) -> *mut crate::FILE;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn fseeko64(stream: *mut crate::FILE, offset: off64_t, whence: c_int) -> c_int;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn fsetpos64(stream: *mut crate::FILE, ptr: *const fpos64_t) -> c_int;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn fstat64(fildes: c_int, buf: *mut stat64) -> c_int;
     pub fn fstatfs(fd: c_int, buf: *mut statfs) -> c_int;
     // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn fstatfs64(fd: c_int, buf: *mut statfs64) -> c_int;
     // FIXME(1.0,deprecate,32): lfs binding to be removed
     pub fn fstatvfs64(fd: c_int, buf: *mut statvfs64) -> c_int;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn ftello64(stream: *mut crate::FILE) -> off64_t;
     pub fn ftok(path: *const c_char, id: c_int) -> crate::key_t;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn ftruncate64(fd: c_int, length: off64_t) -> c_int;
     pub fn futimens(fd: c_int, times: *const crate::timespec) -> c_int;
     pub fn getcontext(ucp: *mut ucontext_t) -> c_int;
@@ -2993,6 +3004,7 @@ extern "C" {
         result: *mut *mut passwd,
     ) -> c_int;
     pub fn getrlimit(resource: c_int, rlim: *mut crate::rlimit) -> c_int;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn getrlimit64(resource: c_int, rlim: *mut rlimit64) -> c_int;
     pub fn gettimeofday(tp: *mut crate::timeval, tz: *mut c_void) -> c_int;
     pub fn getitimer(which: c_int, curr_value: *mut crate::itimerval) -> c_int;
@@ -3044,7 +3056,9 @@ extern "C" {
         width: size_t,
         compar: Option<unsafe extern "C" fn(*const c_void, *const c_void) -> c_int>,
     ) -> *mut c_void;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn lseek64(fd: c_int, offset: off64_t, whence: c_int) -> off64_t;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn lstat64(path: *const c_char, buf: *mut stat64) -> c_int;
     pub fn madvise(addr: caddr_t, len: size_t, advice: c_int) -> c_int;
     pub fn makecontext(ucp: *mut crate::ucontext_t, func: extern "C" fn(), argc: c_int, ...);
@@ -3114,6 +3128,7 @@ extern "C" {
     pub fn nl_langinfo(item: crate::nl_item) -> *mut c_char;
     pub fn nl_langinfo_l(item: crate::nl_item, loc: crate::locale_t) -> *mut c_char;
     pub fn nrand48(xseed: *mut c_ushort) -> c_long;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn open64(path: *const c_char, oflag: c_int, ...) -> c_int;
     pub fn pollset_create(maxfd: c_int) -> pollset_t;
     pub fn pollset_ctl(ps: pollset_t, pollctl_array: *mut poll_ctl, array_length: c_int) -> c_int;
@@ -3127,8 +3142,10 @@ extern "C" {
     pub fn pollset_query(ps: pollset_t, pollfd_query: *mut crate::pollfd) -> c_int;
     pub fn popen(command: *const c_char, mode: *const c_char) -> *mut crate::FILE;
     pub fn posix_fadvise(fd: c_int, offset: off_t, len: off_t, advise: c_int) -> c_int;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn posix_fadvise64(fd: c_int, offset: off64_t, len: off64_t, advise: c_int) -> c_int;
     pub fn posix_fallocate(fd: c_int, offset: off_t, len: off_t) -> c_int;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn posix_fallocate64(fd: c_int, offset: off64_t, len: off64_t) -> c_int;
     pub fn posix_madvise(addr: *mut c_void, len: size_t, advice: c_int) -> c_int;
     pub fn posix_spawn(
@@ -3203,6 +3220,7 @@ extern "C" {
         argv: *const *mut c_char,
         envp: *const *mut c_char,
     ) -> c_int;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn pread64(fd: c_int, buf: *mut c_void, count: size_t, offset: off64_t) -> ssize_t;
     pub fn preadv(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: offset_t) -> ssize_t;
     pub fn ptrace64(
@@ -3214,6 +3232,7 @@ extern "C" {
     ) -> c_int;
     pub fn pututline(u: *const utmp) -> *mut utmp;
     pub fn pututxline(ut: *const utmpx) -> *mut utmpx;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn pwrite64(fd: c_int, buf: *const c_void, count: size_t, offset: off64_t) -> ssize_t;
     pub fn pwritev(fd: c_int, iov: *const crate::iovec, iovcnt: c_int, offset: offset_t)
         -> ssize_t;
@@ -3302,6 +3321,7 @@ extern "C" {
     pub fn setpriority(which: c_int, who: id_t, priority: c_int) -> c_int;
     pub fn setpwent();
     pub fn setrlimit(resource: c_int, rlim: *const crate::rlimit) -> c_int;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn setrlimit64(resource: c_int, rlim: *const rlimit64) -> c_int;
     pub fn settimeofday(tv: *const crate::timeval, tz: *const crate::timezone) -> c_int;
     pub fn setitimer(
@@ -3329,7 +3349,9 @@ extern "C" {
     pub fn splice(socket1: c_int, socket2: c_int, flags: c_int) -> c_int;
     pub fn srand(seed: c_uint);
     pub fn srand48(seed: c_long);
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn stat64(path: *const c_char, buf: *mut stat64) -> c_int;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn stat64at(dirfd: c_int, path: *const c_char, buf: *mut stat64, flags: c_int) -> c_int;
     pub fn statfs(path: *const c_char, buf: *mut statfs) -> c_int;
     // FIXME(1.0,deprecate,64): lfs binding to be removed
@@ -3376,6 +3398,7 @@ extern "C" {
         new_value: *const crate::itimerspec,
         old_value: *mut crate::itimerspec,
     ) -> c_int;
+    // FIXME(1.0,deprecate): lfs binding to be removed
     pub fn truncate64(path: *const c_char, length: off64_t) -> c_int;
     pub fn uname(buf: *mut crate::utsname) -> c_int;
     pub fn updwtmp(file: *const c_char, u: *const utmp);

--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -138,6 +138,7 @@ s! {
         pub msg_flags: c_int,
     }
 
+    // FIXME(1.0,deprecate,32): lfs binding to be removed.
     pub struct statvfs64 {
         pub f_bsize: crate::blksize64_t,
         pub f_frsize: crate::blksize64_t,
@@ -271,6 +272,7 @@ s! {
         pub tv_nsec: c_int,
     }
 
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub struct statfs64 {
         pub f_version: c_int,
         pub f_type: c_int,
@@ -2928,7 +2930,9 @@ extern "C" {
     pub fn fsetpos64(stream: *mut crate::FILE, ptr: *const fpos64_t) -> c_int;
     pub fn fstat64(fildes: c_int, buf: *mut stat64) -> c_int;
     pub fn fstatfs(fd: c_int, buf: *mut statfs) -> c_int;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn fstatfs64(fd: c_int, buf: *mut statfs64) -> c_int;
+    // FIXME(1.0,deprecate,32): lfs binding to be removed
     pub fn fstatvfs64(fd: c_int, buf: *mut statvfs64) -> c_int;
     pub fn ftello64(stream: *mut crate::FILE) -> off64_t;
     pub fn ftok(path: *const c_char, id: c_int) -> crate::key_t;
@@ -3328,7 +3332,9 @@ extern "C" {
     pub fn stat64(path: *const c_char, buf: *mut stat64) -> c_int;
     pub fn stat64at(dirfd: c_int, path: *const c_char, buf: *mut stat64, flags: c_int) -> c_int;
     pub fn statfs(path: *const c_char, buf: *mut statfs) -> c_int;
+    // FIXME(1.0,deprecate,64): lfs binding to be removed
     pub fn statfs64(path: *const c_char, buf: *mut statfs64) -> c_int;
+    // FIXME(1.0,deprecate,32): lfs binding to be removed
     pub fn statvfs64(path: *const c_char, buf: *mut statvfs64) -> c_int;
     pub fn statx(path: *const c_char, buf: *mut stat, length: c_int, command: c_int) -> c_int;
     pub fn strcasecmp_l(


### PR DESCRIPTION
## Description

Stems from rust-lang/libc#5259. Is concerned only with LFS matters in AIX. See the patch
messages for details on the changes and sources. This follows the initial stages
of the plan outlined at rust-lang/libc#4805.

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] Commit messages permalink to headers for added or changed API
- [x] Placeholder or unstable values like `*LAST` or `*MAX` have the standard
  doc comment
- [ ] Tested locally (`cargo test -p libc-test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
