### PR TITLE
ci: normalize paths before the style ignore-file check

### DIFF
--- a/ci/style.py
+++ b/ci/style.py
@@ -26,7 +26,7 @@ def main():
         fmt_files.extend(iglob(f"{dir}/**/*.rs", recursive=True))
 
     for file in fmt_files:
-        if file in IGNORE_FILES:
+        if Path(file).as_posix() in IGNORE_FILES:
             continue
         fmt_one(Path(file), check_only)
 


### PR DESCRIPTION
`ci/style.py` cannot run on Windows. glob returns `src\macros.rs` and
`IGNORE_FILES` holds `src/macros.rs`, so the file it means to skip is formatted
anyway and rustfmt fails it on width.

`as_posix()` before the comparison. Nothing changes where paths already use
forward slashes.

`libc-0.2` carries the same line.

@rustbot label +stable-nominated
