### PR TITLE
hermit: make iovec fields public

### DIFF
--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -51,8 +51,8 @@ s! {
     }
 
     pub struct iovec {
-        iov_base: *mut c_void,
-        iov_len: usize,
+        pub iov_base: *mut c_void,
+        pub iov_len: usize,
     }
 
     pub struct pollfd {


### PR DESCRIPTION
Make the `iovec` fields public on Hermit OS, matching the visibility provided on other supported platforms.

@rustbot label +stable-nominated
