### PR TITLE
linux/l4re: remove IPPROTO_MAX from shared file

### DIFF
--- a/src/unix/linux_like/l4re/uclibc/mod.rs
+++ b/src/unix/linux_like/l4re/uclibc/mod.rs
@@ -410,6 +410,8 @@ pub const ENOTSUP: c_int = EOPNOTSUPP;
 pub const IPV6_JOIN_GROUP: c_int = 20;
 pub const IPV6_LEAVE_GROUP: c_int = 21;
 
+pub const IPPROTO_MAX: c_int = 256;
+
 // Different than Gnu.
 pub const FILENAME_MAX: c_uint = 4095;
 

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -1328,6 +1328,11 @@ pub const IPV6_FREEBIND: c_int = 78;
 pub const IPV6_FLOWINFO_FLOWLABEL: c_int = 0x000fffff;
 pub const IPV6_FLOWINFO_PRIORITY: c_int = 0x0ff00000;
 
+// netinet/in.h
+// NOTE: These are in addition to the constants defined in src/unix/mod.rs
+
+pub const IPPROTO_MAX: c_int = 263;
+
 // SO_MEMINFO offsets
 pub const SK_MEMINFO_RMEM_ALLOC: c_int = 0;
 pub const SK_MEMINFO_RCVBUF: c_int = 1;

--- a/src/unix/linux_like/linux_l4re_shared.rs
+++ b/src/unix/linux_like/linux_l4re_shared.rs
@@ -945,11 +945,6 @@ pub const PTHREAD_EXPLICIT_SCHED: c_int = 1;
 #[cfg(not(target_os = "l4re"))]
 pub const __SIZEOF_PTHREAD_COND_T: usize = 48;
 
-// netinet/in.h
-// NOTE: These are in addition to the constants defined in src/unix/mod.rs
-
-pub const IPPROTO_MAX: c_int = 263;
-
 // System V IPC
 pub const IPC_PRIVATE: crate::key_t = 0;
 


### PR DESCRIPTION
IPPROTO_MAX has changed for Linux but stayed on the old value for L4Re.