### PR TITLE
ci: Don't have renovate pin Docker digests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,6 +24,11 @@
       // Every month
       schedule: "* 0 1 * *",
       groupName: "Github Actions",
+    },
+    {
+      // Don't updates such as 23.10 -> mantic-20240530
+      "matchDatasources": ["docker"],
+      "pinDigests": false
     }
   ],
   // Receive any update that fixes security vulnerabilities.


### PR DESCRIPTION
Avoid PRs such as [1] changing numbered tags to a codename and date.

[1]: https://github.com/rust-lang/libc/pull/5428