### PR TITLE
Fix WIFSTOPPED on NetBSD

### DIFF
--- a/src/unix/bsd/netbsdlike/netbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/netbsd/mod.rs
@@ -1875,7 +1875,7 @@ f! {
     }
 
     pub const safe fn WIFSTOPPED(status: c_int) -> bool {
-        (status & 0o177) == 0o177
+        (status & 0o177) == 0o177 && !WIFCONTINUED(status)
     }
 
     pub const safe fn WIFCONTINUED(status: c_int) -> bool {


### PR DESCRIPTION
If we expand the definitions from
https://github.com/NetBSD/src/blob/d04b0c735abc997743bb3faa74464524cbe7becd/sys/sys/wait.h#L61
we get

	#define WIFCONTINUED(x)	(x == 0xffff)
	#define WIFSTOPPED(x)	((x & 0177) == 0177 && !WIFCONTINUED(x))

Our definition of WIFSTOPPED forgot the !WIFCONTINUED(x) condition.
Siince the wait(3p) status for "continued" is 0xffff, this causes
WIFSTOPPED to return true for continued child processes.

Fix this.

Originally reported at https://github.com/fish-shell/fish-shell/issues/12929
