### PR TITLE
build: Don't warn when enabling opting into musl 1.2 via multiple ways

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -220,17 +220,21 @@ fn main() {
 
     let mut musl_v1_2_env = env_flag("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2");
     if let Ok(old_musl_v1_2_3_env) = env::var("CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2_3") {
-        println!(
-            "cargo:warning=`--cfg=libc_unstable_musl_v1_2_3` will be removed; \
-            set `--cfg=libc_unstable_musl_v1_2`instead"
-        );
+        if !musl_v1_2_env {
+            println!(
+                "cargo:warning=`--cfg=libc_unstable_musl_v1_2_3` will be removed; \
+                set `--cfg=libc_unstable_musl_v1_2`instead"
+            );
+        }
         musl_v1_2_env |= old_musl_v1_2_3_env != "0";
     }
     if let Ok(old_musl_v1_2_3_env) = env::var("RUST_LIBC_UNSTABLE_MUSL_V1_2_3") {
-        println!(
-            "cargo:warning=RUST_LIBC_UNSTABLE_MUSL_V1_2_3 will be removed; \
-            set `--cfg=libc_unstable_musl_v1_2` via RUSTFLAGS instead"
-        );
+        if !musl_v1_2_env {
+            println!(
+                "cargo:warning=RUST_LIBC_UNSTABLE_MUSL_V1_2_3 will be removed; \
+                set `--cfg=libc_unstable_musl_v1_2` via RUSTFLAGS instead"
+            );
+        }
         musl_v1_2_env |= old_musl_v1_2_3_env != "0";
     }
 


### PR DESCRIPTION
In Alpine, we have to set both the old and new `cfg` *and* the environment variable since various versions of libc are being used by packaged software.

This will then emit the warnings about the options being deprecated, even though we fully intentionally set them. I believe the primary purpose of the warnings is to tell people to migrate to the new `cfg`, so we can just not print a warning if musl 1.2 is being opted into via a different way (and the `cfg` or env var has no effect) already.