### PR TITLE
glibc: Add `f_type` to `statvfs` and `statvfs64`

### DIFF
--- a/libc-test/build/main.rs
+++ b/libc-test/build/main.rs
@@ -5200,9 +5200,12 @@ fn test_linux(t: &Target) {
             }
             // invalid application of 'sizeof' to incomplete type 'long unsigned int[]'
             ("mcontext_t", "__extcontext") if musl && loongarch64 => true,
-            // FIXME(#4121): a new field was added from `f_spare`
-            ("statvfs", "__f_spare") => true,
-            ("statvfs64", "__f_spare") => true,
+            // glibc 2.39 took one of the six spares for `f_type`
+            ("statvfs" | "statvfs64", "f_type" | "__f_spare")
+                if gnu && versions.glibc.unwrap() < (2, 39) =>
+            {
+                true
+            }
             // the `xsk_tx_metadata_union` field is an anonymous union
             ("xsk_tx_metadata", "xsk_tx_metadata_union") => true,
             // After musl 1.2.0, the type becomes `int` instead of `long`.

--- a/src/new/glibc/mod.rs
+++ b/src/new/glibc/mod.rs
@@ -24,6 +24,14 @@ mod posix {
 #[cfg(target_os = "linux")]
 pub(crate) mod signal;
 
+/// Source directory: `io/sys/`
+///
+/// <https://github.com/sailfishos-mirror/glibc/tree/master/io/sys>
+pub(crate) mod sys {
+    #[cfg(target_os = "linux")]
+    pub(crate) mod statvfs;
+}
+
 /// Source directory: `sysdeps/`
 ///
 /// <https://github.com/sailfishos-mirror/glibc/tree/master/sysdeps>

--- a/src/new/glibc/sys/statvfs.rs
+++ b/src/new/glibc/sys/statvfs.rs
@@ -1,0 +1,15 @@
+//! Header: `io/sys/statvfs.h`
+
+pub use super::super::sysdeps::unix::linux::bits::statvfs::*;
+use crate::prelude::*;
+
+extern "C" {
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "statvfs64")]
+    pub fn statvfs(path: *const c_char, buf: *mut statvfs) -> c_int;
+    #[cfg_attr(gnu_file_offset_bits64, link_name = "fstatvfs64")]
+    pub fn fstatvfs(fd: c_int, buf: *mut statvfs) -> c_int;
+    // FIXME(1.0,deprecate): lfs binding to be removed
+    pub fn statvfs64(path: *const c_char, buf: *mut statvfs64) -> c_int;
+    // FIXME(1.0,deprecate): lfs binding to be removed
+    pub fn fstatvfs64(fd: c_int, buf: *mut statvfs64) -> c_int;
+}

--- a/src/new/glibc/sysdeps/unix/linux/bits/statvfs.rs
+++ b/src/new/glibc/sysdeps/unix/linux/bits/statvfs.rs
@@ -1,0 +1,53 @@
+//! Header: `sysdeps/unix/sysv/linux/bits/statvfs.h`
+
+use crate::prelude::*;
+
+s! {
+    pub struct statvfs {
+        pub f_bsize: c_ulong,
+        pub f_frsize: c_ulong,
+        pub f_blocks: crate::fsblkcnt_t,
+        pub f_bfree: crate::fsblkcnt_t,
+        pub f_bavail: crate::fsblkcnt_t,
+        pub f_files: crate::fsfilcnt_t,
+        pub f_ffree: crate::fsfilcnt_t,
+        pub f_favail: crate::fsfilcnt_t,
+        pub f_fsid: c_ulong,
+        // Mirrors `_STATVFSBUF_F_UNUSED` in the header. x32 is excluded because its
+        // `__SYSCALL_WORDSIZE` is 64, aarch64 because glibc always sets `__WORDSIZE` to 64.
+        #[cfg(all(
+            target_pointer_width = "32",
+            not(any(target_arch = "x86_64", target_arch = "aarch64"))
+        ))]
+        __f_unused: Padding<c_int>,
+        pub f_flag: c_ulong,
+        pub f_namemax: c_ulong,
+        __f_spare: [c_int; 6],
+    }
+
+    pub struct statvfs64 {
+        pub f_bsize: c_ulong,
+        pub f_frsize: c_ulong,
+        pub f_blocks: u64,
+        pub f_bfree: u64,
+        pub f_bavail: u64,
+        pub f_files: u64,
+        pub f_ffree: u64,
+        pub f_favail: u64,
+        pub f_fsid: c_ulong,
+        // FIXME(riscv32): glibc declares this field on riscv32 too, but we have never
+        // declared it here.
+        #[cfg(all(
+            target_pointer_width = "32",
+            not(any(
+                target_arch = "x86_64",
+                target_arch = "aarch64",
+                target_arch = "riscv32"
+            ))
+        ))]
+        __f_unused: Padding<c_int>,
+        pub f_flag: c_ulong,
+        pub f_namemax: c_ulong,
+        __f_spare: [c_int; 6],
+    }
+}

