### PR TITLE
deprecate the `<int type>_{MIN,MAX}` constants

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -1184,9 +1184,9 @@ cfg_if! {
 pub const HOST_NAME_MAX: c_int = 255;
 
 #[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
-pub const INT_MIN: c_int = -1 - 0x7fffffff;
+pub const INT_MIN: c_int = c_int::MIN;
 #[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
-pub const INT_MAX: c_int = 0x7fffffff;
+pub const INT_MAX: c_int = c_int::MAX;
 
 pub const SIG_DFL: sighandler_t = 0 as sighandler_t;
 pub const SIG_IGN: sighandler_t = 1 as sighandler_t;

--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -1183,7 +1183,9 @@ cfg_if! {
 
 pub const HOST_NAME_MAX: c_int = 255;
 
+#[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
 pub const INT_MIN: c_int = -1 - 0x7fffffff;
+#[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
 pub const INT_MAX: c_int = 0x7fffffff;
 
 pub const SIG_DFL: sighandler_t = 0 as sighandler_t;

--- a/src/new/qurt/limits.rs
+++ b/src/new/qurt/limits.rs
@@ -5,23 +5,37 @@ use crate::prelude::*;
 
 // Character properties
 pub const CHAR_BIT: c_uint = 8;
+#[deprecated(since = "0.2.190", note = "Use `c_char::MAX` instead.")]
 pub const CHAR_MAX: c_char = 255; // unsigned char on Hexagon
+#[deprecated(since = "0.2.190", note = "Use `c_char::MIN` instead.")]
 pub const CHAR_MIN: c_char = 0;
+#[deprecated(since = "0.2.190", note = "Use `c_schar::MAX` instead.")]
 pub const SCHAR_MAX: i8 = 127;
+#[deprecated(since = "0.2.190", note = "Use `c_schar::MIN` instead.")]
 pub const SCHAR_MIN: i8 = -128;
+#[deprecated(since = "0.2.190", note = "Use `c_uchar::MAX` instead.")]
 pub const UCHAR_MAX: c_uchar = 255;
 
 // Integer properties
+#[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
 pub const INT_MAX: c_int = 2147483647;
+#[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
 pub const INT_MIN: c_int = -2147483647 - 1;
+#[deprecated(since = "0.2.190", note = "Use `c_uint::MAX` instead.")]
 pub const UINT_MAX: c_uint = 4294967295;
 
+#[deprecated(since = "0.2.190", note = "Use `c_long::MAX` instead.")]
 pub const LONG_MAX: c_long = 2147483647;
+#[deprecated(since = "0.2.190", note = "Use `c_long::MIN` instead.")]
 pub const LONG_MIN: c_long = -2147483647 - 1;
+#[deprecated(since = "0.2.190", note = "Use `c_ulong::MAX` instead.")]
 pub const ULONG_MAX: c_ulong = 4294967295;
 
+#[deprecated(since = "0.2.190", note = "Use `c_short::MAX` instead.")]
 pub const SHRT_MAX: c_short = 32767;
+#[deprecated(since = "0.2.190", note = "Use `c_short::MIN` instead.")]
 pub const SHRT_MIN: c_short = -32768;
+#[deprecated(since = "0.2.190", note = "Use `c_ushort::MAX` instead.")]
 pub const USHRT_MAX: c_ushort = 65535;
 
 // POSIX Limits

--- a/src/new/qurt/limits.rs
+++ b/src/new/qurt/limits.rs
@@ -6,37 +6,37 @@ use crate::prelude::*;
 // Character properties
 pub const CHAR_BIT: c_uint = 8;
 #[deprecated(since = "0.2.190", note = "Use `c_char::MAX` instead.")]
-pub const CHAR_MAX: c_char = 255; // unsigned char on Hexagon
+pub const CHAR_MAX: c_char = c_char::MAX; // unsigned char on Hexagon
 #[deprecated(since = "0.2.190", note = "Use `c_char::MIN` instead.")]
-pub const CHAR_MIN: c_char = 0;
-#[deprecated(since = "0.2.190", note = "Use `c_schar::MAX` instead.")]
-pub const SCHAR_MAX: i8 = 127;
-#[deprecated(since = "0.2.190", note = "Use `c_schar::MIN` instead.")]
-pub const SCHAR_MIN: i8 = -128;
+pub const CHAR_MIN: c_char = c_char::MIN;
+#[deprecated(since = "0.2.190", note = "Use `i8::MAX` instead.")]
+pub const SCHAR_MAX: i8 = i8::MAX;
+#[deprecated(since = "0.2.190", note = "Use `i8::MIN` instead.")]
+pub const SCHAR_MIN: i8 = i8::MIN;
 #[deprecated(since = "0.2.190", note = "Use `c_uchar::MAX` instead.")]
-pub const UCHAR_MAX: c_uchar = 255;
+pub const UCHAR_MAX: c_uchar = c_uchar::MAX;
 
 // Integer properties
 #[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
-pub const INT_MAX: c_int = 2147483647;
+pub const INT_MAX: c_int = c_int::MAX;
 #[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
-pub const INT_MIN: c_int = -2147483647 - 1;
+pub const INT_MIN: c_int = c_int::MIN;
 #[deprecated(since = "0.2.190", note = "Use `c_uint::MAX` instead.")]
-pub const UINT_MAX: c_uint = 4294967295;
+pub const UINT_MAX: c_uint = c_uint::MAX;
 
 #[deprecated(since = "0.2.190", note = "Use `c_long::MAX` instead.")]
-pub const LONG_MAX: c_long = 2147483647;
+pub const LONG_MAX: c_long = c_long::MAX;
 #[deprecated(since = "0.2.190", note = "Use `c_long::MIN` instead.")]
-pub const LONG_MIN: c_long = -2147483647 - 1;
+pub const LONG_MIN: c_long = c_long::MIN;
 #[deprecated(since = "0.2.190", note = "Use `c_ulong::MAX` instead.")]
-pub const ULONG_MAX: c_ulong = 4294967295;
+pub const ULONG_MAX: c_ulong = c_ulong::MAX;
 
 #[deprecated(since = "0.2.190", note = "Use `c_short::MAX` instead.")]
-pub const SHRT_MAX: c_short = 32767;
+pub const SHRT_MAX: c_short = c_short::MAX;
 #[deprecated(since = "0.2.190", note = "Use `c_short::MIN` instead.")]
-pub const SHRT_MIN: c_short = -32768;
+pub const SHRT_MIN: c_short = c_short::MIN;
 #[deprecated(since = "0.2.190", note = "Use `c_ushort::MAX` instead.")]
-pub const USHRT_MAX: c_ushort = 65535;
+pub const USHRT_MAX: c_ushort = c_ushort::MAX;
 
 // POSIX Limits
 pub const ARG_MAX: c_int = 4096;

--- a/src/sgx.rs
+++ b/src/sgx.rs
@@ -12,6 +12,6 @@ pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
 #[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
-pub const INT_MIN: c_int = -2147483648;
+pub const INT_MIN: c_int = c_int::MIN;
 #[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
-pub const INT_MAX: c_int = 2147483647;
+pub const INT_MAX: c_int = c_int::MAX;

--- a/src/sgx.rs
+++ b/src/sgx.rs
@@ -11,5 +11,7 @@ pub type intptr_t = isize;
 pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
+#[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
 pub const INT_MIN: c_int = -2147483648;
+#[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
 pub const INT_MAX: c_int = 2147483647;

--- a/src/solid/mod.rs
+++ b/src/solid/mod.rs
@@ -177,9 +177,9 @@ s! {
 }
 
 #[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
-pub const INT_MIN: c_int = -2147483648;
+pub const INT_MIN: c_int = c_int::MIN;
 #[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
-pub const INT_MAX: c_int = 2147483647;
+pub const INT_MAX: c_int = c_int::MAX;
 
 pub const EXIT_FAILURE: c_int = 1;
 pub const EXIT_SUCCESS: c_int = 0;

--- a/src/solid/mod.rs
+++ b/src/solid/mod.rs
@@ -176,7 +176,9 @@ s! {
     }
 }
 
+#[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
 pub const INT_MIN: c_int = -2147483648;
+#[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
 pub const INT_MAX: c_int = 2147483647;
 
 pub const EXIT_FAILURE: c_int = 1;

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -14,6 +14,6 @@ pub type off_t = i64;
 pub type wchar_t = u32;
 
 #[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
-pub const INT_MIN: c_int = -2147483648;
+pub const INT_MIN: c_int = c_int::MIN;
 #[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
-pub const INT_MAX: c_int = 2147483647;
+pub const INT_MAX: c_int = c_int::MAX;

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -13,5 +13,7 @@ pub type ssize_t = isize;
 pub type off_t = i64;
 pub type wchar_t = u32;
 
+#[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
 pub const INT_MIN: c_int = -2147483648;
+#[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
 pub const INT_MAX: c_int = 2147483647;

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -2634,42 +2634,79 @@ pub const TCP_REPAIR_OFF: c_int = 0;
 pub const TCP_REPAIR_OFF_NO_WP: c_int = -1;
 
 // stdint.h
+#[deprecated(since = "0.2.190", note = "Use `i8::MIN` instead.")]
 pub const INT8_MIN: i8 = -128;
+#[deprecated(since = "0.2.190", note = "Use `i16::MIN` instead.")]
 pub const INT16_MIN: i16 = -32768;
+#[deprecated(since = "0.2.190", note = "Use `i32::MIN` instead.")]
 pub const INT32_MIN: i32 = -2147483648;
+#[deprecated(since = "0.2.190", note = "Use `i8::MAX` instead.")]
 pub const INT8_MAX: i8 = 127;
+#[deprecated(since = "0.2.190", note = "Use `i16::MAX` instead.")]
 pub const INT16_MAX: i16 = 32767;
+#[deprecated(since = "0.2.190", note = "Use `i32::MAX` instead.")]
 pub const INT32_MAX: i32 = 2147483647;
+#[deprecated(since = "0.2.190", note = "Use `u8::MAX` instead.")]
 pub const UINT8_MAX: u8 = 255;
+#[deprecated(since = "0.2.190", note = "Use `u16::MAX` instead.")]
 pub const UINT16_MAX: u16 = 65535;
+#[deprecated(since = "0.2.190", note = "Use `u32::MAX` instead.")]
 pub const UINT32_MAX: u32 = 4294967295;
+#[deprecated(since = "0.2.190", note = "Use `int_least8_t::MIN` instead.")]
 pub const INT_LEAST8_MIN: int_least8_t = -128;
+#[deprecated(since = "0.2.190", note = "Use `int_least16_t::MIN` instead.")]
 pub const INT_LEAST16_MIN: int_least16_t = -32768;
+#[deprecated(since = "0.2.190", note = "Use `int_least32_t::MIN` instead.")]
 pub const INT_LEAST32_MIN: int_least32_t = -2147483648;
+#[deprecated(since = "0.2.190", note = "Use `int_least8_t::MAX` instead.")]
 pub const INT_LEAST8_MAX: int_least8_t = 127;
+#[deprecated(since = "0.2.190", note = "Use `int_least16_t::MAX` instead.")]
 pub const INT_LEAST16_MAX: int_least16_t = 32767;
+#[deprecated(since = "0.2.190", note = "Use `int_least32_t::MAX` instead.")]
 pub const INT_LEAST32_MAX: int_least32_t = 2147483647;
+#[deprecated(since = "0.2.190", note = "Use `uint_least8_t::MAX` instead.")]
 pub const UINT_LEAST8_MAX: uint_least8_t = 255;
+#[deprecated(since = "0.2.190", note = "Use `uint_least16_t::MAX` instead.")]
 pub const UINT_LEAST16_MAX: uint_least16_t = 65535;
+#[deprecated(since = "0.2.190", note = "Use `uint_least32_t::MAX` instead.")]
 pub const UINT_LEAST32_MAX: uint_least32_t = 4294967295;
+#[deprecated(since = "0.2.190", note = "Use `int_fast8_t::MIN` instead.")]
 pub const INT_FAST8_MIN: int_fast8_t = -128;
+#[deprecated(since = "0.2.190", note = "Use `int_fast16_t::MIN` instead.")]
 pub const INT_FAST16_MIN: int_fast16_t = -2147483648;
+#[deprecated(since = "0.2.190", note = "Use `int_fast32_t::MIN` instead.")]
 pub const INT_FAST32_MIN: int_fast32_t = -2147483648;
+#[deprecated(since = "0.2.190", note = "Use `int_fast8_t::MAX` instead.")]
 pub const INT_FAST8_MAX: int_fast8_t = 127;
+#[deprecated(since = "0.2.190", note = "Use `int_fast16_t::MAX` instead.")]
 pub const INT_FAST16_MAX: int_fast16_t = 2147483647;
+#[deprecated(since = "0.2.190", note = "Use `int_fast32_t::MAX` instead.")]
 pub const INT_FAST32_MAX: int_fast32_t = 2147483647;
+#[deprecated(since = "0.2.190", note = "Use `uint_fast8_t::MAX` instead.")]
 pub const UINT_FAST8_MAX: uint_fast8_t = 255;
+#[deprecated(since = "0.2.190", note = "Use `uint_fast16_t::MAX` instead.")]
 pub const UINT_FAST16_MAX: uint_fast16_t = 4294967295;
+#[deprecated(since = "0.2.190", note = "Use `uint_fast32_t::MAX` instead.")]
 pub const UINT_FAST32_MAX: uint_fast32_t = 4294967295;
+#[deprecated(since = "0.2.190", note = "Use `intptr_t::MIN` instead.")]
 pub const INTPTR_MIN: __intptr_t = -2147483648;
+#[deprecated(since = "0.2.190", note = "Use `intptr_t::MAX` instead.")]
 pub const INTPTR_MAX: __intptr_t = 2147483647;
+#[deprecated(since = "0.2.190", note = "Use `uintptr_t::MAX` instead.")]
 pub const UINTPTR_MAX: usize = 4294967295;
+#[deprecated(since = "0.2.190", note = "Use `ptrdiff_t::MIN` instead.")]
 pub const PTRDIFF_MIN: __ptrdiff_t = -2147483648;
+#[deprecated(since = "0.2.190", note = "Use `ptrdiff_t::MAX` instead.")]
 pub const PTRDIFF_MAX: __ptrdiff_t = 2147483647;
+#[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
 pub const SIG_ATOMIC_MIN: __sig_atomic_t = -2147483648;
+#[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
 pub const SIG_ATOMIC_MAX: __sig_atomic_t = 2147483647;
+#[deprecated(since = "0.2.190", note = "Use `size_t::MAX` instead.")]
 pub const SIZE_MAX: usize = 4294967295;
+#[deprecated(since = "0.2.190", note = "Use `wint_t::MIN` instead.")]
 pub const WINT_MIN: wint_t = 0;
+#[deprecated(since = "0.2.190", note = "Use `wint_t::MAX` instead.")]
 pub const WINT_MAX: wint_t = 4294967295;
 pub const INT8_WIDTH: usize = 8;
 pub const UINT8_WIDTH: usize = 8;

--- a/src/unix/hurd/mod.rs
+++ b/src/unix/hurd/mod.rs
@@ -1,7 +1,10 @@
 #![allow(dead_code)]
 
-use crate::c_schar;
 use crate::prelude::*;
+use crate::{
+    c_schar,
+    ptrdiff_t,
+};
 
 // types
 pub type __s16_type = c_short;
@@ -2635,79 +2638,79 @@ pub const TCP_REPAIR_OFF_NO_WP: c_int = -1;
 
 // stdint.h
 #[deprecated(since = "0.2.190", note = "Use `i8::MIN` instead.")]
-pub const INT8_MIN: i8 = -128;
+pub const INT8_MIN: i8 = i8::MIN;
 #[deprecated(since = "0.2.190", note = "Use `i16::MIN` instead.")]
-pub const INT16_MIN: i16 = -32768;
+pub const INT16_MIN: i16 = i16::MIN;
 #[deprecated(since = "0.2.190", note = "Use `i32::MIN` instead.")]
-pub const INT32_MIN: i32 = -2147483648;
+pub const INT32_MIN: i32 = i32::MIN;
 #[deprecated(since = "0.2.190", note = "Use `i8::MAX` instead.")]
-pub const INT8_MAX: i8 = 127;
+pub const INT8_MAX: i8 = i8::MAX;
 #[deprecated(since = "0.2.190", note = "Use `i16::MAX` instead.")]
-pub const INT16_MAX: i16 = 32767;
+pub const INT16_MAX: i16 = i16::MAX;
 #[deprecated(since = "0.2.190", note = "Use `i32::MAX` instead.")]
-pub const INT32_MAX: i32 = 2147483647;
+pub const INT32_MAX: i32 = i32::MAX;
 #[deprecated(since = "0.2.190", note = "Use `u8::MAX` instead.")]
-pub const UINT8_MAX: u8 = 255;
+pub const UINT8_MAX: u8 = u8::MAX;
 #[deprecated(since = "0.2.190", note = "Use `u16::MAX` instead.")]
-pub const UINT16_MAX: u16 = 65535;
+pub const UINT16_MAX: u16 = u16::MAX;
 #[deprecated(since = "0.2.190", note = "Use `u32::MAX` instead.")]
-pub const UINT32_MAX: u32 = 4294967295;
+pub const UINT32_MAX: u32 = u32::MAX;
 #[deprecated(since = "0.2.190", note = "Use `int_least8_t::MIN` instead.")]
-pub const INT_LEAST8_MIN: int_least8_t = -128;
+pub const INT_LEAST8_MIN: int_least8_t = int_least8_t::MIN;
 #[deprecated(since = "0.2.190", note = "Use `int_least16_t::MIN` instead.")]
-pub const INT_LEAST16_MIN: int_least16_t = -32768;
+pub const INT_LEAST16_MIN: int_least16_t = int_least16_t::MIN;
 #[deprecated(since = "0.2.190", note = "Use `int_least32_t::MIN` instead.")]
-pub const INT_LEAST32_MIN: int_least32_t = -2147483648;
+pub const INT_LEAST32_MIN: int_least32_t = int_least32_t::MIN;
 #[deprecated(since = "0.2.190", note = "Use `int_least8_t::MAX` instead.")]
-pub const INT_LEAST8_MAX: int_least8_t = 127;
+pub const INT_LEAST8_MAX: int_least8_t = int_least8_t::MAX;
 #[deprecated(since = "0.2.190", note = "Use `int_least16_t::MAX` instead.")]
-pub const INT_LEAST16_MAX: int_least16_t = 32767;
+pub const INT_LEAST16_MAX: int_least16_t = int_least16_t::MAX;
 #[deprecated(since = "0.2.190", note = "Use `int_least32_t::MAX` instead.")]
-pub const INT_LEAST32_MAX: int_least32_t = 2147483647;
+pub const INT_LEAST32_MAX: int_least32_t = int_least32_t::MAX;
 #[deprecated(since = "0.2.190", note = "Use `uint_least8_t::MAX` instead.")]
-pub const UINT_LEAST8_MAX: uint_least8_t = 255;
+pub const UINT_LEAST8_MAX: uint_least8_t = uint_least8_t::MAX;
 #[deprecated(since = "0.2.190", note = "Use `uint_least16_t::MAX` instead.")]
-pub const UINT_LEAST16_MAX: uint_least16_t = 65535;
+pub const UINT_LEAST16_MAX: uint_least16_t = uint_least16_t::MAX;
 #[deprecated(since = "0.2.190", note = "Use `uint_least32_t::MAX` instead.")]
-pub const UINT_LEAST32_MAX: uint_least32_t = 4294967295;
+pub const UINT_LEAST32_MAX: uint_least32_t = uint_least32_t::MAX;
 #[deprecated(since = "0.2.190", note = "Use `int_fast8_t::MIN` instead.")]
-pub const INT_FAST8_MIN: int_fast8_t = -128;
+pub const INT_FAST8_MIN: int_fast8_t = int_fast8_t::MIN;
 #[deprecated(since = "0.2.190", note = "Use `int_fast16_t::MIN` instead.")]
-pub const INT_FAST16_MIN: int_fast16_t = -2147483648;
+pub const INT_FAST16_MIN: int_fast16_t = int_fast16_t::MIN;
 #[deprecated(since = "0.2.190", note = "Use `int_fast32_t::MIN` instead.")]
-pub const INT_FAST32_MIN: int_fast32_t = -2147483648;
+pub const INT_FAST32_MIN: int_fast32_t = int_fast32_t::MIN;
 #[deprecated(since = "0.2.190", note = "Use `int_fast8_t::MAX` instead.")]
-pub const INT_FAST8_MAX: int_fast8_t = 127;
+pub const INT_FAST8_MAX: int_fast8_t = int_fast8_t::MAX;
 #[deprecated(since = "0.2.190", note = "Use `int_fast16_t::MAX` instead.")]
-pub const INT_FAST16_MAX: int_fast16_t = 2147483647;
+pub const INT_FAST16_MAX: int_fast16_t = int_fast16_t::MAX;
 #[deprecated(since = "0.2.190", note = "Use `int_fast32_t::MAX` instead.")]
-pub const INT_FAST32_MAX: int_fast32_t = 2147483647;
+pub const INT_FAST32_MAX: int_fast32_t = int_fast32_t::MAX;
 #[deprecated(since = "0.2.190", note = "Use `uint_fast8_t::MAX` instead.")]
-pub const UINT_FAST8_MAX: uint_fast8_t = 255;
+pub const UINT_FAST8_MAX: uint_fast8_t = uint_fast8_t::MAX;
 #[deprecated(since = "0.2.190", note = "Use `uint_fast16_t::MAX` instead.")]
-pub const UINT_FAST16_MAX: uint_fast16_t = 4294967295;
+pub const UINT_FAST16_MAX: uint_fast16_t = uint_fast16_t::MAX;
 #[deprecated(since = "0.2.190", note = "Use `uint_fast32_t::MAX` instead.")]
-pub const UINT_FAST32_MAX: uint_fast32_t = 4294967295;
+pub const UINT_FAST32_MAX: uint_fast32_t = uint_fast32_t::MAX;
 #[deprecated(since = "0.2.190", note = "Use `intptr_t::MIN` instead.")]
-pub const INTPTR_MIN: __intptr_t = -2147483648;
+pub const INTPTR_MIN: intptr_t = intptr_t::MIN;
 #[deprecated(since = "0.2.190", note = "Use `intptr_t::MAX` instead.")]
-pub const INTPTR_MAX: __intptr_t = 2147483647;
+pub const INTPTR_MAX: intptr_t = intptr_t::MAX;
 #[deprecated(since = "0.2.190", note = "Use `uintptr_t::MAX` instead.")]
-pub const UINTPTR_MAX: usize = 4294967295;
+pub const UINTPTR_MAX: uintptr_t = uintptr_t::MAX;
 #[deprecated(since = "0.2.190", note = "Use `ptrdiff_t::MIN` instead.")]
-pub const PTRDIFF_MIN: __ptrdiff_t = -2147483648;
+pub const PTRDIFF_MIN: ptrdiff_t = ptrdiff_t::MIN;
 #[deprecated(since = "0.2.190", note = "Use `ptrdiff_t::MAX` instead.")]
-pub const PTRDIFF_MAX: __ptrdiff_t = 2147483647;
+pub const PTRDIFF_MAX: ptrdiff_t = ptrdiff_t::MAX;
 #[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
-pub const SIG_ATOMIC_MIN: __sig_atomic_t = -2147483648;
+pub const SIG_ATOMIC_MIN: __sig_atomic_t = c_int::MIN;
 #[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
-pub const SIG_ATOMIC_MAX: __sig_atomic_t = 2147483647;
+pub const SIG_ATOMIC_MAX: __sig_atomic_t = c_int::MAX;
 #[deprecated(since = "0.2.190", note = "Use `size_t::MAX` instead.")]
-pub const SIZE_MAX: usize = 4294967295;
+pub const SIZE_MAX: size_t = size_t::MAX;
 #[deprecated(since = "0.2.190", note = "Use `wint_t::MIN` instead.")]
-pub const WINT_MIN: wint_t = 0;
+pub const WINT_MIN: wint_t = wint_t::MIN;
 #[deprecated(since = "0.2.190", note = "Use `wint_t::MAX` instead.")]
-pub const WINT_MAX: wint_t = 4294967295;
+pub const WINT_MAX: wint_t = wint_t::MAX;
 pub const INT8_WIDTH: usize = 8;
 pub const UINT8_WIDTH: usize = 8;
 pub const INT16_WIDTH: usize = 16;

--- a/src/unix/linux_like/android/mod.rs
+++ b/src/unix/linux_like/android/mod.rs
@@ -1977,7 +1977,7 @@ pub const NF_BR_POST_ROUTING: c_int = 4;
 pub const NF_BR_BROUTING: c_int = 5;
 pub const NF_BR_NUMHOOKS: c_int = 6;
 
-pub const NF_BR_PRI_FIRST: c_int = crate::INT_MIN;
+pub const NF_BR_PRI_FIRST: c_int = c_int::MIN;
 pub const NF_BR_PRI_NAT_DST_BRIDGED: c_int = -300;
 pub const NF_BR_PRI_FILTER_BRIDGED: c_int = -200;
 pub const NF_BR_PRI_BRNF: c_int = 0;
@@ -1987,7 +1987,7 @@ pub const NF_BR_PRI_NAT_SRC: c_int = 300;
 
 /// Constants may change across releases. See the [usage guidelines](crate#usage-guidelines)
 /// for details.
-pub const NF_BR_PRI_LAST: c_int = crate::INT_MAX;
+pub const NF_BR_PRI_LAST: c_int = c_int::MAX;
 
 // linux/netfilter_ipv4.h
 pub const NF_IP_PRE_ROUTING: c_int = 0;
@@ -1997,7 +1997,7 @@ pub const NF_IP_LOCAL_OUT: c_int = 3;
 pub const NF_IP_POST_ROUTING: c_int = 4;
 pub const NF_IP_NUMHOOKS: c_int = 5;
 
-pub const NF_IP_PRI_FIRST: c_int = crate::INT_MIN;
+pub const NF_IP_PRI_FIRST: c_int = c_int::MIN;
 pub const NF_IP_PRI_RAW_BEFORE_DEFRAG: c_int = -450;
 pub const NF_IP_PRI_CONNTRACK_DEFRAG: c_int = -400;
 pub const NF_IP_PRI_RAW: c_int = -300;
@@ -2010,11 +2010,11 @@ pub const NF_IP_PRI_SECURITY: c_int = 50;
 pub const NF_IP_PRI_NAT_SRC: c_int = 100;
 pub const NF_IP_PRI_SELINUX_LAST: c_int = 225;
 pub const NF_IP_PRI_CONNTRACK_HELPER: c_int = 300;
-pub const NF_IP_PRI_CONNTRACK_CONFIRM: c_int = crate::INT_MAX;
+pub const NF_IP_PRI_CONNTRACK_CONFIRM: c_int = c_int::MAX;
 
 /// Constants may change across releases. See the [usage guidelines](crate#usage-guidelines)
 /// for details.
-pub const NF_IP_PRI_LAST: c_int = crate::INT_MAX;
+pub const NF_IP_PRI_LAST: c_int = c_int::MAX;
 
 // linux/netfilter_ipv6.h
 pub const NF_IP6_PRE_ROUTING: c_int = 0;
@@ -2024,7 +2024,7 @@ pub const NF_IP6_LOCAL_OUT: c_int = 3;
 pub const NF_IP6_POST_ROUTING: c_int = 4;
 pub const NF_IP6_NUMHOOKS: c_int = 5;
 
-pub const NF_IP6_PRI_FIRST: c_int = crate::INT_MIN;
+pub const NF_IP6_PRI_FIRST: c_int = c_int::MIN;
 pub const NF_IP6_PRI_RAW_BEFORE_DEFRAG: c_int = -450;
 pub const NF_IP6_PRI_CONNTRACK_DEFRAG: c_int = -400;
 pub const NF_IP6_PRI_RAW: c_int = -300;
@@ -2040,7 +2040,7 @@ pub const NF_IP6_PRI_CONNTRACK_HELPER: c_int = 300;
 
 /// Constants may change across releases. See the [usage guidelines](crate#usage-guidelines)
 /// for details.
-pub const NF_IP6_PRI_LAST: c_int = crate::INT_MAX;
+pub const NF_IP6_PRI_LAST: c_int = c_int::MAX;
 
 // linux/netfilter_ipv6/ip6_tables.h
 pub const IP6T_SO_ORIGINAL_DST: c_int = 80;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1780,7 +1780,7 @@ pub const NF_BR_POST_ROUTING: c_int = 4;
 pub const NF_BR_BROUTING: c_int = 5;
 pub const NF_BR_NUMHOOKS: c_int = 6;
 
-pub const NF_BR_PRI_FIRST: c_int = crate::INT_MIN;
+pub const NF_BR_PRI_FIRST: c_int = c_int::MIN;
 pub const NF_BR_PRI_NAT_DST_BRIDGED: c_int = -300;
 pub const NF_BR_PRI_FILTER_BRIDGED: c_int = -200;
 pub const NF_BR_PRI_BRNF: c_int = 0;
@@ -1790,7 +1790,7 @@ pub const NF_BR_PRI_NAT_SRC: c_int = 300;
 
 /// Constants may change across releases. See the [usage guidelines](crate#usage-guidelines)
 /// for details.
-pub const NF_BR_PRI_LAST: c_int = crate::INT_MAX;
+pub const NF_BR_PRI_LAST: c_int = c_int::MAX;
 
 // linux/netfilter_ipv4.h
 pub const NF_IP_PRE_ROUTING: c_int = 0;
@@ -1800,7 +1800,7 @@ pub const NF_IP_LOCAL_OUT: c_int = 3;
 pub const NF_IP_POST_ROUTING: c_int = 4;
 pub const NF_IP_NUMHOOKS: c_int = 5;
 
-pub const NF_IP_PRI_FIRST: c_int = crate::INT_MIN;
+pub const NF_IP_PRI_FIRST: c_int = c_int::MIN;
 pub const NF_IP_PRI_RAW_BEFORE_DEFRAG: c_int = -450;
 pub const NF_IP_PRI_CONNTRACK_DEFRAG: c_int = -400;
 pub const NF_IP_PRI_RAW: c_int = -300;
@@ -1813,11 +1813,11 @@ pub const NF_IP_PRI_SECURITY: c_int = 50;
 pub const NF_IP_PRI_NAT_SRC: c_int = 100;
 pub const NF_IP_PRI_SELINUX_LAST: c_int = 225;
 pub const NF_IP_PRI_CONNTRACK_HELPER: c_int = 300;
-pub const NF_IP_PRI_CONNTRACK_CONFIRM: c_int = crate::INT_MAX;
+pub const NF_IP_PRI_CONNTRACK_CONFIRM: c_int = c_int::MAX;
 
 /// Constants may change across releases. See the [usage guidelines](crate#usage-guidelines)
 /// for details.
-pub const NF_IP_PRI_LAST: c_int = crate::INT_MAX;
+pub const NF_IP_PRI_LAST: c_int = c_int::MAX;
 
 // linux/netfilter_ipv6.h
 pub const NF_IP6_PRE_ROUTING: c_int = 0;
@@ -1827,7 +1827,7 @@ pub const NF_IP6_LOCAL_OUT: c_int = 3;
 pub const NF_IP6_POST_ROUTING: c_int = 4;
 pub const NF_IP6_NUMHOOKS: c_int = 5;
 
-pub const NF_IP6_PRI_FIRST: c_int = crate::INT_MIN;
+pub const NF_IP6_PRI_FIRST: c_int = c_int::MIN;
 pub const NF_IP6_PRI_RAW_BEFORE_DEFRAG: c_int = -450;
 pub const NF_IP6_PRI_CONNTRACK_DEFRAG: c_int = -400;
 pub const NF_IP6_PRI_RAW: c_int = -300;
@@ -1843,7 +1843,7 @@ pub const NF_IP6_PRI_CONNTRACK_HELPER: c_int = 300;
 
 /// Constants may change across releases. See the [usage guidelines](crate#usage-guidelines)
 /// for details.
-pub const NF_IP6_PRI_LAST: c_int = crate::INT_MAX;
+pub const NF_IP6_PRI_LAST: c_int = c_int::MAX;
 
 // linux/netfilter_ipv6/ip6_tables.h
 pub const IP6T_SO_ORIGINAL_DST: c_int = 80;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -245,7 +245,9 @@ cfg_if! {
     }
 }
 
