### PR TITLE
fix(ci): pin cc to 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",

--- a/ctest-test/Cargo.toml
+++ b/ctest-test/Cargo.toml
@@ -7,7 +7,8 @@ rust-version = "1.88"
 
 [build-dependencies]
 ctest = { path = "../ctest" }
-cc = "1.2"
+# FIXME: Unpin once https://github.com/rust-lang/cc-rs/pull/1845 is released.
+cc = "=1.4.0"
 
 [dev-dependencies]
 ctest = { path = "../ctest" }


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md> -->

## Description

<!-- Add a short description about what this change does, or say "See commit
messages" if details are there. -->

this unblocks CI, we can remove the pin once https://github.com/rust-lang/cc-rs/pull/1845 is released

## Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. See the pull request guidelines
for help
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md#submitting-a-pull-request>.
-->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] Commit messages permalink to headers for added or changed API
- [ ] Placeholder or unstable values like `*LAST` or `*MAX` have the standard
  doc comment
- [ ] Tested locally (`cargo test -p libc-test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If it is, delete the following
line: -->

@rustbot label +stable-nominated
