### PR TITLE
musl: Make rustc-dep-of-std imply musl_v1_2

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -151,7 +151,8 @@ fn main() {
         _ => (),
     }
 
-    let mut musl_v1_2 = env_flag("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2");
+    let mut musl_v1_2 =
+        env_flag("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2") || env_flag("CARGO_FEATURE_RUSTC_DEP_OF_STD");
     if let Ok(old_musl_v1_2_3) = env::var("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2_3") {
         println!(
             "cargo:warning=`--cfg=libc_unstable_musl_v1_2_3` will be removed; \

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -6,27 +6,21 @@ pub type clock_t = c_long;
 #[cfg(musl32_time64)]
 pub type time_t = i64;
 #[cfg(not(musl32_time64))]
-#[cfg_attr(
-    not(feature = "rustc-dep-of-std"),
-    deprecated(
-        since = "0.2.80",
-        note = "This type is changed to 64-bit in musl 1.2.0, \
-                we'll follow that change in the future release. \
-                See #1848 for more info."
-    )
+#[deprecated(
+    since = "0.2.80",
+    note = "This type is changed to 64-bit in musl 1.2.0, \
+            we'll follow that change in the future release. \
+            See #1848 for more info."
 )]
 pub type time_t = c_long;
 #[cfg(musl32_time64)]
 pub type suseconds_t = i64;
 #[cfg(not(musl32_time64))]
-#[cfg_attr(
-    not(feature = "rustc-dep-of-std"),
-    deprecated(
-        since = "0.2.80",
-        note = "This type is changed to 64-bit in musl 1.2.0, \
-                we'll follow that change in the future release. \
-                See #1848 for more info."
-    )
+#[deprecated(
+    since = "0.2.80",
+    note = "This type is changed to 64-bit in musl 1.2.0, \
+            we'll follow that change in the future release. \
+            See #1848 for more info."
 )]
 pub type suseconds_t = c_long;
 pub type ino_t = u64;


### PR DESCRIPTION
The musl baseline for Rust is 1.2.5 since 1.93.0. Therefore, it is safe to make rustc-dep-of-std imply musl_v1_2, and this lets us start using statx from libc in std.