### PR TITLE
newlib: correct RTEMS scalar type widths

### DIFF
--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -3,13 +3,23 @@ use crate::prelude::*;
 pub type blkcnt_t = i32;
 pub type blksize_t = i32;
 
-pub type clockid_t = c_ulong;
+cfg_if! {
+    if #[cfg(target_os = "rtems")] {
+        pub type clockid_t = c_int;
+    } else {
+        pub type clockid_t = c_ulong;
+    }
+}
 
 cfg_if! {
     if #[cfg(any(target_os = "espidf", target_os = "vita"))] {
         pub type dev_t = c_short;
         pub type ino_t = c_ushort;
         pub type off_t = c_long;
+    } else if #[cfg(target_os = "rtems")] {
+        pub type dev_t = u64;
+        pub type ino_t = u64;
+        pub type off_t = i64;
     } else if #[cfg(any(target_arch = "arm", target_arch = "powerpc"))] {
         pub type dev_t = u32;
         pub type ino_t = u32;
@@ -29,7 +39,13 @@ pub type nfds_t = u32;
 pub type nlink_t = c_ushort;
 pub type pthread_t = c_ulong;
 pub type pthread_key_t = c_uint;
-pub type rlim_t = u32;
+cfg_if! {
+    if #[cfg(target_os = "rtems")] {
+        pub type rlim_t = i64;
+    } else {
+        pub type rlim_t = u32;
+    }
+}
 
 cfg_if! {
     if #[cfg(target_os = "horizon")] {

--- a/src/unix/newlib/rtems/mod.rs
+++ b/src/unix/newlib/rtems/mod.rs
@@ -1,6 +1,8 @@
 use crate::prelude::*;
 
-pub type clock_t = c_long;
+// RTEMS defines `clock_t` as `__uint64_t` (`<machine/_types.h>` via
+// `<sys/types.h>`), not `long` as plain newlib arm targets did.
+pub type clock_t = u64;
 pub type wchar_t = u32;
 
 s! {


### PR DESCRIPTION
This picks up where rust-lang/libc#5308 left off. RTEMS defines dev_t, ino_t and
clock_t as 64-bit, rlim_t as signed 64-bit, and clockid_t as a signed
int (newlib's <machine/_types.h>), but libc currently has them all
32-bit and clockid_t unsigned. time_t and off_t from rust-lang/libc#5308 are already
correct on main, so only the remaining five are touched here.

Definitions in RTEMS's newlib, at the commit the RTEMS 7 tools pin
(`newlib/libc/sys/rtems/include/machine/_types.h`):

- `__dev_t`: https://github.com/RTEMS/sourceware-mirror-newlib-cygwin/blob/7d4336cf6e519c2a4c9baac10da7a785d88d30c5/newlib/libc/sys/rtems/include/machine/_types.h#L12
- `__ino_t`: https://github.com/RTEMS/sourceware-mirror-newlib-cygwin/blob/7d4336cf6e519c2a4c9baac10da7a785d88d30c5/newlib/libc/sys/rtems/include/machine/_types.h#L21
- `_CLOCK_T_` (`clock_t`): https://github.com/RTEMS/sourceware-mirror-newlib-cygwin/blob/7d4336cf6e519c2a4c9baac10da7a785d88d30c5/newlib/libc/sys/rtems/include/machine/_types.h#L27
- `_CLOCKID_T_` (`clockid_t`): https://github.com/RTEMS/sourceware-mirror-newlib-cygwin/blob/7d4336cf6e519c2a4c9baac10da7a785d88d30c5/newlib/libc/sys/rtems/include/machine/_types.h#L30
- `__rlim_t`: https://github.com/RTEMS/sourceware-mirror-newlib-cygwin/blob/7d4336cf6e519c2a4c9baac10da7a785d88d30c5/newlib/libc/sys/rtems/include/machine/_types.h#L39