### PR TITLE
OpenBSD: add getexecpath()

### DIFF
--- a/libc-test/semver/openbsd.txt
+++ b/libc-test/semver/openbsd.txt
@@ -1187,6 +1187,7 @@ futimes
 getdomainname
 getdtablesize
 getentropy
+getexecpath
 getfsstat
 getgrent
 getgrgid

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -2056,6 +2056,7 @@ extern "C" {
     pub fn getfsstat(buf: *mut statfs, bufsize: size_t, flags: c_int) -> c_int;
 
     pub fn elf_aux_info(aux: c_int, buf: *mut c_void, buflen: c_int) -> c_int;
+    pub fn getexecpath(buf: *mut c_char, bufsize: size_t) -> c_int;
 }
 
 #[link(name = "execinfo")]


### PR DESCRIPTION
# Description

add getexecpath() support for OpenBSD.

# Sources

https://github.com/openbsd/src/blob/6f5c51ae477e3fbcceb5c62bf24ab89dede0d1c6/include/unistd.h

@rustbot label +stable-nominated