### PR TITLE
linux_like: Expose statx on all musl versions

### DIFF
--- a/libc-test/build/main.rs
+++ b/libc-test/build/main.rs
@@ -4413,8 +4413,8 @@ fn test_linux(t: &Target) {
             // FIXME(musl): Struct has changed for new musl versions
             "tcp_info" if musl => true,
 
-            // FIXME(musl): Supported in new musl but we don't have a new enough version in CI.
-            "statx" | "statx_timestamp" if musl => true,
+            // Added in musl 1.2.5
+            "statx" | "statx_timestamp" if old_musl => true,
 
             // FIXME(musl): New fields in newer versions
             "utmpx" if !old_musl => true,
@@ -5043,15 +5043,14 @@ fn test_linux(t: &Target) {
             // assume it's a int instead.
             "getnameinfo" if uclibc => true,
 
-            // FIXME(musl): This needs musl 1.2.2 or later, which is newer than what we test with
-            // on CI.
-            "gettid" | "reallocarray" if musl => true,
+            // Added in musl 1.2.2
+            "gettid" | "reallocarray" if old_musl => true,
             // Needs musl 1.2.3 or later.
-            "pthread_getname_np" if musl => true,
+            "pthread_getname_np" if old_musl => true,
             // Added in musl 1.2.5
-            "preadv2" | "pwritev2" if musl => true,
-            // FIXME(musl): Supported in new musl but we don't have a new enough version in CI.
-            "statx" if musl => true,
+            "preadv2" | "pwritev2" if old_musl => true,
+            // Added in musl 1.2.5
+            "statx" if old_musl => true,
             // FIXME(musl): Supported since musl 1.2.6 but not yet in CI.
             "renameat2" if musl => true,
 

--- a/src/unix/linux_like/linux/musl/mod.rs
+++ b/src/unix/linux_like/linux/musl/mod.rs
@@ -176,6 +176,47 @@ s! {
         _align: [usize; 0],
     }
 
+    // musl's uint64_t is an unsigned long instead of an unsigned long long on
+    // 64-bit targets, so it's not a __u64 (which is c_ulonglong), but rather a
+    // real u64. This is also how we handle musl's uint64_t elsewhere.
+    pub struct statx {
+        pub stx_mask: u32,
+        pub stx_blksize: u32,
+        pub stx_attributes: u64,
+        pub stx_nlink: u32,
+        pub stx_uid: u32,
+        pub stx_gid: u32,
+        pub stx_mode: u16,
+        __statx_pad1: Padding<[u16; 1]>,
+        pub stx_ino: u64,
+        pub stx_size: u64,
+        pub stx_blocks: u64,
+        pub stx_attributes_mask: u64,
+        pub stx_atime: statx_timestamp,
+        pub stx_btime: statx_timestamp,
+        pub stx_ctime: statx_timestamp,
+        pub stx_mtime: statx_timestamp,
+        pub stx_rdev_major: u32,
+        pub stx_rdev_minor: u32,
+        pub stx_dev_major: u32,
+        pub stx_dev_minor: u32,
+        pub stx_mnt_id: u64,
+        pub stx_dio_mem_align: u32,
+        pub stx_dio_offset_align: u32,
+        pub stx_subvol: u64,
+        pub stx_atomic_write_unit_min: u32,
+        pub stx_atomic_write_unit_max: u32,
+        pub stx_atomic_write_segments_max: u32,
+        __statx_pad2: Padding<[u32; 1]>,
+        __statx_pad3: Padding<[u64; 9]>,
+    }
+
+    pub struct statx_timestamp {
+        pub tv_sec: i64,
+        pub tv_nsec: u32,
+        __statx_timestamp_pad1: Padding<[i32; 1]>,
+    }
+
     pub struct statvfs {
         pub f_bsize: c_ulong,
         pub f_frsize: c_ulong,

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -276,8 +276,8 @@ cfg_if! {
 cfg_if! {
     if #[cfg(any(
         target_env = "gnu",
+        target_env = "musl",
         target_os = "android",
-        all(target_env = "musl", musl_v1_2)
     ))] {
         s! {
             pub struct statx {
@@ -1705,8 +1705,8 @@ cfg_if! {
 cfg_if! {
     if #[cfg(any(
         target_env = "gnu",
+        target_env = "musl",
         target_os = "android",
-        all(target_env = "musl", musl_v1_2),
         target_os = "l4re"
     ))] {
         pub const AT_STATX_SYNC_TYPE: c_int = 0x6000;
@@ -2313,8 +2313,8 @@ cfg_if! {
 cfg_if! {
     if #[cfg(any(
         target_env = "gnu",
+        target_env = "musl",
         target_os = "android",
-        all(target_env = "musl", musl_v1_2)
     ))] {
         extern "C" {
             pub fn statx(

--- a/src/unix/linux_like/mod.rs
+++ b/src/unix/linux_like/mod.rs
@@ -274,11 +274,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(any(
-        target_env = "gnu",
-        target_env = "musl",
-        target_os = "android",
-    ))] {
+    if #[cfg(any(target_env = "gnu", target_os = "android"))] {
         s! {
             pub struct statx {
                 pub stx_mask: crate::__u32,


### PR DESCRIPTION
Exposing the constants and the method in itself is not a breaking change, users are responsible for knowing whether they can call the method without running into linker errors, just like on glibc.