### PR TITLE
musl: Add `*_SUPER_MAGIC` constants

### DIFF
--- a/src/unix/linux_like/linux/gnu/mod.rs
+++ b/src/unix/linux_like/linux/gnu/mod.rs
@@ -767,19 +767,6 @@ pub const O_ACCMODE: c_int = 3;
 pub const ST_RELATIME: c_ulong = 4096;
 pub const NI_MAXHOST: crate::socklen_t = 1025;
 
-// Most `*_SUPER_MAGIC` constants are defined at the `linux_like` level; the
-// following are only available on newer Linux versions than the versions
-// currently used in CI in some configurations, so we define them here.
-cfg_if! {
-    if #[cfg(not(target_arch = "s390x"))] {
-        pub const BINDERFS_SUPER_MAGIC: c_long = 0x6c6f6f70;
-        pub const XFS_SUPER_MAGIC: c_long = 0x58465342;
-    } else if #[cfg(target_arch = "s390x")] {
-        pub const BINDERFS_SUPER_MAGIC: c_uint = 0x6c6f6f70;
-        pub const XFS_SUPER_MAGIC: c_uint = 0x58465342;
-    }
-}
-
 pub const CPU_SETSIZE: c_int = 0x400;
 
 pub const PTRACE_TRACEME: c_uint = 0;

--- a/src/unix/linux_like/linux/mod.rs
+++ b/src/unix/linux_like/linux/mod.rs
@@ -2558,6 +2558,20 @@ pub const IN_ONLYDIR: u32 = 0x0100_0000;
 pub const IN_DONT_FOLLOW: u32 = 0x0200_0000;
 pub const IN_EXCL_UNLINK: u32 = 0x0400_0000;
 
+// uapi/linux/magic.h
+// Most `*_SUPER_MAGIC` constants are defined at the `linux_like` level; the
+// following are only available on newer Linux versions than the versions
+// currently used in CI in some configurations, so we define them here.
+cfg_if! {
+    if #[cfg(not(target_arch = "s390x"))] {
+        pub const BINDERFS_SUPER_MAGIC: c_long = 0x6c6f6f70;
+        pub const XFS_SUPER_MAGIC: c_long = 0x58465342;
+    } else if #[cfg(target_arch = "s390x")] {
+        pub const BINDERFS_SUPER_MAGIC: c_uint = 0x6c6f6f70;
+        pub const XFS_SUPER_MAGIC: c_uint = 0x58465342;
+    }
+}
+
 // uapi/linux/securebits.h
 const SECURE_NOROOT: c_int = 0;
 const SECURE_NOROOT_LOCKED: c_int = 1;

--- a/src/unix/linux_like/linux/uclibc/mod.rs
+++ b/src/unix/linux_like/linux/uclibc/mod.rs
@@ -229,12 +229,6 @@ pub const MCL_ONFAULT: c_int = 0x0004;
 
 pub const AF_VSOCK: c_int = 40;
 
-// Most `*_SUPER_MAGIC` constants are defined at the `linux_like` level; the
-// following are only available on newer Linux versions than the versions
-// currently used in CI in some configurations, so we define them here.
-pub const BINDERFS_SUPER_MAGIC: c_long = 0x6c6f6f70;
-pub const XFS_SUPER_MAGIC: c_long = 0x58465342;
-
 pub const PTRACE_TRACEME: c_int = 0;
 pub const PTRACE_PEEKTEXT: c_int = 1;
 pub const PTRACE_PEEKDATA: c_int = 2;


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md> -->

## Description

IIUC, they were not added as part of https://github.com/rust-lang/libc/pull/2639 because Musl kernel headers were too old.

## Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. See the pull request guidelines
for help
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md#submitting-a-pull-request>.
-->

- [x] Relevant tests in `libc-test/semver` have been updated
- [ ] Commit messages permalink to headers for added or changed API
- [x] Placeholder or unstable values like `*LAST` or `*MAX` have the standard
  doc comment
- [ ] Tested locally (`cargo test -p libc-test --target mytarget`);
  especially relevant for platforms that may not be checked in CI