+#[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
 pub const INT_MIN: c_int = -2147483648;
+#[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
 pub const INT_MAX: c_int = 2147483647;
 
 pub const SIG_DFL: sighandler_t = 0 as sighandler_t;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -246,9 +246,9 @@ cfg_if! {
 }
 
 #[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
-pub const INT_MIN: c_int = -2147483648;
+pub const INT_MIN: c_int = c_int::MIN;
 #[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
-pub const INT_MAX: c_int = 2147483647;
+pub const INT_MAX: c_int = c_int::MAX;
 
 pub const SIG_DFL: sighandler_t = 0 as sighandler_t;
 pub const SIG_IGN: sighandler_t = 1 as sighandler_t;

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -677,9 +677,9 @@ pub const EAI_SOCKTYPE: c_int = 10;
 pub const EAI_SYSTEM: c_int = 11;
 
 #[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
-pub const INT_MAX: c_int = 0x7fffffff;
+pub const INT_MAX: c_int = c_int::MAX;
 #[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
-pub const INT_MIN: c_int = -0x7fffffff - 1;
+pub const INT_MIN: c_int = c_int::MIN;
 
 // FIXME(vxworks): This is not defined in vxWorks, but we have to define it here
 // to make the building pass for getrandom and std

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -676,7 +676,9 @@ pub const EAI_SERVICE: c_int = 9;
 pub const EAI_SOCKTYPE: c_int = 10;
 pub const EAI_SYSTEM: c_int = 11;
 
+#[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
 pub const INT_MAX: c_int = 0x7fffffff;
+#[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
 pub const INT_MIN: c_int = -0x7fffffff - 1;
 
 // FIXME(vxworks): This is not defined in vxWorks, but we have to define it here

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -677,7 +677,7 @@ pub const EAI_SOCKTYPE: c_int = 10;
 pub const EAI_SYSTEM: c_int = 11;
 
 pub const INT_MAX: c_int = 0x7fffffff;
-pub const INT_MIN: c_int = -INT_MAX - 1;
+pub const INT_MIN: c_int = -0x7fffffff - 1;
 
 // FIXME(vxworks): This is not defined in vxWorks, but we have to define it here
 // to make the building pass for getrandom and std

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -97,9 +97,9 @@ s! {
 }
 
 #[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
-pub const INT_MIN: c_int = -2147483648;
+pub const INT_MIN: c_int = c_int::MIN;
 #[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
-pub const INT_MAX: c_int = 2147483647;
+pub const INT_MAX: c_int = c_int::MAX;
 
 pub const EXIT_FAILURE: c_int = 1;
 pub const EXIT_SUCCESS: c_int = 0;

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -96,7 +96,9 @@ s! {
     }
 }
 
+#[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
 pub const INT_MIN: c_int = -2147483648;
