### PR TITLE
cleanup: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,6 @@ version = "0.1.0"
 dependencies = [
  "cc",
  "ctest",
- "libc 1.0.0-alpha.4",
 ]
 
 [[package]]

--- a/ctest-test/Cargo.toml
+++ b/ctest-test/Cargo.toml
@@ -12,9 +12,6 @@ cc = "1.4.2"
 [dev-dependencies]
 ctest = { path = "../ctest" }
 
-[dependencies]
-libc = { path = ".." }
-
 [[bin]]
 name = "t1"
 test = false


### PR DESCRIPTION
Contributes to https://github.com/rust-lang/libc/issues/5496.

```console
warning: unused dependency `libc`
  --> ctest-test/Cargo.toml:16:1
   |
16 | libc = { path = ".." }
   | ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `cargo::unused_dependencies` is set to `warn` by default
```

