### PR TITLE
android: stop skipping `ioctl` in tests

### DIFF
--- a/libc-test/build/main.rs
+++ b/libc-test/build/main.rs
@@ -1983,6 +1983,10 @@ fn test_android(target: &str) {
     let mut cfg = ctest_cfg();
     cfg.define("_GNU_SOURCE", None);
 
+    // This ensure we avoid the `ioctl` overload for request parameters that use
+    // an unsigned integer instead of a signed integer.
+    cfg.define("BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD", None);
+
     headers!(
         cfg,
         "arpa/inet.h",
@@ -2405,10 +2409,6 @@ fn test_android(target: &str) {
 
             // Added in API level 24
             "if_nameindex" | "if_freenameindex" => true,
-
-            // FIXME(ctest): In our current method of testing, we cast the function to a `void *`,
-            // which is not possible for functions that have been overloaded.
-            "ioctl" => true,
 
             _ => false,
         }


### PR DESCRIPTION
## Description

Removes a skip in ctest for `ioctl` in Android targets. This was previously not
possible because there were issues with an overload exposed in Bionic libc. This
overload, though, is only conditionally exposed.

The macro used to skip the definition upstream has been added to the `#define`s
that we have set up in `test_android` in libc-test's build script.

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated
- [x] Commit messages permalink to headers for added or changed API
- [x] Placeholder or unstable values like `*LAST` or `*MAX` have the standard
  doc comment
- [ ] Tested locally (`cargo test -p libc-test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated
