### PR TITLE
libc-test: re-enable some skipped tests on powerpc64

### DIFF
--- a/libc-test/build/main.rs
+++ b/libc-test/build/main.rs
@@ -4333,7 +4333,7 @@ fn test_linux(target: &str) {
 
         // FIXME(rust-lang/rust#43894): pass by value for structs that are not an even 32/64 bits
         // on big-endian systems corrupts the value for unknown reasons.
-        if (sparc64 || ppc || ppc64 || s390x)
+        if (sparc64 || ppc || s390x)
             && (ty == "sockaddr_pkt"
                 || ty == "tpacket_auxdata"
                 || ty == "tpacket_hdr_variant1"
@@ -4374,7 +4374,7 @@ fn test_linux(target: &str) {
 
             // FIXME(ppc): tests fail due to a field type mismatch (`long long unsigned` vs
             // `long unsigned`).
-            "clone_args" if ppc64 => true,
+            "clone_args" if ppc64 && gnu => true,
 
             // Linux >= 6.13 (pidfd_info.exit_code: Linux >= 6.15)
             // Might differ between kernel versions
@@ -5289,7 +5289,7 @@ fn test_linux(target: &str) {
         "bcm_msg_head" => true,
 
         // FIXME(linux): the call ABI of max_align_t is incorrect on these platforms:
-        "max_align_t" if i686 || ppc64 => true,
+        "max_align_t" if i686 => true,
 
         _ => false,
     });


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md> -->

## Description

These tests pass just fine for me on `powerpc64le-unknown-linux-musl`, on `powerpc64-unknown-linux-musl` and on `powerpc64le-unknown-linux-gnu`.

## Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. See the pull request guidelines
for help
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md#submitting-a-pull-request>.
-->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] Commit messages permalink to headers for added or changed API
- [ ] Placeholder or unstable values like `*LAST` or `*MAX` have the standard
  doc comment
- [x] Tested locally (`cargo test -p libc-test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If it is, delete the following
line: -->
@rustbot label +stable-nominated
