### PR TITLE
glibc: add `__f_unused` to `statvfs64` on riscv32

### DIFF
--- a/src/new/glibc/sysdeps/unix/linux/bits/statvfs.rs
+++ b/src/new/glibc/sysdeps/unix/linux/bits/statvfs.rs
@@ -37,15 +37,12 @@ s! {
         pub f_ffree: u64,
         pub f_favail: u64,
         pub f_fsid: c_ulong,
-        // FIXME(riscv32): glibc declares this field on riscv32 too, but we have
-        // never declared it here.
+        // Mirrors `_STATVFSBUF_F_UNUSED` in the header. x32 is excluded because
+        // its `__SYSCALL_WORDSIZE` is 64, aarch64 because glibc always sets
+        // `__WORDSIZE` to 64.
         #[cfg(all(
             target_pointer_width = "32",
-            not(any(
-                target_arch = "x86_64",
-                target_arch = "aarch64",
-                target_arch = "riscv32"
-            ))
+            not(any(target_arch = "x86_64", target_arch = "aarch64"))
         ))]
         __f_unused: Padding<c_int>,
         pub f_flag: c_ulong,


### PR DESCRIPTION
`statvfs64` is missing `__f_unused` on riscv32, so every field after `f_fsid`
sits four bytes off.

glibc gates both structs on the same macro and riscv32 satisfies it: `__WORDSIZE`
is 32 there and nothing defines `__SYSCALL_WORDSIZE`. `statvfs` already carries
the field. This was the FIXME left in rust-lang/libc#5434.

There is no riscv32 ctest job, so I checked with a probe instead:
`offset_of!(statvfs64, f_flag)` moves 60 to 64 on riscv32 and stays 72 on
x86_64.

Closes rust-lang/libc#5512
