### PR TITLE
Define max_align_t for s390x-linux

### DIFF
--- a/libc-test/semver/linux-s390x.txt
+++ b/libc-test/semver/linux-s390x.txt
@@ -104,4 +104,5 @@ flock64
 fpreg_t
 fpregset_t
 greg_t
+max_align_t
 termios2

--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -237,6 +237,13 @@ cfg_if! {
     }
 }
 
+s_no_extra_traits! {
+    #[repr(align(8))]
+    pub struct max_align_t {
+        priv_: [i64; 3],
+    }
+}
+
 pub const POSIX_FADV_DONTNEED: c_int = 6;
 pub const POSIX_FADV_NOREUSE: c_int = 7;
 


### PR DESCRIPTION
Define max_align_t for s390x-linux

The proper value for max_align_t was determined with the help of a small C program which yielded a size of 24 for max_align_t with an alignment of 8 bytes when compiled and run on s390x-linux:

```
glaubitz@zelenka:~$ cat max_align_t.c
#include <stdio.h>
#include <stddef.h>

int main() {

        printf("sizeof(max_align_t): %d\n", sizeof(max_align_t));
        printf("_Alignof(max_align_t): %d\n", _Alignof(max_align_t));
        return 0;
}
glaubitz@zelenka:~$ gcc max_align_t.c -o max_align_t
glaubitz@zelenka:~$ ./max_align_t
sizeof(max_align_t): 24
_Alignof(max_align_t): 8
glaubitz@zelenka:~$
```