### PR TITLE
Fix unspecified transmute between slice types

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -117,8 +117,10 @@ pub(crate) const fn u32_cast_ioctl(x: u32) -> crate::Ioctl {
 #[allow(unused)]
 pub(crate) const fn u8_slice_cast_char_slice(x: &[u8]) -> &[c_char] {
     assert!(size_of::<u8>() == size_of::<c_char>());
+    let len = x.len();
+    let ptr = x.as_ptr();
     // SAFETY: same repr, possibly just a sign cast
-    unsafe { mem::transmute::<&[u8], &[c_char]>(x) }
+    unsafe { core::slice::from_raw_parts(ptr.cast::<c_char>(), len) }
 }
 
 /// Replace bytes in an array with those from a slice. This is a polyfill for `[T]::copy_from_slice`


### PR DESCRIPTION
The layout of slices is currently not specified in Rust. This PR replaces a `transmute` between slices of different types with the equivalent pointer cast to keep all involved behaviour specified.