### PR TITLE
glibc: Move `signal.h` definitions to `src/new`

### DIFF
--- a/src/new/glibc/bits/signum_generic.rs
+++ b/src/new/glibc/bits/signum_generic.rs
@@ -1,0 +1,19 @@
+//! Header: `bits/signum-generic.h`
+
+use crate::prelude::*;
+
+pub const SIGINT: c_int = 2;
+pub const SIGILL: c_int = 4;
+pub const SIGABRT: c_int = 6;
+pub const SIGFPE: c_int = 8;
+pub const SIGSEGV: c_int = 11;
+pub const SIGTERM: c_int = 15;
+
+pub const SIGHUP: c_int = 1;
+pub const SIGQUIT: c_int = 3;
+pub const SIGTRAP: c_int = 5;
+pub const SIGKILL: c_int = 9;
+pub const SIGPIPE: c_int = 13;
+pub const SIGALRM: c_int = 14;
+
+pub use super::super::sysdeps::unix::linux::bits::signum_arch::*;

--- a/src/new/glibc/mod.rs
+++ b/src/new/glibc/mod.rs
@@ -6,12 +6,23 @@
 //! This module structure is modeled after glibc's source tree. Its build system selects headers
 //! from different locations based on the platform, which we mimic here with reexports.
 
+/// Source directory: `bits/`
+///
+/// <https://github.com/sailfishos-mirror/glibc/tree/master/bits>
+mod bits {
+    #[cfg(target_os = "linux")]
+    pub(crate) mod signum_generic;
+}
+
 /// Source directory: `posix/`
 ///
 /// <https://github.com/sailfishos-mirror/glibc/tree/master/posix>
 mod posix {
     pub(crate) mod unistd;
 }
+
+#[cfg(target_os = "linux")]
+pub(crate) mod signal;
 
 /// Source directory: `sysdeps/`
 ///

--- a/src/new/glibc/signal.rs
+++ b/src/new/glibc/signal.rs
@@ -1,0 +1,9 @@
+//! Header: `signal/signal.h`
+
+pub use super::bits::signum_generic::*;
+pub use super::sysdeps::unix::linux::bits::sigaction::*;
+use crate::prelude::*;
+
+extern "C" {
+    pub fn sigaction(signum: c_int, act: *const sigaction, oldact: *mut sigaction) -> c_int;
+}

--- a/src/new/glibc/sysdeps/unix/linux/bits/sigaction.rs
+++ b/src/new/glibc/sysdeps/unix/linux/bits/sigaction.rs
@@ -1,0 +1,31 @@
+//! Header: `sysdeps/unix/sysv/linux/bits/sigaction.h`
+
+use crate::prelude::*;
+
+s! {
+    // FIXME(1.0): This should not implement `PartialEq`
+    #[allow(unpredictable_function_pointer_comparisons)]
+    pub struct sigaction {
+        pub sa_sigaction: crate::sighandler_t,
+        pub sa_mask: crate::sigset_t,
+        pub sa_flags: c_int,
+        // This function should be unsafe everywhere but is currently only done on
+        // newer arches.
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+        pub sa_restorer: Option<unsafe extern "C" fn()>,
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+        pub sa_restorer: Option<extern "C" fn()>,
+    }
+}
+
+pub const SA_NOCLDSTOP: c_int = 0x00000001;
+pub const SA_NOCLDWAIT: c_int = 0x00000002;
+pub const SA_SIGINFO: c_int = 0x00000004;
+pub const SA_ONSTACK: c_int = 0x08000000;
+pub const SA_RESTART: c_int = 0x10000000;
+pub const SA_NODEFER: c_int = 0x40000000;
+pub const SA_RESETHAND: c_int = u32_cast_int(0x80000000);
+
+pub const SIG_BLOCK: c_int = 0;
+pub const SIG_UNBLOCK: c_int = 1;
+pub const SIG_SETMASK: c_int = 2;

--- a/src/new/glibc/sysdeps/unix/linux/bits/signum_arch.rs
+++ b/src/new/glibc/sysdeps/unix/linux/bits/signum_arch.rs
@@ -1,0 +1,28 @@
+//! Header: `sysdeps/unix/sysv/linux/bits/signum-arch.h`
+
+use crate::prelude::*;
+
+pub const SIGSTKFLT: c_int = 16;
+pub const SIGPWR: c_int = 30;
+
+pub const SIGBUS: c_int = 7;
+pub const SIGSYS: c_int = 31;
+
+pub const SIGURG: c_int = 23;
+pub const SIGSTOP: c_int = 19;
+pub const SIGTSTP: c_int = 20;
+pub const SIGCONT: c_int = 18;
+pub const SIGCHLD: c_int = 17;
+pub const SIGTTIN: c_int = 21;
+pub const SIGTTOU: c_int = 22;
+pub const SIGPOLL: c_int = 29;
+pub const SIGXFSZ: c_int = 25;
+pub const SIGXCPU: c_int = 24;
+pub const SIGVTALRM: c_int = 26;
+pub const SIGPROF: c_int = 27;
+pub const SIGUSR1: c_int = 10;
+pub const SIGUSR2: c_int = 12;
+
+pub const SIGWINCH: c_int = 28;
+
+pub const SIGIO: c_int = SIGPOLL;

--- a/src/new/glibc/sysdeps/unix/linux/mips/bits/sigaction.rs
+++ b/src/new/glibc/sysdeps/unix/linux/mips/bits/sigaction.rs
@@ -1,0 +1,29 @@
+//! Header: `sysdeps/unix/sysv/linux/mips/bits/sigaction.h`
+
+use crate::prelude::*;
+
+s! {
+    //
+    // FIXME(1.0): This should not implement `PartialEq`
+    #[allow(unpredictable_function_pointer_comparisons)]
+    pub struct sigaction {
+        pub sa_flags: c_int,
+        pub sa_sigaction: crate::sighandler_t,
+        pub sa_mask: crate::sigset_t,
+        pub sa_restorer: Option<extern "C" fn()>,
+        #[cfg(target_pointer_width = "32")]
+        _resv: [c_int; 1],
+    }
+}
+
+pub const SA_NOCLDSTOP: c_int = 0x00000001;
+pub const SA_NOCLDWAIT: c_int = 0x00010000;
+pub const SA_SIGINFO: c_int = 0x00000008;
+pub const SA_ONSTACK: c_int = 0x08000000;
+pub const SA_RESTART: c_int = 0x10000000;
+pub const SA_NODEFER: c_int = 0x40000000;
+pub const SA_RESETHAND: c_int = u32_cast_int(0x80000000);
+
+pub const SIG_BLOCK: c_int = 0x1;
+pub const SIG_UNBLOCK: c_int = 0x2;
+pub const SIG_SETMASK: c_int = 3;

--- a/src/new/glibc/sysdeps/unix/linux/mips/bits/signum_arch.rs
+++ b/src/new/glibc/sysdeps/unix/linux/mips/bits/signum_arch.rs
@@ -1,0 +1,28 @@
+//! Header: `sysdeps/unix/sysv/linux/mips/bits/signum-arch.h`
+
+use crate::prelude::*;
+
+pub const SIGEMT: c_int = 7;
+pub const SIGPWR: c_int = 19;
+
+pub const SIGBUS: c_int = 10;
+pub const SIGSYS: c_int = 12;
+
+pub const SIGURG: c_int = 21;
+pub const SIGSTOP: c_int = 23;
+pub const SIGTSTP: c_int = 24;
+pub const SIGCONT: c_int = 25;
+pub const SIGCHLD: c_int = 18;
+pub const SIGTTIN: c_int = 26;
+pub const SIGTTOU: c_int = 27;
+pub const SIGPOLL: c_int = 22;
+pub const SIGXCPU: c_int = 30;
+pub const SIGVTALRM: c_int = 28;
+pub const SIGPROF: c_int = 29;
+pub const SIGXFSZ: c_int = 31;
+pub const SIGUSR1: c_int = 16;
+pub const SIGUSR2: c_int = 17;
+
+pub const SIGWINCH: c_int = 20;
+
+pub const SIGIO: c_int = SIGPOLL;

