### PR TITLE
[0.2] OpenBSD: Deprecate `syscall`, `mincore`, and `KERN_NSELCOLL`

### DIFF
--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -865,6 +865,10 @@ cfg_if! {
     // on iOS and macOS).
     if #[cfg(not(any(target_os = "tvos", target_os = "watchos")))] {
         extern "C" {
+            #[cfg_attr(
+                target_os = "openbsd",
+                deprecated(since = "0.2.190", note = "Removed in OpenBSD 7.5")
+            )]
             pub fn syscall(num: c_int, ...) -> c_int;
         }
     }

--- a/src/unix/bsd/netbsdlike/mod.rs
+++ b/src/unix/bsd/netbsdlike/mod.rs
@@ -713,6 +713,10 @@ extern "C" {
         addrlen: *mut crate::socklen_t,
         flags: c_int,
     ) -> c_int;
+    #[cfg_attr(
+        target_os = "openbsd",
+        deprecated(since = "0.2.190", note = "Removed in OpenBSD 6.5")
+    )]
     pub fn mincore(addr: *mut c_void, len: size_t, vec: *mut c_char) -> c_int;
     #[cfg_attr(target_os = "netbsd", link_name = "__clock_getres50")]
     pub fn clock_getres(clk_id: crate::clockid_t, tp: *mut crate::timespec) -> c_int;

--- a/src/unix/bsd/netbsdlike/openbsd/mod.rs
+++ b/src/unix/bsd/netbsdlike/openbsd/mod.rs
@@ -1407,6 +1407,7 @@ pub const KERN_MALLOCSTATS: c_int = 39;
 pub const KERN_CPTIME: c_int = 40;
 pub const KERN_NCHSTATS: c_int = 41;
 pub const KERN_FORKSTAT: c_int = 42;
+#[deprecated(since = "0.2.190", note = "Removed in OpenBSD 7.2")]
 pub const KERN_NSELCOLL: c_int = 43;
 pub const KERN_TTY: c_int = 44;
 pub const KERN_CCPU: c_int = 45;


### PR DESCRIPTION
Commit 790e5c6d3900 ("Remove removed items in OpenBSD") removed these items on `main`, but there was no backport or deprecation to 0.2. Mark these items deprecated here.

Relevant relnotes, from [1]:

> Antiquated mincore(2) will not be needed and was removed, eliminating
> an interface that exposed physical machine information unnecessarily. 

From [2]:

> Removed the obsolete kern.nselcoll sysctl(2). 

From [3]:

> Removed support for syscall(2), the "indirection system call," a
> dangerous alternative entry point for all system calls and incompatible
> with the precision system call entry point scheme we are heading
> towards.

[1]: https://www.openbsd.org/plus65.html
[2]: https://www.openbsd.org/plus72.html
[3]: https://www.openbsd.org/plus75.html