### PR TITLE
libc: Make `rustc-dep-of-std` work in tests

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -833,6 +833,7 @@ macro_rules! offset_of {
 #[cfg(test)]
 mod tests {
     use core::any::TypeId;
+    use core::prelude::v1::*;
 
     use crate::types::CEnumRepr;
 
@@ -1150,6 +1151,8 @@ mod tests {
 #[cfg(test)]
 #[allow(unused)]
 mod macro_checks {
+    use core::prelude::v1::*;
+
     s! {
         pub struct S1 {
             pub a: u32,


### PR DESCRIPTION
Contributes to https://github.com/rust-lang/libc/issues/5496.