--- a/src/new/glibc/sysdeps/unix/linux/mod.rs
+++ b/src/new/glibc/sysdeps/unix/linux/mod.rs
@@ -2,6 +2,39 @@
 //!
 //! <https://github.com/sailfishos-mirror/glibc/tree/master/sysdeps/unix/sysv/linux>
 
+/// Directory: `sysdeps/unix/sysv/linux/bits`
+pub(crate) mod bits {
+    #[cfg_attr(
+        any(
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "mips",
+            target_arch = "mips32r6",
+        ),
+        path = "../mips/bits/sigaction.rs"
+    )]
+    #[cfg_attr(target_arch = "s390x", path = "../s390/bits/sigaction.rs")]
+    #[cfg_attr(
+        any(target_arch = "sparc", target_arch = "sparc64"),
+        path = "../sparc/bits/sigaction.rs"
+    )]
+    pub(crate) mod sigaction;
+    #[cfg_attr(
+        any(
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "mips",
+            target_arch = "mips32r6",
+        ),
+        path = "../mips/bits/signum_arch.rs"
+    )]
+    #[cfg_attr(
+        any(target_arch = "sparc", target_arch = "sparc64"),
+        path = "../sparc/bits/signum_arch.rs"
+    )]
+    pub(crate) mod signum_arch;
+}
+
 /// Directory: `net/`
 ///
 /// Source directory: `sysdeps/unix/sysv/linux/net`

--- a/src/new/glibc/sysdeps/unix/linux/s390/bits/sigaction.rs
+++ b/src/new/glibc/sysdeps/unix/linux/s390/bits/sigaction.rs
@@ -1,0 +1,27 @@
+//! Header: `sysdeps/unix/sysv/linux/s390/bits/sigaction.h`
+
+use crate::prelude::*;
+
+s! {
+    // FIXME(1.0): This should not implement `PartialEq`
+    #[allow(unpredictable_function_pointer_comparisons)]
+    pub struct sigaction {
+        pub sa_sigaction: crate::sighandler_t,
+        __glibc_reserved0: Padding<c_int>,
+        pub sa_flags: c_int,
+        pub sa_restorer: Option<extern "C" fn()>,
+        pub sa_mask: crate::sigset_t,
+    }
+}
+
+pub const SA_NOCLDSTOP: c_int = 0x00000001;
+pub const SA_NOCLDWAIT: c_int = 2;
+pub const SA_SIGINFO: c_int = 4;
+pub const SA_ONSTACK: c_int = 0x08000000;
+pub const SA_RESTART: c_int = 0x10000000;
+pub const SA_NODEFER: c_int = 0x40000000;
+pub const SA_RESETHAND: c_int = u32_cast_int(0x80000000);
+
+pub const SIG_BLOCK: c_int = 0;
+pub const SIG_UNBLOCK: c_int = 1;
+pub const SIG_SETMASK: c_int = 2;

--- a/src/new/glibc/sysdeps/unix/linux/sparc/bits/sigaction.rs
+++ b/src/new/glibc/sysdeps/unix/linux/sparc/bits/sigaction.rs
@@ -1,0 +1,28 @@
+//! Header: `sysdeps/unix/sysv/linux/sparc/bits/sigaction.h`
+
+use crate::prelude::*;
+
+s! {
+    // FIXME(1.0): This should not implement `PartialEq`
+    #[allow(unpredictable_function_pointer_comparisons)]
+    pub struct sigaction {
+        pub sa_sigaction: crate::sighandler_t,
+        pub sa_mask: crate::sigset_t,
+        #[cfg(target_pointer_width = "64")]
+        __reserved0: Padding<c_int>,
+        pub sa_flags: c_int,
+        pub sa_restorer: Option<extern "C" fn()>,
+    }
+}
+
+pub const SA_NOCLDSTOP: c_int = 0x00000008;
+pub const SA_NOCLDWAIT: c_int = 0x100;
+pub const SA_SIGINFO: c_int = 0x200;
+pub const SA_ONSTACK: c_int = 1;
+pub const SA_RESTART: c_int = 0x2;
+pub const SA_NODEFER: c_int = 0x20;
+pub const SA_RESETHAND: c_int = 0x4;
+
+pub const SIG_BLOCK: c_int = 1;
+pub const SIG_UNBLOCK: c_int = 2;
+pub const SIG_SETMASK: c_int = 4;

--- a/src/new/glibc/sysdeps/unix/linux/sparc/bits/signum_arch.rs
+++ b/src/new/glibc/sysdeps/unix/linux/sparc/bits/signum_arch.rs
@@ -1,0 +1,28 @@
+//! Header: `sysdeps/unix/sysv/linux/sparc/bits/signum-arch.h`
+
+use crate::prelude::*;
+
+pub const SIGEMT: c_int = 7;
+pub const SIGPWR: c_int = 29;
+
+pub const SIGBUS: c_int = 10;
+pub const SIGSYS: c_int = 12;
+
+pub const SIGURG: c_int = 16;
+pub const SIGSTOP: c_int = 17;
+pub const SIGTSTP: c_int = 18;
+pub const SIGCONT: c_int = 19;
+pub const SIGCHLD: c_int = 20;
+pub const SIGTTIN: c_int = 21;
+pub const SIGTTOU: c_int = 22;
+pub const SIGPOLL: c_int = 23;
+pub const SIGXCPU: c_int = 24;
+pub const SIGVTALRM: c_int = 26;
+pub const SIGPROF: c_int = 27;
+pub const SIGXFSZ: c_int = 25;
+pub const SIGUSR1: c_int = 30;
+pub const SIGUSR2: c_int = 31;
+
+pub const SIGWINCH: c_int = 28;
+
+pub const SIGIO: c_int = SIGPOLL;

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -196,6 +196,8 @@ cfg_if! {
         pub use linux::types::*;
         #[cfg(target_env = "gnu")]
         pub use net::route::*;
+        #[cfg(target_env = "gnu")]
+        pub use signal::*;
     } else if #[cfg(target_vendor = "apple")] {
         pub use net::bpf::*;
         pub use netinet::tcp::*;