--- a/src/new/glibc/sysdeps/unix/linux/bits/statvfs.rs
+++ b/src/new/glibc/sysdeps/unix/linux/bits/statvfs.rs
@@ -22,7 +22,8 @@ s! {
         __f_unused: Padding<c_int>,
         pub f_flag: c_ulong,
         pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
+        pub f_type: c_uint,
+        __f_spare: [c_int; 5],
     }
 
     pub struct statvfs64 {
@@ -48,6 +49,7 @@ s! {
         __f_unused: Padding<c_int>,
         pub f_flag: c_ulong,
         pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
+        pub f_type: c_uint,
+        __f_spare: [c_int; 5],
     }
 }

--- a/src/new/glibc/sysdeps/unix/linux/mod.rs
+++ b/src/new/glibc/sysdeps/unix/linux/mod.rs
@@ -33,6 +33,7 @@ pub(crate) mod bits {
         path = "../sparc/bits/signum_arch.rs"
     )]
     pub(crate) mod signum_arch;
+    pub(crate) mod statvfs;
 }
 
 /// Directory: `net/`

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -201,6 +201,8 @@ cfg_if! {
         pub use net::route::*;
         #[cfg(target_env = "gnu")]
         pub use signal::*;
+        #[cfg(target_env = "gnu")]
+        pub use sys::statvfs::*;
     } else if #[cfg(target_vendor = "apple")] {
         #[cfg(target_os = "macos")]
         pub use net::bpf::*;

