### PR TITLE
correct siginfo_t and add other signal related items for redox

### DIFF
--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -275,42 +275,52 @@ s! {
     pub struct pthread_attr_t {
         bytes: [u8; _PTHREAD_ATTR_SIZE],
     }
+
     #[repr(align(4))]
     pub struct pthread_barrier_t {
         bytes: [u8; _PTHREAD_BARRIER_SIZE],
     }
+
     #[repr(align(4))]
     pub struct pthread_barrierattr_t {
         bytes: [u8; _PTHREAD_BARRIERATTR_SIZE],
     }
+
     #[repr(align(4))]
     pub struct pthread_mutex_t {
         bytes: [u8; _PTHREAD_MUTEX_SIZE],
     }
+
     #[repr(align(4))]
     pub struct pthread_rwlock_t {
         bytes: [u8; _PTHREAD_RWLOCK_SIZE],
     }
+
     #[repr(align(4))]
     pub struct pthread_mutexattr_t {
         bytes: [u8; _PTHREAD_MUTEXATTR_SIZE],
     }
+
     #[repr(align(1))]
     pub struct pthread_rwlockattr_t {
         bytes: [u8; _PTHREAD_RWLOCKATTR_SIZE],
     }
+
     #[repr(align(4))]
     pub struct pthread_cond_t {
         bytes: [u8; _PTHREAD_COND_SIZE],
     }
+
     #[repr(align(4))]
     pub struct pthread_condattr_t {
         bytes: [u8; _PTHREAD_CONDATTR_SIZE],
     }
+
     #[repr(align(4))]
     pub struct pthread_once_t {
         bytes: [u8; _PTHREAD_ONCE_SIZE],
     }
+
     #[repr(align(4))]
     pub struct pthread_spinlock_t {
         bytes: [u8; _PTHREAD_SPINLOCK_SIZE],
@@ -335,10 +345,12 @@ s! {
         _signum: c_uint,
         pub uc_mcontext: mcontext_t,
     }
+
     #[cfg(target_arch = "x86")]
     pub struct mcontext {
         _opaque: [c_uchar; 512],
     }
+
     #[cfg(target_arch = "x86_64")]
     pub struct mcontext {
         pub ymm_upper: [[c_ulong; 2]; 16],
@@ -362,10 +374,12 @@ s! {
         pub rip: c_ulong,
         pub rsp: c_ulong,
     }
+
     #[cfg(target_arch = "aarch64")]
     pub struct mcontext {
         _opaque: [c_uchar; 272],
     }
+
     #[cfg(target_arch = "riscv64")]
     pub struct mcontext {
         _opaque: [c_uchar; 520],

--- a/src/unix/redox/mod.rs
+++ b/src/unix/redox/mod.rs
@@ -28,8 +28,19 @@ pub type suseconds_t = c_int;
 pub type tcflag_t = u32;
 pub type time_t = c_longlong;
 pub type id_t = c_uint;
+pub type pid_t = c_int;
 pub type uid_t = c_int;
 pub type gid_t = c_int;
+pub type ucontext_t = ucontext;
+pub type stack_t = sigaltstack;
+pub type siginfo_t = siginfo;
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "riscv64"
+))]
+pub type mcontext_t = mcontext;
 
 extern_ty! {
     pub type timezone;
@@ -157,12 +168,21 @@ s! {
         pub sa_mask: crate::sigset_t,
     }
 
-    pub struct siginfo_t {
+    pub struct siginfo {
         pub si_signo: c_int,
         pub si_errno: c_int,
         pub si_code: c_int,
-        _pad: Padding<[c_int; 29]>,
-        _align: [usize; 0],
+        pub si_pid: pid_t,
+        pub si_uid: uid_t,
+        pub si_addr: *mut c_void,
+        pub si_status: c_int,
+        pub si_value: crate::sigval,
+    }
+
+    pub struct sigaltstack {
+        pub ss_sp: *mut c_void,
+        pub ss_flags: c_int,
+        pub ss_size: size_t,
     }
 
     pub struct sockaddr {
@@ -295,7 +315,93 @@ s! {
     pub struct pthread_spinlock_t {
         bytes: [u8; _PTHREAD_SPINLOCK_SIZE],
     }
+
+    pub struct ucontext {
+        #[cfg(any(
+            target_arch = "x86_64",
+            target_arch = "aarch64",
+            target_arch = "riscv64"
+        ))]
+        _pad: [c_ulong; 1], // pad from 7*8 to 64
+
+        #[cfg(target_arch = "x86")]
+        _pad: [c_ulong; 3], // pad from 9*4 to 12*4
+
+        pub uc_link: *mut ucontext_t,
+        pub uc_stack: stack_t,
+        pub uc_sigmask: sigset_t,
+        _sival: c_ulong,
+        _sigcode: c_uint,
+        _signum: c_uint,
+        pub uc_mcontext: mcontext_t,
+    }
+    #[cfg(target_arch = "x86")]
+    pub struct mcontext {
+        _opaque: [c_uchar; 512],
+    }
+    #[cfg(target_arch = "x86_64")]
+    pub struct mcontext {
+        pub ymm_upper: [[c_ulong; 2]; 16],
+        pub fxsave: [[c_ulong; 2]; 29],
+        pub r15: c_ulong, // fxsave "available" +0
+        pub r14: c_ulong, // available +8
+        pub r13: c_ulong, // available +16
+        pub r12: c_ulong, // available +24
+        pub rbp: c_ulong, // available +32
+        pub rbx: c_ulong, // available +40
+        pub r11: c_ulong, // outside fxsave, and so on
+        pub r10: c_ulong,
+        pub r9: c_ulong,
+        pub r8: c_ulong,
+        pub rax: c_ulong,
+        pub rcx: c_ulong,
+        pub rdx: c_ulong,
+        pub rsi: c_ulong,
+        pub rdi: c_ulong,
+        pub rflags: c_ulong,
+        pub rip: c_ulong,
+        pub rsp: c_ulong,
+    }
+    #[cfg(target_arch = "aarch64")]
+    pub struct mcontext {
+        _opaque: [c_uchar; 272],
+    }
+    #[cfg(target_arch = "riscv64")]
+    pub struct mcontext {
+        _opaque: [c_uchar; 520],
+    }
 }
+
+impl siginfo_t {
+    pub unsafe fn si_addr(&self) -> *mut c_void {
+        self.si_addr
+    }
+
+    pub unsafe fn si_code(&self) -> c_int {
+        self.si_code
+    }
+
+    pub unsafe fn si_errno(&self) -> c_int {
+        self.si_errno
+    }
+
+    pub unsafe fn si_pid(&self) -> crate::pid_t {
+        self.si_pid
+    }
+
+    pub unsafe fn si_uid(&self) -> uid_t {
+        self.si_uid
+    }
+
+    pub unsafe fn si_value(&self) -> crate::sigval {
+        self.si_value
+    }
+
+    pub unsafe fn si_status(&self) -> c_int {
+        self.si_status
+    }
+}
+
 const _PTHREAD_ATTR_SIZE: usize = 32;
 const _PTHREAD_RWLOCKATTR_SIZE: usize = 1;
 const _PTHREAD_RWLOCK_SIZE: usize = 4;
@@ -672,6 +778,9 @@ pub const SA_RESTART: c_int = 0x0800_0000;
 pub const SA_NODEFER: c_int = 0x1000_0000;
 pub const SA_RESETHAND: c_int = 0x2000_0000;
 pub const SA_NOCLDSTOP: c_int = 0x4000_0000;
+
+pub const SS_ONSTACK: c_int = 0x00000001;
+pub const SS_DISABLE: c_int = 0x00000002;
 
 // sys/file.h
 pub const LOCK_SH: c_int = 1;
@@ -1334,6 +1443,7 @@ extern "C" {
         timeout: *const crate::timespec,
     ) -> c_int;
     pub fn sigwait(set: *const sigset_t, sig: *mut c_int) -> c_int;
+    pub fn sigaltstack(ss: *const stack_t, oss: *mut stack_t) -> c_int;
 
     // stdlib.h
     pub fn getsubopt(


### PR DESCRIPTION
Corrected `siginfo_t` to match relibc:
- [siginfo struct](https://gitlab.redox-os.org/redox-os/relibc/-/blob/f1772c4bb829e02742275e655d349dda02b27cec/src/header/signal/mod.rs#L152) (siginfo_t struct in libc)
- [siginfo_t pub type pointing to siginfo](https://gitlab.redox-os.org/redox-os/relibc/-/blob/f1772c4bb829e02742275e655d349dda02b27cec/src/header/signal/mod.rs#L185)

Added the following items:
- [sigaltstack struct](https://gitlab.redox-os.org/redox-os/relibc/-/blob/f1772c4bb829e02742275e655d349dda02b27cec/src/header/signal/mod.rs#L99) (stack_t struct in libc)
- [stack_t pub type pointing to sigaltstack struct](https://gitlab.redox-os.org/redox-os/relibc/-/blob/f1772c4bb829e02742275e655d349dda02b27cec/src/header/signal/mod.rs#L188)
- [sigaltstack function](https://gitlab.redox-os.org/redox-os/relibc/-/blob/f1772c4bb829e02742275e655d349dda02b27cec/src/header/signal/mod.rs#L346)
- [SS_ONSTACK constant](https://gitlab.redox-os.org/redox-os/relibc/-/blob/f1772c4bb829e02742275e655d349dda02b27cec/src/header/signal/constants.rs#L131)
- [SS_DISABLE constant](https://gitlab.redox-os.org/redox-os/relibc/-/blob/f1772c4bb829e02742275e655d349dda02b27cec/src/header/signal/constants.rs#L133)
- [pid_t type](https://gitlab.redox-os.org/redox-os/relibc/-/blob/f1772c4bb829e02742275e655d349dda02b27cec/src/header/bits_pid-t/mod.rs#L5)

These changes, when released in a stable 0.2.x release, will allow us to use upstream libc for compiling wasmtime natively on Redox.

Edited to add the following:
- [ucontext struct](https://gitlab.redox-os.org/redox-os/relibc/-/blob/e596d08aeaf43f90b18b961c1155d1c1e3eea416/src/header/signal/redox.rs#L48)
- [ucontext_t pub type pointing to ucontext](https://gitlab.redox-os.org/redox-os/relibc/-/blob/e596d08aeaf43f90b18b961c1155d1c1e3eea416/src/header/signal/redox.rs#L42)
- [mcontext struct x86_64](https://gitlab.redox-os.org/redox-os/relibc/-/blob/e596d08aeaf43f90b18b961c1155d1c1e3eea416/src/header/signal/redox.rs#L82)
- [mcontext struct x86](https://gitlab.redox-os.org/redox-os/relibc/-/blob/e596d08aeaf43f90b18b961c1155d1c1e3eea416/src/header/signal/redox.rs#L74)
- [mcontext struct aarch64](https://gitlab.redox-os.org/redox-os/relibc/-/blob/e596d08aeaf43f90b18b961c1155d1c1e3eea416/src/header/signal/redox.rs#L107)
- [mcontext struct riscv64](https://gitlab.redox-os.org/redox-os/relibc/-/blob/e596d08aeaf43f90b18b961c1155d1c1e3eea416/src/header/signal/redox.rs#L113)
- [mcontext_t pub type pointing to mcontext struct](https://gitlab.redox-os.org/redox-os/relibc/-/blob/e596d08aeaf43f90b18b961c1155d1c1e3eea416/src/header/signal/redox.rs#L44)