### PR TITLE
ctest: allow variadics to be tested.

### DIFF
--- a/ctest/src/cdecl.rs
+++ b/ctest/src/cdecl.rs
@@ -254,6 +254,11 @@ pub(crate) fn func_ptr(args: Vec<CTy>, ret: CTy) -> CTy {
     }
 }
 
+/// Create a variadic function argument.
+pub(crate) fn variadic() -> CTy {
+    named("...", Constness::Mut)
+}
+
 /// Checked with <https://cdecl.org/>.
 #[cfg(test)]
 mod tests {

--- a/ctest/src/tests.rs
+++ b/ctest/src/tests.rs
@@ -108,6 +108,10 @@ fn test_translation_type_bare_fn() {
         "extern \"C\" fn(c_int) -> *const c_void",
         "const void *(*foo)(int)",
     );
+    assert_r2cdecl(
+        "unsafe extern \"C\" fn(*const c_char, i32, ...) -> c_int",
+        "int (*foo)(const char *, int32_t, ...)",
+    );
     // FIXME(ctest): Reimplement support for ABI in a more robust way.
     // assert_r2cdecl(
     //     "Option<extern \"stdcall\" fn(*const c_char, [u32; 16]) -> u8>",

--- a/ctest/src/translator.rs
+++ b/ctest/src/translator.rs
@@ -71,10 +71,6 @@ pub(crate) enum TranslationErrorKind {
     #[error("references to non-primitive types are not allowed")]
     NonPrimitiveReference,
 
-    /// Variadic functions or parameters were found, which cannot be handled.
-    #[error("variadics cannot be translated")]
-    HasVariadics,
-
     /// Lifetimes were found in the type or function signature, which are not supported.
     #[error("lifetimes cannot be translated")]
     HasLifetimes,
@@ -194,13 +190,6 @@ impl<'a> Translator<'a> {
                 function.span(),
             ));
         }
-        if function.variadic.is_some() {
-            return Err(TranslationError::new(
-                TranslationErrorKind::HasVariadics,
-                &function.to_token_stream().to_string(),
-                function.span(),
-            ));
-        }
 
         let mut parameters = function
             .inputs
@@ -213,7 +202,9 @@ impl<'a> Translator<'a> {
             syn::ReturnType::Type(_, ty) => self.translate_type(ty)?,
         };
 
-        if parameters.is_empty() {
+        if function.variadic.is_some() {
+            parameters.push(cdecl::variadic());
+        } else if parameters.is_empty() {
             parameters.push(cdecl::named("void", Constness::Mut));
         }
 

--- a/ctest/tests/input/simple.h
+++ b/ctest/tests/input/simple.h
@@ -33,4 +33,5 @@ union Word
 #define C_B "bac"
 
 extern void *calloc(size_t num, size_t size);
+extern int printf(const char* format, ...);
 extern Byte byte;

--- a/ctest/tests/input/simple.out.with-renames.c
+++ b/ctest/tests/input/simple.out.with-renames.c
@@ -370,6 +370,10 @@ CTEST_EXTERN ctest_void_func ctest_foreign_fn__calloc(void) {
     return (ctest_void_func)calloc;
 }
 
+CTEST_EXTERN ctest_void_func ctest_foreign_fn__printf(void) {
+    return (ctest_void_func)printf;
+}
+
 #ifdef _MSC_VER
     // Pop allow for 4191
     #pragma warning(default:4191)

--- a/ctest/tests/input/simple.out.with-renames.rs
+++ b/ctest/tests/input/simple.out.with-renames.rs
@@ -1089,6 +1089,15 @@ mod generated_tests {
         check_same(actual, expected, "`calloc` function pointer");
     }
 
+    pub fn ctest_foreign_fn_printf() {
+        extern "C" {
+            fn ctest_foreign_fn__printf() -> unsafe extern "C" fn();
+        }
+        let actual = unsafe { ctest_foreign_fn__printf() } as u64;
+        let expected = printf as *const () as u64;
+        check_same(actual, expected, "`printf` function pointer");
+    }
+
 /* Tests if the pointer to the static variable matches in both Rust and C. */
 
     pub fn ctest_static_byte() {
@@ -1153,5 +1162,6 @@ fn run_all() {
     ctest_roundtrip_Person();
     ctest_roundtrip_Word();
     ctest_foreign_fn_calloc();
+    ctest_foreign_fn_printf();
     ctest_static_byte();
 }

--- a/ctest/tests/input/simple.out.with-skips.c
+++ b/ctest/tests/input/simple.out.with-skips.c
@@ -112,6 +112,10 @@ CTEST_EXTERN volatile_char ctest_roundtrip__volatile_char(
 
 /* Query a function's pointer */
 
+CTEST_EXTERN ctest_void_func ctest_foreign_fn__printf(void) {
+    return (ctest_void_func)printf;
+}
+
 #ifdef _MSC_VER
     // Pop allow for 4191
     #pragma warning(default:4191)

--- a/ctest/tests/input/simple.out.with-skips.rs
+++ b/ctest/tests/input/simple.out.with-skips.rs
@@ -228,6 +228,15 @@ mod generated_tests {
 
 /* Check if the Rust and C side function pointers point to the same underlying function. */
 
+    pub fn ctest_foreign_fn_printf() {
+        extern "C" {
+            fn ctest_foreign_fn__printf() -> unsafe extern "C" fn();
+        }
+        let actual = unsafe { ctest_foreign_fn__printf() } as u64;
+        let expected = printf as *const () as u64;
+        check_same(actual, expected, "`printf` function pointer");
+    }
+
 /* Tests if the pointer to the static variable matches in both Rust and C. */
 }
 
@@ -253,4 +262,5 @@ fn run_all() {
     ctest_size_align_volatile_char();
     ctest_signededness_volatile_char();
     ctest_roundtrip_volatile_char();
+    ctest_foreign_fn_printf();
 }

--- a/ctest/tests/input/simple.rs
+++ b/ctest/tests/input/simple.rs
@@ -31,6 +31,7 @@ const B: *const c_char = c"bac".as_ptr();
 
 unsafe extern "C" {
     pub fn calloc(num: usize, size: usize) -> *mut c_void;
+    pub fn printf(format: *const c_char, ...) -> c_int;
 
     pub static byte: Byte;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md> -->

## Description
Removes the check for variadics and adds support for translating variadic types between C and Rust.

While not used currently, might be useful down the line, especially if we ever decide to stop using void pointers for foreign function tests.
<!-- Add a short description about what this change does, or say "See commit
messages" if details are there. -->

Closes rust-lang/libc#4367
## Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. See the pull request guidelines
for help
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md#submitting-a-pull-request>.
-->

- [X] Relevant tests in `libc-test/semver` have been updated
- [X] Commit messages permalink to headers for added or changed API
- [X] Placeholder or unstable values like `*LAST` or `*MAX` have the standard
  doc comment
- [X] Tested locally (`cargo test -p libc-test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If it is, delete the following
line: -->
@rustbot label +stable-nominated