--- a/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/arm/mod.rs
@@ -103,22 +103,6 @@ s! {
         pub f_spare: [crate::__fsword_t; 4],
     }
 
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        __f_unused: Padding<c_int>,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
     pub struct shmid_ds {
         pub shm_perm: crate::ipc_perm,
         pub shm_segsz: size_t,

--- a/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/csky/mod.rs
@@ -90,22 +90,6 @@ s! {
         pub f_spare: [crate::__fsword_t; 4],
     }
 
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        __f_unused: Padding<c_int>,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
     pub struct shmid_ds {
         pub shm_perm: crate::ipc_perm,
         pub shm_segsz: size_t,

--- a/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/m68k/mod.rs
@@ -90,22 +90,6 @@ s! {
         pub f_spare: [crate::__fsword_t; 4],
     }
 
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsblkcnt64_t,
-        pub f_bfree: crate::fsblkcnt64_t,
-        pub f_bavail: crate::fsblkcnt64_t,
-        pub f_files: crate::fsblkcnt64_t,
-        pub f_ffree: crate::fsblkcnt64_t,
-        pub f_favail: crate::fsblkcnt64_t,
-        pub f_fsid: c_ulong,
-        __f_unused: Padding<c_int>,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
     pub struct shmid_ds {
         pub shm_perm: crate::ipc_perm,
         pub shm_segsz: size_t,

--- a/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mips/mod.rs
@@ -150,22 +150,6 @@ s! {
         pub f_spare: [c_long; 5],
     }
 
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        __f_unused: Padding<c_int>,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
     pub struct stack_t {
         pub ss_sp: *mut c_void,
         pub ss_size: size_t,

--- a/src/unix/linux_like/linux/gnu/b32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/mod.rs
@@ -125,22 +125,6 @@ cfg_if! {
 }
 
 s! {
-    pub struct statvfs {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsblkcnt_t,
-        pub f_bfree: crate::fsblkcnt_t,
-        pub f_bavail: crate::fsblkcnt_t,
-        pub f_files: crate::fsfilcnt_t,
-        pub f_ffree: crate::fsfilcnt_t,
-        pub f_favail: crate::fsfilcnt_t,
-        pub f_fsid: c_ulong,
-        __f_unused: Padding<c_int>,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
     pub struct pthread_attr_t {
         __size: [u32; 9],
     }

--- a/src/unix/linux_like/linux/gnu/b32/powerpc.rs
+++ b/src/unix/linux_like/linux/gnu/b32/powerpc.rs
@@ -132,22 +132,6 @@ s! {
         pub f_spare: [crate::__fsword_t; 4],
     }
 
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        __f_unused: Padding<c_int>,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
     pub struct shmid_ds {
         pub shm_perm: crate::ipc_perm,
         #[cfg(gnu_time_bits64)]

--- a/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/riscv32/mod.rs
@@ -75,21 +75,6 @@ s! {
         pub f_spare: [c_long; 4],
     }
 
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsblkcnt64_t,
-        pub f_bfree: crate::fsblkcnt64_t,
-        pub f_bavail: crate::fsblkcnt64_t,
-        pub f_files: crate::fsfilcnt64_t,
-        pub f_ffree: crate::fsfilcnt64_t,
-        pub f_favail: crate::fsfilcnt64_t,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        pub __f_spare: [c_int; 6],
-    }
-
     pub struct siginfo_t {
         pub si_signo: c_int,
         pub si_errno: c_int,

--- a/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/sparc/mod.rs
@@ -118,22 +118,6 @@ s! {
         pub f_spare: [crate::__fsword_t; 4],
     }
 
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        __f_unused: Padding<c_int>,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
     pub struct ipc_perm {
         pub __key: crate::key_t,
         pub uid: crate::uid_t,

--- a/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b32/x86/mod.rs
@@ -177,22 +177,6 @@ s! {
         pub f_spare: [crate::__fsword_t; 4],
     }
 
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        __f_unused: Padding<c_int>,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
     pub struct shmid_ds {
         pub shm_perm: crate::ipc_perm,
         pub shm_segsz: size_t,

--- a/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/aarch64/mod.rs
@@ -103,36 +103,6 @@ s! {
         pub f_spare: [crate::__fsword_t; 4],
     }
 
-    pub struct statvfs {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsblkcnt_t,
-        pub f_bfree: crate::fsblkcnt_t,
-        pub f_bavail: crate::fsblkcnt_t,
-        pub f_files: crate::fsfilcnt_t,
-        pub f_ffree: crate::fsfilcnt_t,
-        pub f_favail: crate::fsfilcnt_t,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
     pub struct pthread_attr_t {
         __size: [usize; 8],
     }

--- a/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/loongarch64/mod.rs
@@ -101,36 +101,6 @@ s! {
         pub l_pid: crate::pid_t,
     }
 
-    pub struct statvfs {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsblkcnt_t,
-        pub f_bfree: crate::fsblkcnt_t,
-        pub f_bavail: crate::fsblkcnt_t,
-        pub f_files: crate::fsfilcnt_t,
-        pub f_ffree: crate::fsfilcnt_t,
-        pub f_favail: crate::fsfilcnt_t,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
     pub struct pthread_attr_t {
         __size: [c_ulong; 7],
     }

--- a/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/mips64/mod.rs
@@ -103,36 +103,6 @@ s! {
         pub f_spare: [c_long; 5],
     }
 
-    pub struct statvfs {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsblkcnt_t,
-        pub f_bfree: crate::fsblkcnt_t,
-        pub f_bavail: crate::fsblkcnt_t,
-        pub f_files: crate::fsfilcnt_t,
-        pub f_ffree: crate::fsfilcnt_t,
-        pub f_favail: crate::fsfilcnt_t,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
     pub struct pthread_attr_t {
         __size: [c_ulong; 7],
     }

--- a/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/powerpc64/mod.rs
@@ -103,36 +103,6 @@ s! {
         pub f_spare: [crate::__fsword_t; 4],
     }
 
-    pub struct statvfs {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsblkcnt_t,
-        pub f_bfree: crate::fsblkcnt_t,
-        pub f_bavail: crate::fsblkcnt_t,
-        pub f_files: crate::fsfilcnt_t,
-        pub f_ffree: crate::fsfilcnt_t,
-        pub f_favail: crate::fsfilcnt_t,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
     pub struct pthread_attr_t {
         __size: [u64; 7],
     }

--- a/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/riscv64/mod.rs
@@ -93,36 +93,6 @@ s! {
         pub f_spare: [c_long; 4],
     }
 
-    pub struct statvfs {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsblkcnt_t,
-        pub f_bfree: crate::fsblkcnt_t,
-        pub f_bavail: crate::fsblkcnt_t,
-        pub f_files: crate::fsfilcnt_t,
-        pub f_ffree: crate::fsfilcnt_t,
-        pub f_favail: crate::fsfilcnt_t,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        pub __f_spare: [c_int; 6],
-    }
-
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsblkcnt64_t,
-        pub f_bfree: crate::fsblkcnt64_t,
-        pub f_bavail: crate::fsblkcnt64_t,
-        pub f_files: crate::fsfilcnt64_t,
-        pub f_ffree: crate::fsfilcnt64_t,
-        pub f_favail: crate::fsfilcnt64_t,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        pub __f_spare: [c_int; 6],
-    }
-
     pub struct siginfo_t {
         pub si_signo: c_int,
         pub si_errno: c_int,

--- a/src/unix/linux_like/linux/gnu/b64/s390x.rs
+++ b/src/unix/linux_like/linux/gnu/b64/s390x.rs
@@ -130,21 +130,6 @@ s! {
         __unused5: Padding<c_ulong>,
     }
 
-    pub struct statvfs {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsblkcnt_t,
-        pub f_bfree: crate::fsblkcnt_t,
-        pub f_bavail: crate::fsblkcnt_t,
-        pub f_files: crate::fsfilcnt_t,
-        pub f_ffree: crate::fsfilcnt_t,
-        pub f_favail: crate::fsfilcnt_t,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
     pub struct __psw_t {
         pub mask: u64,
         pub addr: u64,
@@ -184,21 +169,6 @@ s! {
         pub f_frsize: c_uint,
         pub f_flags: c_uint,
         pub f_spare: [c_uint; 4],
-    }
-
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
     }
 }
 

--- a/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/sparc64/mod.rs
@@ -125,36 +125,6 @@ s! {
         pub f_spare: [crate::__fsword_t; 4],
     }
 
-    pub struct statvfs {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsblkcnt_t,
-        pub f_bfree: crate::fsblkcnt_t,
-        pub f_bavail: crate::fsblkcnt_t,
-        pub f_files: crate::fsfilcnt_t,
-        pub f_ffree: crate::fsfilcnt_t,
-        pub f_favail: crate::fsfilcnt_t,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
     pub struct pthread_attr_t {
         __size: [u64; 7],
     }

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/mod.rs
@@ -123,21 +123,6 @@ s! {
         pub f_spare: [crate::__fsword_t; 4],
     }
 
-    pub struct statvfs64 {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: u64,
-        pub f_bfree: u64,
-        pub f_bavail: u64,
-        pub f_files: u64,
-        pub f_ffree: u64,
-        pub f_favail: u64,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-
     pub struct pthread_attr_t {
         #[cfg(target_pointer_width = "32")]
         __size: [u32; 8],

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/not_x32.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/not_x32.rs
@@ -1,22 +1,5 @@
 use crate::prelude::*;
 
-s! {
-    pub struct statvfs {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsblkcnt_t,
-        pub f_bfree: crate::fsblkcnt_t,
-        pub f_bavail: crate::fsblkcnt_t,
-        pub f_files: crate::fsfilcnt_t,
-        pub f_ffree: crate::fsfilcnt_t,
-        pub f_favail: crate::fsfilcnt_t,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-}
-
 pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
 pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 56;
 pub const __SIZEOF_PTHREAD_BARRIER_T: usize = 32;

--- a/src/unix/linux_like/linux/gnu/b64/x86_64/x32.rs
+++ b/src/unix/linux_like/linux/gnu/b64/x86_64/x32.rs
@@ -1,22 +1,5 @@
 use crate::prelude::*;
 
-s! {
-    pub struct statvfs {
-        pub f_bsize: c_ulong,
-        pub f_frsize: c_ulong,
-        pub f_blocks: crate::fsblkcnt_t,
-        pub f_bfree: crate::fsblkcnt_t,
-        pub f_bavail: crate::fsblkcnt_t,
-        pub f_files: crate::fsfilcnt_t,
-        pub f_ffree: crate::fsfilcnt_t,
-        pub f_favail: crate::fsfilcnt_t,
-        pub f_fsid: c_ulong,
-        pub f_flag: c_ulong,
-        pub f_namemax: c_ulong,
-        __f_spare: [c_int; 6],
-    }
-}
-
 pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 32;
 pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 44;
 pub const __SIZEOF_PTHREAD_BARRIER_T: usize = 20;

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -2159,8 +2159,10 @@ cfg_if! {
             // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn fstatfs64(fd: c_int, buf: *mut statfs64) -> c_int;
             // FIXME(1.0,deprecate): lfs binding to be removed
+            #[cfg(not(all(target_os = "linux", target_env = "gnu")))] // defined in new/glibc
             pub fn statvfs64(path: *const c_char, buf: *mut statvfs64) -> c_int;
             // FIXME(1.0,deprecate): lfs binding to be removed
+            #[cfg(not(all(target_os = "linux", target_env = "gnu")))] // defined in new/glibc
             pub fn fstatvfs64(fd: c_int, buf: *mut statvfs64) -> c_int;
             // FIXME(1.0,deprecate): lfs binding to be removed
             pub fn statfs64(path: *const c_char, buf: *mut statfs64) -> c_int;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1665,8 +1665,10 @@ extern "C" {
     pub fn sem_wait(sem: *mut sem_t) -> c_int;
     pub fn sem_trywait(sem: *mut sem_t) -> c_int;
     pub fn sem_post(sem: *mut sem_t) -> c_int;
+    #[cfg(not(all(target_os = "linux", target_env = "gnu")))] // defined in new/glibc
     #[cfg_attr(gnu_file_offset_bits64, link_name = "statvfs64")]
     pub fn statvfs(path: *const c_char, buf: *mut crate::statvfs) -> c_int;
+    #[cfg(not(all(target_os = "linux", target_env = "gnu")))] // defined in new/glibc
     #[cfg_attr(gnu_file_offset_bits64, link_name = "fstatvfs64")]
     pub fn fstatvfs(fd: c_int, buf: *mut crate::statvfs) -> c_int;
 


### PR DESCRIPTION
glibc 2.39 allocated one of the six reserved `__f_spare` ints to `f_type` for `statvfs` and `statvfs64`, which mirrors `statfs`.
https://github.com/sailfishos-mirror/glibc/commit/92861d93cdad13834f4d8f39504b550a80ad8200

1. Move `statvfs` and `statvfs` defininitions for glibc to `src/new/glibc`, this follows the ongoing migration into `src/new`, which reduces duplication and models glibc's source tree.
The `__f_unused` padding fields is only declared on some targets, so it's gated behind a `cfg`.

	`riscv32` and `riscv64` declared `__f_spare as pub, which was inconsistent with the other declarations and hand no grounded reason to stay, now it's private.

2. Add `f_type` to `statvsfs` and `statvfs64` for glibc in shared declarations, using `c_uint` type.

## Open Questions
1. `riscv32` `statvfs64` doesn't have `__f_unused` in its declaration, but its neighboring `statvfs` has this padding, so I think one of the two must be wrong, for me it seems like accidental bug or inconsistency, however I may be missing some reason behind this. To avoid making changes to the layout of this struct, I didn't touch it here: this field is excluded on `statvfs64` for riscv32`, so no layout changes. Should it be addressed separately?
2. Shared `statvfs64` uses `u64` for the counters, some architectures used `fsblkcnt64_t` / `fsfilcnt64_t`, which should be the same as u64, but wasn't defined on all architectures, so `u64` was used instead.
Are there any specific difference in using `fsblkcnt64_t` / `fsfilcnt64_t` instead of `u64` that I may be missing?

Closes rust-lang/libc#4121

## Checklist

- [x] Relevant tests in `libc-test/semver` have been updated, no change needed.
- [x] Commit messages permalink to headers for added or changed API
- [x] No placeholder or unstable values like *LAST or *MAX.
- [x] Tested locally (`cargo test -p libc-test --target mytarget`); especially relevant for platforms that may not be checked in CI

@rustbot label +stable-nominated




