### PR TITLE
apple: Disable the `mach.h` header in tests

### DIFF
--- a/libc-test/build/main.rs
+++ b/libc-test/build/main.rs
@@ -176,7 +176,6 @@ fn test_apple(t: &Target) {
         (macos, "libproc.h"),
         "limits.h",
         "locale.h",
-        "mach/mach.h",
         "malloc/malloc.h",
         (macos, "net/bpf.h"),
         (macos, "net/dlil.h"),


### PR DESCRIPTION
This was added in https://github.com/rust-lang/libc/commit/f3b2c50d6a974e1e22a542a11356652083b91dec ("Fix iOS, tvOS, watchOS and visionOS tests") but the mach API has been deprecated, so we shouldn't need it.