### PR TITLE
Remove sparc64 roundtrip skips

### DIFF
--- a/libc-test/build/main.rs
+++ b/libc-test/build/main.rs
@@ -5256,30 +5256,6 @@ fn test_linux(target: &str) {
         // FIXME(1.0):
         "mcontext_t" if s390x => true,
 
-        // The test doesn't work on some env:
-        "ipv6_mreq"
-        | "ip_mreq_source"
-        | "sockaddr_in6"
-        | "sockaddr_ll"
-        | "in_pktinfo"
-        | "arpreq"
-        | "arpreq_old"
-        | "sockaddr_un"
-        | "ff_constant_effect"
-        | "ff_ramp_effect"
-        | "ff_condition_effect"
-        | "Elf32_Ehdr"
-        | "Elf32_Chdr"
-        | "ucred"
-        | "in6_pktinfo"
-        | "sockaddr_nl"
-        | "termios"
-        | "nlmsgerr"
-            if sparc64 && gnu =>
-        {
-            true
-        }
-
         // The following types contain Flexible Array Member fields which have unspecified calling
         // convention. The roundtripping tests deliberately pass the structs by value to check "by
         // value" layout consistency, but this would be UB for the these types.


### PR DESCRIPTION
Fixes issues rust-lang/libc#1427 and rust-lang/libc#1558.

The 17 test skips on sparc64 for rustc were due to bugs in the sparc64 ABI implementation. These bugs have been fixed in http://github.com/rust-lang/rust/pull/142680, which was merged on February 12, 2026. Since the libc CI runs every night, these skips are no longer relevant. Removing them will allow the tier2 sparc64 job to properly verify the tests.

We've kept other test skips related to FAM type, max_align_t on i686 and ppc64, s390x mcontext_t, and freebsd gregset because those are separate problems.

Close rust-lang/libc#1427
Close rust-lang/libc#1558.