+#[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
 pub const INT_MAX: c_int = 2147483647;
 
 pub const EXIT_FAILURE: c_int = 1;

--- a/src/xous.rs
+++ b/src/xous.rs
@@ -14,5 +14,7 @@ pub type ssize_t = isize;
 pub type off_t = i64;
 pub type wchar_t = u32;
 
+#[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
 pub const INT_MIN: c_int = -2147483648;
+#[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
 pub const INT_MAX: c_int = 2147483647;

--- a/src/xous.rs
+++ b/src/xous.rs
@@ -15,6 +15,6 @@ pub type off_t = i64;
 pub type wchar_t = u32;
 
 #[deprecated(since = "0.2.190", note = "Use `c_int::MIN` instead.")]
-pub const INT_MIN: c_int = -2147483648;
+pub const INT_MIN: c_int = c_int::MIN;
 #[deprecated(since = "0.2.190", note = "Use `c_int::MAX` instead.")]
-pub const INT_MAX: c_int = 2147483647;
+pub const INT_MAX: c_int = c_int::MAX;


### PR DESCRIPTION
Follow-up to rust-lang/libc#5166. Deprecates the `<int type>_{MIN,MAX}` constants across the platform modules, with notes pointing at the type's own `MIN`/`MAX`.

@rustbot label stable-nominated