### PR TITLE
AIX CI: skip unnamed union symbol and update semver list

### DIFF
--- a/libc-test/build/main.rs
+++ b/libc-test/build/main.rs
@@ -5960,6 +5960,7 @@ fn test_aix(t: &Target) {
         match s.ident() {
             // The field 'u' is actually a unnamed union in the AIX header.
             "poll_ctl_ext" if field.ident() == "u" => true,
+            "pollfd_ext_t" if field.ident() == "u" => true,
 
             // The field 'data' is actually a unnamed union in the AIX header.
             "pollfd_ext" if field.ident() == "data" => true,

--- a/libc-test/semver/aix.txt
+++ b/libc-test/semver/aix.txt
@@ -1789,10 +1789,10 @@ _W_SFWTED
 _W_SLWTED
 _W_STOPPED
 _W_STRC
+__c_anonymous_ld_info__file
+__c_anonymous_pollfd_ext_t_u
 __context64
 __extctx_t
-__ld_info_file
-__pollfd_ext_u
 __tm_context_t
 __vmx_context_t
 __vmxreg_t
@@ -2182,7 +2182,7 @@ poll
 poll_ctl
 poll_ctl_ext
 pollfd
-pollfd_ext
+pollfd_ext_t
 pollset_create
 pollset_ctl
 pollset_destroy


### PR DESCRIPTION
This is a follow-up to commit 7ce8d44f9a9dbf1e09892674a02db7444a3fe729 to fix the CI for AIX.