### PR TITLE
feat: add missing lch* syscalls to *BSD platforms

### DIFF
--- a/libc-test/semver/apple.txt
+++ b/libc-test/semver/apple.txt
@@ -2109,6 +2109,8 @@ key_t
 killpg
 kqueue
 labs
+lchflags
+lchmod
 lio_listio
 listxattr
 load_command

--- a/libc-test/semver/freebsd.txt
+++ b/libc-test/semver/freebsd.txt
@@ -2117,6 +2117,7 @@ kld_load
 kqueue
 labs
 lchflags
+lchmod
 lcong48
 lio_listio
 lockf

--- a/libc-test/semver/netbsd.txt
+++ b/libc-test/semver/netbsd.txt
@@ -1410,6 +1410,7 @@ labs
 lastlog
 lastlogx
 lchflags
+lchmod
 lcong48
 lgetxattr
 lio_listio

--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -4256,6 +4256,8 @@ extern "C" {
     pub fn aio_cancel(fd: c_int, aiocbp: *mut aiocb) -> c_int;
     pub fn chflags(path: *const c_char, flags: c_uint) -> c_int;
     pub fn fchflags(fd: c_int, flags: c_uint) -> c_int;
+    pub fn lchflags(path: *const c_char, flags: c_uint) -> c_int;
+    pub fn lchmod(path: *const c_char, mode: mode_t) -> c_int;
     pub fn clock_getres(clk_id: crate::clockid_t, tp: *mut crate::timespec) -> c_int;
     pub fn clock_gettime(clk_id: crate::clockid_t, tp: *mut crate::timespec) -> c_int;
     pub fn lio_listio(

--- a/src/unix/bsd/freebsdlike/freebsd/mod.rs
+++ b/src/unix/bsd/freebsdlike/freebsd/mod.rs
@@ -4965,6 +4965,8 @@ extern "C" {
         symbol: *const c_char,
         version: *const c_char,
     ) -> *mut c_void;
+
+    pub fn lchmod(path: *const c_char, mode: crate::mode_t) -> c_int;
 }
 
 #[link(name = "memstat")]

--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1910,6 +1910,7 @@ extern "C" {
     pub fn chflags(path: *const c_char, flags: c_ulong) -> c_int;
     pub fn fchflags(fd: c_int, flags: c_ulong) -> c_int;
     pub fn lchflags(path: *const c_char, flags: c_ulong) -> c_int;
+    pub fn lchmod(path: *const c_char, mode: crate::mode_t) -> c_int;
 
     pub fn extattr_list_fd(
         fd: c_int,


### PR DESCRIPTION
This change adds the following system calls to various 4.4BSD derivatives:
 
* FreeBSD(-like)
    * lchmod ([DragonFlyBSD][1], [FreeBSD][2])
* macOS
    * [lchflags][3]
    * [lchmod][4]
* NetBSD
    * [lchmod][5]
 
These system calls are available on all ancient versions of *BSD (4.4BSD, FreeBSD 3.0, etc). More specific historical information about when the functions were added is available in the manpages and headers referenced.
 
1: https://leaf.dragonflybsd.org/cgi/web-man?command=lchmod
2: https://man.freebsd.org/cgi/man.cgi?query=lchmod
3: https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/sys/stat.h#L597
4: https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/sys/stat.h#L598
5: https://man.netbsd.org/lchmod.2