--- a/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
@@ -7,15 +7,6 @@ use crate::{
 pub type wchar_t = u32;
 
 s! {
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
-        pub sa_mask: crate::sigset_t,
-        pub sa_flags: c_int,
-        pub sa_restorer: Option<extern "C" fn()>,
-    }
-
     pub struct statfs {
         pub f_type: crate::__fsword_t,
         pub f_bsize: crate::__fsword_t,
@@ -370,9 +361,6 @@ pub const ENOTRECOVERABLE: c_int = 131;
 pub const EHWPOISON: c_int = 133;
 pub const ERFKILL: c_int = 132;
 
-pub const SA_SIGINFO: c_int = 0x00000004;
-pub const SA_NOCLDWAIT: c_int = 0x00000002;
-
 pub const SOCK_STREAM: c_int = 1;
 pub const SOCK_DGRAM: c_int = 2;
 
@@ -396,29 +384,6 @@ pub const F_SETOWN: c_int = 8;
 pub const EFD_NONBLOCK: c_int = 0x800;
 pub const SFD_NONBLOCK: c_int = 0x0800;
 
-pub const SIGCHLD: c_int = 17;
-pub const SIGBUS: c_int = 7;
-pub const SIGUSR1: c_int = 10;
-pub const SIGUSR2: c_int = 12;
-pub const SIGCONT: c_int = 18;
-pub const SIGSTOP: c_int = 19;
-pub const SIGTSTP: c_int = 20;
-pub const SIGURG: c_int = 23;
-pub const SIGIO: c_int = 29;
-pub const SIGSYS: c_int = 31;
-pub const SIGSTKFLT: c_int = 16;
-pub const SIGPOLL: c_int = 29;
-pub const SIGPWR: c_int = 30;
-pub const SIG_SETMASK: c_int = 2;
-pub const SIG_BLOCK: c_int = 0x000000;
-pub const SIG_UNBLOCK: c_int = 0x01;
-pub const SIGTTIN: c_int = 21;
-pub const SIGTTOU: c_int = 22;
-pub const SIGXCPU: c_int = 24;
-pub const SIGXFSZ: c_int = 25;
-pub const SIGVTALRM: c_int = 26;
-pub const SIGPROF: c_int = 27;
-pub const SIGWINCH: c_int = 28;
 pub const SIGSTKSZ: size_t = 8192;
 pub const MINSIGSTKSZ: size_t = 2048;
 pub const CBAUD: crate::tcflag_t = 0o0010017;

--- a/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
@@ -7,15 +7,6 @@ use crate::{
 pub type wchar_t = u32;
 
 s! {
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
-        pub sa_mask: crate::sigset_t,
-        pub sa_flags: c_int,
-        pub sa_restorer: Option<extern "C" fn()>,
-    }
-
     pub struct statfs {
         pub f_type: crate::__fsword_t,
         pub f_bsize: crate::__fsword_t,
@@ -296,9 +287,6 @@ pub const ENOTRECOVERABLE: c_int = 131;
 pub const EHWPOISON: c_int = 133;
 pub const ERFKILL: c_int = 132;
 
-pub const SA_SIGINFO: c_int = 0x00000004;
-pub const SA_NOCLDWAIT: c_int = 0x00000002;
-
 pub const SOCK_STREAM: c_int = 1;
 pub const SOCK_DGRAM: c_int = 2;
 
@@ -316,29 +304,6 @@ pub const F_SETOWN: c_int = 8;
 pub const EFD_NONBLOCK: c_int = 0x800;
 pub const SFD_NONBLOCK: c_int = 0x0800;
 
-pub const SIGCHLD: c_int = 17;
-pub const SIGBUS: c_int = 7;
-pub const SIGUSR1: c_int = 10;
-pub const SIGUSR2: c_int = 12;
-pub const SIGCONT: c_int = 18;
-pub const SIGSTOP: c_int = 19;
-pub const SIGTSTP: c_int = 20;
-pub const SIGURG: c_int = 23;
-pub const SIGIO: c_int = 29;
-pub const SIGSYS: c_int = 31;
-pub const SIGSTKFLT: c_int = 16;
-pub const SIGPOLL: c_int = 29;
-pub const SIGPWR: c_int = 30;
-pub const SIG_SETMASK: c_int = 2;
-pub const SIG_BLOCK: c_int = 0x000000;
-pub const SIG_UNBLOCK: c_int = 0x01;
-pub const SIGTTIN: c_int = 21;
-pub const SIGTTOU: c_int = 22;
-pub const SIGXCPU: c_int = 24;
-pub const SIGXFSZ: c_int = 25;
-pub const SIGVTALRM: c_int = 26;
-pub const SIGPROF: c_int = 27;
-pub const SIGWINCH: c_int = 28;
 pub const SIGSTKSZ: size_t = 8192;
 pub const MINSIGSTKSZ: size_t = 2048;
 pub const CBAUD: crate::tcflag_t = 0o0010017;

--- a/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
@@ -7,15 +7,6 @@ use crate::{
 pub type wchar_t = i32;
 
 s! {
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
-        pub sa_mask: crate::sigset_t,
-        pub sa_flags: c_int,
-        pub sa_restorer: Option<extern "C" fn()>,
-    }
-
     pub struct statfs {
         pub f_type: crate::__fsword_t,
         pub f_bsize: crate::__fsword_t,
@@ -289,9 +280,6 @@ pub const ENOTRECOVERABLE: c_int = 131;
 pub const EHWPOISON: c_int = 133;
 pub const ERFKILL: c_int = 132;
 
-pub const SA_SIGINFO: c_int = 0x00000004;
-pub const SA_NOCLDWAIT: c_int = 0x00000002;
-
 pub const SOCK_STREAM: c_int = 1;
 pub const SOCK_DGRAM: c_int = 2;
 
@@ -314,29 +302,6 @@ pub const POLLWRBAND: c_short = 0x200;
 pub const EFD_NONBLOCK: c_int = 0x800;
 pub const SFD_NONBLOCK: c_int = 0x0800;
 
-pub const SIGCHLD: c_int = 17;
-pub const SIGBUS: c_int = 7;
-pub const SIGUSR1: c_int = 10;
-pub const SIGUSR2: c_int = 12;
-pub const SIGCONT: c_int = 18;
-pub const SIGSTOP: c_int = 19;
-pub const SIGTSTP: c_int = 20;
-pub const SIGURG: c_int = 23;
-pub const SIGIO: c_int = 29;
-pub const SIGSYS: c_int = 31;
-pub const SIGSTKFLT: c_int = 16;
-pub const SIGPOLL: c_int = 29;
-pub const SIGPWR: c_int = 30;
-pub const SIG_SETMASK: c_int = 2;
-pub const SIG_BLOCK: c_int = 0x000000;
-pub const SIG_UNBLOCK: c_int = 0x01;
-pub const SIGTTIN: c_int = 21;
-pub const SIGTTOU: c_int = 22;
-pub const SIGXCPU: c_int = 24;
-pub const SIGXFSZ: c_int = 25;
-pub const SIGVTALRM: c_int = 26;
-pub const SIGPROF: c_int = 27;
-pub const SIGWINCH: c_int = 28;
 pub const SIGSTKSZ: size_t = 8192;
 pub const MINSIGSTKSZ: size_t = 2048;
 pub const CBAUD: crate::tcflag_t = 0o0010017;

--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -166,16 +166,6 @@ s! {
         __f_spare: [c_int; 6],
     }
 
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_flags: c_int,
-        pub sa_sigaction: crate::sighandler_t,
-        pub sa_mask: crate::sigset_t,
-        pub sa_restorer: Option<extern "C" fn()>,
-        _resv: [c_int; 1],
-    }
-
     pub struct stack_t {
         pub ss_sp: *mut c_void,
         pub ss_size: size_t,
@@ -764,33 +754,6 @@ pub const MAP_STACK: c_int = 0x40000;
 
 pub const SOCK_STREAM: c_int = 2;
 pub const SOCK_DGRAM: c_int = 1;
-
-pub const SA_SIGINFO: c_int = 0x00000008;
-pub const SA_NOCLDWAIT: c_int = 0x00010000;
-
-pub const SIGEMT: c_int = 7;
-pub const SIGCHLD: c_int = 18;
-pub const SIGBUS: c_int = 10;
-pub const SIGTTIN: c_int = 26;
-pub const SIGTTOU: c_int = 27;
-pub const SIGXCPU: c_int = 30;
-pub const SIGXFSZ: c_int = 31;
-pub const SIGVTALRM: c_int = 28;
-pub const SIGPROF: c_int = 29;
-pub const SIGWINCH: c_int = 20;
-pub const SIGUSR1: c_int = 16;
-pub const SIGUSR2: c_int = 17;
-pub const SIGCONT: c_int = 25;
-pub const SIGSTOP: c_int = 23;
-pub const SIGTSTP: c_int = 24;
-pub const SIGURG: c_int = 21;
-pub const SIGIO: c_int = 22;
-pub const SIGSYS: c_int = 12;
-pub const SIGPOLL: c_int = 22;
-pub const SIGPWR: c_int = 19;
-pub const SIG_SETMASK: c_int = 3;
-pub const SIG_BLOCK: c_int = 0x1;
-pub const SIG_UNBLOCK: c_int = 0x2;
 
 pub const POLLWRNORM: c_short = 0x004;
 pub const POLLWRBAND: c_short = 0x100;

--- a/src/unix/linux_like/linux/gnu/b32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mod.rs
@@ -299,8 +299,6 @@ cfg_if! {
         pub const O_PATH: c_int = 0x1000000;
         pub const O_TMPFILE: c_int = 0x2000000 | O_DIRECTORY;
 
-        pub const SA_ONSTACK: c_int = 1;
-
         pub const PTRACE_DETACH: c_uint = 11;
 
         pub const F_RDLCK: c_int = 1;
@@ -329,11 +327,6 @@ cfg_if! {
         pub const EPROTO: c_int = 86;
         pub const EDOTDOT: c_int = 88;
 
-        pub const SA_NODEFER: c_int = 0x20;
-        pub const SA_RESETHAND: c_int = 0x4;
-        pub const SA_RESTART: c_int = 0x2;
-        pub const SA_NOCLDSTOP: c_int = 0x00000008;
-
         pub const EPOLL_CLOEXEC: c_int = 0x400000;
 
         pub const EFD_CLOEXEC: c_int = 0x400000;
@@ -341,8 +334,6 @@ cfg_if! {
         pub const O_NOATIME: c_int = 0o1000000;
         pub const O_PATH: c_int = 0o10000000;
         pub const O_TMPFILE: c_int = 0o20000000 | O_DIRECTORY;
-
-        pub const SA_ONSTACK: c_int = 0x08000000;
 
         pub const PTRACE_DETACH: c_uint = 17;
 
@@ -370,11 +361,6 @@ cfg_if! {
         pub const ECOMM: c_int = 70;
         pub const EPROTO: c_int = 71;
         pub const EDOTDOT: c_int = 73;
-
-        pub const SA_NODEFER: c_int = 0x40000000;
-        pub const SA_RESETHAND: c_int = u32_cast_int(0x80000000);
-        pub const SA_RESTART: c_int = 0x10000000;
-        pub const SA_NOCLDSTOP: c_int = 0x00000001;
 
         pub const EPOLL_CLOEXEC: c_int = 0x80000;
 

--- a/src/unix/linux_like/linux/gnu/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/gnu/b32/powerpc.rs
@@ -7,15 +7,6 @@ use crate::{
 pub type wchar_t = i32;
 
 s! {
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
-        pub sa_mask: crate::sigset_t,
-        pub sa_flags: c_int,
-        pub sa_restorer: Option<extern "C" fn()>,
-    }
-
     pub struct statfs {
         pub f_type: crate::__fsword_t,
         pub f_bsize: crate::__fsword_t,
@@ -345,9 +336,6 @@ pub const ENOTRECOVERABLE: c_int = 131;
 pub const EHWPOISON: c_int = 133;
 pub const ERFKILL: c_int = 132;
 
-pub const SA_SIGINFO: c_int = 0x00000004;
-pub const SA_NOCLDWAIT: c_int = 0x00000002;
-
 pub const SOCK_STREAM: c_int = 1;
 pub const SOCK_DGRAM: c_int = 2;
 
@@ -371,29 +359,6 @@ pub const F_SETOWN: c_int = 8;
 pub const EFD_NONBLOCK: c_int = 0x800;
 pub const SFD_NONBLOCK: c_int = 0x0800;
 
-pub const SIGCHLD: c_int = 17;
-pub const SIGBUS: c_int = 7;
-pub const SIGUSR1: c_int = 10;
-pub const SIGUSR2: c_int = 12;
-pub const SIGCONT: c_int = 18;
-pub const SIGSTOP: c_int = 19;
-pub const SIGTSTP: c_int = 20;
-pub const SIGURG: c_int = 23;
-pub const SIGIO: c_int = 29;
-pub const SIGSYS: c_int = 31;
-pub const SIGSTKFLT: c_int = 16;
-pub const SIGPOLL: c_int = 29;
-pub const SIGPWR: c_int = 30;
-pub const SIG_SETMASK: c_int = 2;
-pub const SIG_BLOCK: c_int = 0x000000;
-pub const SIG_UNBLOCK: c_int = 0x01;
-pub const SIGTTIN: c_int = 21;
-pub const SIGTTOU: c_int = 22;
-pub const SIGXCPU: c_int = 24;
-pub const SIGXFSZ: c_int = 25;
-pub const SIGVTALRM: c_int = 26;
-pub const SIGPROF: c_int = 27;
-pub const SIGWINCH: c_int = 28;
 pub const SIGSTKSZ: size_t = 0x4000;
 pub const MINSIGSTKSZ: size_t = 4096;
 pub const CBAUD: crate::tcflag_t = 0xff;

--- a/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
@@ -111,15 +111,6 @@ s! {
         pub ss_size: size_t,
     }
 
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
-        pub sa_mask: crate::sigset_t,
-        pub sa_flags: c_int,
-        pub sa_restorer: Option<unsafe extern "C" fn()>,
-    }
-
     pub struct ipc_perm {
         pub __key: crate::key_t,
         pub uid: crate::uid_t,
@@ -335,31 +326,6 @@ pub const ERFKILL: c_int = 132;
 
 pub const SOCK_STREAM: c_int = 1;
 pub const SOCK_DGRAM: c_int = 2;
-pub const SA_SIGINFO: c_int = 4;
-pub const SA_NOCLDWAIT: c_int = 2;
-pub const SIGTTIN: c_int = 21;
-pub const SIGTTOU: c_int = 22;
-pub const SIGXCPU: c_int = 24;
-pub const SIGXFSZ: c_int = 25;
-pub const SIGVTALRM: c_int = 26;
-pub const SIGPROF: c_int = 27;
-pub const SIGWINCH: c_int = 28;
-pub const SIGCHLD: c_int = 17;
-pub const SIGBUS: c_int = 7;
-pub const SIGUSR1: c_int = 10;
-pub const SIGUSR2: c_int = 12;
-pub const SIGCONT: c_int = 18;
-pub const SIGSTOP: c_int = 19;
-pub const SIGTSTP: c_int = 20;
-pub const SIGURG: c_int = 23;
-pub const SIGIO: c_int = 29;
-pub const SIGSYS: c_int = 31;
-pub const SIGSTKFLT: c_int = 16;
-pub const SIGPOLL: c_int = 29;
-pub const SIGPWR: c_int = 30;
-pub const SIG_SETMASK: c_int = 2;
-pub const SIG_BLOCK: c_int = 0;
-pub const SIG_UNBLOCK: c_int = 1;
 pub const POLLWRNORM: c_short = 256;
 pub const POLLWRBAND: c_short = 512;
 pub const O_ASYNC: c_int = 8192;

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -9,15 +9,6 @@ use crate::{
 pub type wchar_t = i32;
 
 s! {
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
-        pub sa_mask: crate::sigset_t,
-        pub sa_flags: c_int,
-        pub sa_restorer: Option<extern "C" fn()>,
-    }
-
     pub struct statfs {
         pub f_type: crate::__fsword_t,
         pub f_bsize: crate::__fsword_t,
@@ -315,33 +306,6 @@ pub const ERFKILL: c_int = 134;
 
 pub const SOCK_STREAM: c_int = 1;
 pub const SOCK_DGRAM: c_int = 2;
-
-pub const SA_SIGINFO: c_int = 0x200;
-pub const SA_NOCLDWAIT: c_int = 0x100;
-
-pub const SIGEMT: c_int = 7;
-pub const SIGTTIN: c_int = 21;
-pub const SIGTTOU: c_int = 22;
-pub const SIGXCPU: c_int = 24;
-pub const SIGXFSZ: c_int = 25;
-pub const SIGVTALRM: c_int = 26;
-pub const SIGPROF: c_int = 27;
-pub const SIGWINCH: c_int = 28;
-pub const SIGCHLD: c_int = 20;
-pub const SIGBUS: c_int = 10;
-pub const SIGUSR1: c_int = 30;
-pub const SIGUSR2: c_int = 31;
-pub const SIGCONT: c_int = 19;
-pub const SIGSTOP: c_int = 17;
-pub const SIGTSTP: c_int = 18;
-pub const SIGURG: c_int = 16;
-pub const SIGIO: c_int = 23;
-pub const SIGSYS: c_int = 12;
-pub const SIGPOLL: c_int = 23;
-pub const SIGPWR: c_int = 29;
-pub const SIG_SETMASK: c_int = 4;
-pub const SIG_BLOCK: c_int = 1;
-pub const SIG_UNBLOCK: c_int = 2;
 
 pub const POLLWRNORM: c_short = 4;
 pub const POLLWRBAND: c_short = 0x100;

--- a/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
@@ -8,15 +8,6 @@ pub type wchar_t = i32;
 pub type greg_t = i32;
 
 s! {
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
-        pub sa_mask: crate::sigset_t,
-        pub sa_flags: c_int,
-        pub sa_restorer: Option<extern "C" fn()>,
-    }
-
     pub struct statfs {
         pub f_type: crate::__fsword_t,
         pub f_bsize: crate::__fsword_t,
@@ -416,9 +407,6 @@ pub const ENOTRECOVERABLE: c_int = 131;
 pub const EHWPOISON: c_int = 133;
 pub const ERFKILL: c_int = 132;
 
-pub const SA_SIGINFO: c_int = 0x00000004;
-pub const SA_NOCLDWAIT: c_int = 0x00000002;
-
 pub const SOCK_STREAM: c_int = 1;
 pub const SOCK_DGRAM: c_int = 2;
 
@@ -447,29 +435,6 @@ pub const POLLWRBAND: c_short = 0x200;
 pub const EFD_NONBLOCK: c_int = 0x800;
 pub const SFD_NONBLOCK: c_int = 0x0800;
 
-pub const SIGCHLD: c_int = 17;
-pub const SIGBUS: c_int = 7;
-pub const SIGUSR1: c_int = 10;
-pub const SIGUSR2: c_int = 12;
-pub const SIGCONT: c_int = 18;
-pub const SIGSTOP: c_int = 19;
-pub const SIGTSTP: c_int = 20;
-pub const SIGURG: c_int = 23;
-pub const SIGIO: c_int = 29;
-pub const SIGSYS: c_int = 31;
-pub const SIGSTKFLT: c_int = 16;
-pub const SIGPOLL: c_int = 29;
-pub const SIGPWR: c_int = 30;
-pub const SIG_SETMASK: c_int = 2;
-pub const SIG_BLOCK: c_int = 0x000000;
-pub const SIG_UNBLOCK: c_int = 0x01;
-pub const SIGTTIN: c_int = 21;
-pub const SIGTTOU: c_int = 22;
-pub const SIGXCPU: c_int = 24;
-pub const SIGXFSZ: c_int = 25;
-pub const SIGVTALRM: c_int = 26;
-pub const SIGPROF: c_int = 27;
-pub const SIGWINCH: c_int = 28;
 pub const SIGSTKSZ: size_t = 8192;
 pub const MINSIGSTKSZ: size_t = 2048;
 pub const CBAUD: crate::tcflag_t = 0o0010017;

--- a/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
@@ -12,17 +12,6 @@ pub type blksize_t = i32;
 pub type suseconds_t = i64;
 
 s! {
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
-        pub sa_mask: crate::sigset_t,
-        #[cfg(target_arch = "sparc64")]
-        __reserved0: Padding<c_int>,
-        pub sa_flags: c_int,
-        pub sa_restorer: Option<extern "C" fn()>,
-    }
-
     pub struct statfs {
         pub f_type: crate::__fsword_t,
         pub f_bsize: crate::__fsword_t,
@@ -361,34 +350,6 @@ pub const POSIX_FADV_NOREUSE: c_int = 5;
 pub const SOCK_STREAM: c_int = 1;
 pub const SOCK_DGRAM: c_int = 2;
 
-pub const SA_ONSTACK: c_int = 0x08000000;
-pub const SA_SIGINFO: c_int = 0x00000004;
-pub const SA_NOCLDWAIT: c_int = 0x00000002;
-
-pub const SIGTTIN: c_int = 21;
-pub const SIGTTOU: c_int = 22;
-pub const SIGXCPU: c_int = 24;
-pub const SIGXFSZ: c_int = 25;
-pub const SIGVTALRM: c_int = 26;
-pub const SIGPROF: c_int = 27;
-pub const SIGWINCH: c_int = 28;
-pub const SIGCHLD: c_int = 17;
-pub const SIGBUS: c_int = 7;
-pub const SIGUSR1: c_int = 10;
-pub const SIGUSR2: c_int = 12;
-pub const SIGCONT: c_int = 18;
-pub const SIGSTOP: c_int = 19;
-pub const SIGTSTP: c_int = 20;
-pub const SIGURG: c_int = 23;
-pub const SIGIO: c_int = 29;
-pub const SIGSYS: c_int = 31;
-pub const SIGSTKFLT: c_int = 16;
-pub const SIGPOLL: c_int = 29;
-pub const SIGPWR: c_int = 30;
-pub const SIG_SETMASK: c_int = 2;
-pub const SIG_BLOCK: c_int = 0x000000;
-pub const SIG_UNBLOCK: c_int = 0x01;
-
 pub const POLLWRNORM: c_short = 0x100;
 pub const POLLWRBAND: c_short = 0x200;
 
@@ -436,11 +397,6 @@ pub const ESRMNT: c_int = 69;
 pub const ECOMM: c_int = 70;
 pub const EPROTO: c_int = 71;
 pub const EDOTDOT: c_int = 73;
-
-pub const SA_NODEFER: c_int = 0x40000000;
-pub const SA_RESETHAND: c_int = u32_cast_int(0x80000000);
-pub const SA_RESTART: c_int = 0x10000000;
-pub const SA_NOCLDSTOP: c_int = 0x00000001;
 
 pub const EPOLL_CLOEXEC: c_int = 0x80000;
 

--- a/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
@@ -135,15 +135,6 @@ s! {
         __size: [c_ulong; 7],
     }
 
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
-        pub sa_mask: crate::sigset_t,
-        pub sa_flags: c_int,
-        pub sa_restorer: Option<extern "C" fn()>,
-    }
-
     pub struct stack_t {
         pub ss_sp: *mut c_void,
         pub ss_flags: c_int,
@@ -724,36 +715,6 @@ pub const SOCK_DGRAM: c_int = 2;
 
 pub const SFD_NONBLOCK: c_int = 0x800;
 pub const SFD_CLOEXEC: c_int = 0x080000;
-pub const SA_NODEFER: c_int = 0x40000000;
-pub const SA_RESETHAND: c_int = u32_cast_int(0x80000000);
-pub const SA_RESTART: c_int = 0x10000000;
-pub const SA_NOCLDSTOP: c_int = 0x00000001;
-pub const SA_ONSTACK: c_int = 0x08000000;
-pub const SA_SIGINFO: c_int = 0x00000004;
-pub const SA_NOCLDWAIT: c_int = 0x00000002;
-pub const SIG_BLOCK: c_int = 0;
-pub const SIG_UNBLOCK: c_int = 1;
-pub const SIG_SETMASK: c_int = 2;
-pub const SIGBUS: c_int = 7;
-pub const SIGUSR1: c_int = 10;
-pub const SIGUSR2: c_int = 12;
-pub const SIGSTKFLT: c_int = 16;
-pub const SIGCHLD: c_int = 17;
-pub const SIGCONT: c_int = 18;
-pub const SIGSTOP: c_int = 19;
-pub const SIGTSTP: c_int = 20;
-pub const SIGTTIN: c_int = 21;
-pub const SIGTTOU: c_int = 22;
-pub const SIGURG: c_int = 23;
-pub const SIGXCPU: c_int = 24;
-pub const SIGXFSZ: c_int = 25;
-pub const SIGVTALRM: c_int = 26;
-pub const SIGPROF: c_int = 27;
-pub const SIGWINCH: c_int = 28;
-pub const SIGIO: c_int = 29;
-pub const SIGPOLL: c_int = 29;
-pub const SIGPWR: c_int = 30;
-pub const SIGSYS: c_int = 31;
 
 pub const POLLWRNORM: c_short = 0x100;
 pub const POLLWRBAND: c_short = 0x200;

--- a/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
@@ -137,15 +137,6 @@ s! {
         __size: [c_ulong; 7],
     }
 
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_flags: c_int,
-        pub sa_sigaction: crate::sighandler_t,
-        pub sa_mask: crate::sigset_t,
-        pub sa_restorer: Option<extern "C" fn()>,
-    }
-
     pub struct stack_t {
         pub ss_sp: *mut c_void,
         pub ss_size: size_t,
@@ -581,11 +572,6 @@ pub const ECOMM: c_int = 70;
 pub const EPROTO: c_int = 71;
 pub const EDOTDOT: c_int = 73;
 
-pub const SA_NODEFER: c_int = 0x40000000;
-pub const SA_RESETHAND: c_int = u32_cast_int(0x80000000);
-pub const SA_RESTART: c_int = 0x10000000;
-pub const SA_NOCLDSTOP: c_int = 0x00000001;
-
 pub const POSIX_FADV_DONTNEED: c_int = 4;
 pub const POSIX_FADV_NOREUSE: c_int = 5;
 
@@ -707,34 +693,6 @@ pub const MAP_HUGETLB: c_int = 0x080000;
 
 pub const SOCK_STREAM: c_int = 2;
 pub const SOCK_DGRAM: c_int = 1;
-
-pub const SA_ONSTACK: c_int = 0x08000000;
-pub const SA_SIGINFO: c_int = 0x00000008;
-pub const SA_NOCLDWAIT: c_int = 0x00010000;
-
-pub const SIGEMT: c_int = 7;
-pub const SIGCHLD: c_int = 18;
-pub const SIGBUS: c_int = 10;
-pub const SIGTTIN: c_int = 26;
-pub const SIGTTOU: c_int = 27;
-pub const SIGXCPU: c_int = 30;
-pub const SIGXFSZ: c_int = 31;
-pub const SIGVTALRM: c_int = 28;
-pub const SIGPROF: c_int = 29;
-pub const SIGWINCH: c_int = 20;
-pub const SIGUSR1: c_int = 16;
-pub const SIGUSR2: c_int = 17;
-pub const SIGCONT: c_int = 25;
-pub const SIGSTOP: c_int = 23;
-pub const SIGTSTP: c_int = 24;
-pub const SIGURG: c_int = 21;
-pub const SIGIO: c_int = 22;
-pub const SIGSYS: c_int = 12;
-pub const SIGPOLL: c_int = 22;
-pub const SIGPWR: c_int = 19;
-pub const SIG_SETMASK: c_int = 3;
-pub const SIG_BLOCK: c_int = 0x1;
-pub const SIG_UNBLOCK: c_int = 0x2;
 
 pub const POLLWRNORM: c_short = 0x004;
 pub const POLLWRBAND: c_short = 0x100;

--- a/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
@@ -14,17 +14,6 @@ pub type gregset_t = [c_ulong; __NGREG];
 pub type fpregset_t = [c_ulong; __NFPREG];
 
 s! {
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
-        pub sa_mask: crate::sigset_t,
-        #[cfg(target_arch = "sparc64")]
-        __reserved0: Padding<c_int>,
-        pub sa_flags: c_int,
-        pub sa_restorer: Option<extern "C" fn()>,
-    }
-
     pub struct statfs {
         pub f_type: crate::__fsword_t,
         pub f_bsize: crate::__fsword_t,
@@ -396,34 +385,6 @@ pub const ERFKILL: c_int = 132;
 pub const SOCK_STREAM: c_int = 1;
 pub const SOCK_DGRAM: c_int = 2;
 
-pub const SA_ONSTACK: c_int = 0x08000000;
-pub const SA_SIGINFO: c_int = 0x00000004;
-pub const SA_NOCLDWAIT: c_int = 0x00000002;
-
-pub const SIGTTIN: c_int = 21;
-pub const SIGTTOU: c_int = 22;
-pub const SIGXCPU: c_int = 24;
-pub const SIGXFSZ: c_int = 25;
-pub const SIGVTALRM: c_int = 26;
-pub const SIGPROF: c_int = 27;
-pub const SIGWINCH: c_int = 28;
-pub const SIGCHLD: c_int = 17;
-pub const SIGBUS: c_int = 7;
-pub const SIGUSR1: c_int = 10;
-pub const SIGUSR2: c_int = 12;
-pub const SIGCONT: c_int = 18;
-pub const SIGSTOP: c_int = 19;
-pub const SIGTSTP: c_int = 20;
-pub const SIGURG: c_int = 23;
-pub const SIGIO: c_int = 29;
-pub const SIGSYS: c_int = 31;
-pub const SIGSTKFLT: c_int = 16;
-pub const SIGPOLL: c_int = 29;
-pub const SIGPWR: c_int = 30;
-pub const SIG_SETMASK: c_int = 2;
-pub const SIG_BLOCK: c_int = 0x000000;
-pub const SIG_UNBLOCK: c_int = 0x01;
-
 pub const POLLWRNORM: c_short = 0x100;
 pub const POLLWRBAND: c_short = 0x200;
 
@@ -475,11 +436,6 @@ pub const ESRMNT: c_int = 69;
 pub const ECOMM: c_int = 70;
 pub const EPROTO: c_int = 71;
 pub const EDOTDOT: c_int = 73;
-
-pub const SA_NODEFER: c_int = 0x40000000;
-pub const SA_RESETHAND: c_int = u32_cast_int(0x80000000);
-pub const SA_RESTART: c_int = 0x10000000;
-pub const SA_NOCLDSTOP: c_int = 0x00000001;
 
 pub const EPOLL_CLOEXEC: c_int = 0x80000;
 

--- a/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
@@ -144,15 +144,6 @@ s! {
         pub ss_size: size_t,
     }
 
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
-        pub sa_mask: crate::sigset_t,
-        pub sa_flags: c_int,
-        pub sa_restorer: Option<unsafe extern "C" fn()>,
-    }
-
     pub struct ipc_perm {
         pub __key: crate::key_t,
         pub uid: crate::uid_t,
@@ -392,32 +383,6 @@ pub const ERFKILL: c_int = 132;
 
 pub const SOCK_STREAM: c_int = 1;
 pub const SOCK_DGRAM: c_int = 2;
-pub const SA_ONSTACK: c_int = 134217728;
-pub const SA_SIGINFO: c_int = 4;
-pub const SA_NOCLDWAIT: c_int = 2;
-pub const SIGTTIN: c_int = 21;
-pub const SIGTTOU: c_int = 22;
-pub const SIGXCPU: c_int = 24;
-pub const SIGXFSZ: c_int = 25;
-pub const SIGVTALRM: c_int = 26;
-pub const SIGPROF: c_int = 27;
-pub const SIGWINCH: c_int = 28;
-pub const SIGCHLD: c_int = 17;
-pub const SIGBUS: c_int = 7;
-pub const SIGUSR1: c_int = 10;
-pub const SIGUSR2: c_int = 12;
-pub const SIGCONT: c_int = 18;
-pub const SIGSTOP: c_int = 19;
-pub const SIGTSTP: c_int = 20;
-pub const SIGURG: c_int = 23;
-pub const SIGIO: c_int = 29;
-pub const SIGSYS: c_int = 31;
-pub const SIGSTKFLT: c_int = 16;
-pub const SIGPOLL: c_int = 29;
-pub const SIGPWR: c_int = 30;
-pub const SIG_SETMASK: c_int = 2;
-pub const SIG_BLOCK: c_int = 0;
-pub const SIG_UNBLOCK: c_int = 1;
 pub const POLLWRNORM: c_short = 256;
 pub const POLLWRBAND: c_short = 512;
 pub const O_ASYNC: c_int = 8192;
@@ -457,10 +422,6 @@ pub const ESRMNT: c_int = 69;
 pub const ECOMM: c_int = 70;
 pub const EPROTO: c_int = 71;
 pub const EDOTDOT: c_int = 73;
-pub const SA_NODEFER: c_int = 1073741824;
-pub const SA_RESETHAND: c_int = -2147483648;
-pub const SA_RESTART: c_int = 268435456;
-pub const SA_NOCLDSTOP: c_int = 1;
 pub const EPOLL_CLOEXEC: c_int = 524288;
 pub const EFD_CLOEXEC: c_int = 524288;
 pub const __SIZEOF_PTHREAD_CONDATTR_T: usize = 4;

--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -13,16 +13,6 @@ pub type wchar_t = i32;
 pub type greg_t = u64;
 
 s! {
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
-        __glibc_reserved0: Padding<c_int>,
-        pub sa_flags: c_int,
-        pub sa_restorer: Option<extern "C" fn()>,
-        pub sa_mask: crate::sigset_t,
-    }
-
     pub struct statfs {
         pub f_type: c_uint,
         pub f_bsize: c_uint,
@@ -276,11 +266,6 @@ pub const ECOMM: c_int = 70;
 pub const EPROTO: c_int = 71;
 pub const EDOTDOT: c_int = 73;
 
-pub const SA_NODEFER: c_int = 0x40000000;
-pub const SA_RESETHAND: c_int = u32_cast_int(0x80000000);
-pub const SA_RESTART: c_int = 0x10000000;
-pub const SA_NOCLDSTOP: c_int = 0x00000001;
-
 pub const EPOLL_CLOEXEC: c_int = 0x80000;
 
 pub const EFD_CLOEXEC: c_int = 0x80000;
@@ -310,13 +295,8 @@ pub const O_APPEND: c_int = 1024;
 pub const O_CREAT: c_int = 64;
 pub const O_EXCL: c_int = 128;
 pub const O_NONBLOCK: c_int = 2048;
-pub const SA_NOCLDWAIT: c_int = 2;
-pub const SA_ONSTACK: c_int = 0x08000000;
-pub const SA_SIGINFO: c_int = 4;
-pub const SIGBUS: c_int = 7;
 pub const SIGSTKSZ: size_t = 0x2000;
 pub const MINSIGSTKSZ: size_t = 2048;
-pub const SIG_SETMASK: c_int = 2;
 
 pub const SOCK_STREAM: c_int = 1;
 pub const SOCK_DGRAM: c_int = 2;
@@ -414,28 +394,6 @@ pub const EOWNERDEAD: c_int = 130;
 pub const ENOTRECOVERABLE: c_int = 131;
 pub const EHWPOISON: c_int = 133;
 pub const ERFKILL: c_int = 132;
-
-pub const SIGTTIN: c_int = 21;
-pub const SIGTTOU: c_int = 22;
-pub const SIGXCPU: c_int = 24;
-pub const SIGXFSZ: c_int = 25;
-pub const SIGVTALRM: c_int = 26;
-pub const SIGPROF: c_int = 27;
-pub const SIGWINCH: c_int = 28;
-pub const SIGCHLD: c_int = 17;
-pub const SIGUSR1: c_int = 10;
-pub const SIGUSR2: c_int = 12;
-pub const SIGCONT: c_int = 18;
-pub const SIGSTOP: c_int = 19;
-pub const SIGTSTP: c_int = 20;
-pub const SIGURG: c_int = 23;
-pub const SIGIO: c_int = 29;
-pub const SIGSYS: c_int = 31;
-pub const SIGSTKFLT: c_int = 16;
-pub const SIGPOLL: c_int = 29;
-pub const SIGPWR: c_int = 30;
-pub const SIG_BLOCK: c_int = 0x000000;
-pub const SIG_UNBLOCK: c_int = 0x01;
 
 pub const O_ASYNC: c_int = 0x2000;
 pub const O_NDELAY: c_int = 0x800;

--- a/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
@@ -12,17 +12,6 @@ pub type blksize_t = i64;
 pub type suseconds_t = i32;
 
 s! {
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
-        pub sa_mask: crate::sigset_t,
-        #[cfg(target_arch = "sparc64")]
-        __reserved0: Padding<c_int>,
-        pub sa_flags: c_int,
-        pub sa_restorer: Option<extern "C" fn()>,
-    }
-
     pub struct statfs {
         pub f_type: crate::__fsword_t,
         pub f_bsize: crate::__fsword_t,
@@ -321,34 +310,6 @@ pub const ERFKILL: c_int = 134;
 pub const SOCK_STREAM: c_int = 1;
 pub const SOCK_DGRAM: c_int = 2;
 
-pub const SA_ONSTACK: c_int = 1;
-pub const SA_SIGINFO: c_int = 0x200;
-pub const SA_NOCLDWAIT: c_int = 0x100;
-
-pub const SIGEMT: c_int = 7;
-pub const SIGTTIN: c_int = 21;
-pub const SIGTTOU: c_int = 22;
-pub const SIGXCPU: c_int = 24;
-pub const SIGXFSZ: c_int = 25;
-pub const SIGVTALRM: c_int = 26;
-pub const SIGPROF: c_int = 27;
-pub const SIGWINCH: c_int = 28;
-pub const SIGCHLD: c_int = 20;
-pub const SIGBUS: c_int = 10;
-pub const SIGUSR1: c_int = 30;
-pub const SIGUSR2: c_int = 31;
-pub const SIGCONT: c_int = 19;
-pub const SIGSTOP: c_int = 17;
-pub const SIGTSTP: c_int = 18;
-pub const SIGURG: c_int = 16;
-pub const SIGIO: c_int = 23;
-pub const SIGSYS: c_int = 12;
-pub const SIGPOLL: c_int = 23;
-pub const SIGPWR: c_int = 29;
-pub const SIG_SETMASK: c_int = 4;
-pub const SIG_BLOCK: c_int = 1;
-pub const SIG_UNBLOCK: c_int = 2;
-
 pub const POLLWRNORM: c_short = 4;
 pub const POLLWRBAND: c_short = 0x100;
 
@@ -399,11 +360,6 @@ pub const ESRMNT: c_int = 84;
 pub const ECOMM: c_int = 85;
 pub const EPROTO: c_int = 86;
 pub const EDOTDOT: c_int = 88;
-
-pub const SA_NODEFER: c_int = 0x20;
-pub const SA_RESETHAND: c_int = 0x4;
-pub const SA_RESTART: c_int = 0x2;
-pub const SA_NOCLDSTOP: c_int = 0x00000008;
 
 pub const EPOLL_CLOEXEC: c_int = 0x400000;
 

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -13,17 +13,6 @@ pub type greg_t = i64;
 pub type suseconds_t = i64;
 
 s! {
-    // FIXME(1.0): This should not implement `PartialEq`
-    #[allow(unpredictable_function_pointer_comparisons)]
-    pub struct sigaction {
-        pub sa_sigaction: crate::sighandler_t,
-        pub sa_mask: crate::sigset_t,
-        #[cfg(target_arch = "sparc64")]
-        __reserved0: Padding<c_int>,
-        pub sa_flags: c_int,
-        pub sa_restorer: Option<extern "C" fn()>,
-    }
-
     pub struct statfs {
         pub f_type: crate::__fsword_t,
         pub f_bsize: crate::__fsword_t,
@@ -426,34 +415,6 @@ pub const ERFKILL: c_int = 132;
 pub const SOCK_STREAM: c_int = 1;
 pub const SOCK_DGRAM: c_int = 2;
 
-pub const SA_ONSTACK: c_int = 0x08000000;
-pub const SA_SIGINFO: c_int = 0x00000004;
-pub const SA_NOCLDWAIT: c_int = 0x00000002;
-
-pub const SIGTTIN: c_int = 21;
-pub const SIGTTOU: c_int = 22;
-pub const SIGXCPU: c_int = 24;
-pub const SIGXFSZ: c_int = 25;
-pub const SIGVTALRM: c_int = 26;
-pub const SIGPROF: c_int = 27;
-pub const SIGWINCH: c_int = 28;
-pub const SIGCHLD: c_int = 17;
-pub const SIGBUS: c_int = 7;
-pub const SIGUSR1: c_int = 10;
-pub const SIGUSR2: c_int = 12;
-pub const SIGCONT: c_int = 18;
-pub const SIGSTOP: c_int = 19;
-pub const SIGTSTP: c_int = 20;
-pub const SIGURG: c_int = 23;
-pub const SIGIO: c_int = 29;
-pub const SIGSYS: c_int = 31;
-pub const SIGSTKFLT: c_int = 16;
-pub const SIGPOLL: c_int = 29;
-pub const SIGPWR: c_int = 30;
-pub const SIG_SETMASK: c_int = 2;
-pub const SIG_BLOCK: c_int = 0x000000;
-pub const SIG_UNBLOCK: c_int = 0x01;
-
 pub const POLLWRNORM: c_short = 0x100;
 pub const POLLWRBAND: c_short = 0x200;
 
@@ -506,11 +467,6 @@ pub const ESRMNT: c_int = 69;
 pub const ECOMM: c_int = 70;
 pub const EPROTO: c_int = 71;
 pub const EDOTDOT: c_int = 73;
-
-pub const SA_NODEFER: c_int = 0x40000000;
-pub const SA_RESETHAND: c_int = u32_cast_int(0x80000000);
-pub const SA_RESTART: c_int = 0x10000000;
-pub const SA_NOCLDSTOP: c_int = 0x00000001;
 
 pub const EPOLL_CLOEXEC: c_int = 0x80000;
 

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -470,8 +470,6 @@ pub const F_SEAL_WRITE: c_int = 0x0008;
 
 // FIXME(#235): Include file sealing fcntls once we have a way to verify them.
 
-pub const SIGTRAP: c_int = 5;
-
 pub const PTHREAD_CREATE_JOINABLE: c_int = 0;
 pub const PTHREAD_CREATE_DETACHED: c_int = 1;
 
@@ -520,17 +518,24 @@ pub const F_OK: c_int = 0;
 pub const R_OK: c_int = 4;
 pub const W_OK: c_int = 2;
 pub const X_OK: c_int = 1;
-pub const SIGHUP: c_int = 1;
-pub const SIGINT: c_int = 2;
-pub const SIGQUIT: c_int = 3;
-pub const SIGILL: c_int = 4;
-pub const SIGABRT: c_int = 6;
-pub const SIGFPE: c_int = 8;
-pub const SIGKILL: c_int = 9;
-pub const SIGSEGV: c_int = 11;
-pub const SIGPIPE: c_int = 13;
-pub const SIGALRM: c_int = 14;
-pub const SIGTERM: c_int = 15;
+
+cfg_if! {
+    // defined in src/new/glibc
+    if #[cfg(not(all(target_os = "linux", target_env = "gnu")))] {
+        pub const SIGHUP: c_int = 1;
+        pub const SIGINT: c_int = 2;
+        pub const SIGQUIT: c_int = 3;
+        pub const SIGILL: c_int = 4;
+        pub const SIGTRAP: c_int = 5;
+        pub const SIGABRT: c_int = 6;
+        pub const SIGFPE: c_int = 8;
+        pub const SIGKILL: c_int = 9;
+        pub const SIGSEGV: c_int = 11;
+        pub const SIGPIPE: c_int = 13;
+        pub const SIGALRM: c_int = 14;
+        pub const SIGTERM: c_int = 15;
+    }
+}
 
 const SIGEV_MAX_SIZE: usize = 64;
 cfg_if! {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -2321,6 +2321,7 @@ cfg_if! {
             #[cfg(not(target_os = "l4re"))]
             pub fn open_memstream(ptr: *mut *mut c_char, sizeloc: *mut size_t) -> *mut FILE;
             pub fn atexit(cb: extern "C" fn()) -> c_int;
+            #[cfg(not(all(target_os = "linux", target_env = "gnu")))] // defined in new/glibc
             #[cfg_attr(target_os = "netbsd", link_name = "__sigaction14")]
             pub fn sigaction(signum: c_int, act: *const sigaction, oldact: *mut sigaction)
                 -> c_int;


### PR DESCRIPTION
This allows for quite a bit of cleanup. Links:

* https://github.com/sailfishos-mirror/glibc/blob/ae646973c5957b7eed06cb80d49d13b42178072d/signal/signal.h
* https://github.com/sailfishos-mirror/glibc/blob/ae646973c5957b7eed06cb80d49d13b42178072d/sysdeps/unix/sysv/linux/bits/sigaction.h
* https://github.com/sailfishos-mirror/glibc/blob/ae646973c5957b7eed06cb80d49d13b42178072d/sysdeps/unix/sysv/linux/mips/bits/sigaction.h
* https://github.com/sailfishos-mirror/glibc/blob/ae646973c5957b7eed06cb80d49d13b42178072d/sysdeps/unix/sysv/linux/s390/bits/sigaction.h
* https://github.com/sailfishos-mirror/glibc/blob/ae646973c5957b7eed06cb80d49d13b42178072d/sysdeps/unix/sysv/linux/sparc/bits/sigaction.h
* https://github.com/sailfishos-mirror/glibc/blob/ae646973c5957b7eed06cb80d49d13b42178072d/bits/signum-generic.h#L76
* https://github.com/sailfishos-mirror/glibc/blob/ae646973c5957b7eed06cb80d49d13b42178072d/sysdeps/unix/sysv/linux/bits/signum-arch.h
* https://github.com/sailfishos-mirror/glibc/blob/ae646973c5957b7eed06cb80d49d13b42178072d/sysdeps/unix/sysv/linux/mips/bits/signum-arch.h
* https://github.com/sailfishos-mirror/glibc/blob/ae646973c5957b7eed06cb80d49d13b42178072d/sysdeps/unix/sysv/linux/sparc/bits/signum-arch.h