### PR TITLE
unix: Deprecate the POSIX-obsoleted `tmpnam`, `tempnam`

### DIFF
--- a/src/fuchsia/mod.rs
+++ b/src/fuchsia/mod.rs
@@ -3828,6 +3828,10 @@ extern "C" {
     pub fn mkstemp(template: *mut c_char) -> c_int;
     pub fn mkdtemp(template: *mut c_char) -> *mut c_char;
 
+    #[deprecated(
+        since = "0.2.190",
+        note = "function is obsolete; prefer tmpfile, mkstemp, or similar"
+    )]
     pub fn tmpnam(ptr: *mut c_char) -> *mut c_char;
 
     pub fn openlog(ident: *const c_char, logopt: c_int, facility: c_int);

--- a/src/new/qurt/stdio.rs
+++ b/src/new/qurt/stdio.rs
@@ -65,6 +65,10 @@ extern "C" {
     pub fn remove(filename: *const c_char) -> c_int;
     pub fn rename(old: *const c_char, new: *const c_char) -> c_int;
     pub fn tmpfile() -> *mut FILE;
+    #[deprecated(
+        since = "0.2.190",
+        note = "function is obsolete; prefer tmpfile, mkstemp, or similar"
+    )]
     pub fn tmpnam(s: *mut c_char) -> *mut c_char;
 
     // Buffer control

--- a/src/solid/mod.rs
+++ b/src/solid/mod.rs
@@ -461,6 +461,10 @@ extern "C" {
     pub fn vprintf(arg1: *const c_char, arg2: __va_list) -> c_int;
     pub fn gets(arg1: *mut c_char) -> *mut c_char;
     pub fn sprintf(arg1: *mut c_char, arg2: *const c_char, ...) -> c_int;
+    #[deprecated(
+        since = "0.2.190",
+        note = "function is obsolete; prefer tmpfile, mkstemp, or similar"
+    )]
     pub fn tmpnam(arg1: *const c_char) -> *mut c_char;
     pub fn vsprintf(arg1: *mut c_char, arg2: *const c_char, arg3: __va_list) -> c_int;
     pub fn rename(arg1: *const c_char, arg2: *const c_char) -> c_int;
@@ -507,6 +511,10 @@ extern "C" {
     ) -> c_int;
     pub fn getw(arg1: *mut FILE) -> c_int;
     pub fn putw(arg1: c_int, arg2: *mut FILE) -> c_int;
+    #[deprecated(
+        since = "0.2.190",
+        note = "function is obsolete; prefer tmpfile, mkstemp, or similar"
+    )]
     pub fn tempnam(arg1: *const c_char, arg2: *const c_char) -> *mut c_char;
     pub fn fseeko(stream: *mut FILE, offset: off_t, whence: c_int) -> c_int;
     pub fn ftello(stream: *mut FILE) -> off_t;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -2156,6 +2156,10 @@ extern "C" {
     pub fn mkstemp(template: *mut c_char) -> c_int;
     pub fn mkdtemp(template: *mut c_char) -> *mut c_char;
 
+    #[deprecated(
+        since = "0.2.190",
+        note = "function is obsolete; prefer tmpfile, mkstemp, or similar"
+    )]
     pub fn tmpnam(ptr: *mut c_char) -> *mut c_char;
 
     pub fn openlog(ident: *const c_char, logopt: c_int, facility: c_int);

--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -1776,6 +1776,10 @@ extern "C" {
     pub fn ftello(stream: *mut crate::FILE) -> off_t;
     pub fn mkstemp(template: *mut c_char) -> c_int;
 
+    #[deprecated(
+        since = "0.2.190",
+        note = "function is obsolete; prefer tmpfile, mkstemp, or similar"
+    )]
     pub fn tmpnam(ptr: *mut c_char) -> *mut c_char;
 
     pub fn openlog(ident: *const c_char, logopt: c_int, facility: c_int);


### PR DESCRIPTION
`tmpnam` is TOCTOU-prone and not thread-safe if called with NULL, and has been marked obsolete by POSIX [1] and glibc [2]. `tempnam` is also TOCTOU-prone and marked obsolete by POSIX [3], and glib docs say "Never use this function". We don't have these on all platforms, but mark them deprecated where they still exist.

Closes: https://github.com/rust-lang/libc/issues/5211

[1]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/tmpnam.html
[2]: https://man7.org/linux/man-pages/man3/tmpnam.3.html
[3]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/tempnam.html
[4]: https://man7.org/linux/man-pages/man3/tempnam.3.html