### PR TITLE
ci: Add configuration for renovatebot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,37 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:recommended",
+    ":maintainLockFilesMonthly",
+    "helpers:pinGitHubActionDigestsToSemver"
+  ],
+  packageRules: [
+    {
+      matchCategories: [
+        "rust"
+      ],
+      matchJsonata: [
+        "isBreaking != true"
+      ],
+      // Disable non-breaking change updates because they
+      // are updated periodically with lockfile maintainance.
+      enabled: false,
+    },
+    {
+      matchManagers: [
+        "github-actions"
+      ],
+      // Every month
+      schedule: "* 0 1 * *",
+      groupName: "Github Actions",
+    }
+  ],
+  // Receive any update that fixes security vulnerabilities.
+  // We need this because we disabled "patch" updates for Rust.
+  // Note: You need to enable "Dependabot alerts" in "Code security" GitHub
+  // Settings to receive security updates.
+  // See https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts
+  vulnerabilityAlerts: {
+    enabled: true,
+  },
+}


### PR DESCRIPTION
Based on the configuration for `compiler-builtins` [1].

[1]: https://github.com/rust-lang/compiler-builtins/blob/af778498377a1bb72aefee685edf7aebd79df5b0/.github/renovate.json5